### PR TITLE
fix: Redis connection timeout graceful standby mode improvement

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1431,6 +1431,13 @@ PY
     fi
 
     echo "=== REDIS PREFLIGHT HEALTH: ${_redis_health} ==="
+    
+    # Allow graceful standby retry instead of crash when Redis is unreachable
+    if [ "${_redis_health}" = "degraded" ]; then
+        export NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS=false
+        echo "   ℹ️  Redis degraded: entering fail-closed standby mode (retry-enabled)"
+        echo "      Bot will retry lock acquisition every 5s until Redis recovers"
+    fi
 elif [ "${_REDIS_STARTUP_CHECK}" != "true" ]; then
     echo "ℹ️  Redis startup preflight disabled (NIJA_REDIS_STARTUP_CHECK=${NIJA_REDIS_STARTUP_CHECK:-false})"
 fi

--- a/start.sh
+++ b/start.sh
@@ -191,6 +191,10 @@ if [ "${_UNSAFE_BYPASS}" = "true" ] && [ "${_STRICT_LEASE}" = "true" ]; then
 fi
 
 if [ "${_LIVE_MODE}" = "true" ] && [ "${_REDIS_CONFIGURED}" = "true" ] && [ "${_STRICT_LEASE}" = "true" ]; then
+    # Allow graceful standby retry instead of immediate exit when Redis is unreachable
+    # This lets the bot enter fail-closed standby and retry every 5s until Redis recovers
+    export NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS="${NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS:-false}"
+    
     # Fail-fast defaults for trading safety (override via env if needed).
     export NIJA_REDIS_LEASE_TTL_MS="${NIJA_REDIS_LEASE_TTL_MS:-600000}"
     export NIJA_REDIS_LEASE_ACQUIRE_TIMEOUT_S="${NIJA_REDIS_LEASE_ACQUIRE_TIMEOUT_S:-5}"
@@ -1431,13 +1435,6 @@ PY
     fi
 
     echo "=== REDIS PREFLIGHT HEALTH: ${_redis_health} ==="
-    
-    # Allow graceful standby retry instead of crash when Redis is unreachable
-    if [ "${_redis_health}" = "degraded" ]; then
-        export NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS=false
-        echo "   ℹ️  Redis degraded: entering fail-closed standby mode (retry-enabled)"
-        echo "      Bot will retry lock acquisition every 5s until Redis recovers"
-    fi
 elif [ "${_REDIS_STARTUP_CHECK}" != "true" ]; then
     echo "ℹ️  Redis startup preflight disabled (NIJA_REDIS_STARTUP_CHECK=${NIJA_REDIS_STARTUP_CHECK:-false})"
 fi


### PR DESCRIPTION
## Summary

Fixes Redis connection timeout crash by enabling graceful fail-closed standby mode at startup instead of immediate exit in live mode.

## Problem

The bot was crashing with:
```
❌ FAILED TO ACQUIRE WRITER LOCK
🛑 FAIL-CLOSED STANDBY ACTIVE: trading remains blocked until writer lock is acquired.
Exiting immediately due to NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS=true
```

The default behavior in live mode was to exit immediately when Redis was unreachable, preventing graceful recovery when Redis connection times out.

## Root Cause

In `start.sh`, the environment variable `NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS` was not being set before Python startup, so Python's default (true in live mode) was used, causing immediate exit.

## Solution

Set `NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS=false` **early in start.sh**, right after live mode detection and before Python initialization. This ensures:
- Bot enters graceful fail-closed standby when Redis is unreachable
- Retries lock acquisition every 5 seconds
- Container remains running while waiting for Redis recovery
- No crash loops

## Changes

- `start.sh`: Set `NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS=false` (default) in live mode with Redis configured

## Testing

After deploying:
1. Container will start normally
2. If Redis is unreachable, bot enters standby mode instead of crashing
3. Logs will show retry attempts every 5s
4. Once Redis recovers, bot acquires lock and begins trading

## Root Cause Resolution

This is a graceful fallback. To permanently resolve, ensure:
1. ✅ Redis service is running (green status in Railway)
2. ✅ TCP proxy is enabled on Redis service
3. ✅ `NIJA_REDIS_URL` is set with correct hostname:port
4. ✅ Use `rediss://` (with "ss") for Railway proxy connections