### PR TITLE
Fix live entry runtime telemetry and micro-cap sizing floors

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -86,6 +86,7 @@ for _key, _value in {
     "NIJA_FULL_EXECUTION_OBSERVABILITY": "true",
     "NIJA_KRAKEN_EQUITY_HYDRATION": "true",
     "NIJA_CAPITAL_BALANCE_PROPAGATION": "true",
+    "NIJA_LIVE_ENTRY_RUNTIME_FIXES": "true",
     "NIJA_WRITER_LOCK_STALE_HEARTBEAT_THRESHOLD_S": "90",
     "NIJA_STALE_LOCK_HEARTBEAT_THRESHOLD_S": "90",
     "NIJA_RAILWAY_STALE_LOCK_HEARTBEAT_THRESHOLD_S": "90",
@@ -100,7 +101,15 @@ except Exception as _exc:
     logger.warning("NIJA startup patch unavailable: %s", _exc)
 _strict_live_cleanup("bot_init_after_sitecustomize")
 
-for _key, _value in (("MIN_TRADE_USD", "10"), ("MIN_NOTIONAL_OVERRIDE", "10"), ("MIN_CASH_TO_BUY", "5"), ("KRAKEN_MIN_NOTIONAL_USD", "10"), ("COINBASE_MIN_ORDER_USD", "1"), ("OKX_MIN_ORDER_USD", "10")):
+for _key, _value in (
+    ("MIN_TRADE_USD", "2"),
+    ("MIN_POSITION_USD", "2"),
+    ("MIN_NOTIONAL_OVERRIDE", "2"),
+    ("MIN_CASH_TO_BUY", "5"),
+    ("KRAKEN_MIN_NOTIONAL_USD", "2"),
+    ("COINBASE_MIN_ORDER_USD", "1"),
+    ("OKX_MIN_ORDER_USD", "2"),
+):
     try:
         if float(os.environ.get(_key, _value) or _value) > float(_value):
             os.environ[_key] = _value
@@ -118,6 +127,7 @@ _PATCH_HOOKS = (
     ("full_execution_observability_patch", "Full execution observability"),
     ("decision_pipeline_runtime_patch", "Decision pipeline telemetry"),
     ("no_trade_watchdog_runtime_patch", "Runtime scan diagnostics"),
+    ("live_entry_runtime_fixes", "Live entry runtime fixes"),
     ("okx_runtime_patch", "OKX runtime patch"),
     ("execution_pipeline_runtime_patch", "Execution pipeline runtime patch"),
     ("coinbase_position_runtime_patch", "Coinbase position runtime patch"),

--- a/bot/live_entry_runtime_fixes.py
+++ b/bot/live_entry_runtime_fixes.py
@@ -1,0 +1,367 @@
+"""Runtime fixes for live entry visibility, quote filtering, and pair quarantine.
+
+This module is intentionally defensive: it patches the live core loop only when
+those classes are imported and leaves trade admission logic unchanged except for
+skipping pairs that cannot be funded by the broker's available quote balance or
+that the venue has already reported as unknown.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import re
+import time
+from functools import wraps
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+logger = logging.getLogger("nija.live_entry_runtime_fixes")
+_PATCHED_ATTR = "__nija_live_entry_runtime_fixes__"
+_UNKNOWN_PAIRS: set[tuple[str, str]] = set()
+
+_STABLE_QUOTES = ("USDT", "USDC", "USD", "EUR", "GBP", "BTC", "ETH")
+_BALANCE_ATTRS = (
+    "balance_cache",
+    "_balance_cache",
+    "balances",
+    "_balances",
+    "last_balance",
+    "_last_balance",
+    "last_balance_snapshot",
+    "_last_balance_snapshot",
+    "_last_known_balance_payload",
+    "_last_raw_balances",
+    "raw_balances",
+    "_raw_balances",
+)
+
+
+def _truthy(name: str, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "on", "y", "enabled"}
+
+
+def _broker_name(broker: Any, fallback: str = "unknown") -> str:
+    for attr in ("name", "broker_name", "exchange", "exchange_name", "broker_type"):
+        try:
+            value = getattr(broker, attr, None)
+            if value is None:
+                continue
+            raw = getattr(value, "value", value)
+            if str(raw).strip():
+                return str(raw).strip().lower()
+        except Exception:
+            continue
+    try:
+        cls_name = type(broker).__name__.lower()
+        for key in ("kraken", "coinbase", "okx", "binance", "alpaca"):
+            if key in cls_name:
+                return key
+    except Exception:
+        pass
+    return fallback
+
+
+def _quote_asset(symbol: Any) -> str:
+    raw = str(symbol or "").upper().strip()
+    if not raw:
+        return ""
+    normalized = raw.replace("/", "-").replace("_", "-").replace(":", "-")
+    if "-" in normalized:
+        tail = normalized.rsplit("-", 1)[-1]
+        return re.sub(r"[^A-Z0-9]", "", tail)
+    compact = re.sub(r"[^A-Z0-9]", "", normalized)
+    for quote in sorted(_STABLE_QUOTES, key=len, reverse=True):
+        if compact.endswith(quote) and len(compact) > len(quote):
+            return quote
+    return ""
+
+
+def _flatten_balances(payload: Any, out: MutableMapping[str, float]) -> None:
+    if payload is None:
+        return
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            key_text = str(key).strip().lower()
+            try:
+                if isinstance(value, Mapping):
+                    # Coinbase/OKX often nest available/total values under each currency.
+                    for sub_key in ("available", "free", "balance", "total", "amount", "value"):
+                        if sub_key in value:
+                            out[key_text] = max(out.get(key_text, 0.0), float(value.get(sub_key) or 0.0))
+                            break
+                    _flatten_balances(value, out)
+                elif isinstance(value, (int, float, str)):
+                    numeric = float(value or 0.0)
+                    out[key_text] = max(out.get(key_text, 0.0), numeric)
+            except (TypeError, ValueError):
+                continue
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        for item in payload:
+            _flatten_balances(item, out)
+
+
+def _quote_balances_from_broker(broker: Any) -> dict[str, float]:
+    balances: dict[str, float] = {}
+    for attr in _BALANCE_ATTRS:
+        try:
+            _flatten_balances(getattr(broker, attr, None), balances)
+        except Exception:
+            continue
+    # Common scalar attributes used by bootstrap/capital hydration.
+    scalar_attrs = {
+        "usd": ("usd", "available_usd", "usd_balance", "_usd_balance"),
+        "usdt": ("usdt", "available_usdt", "usdt_balance", "_usdt_balance"),
+        "usdc": ("usdc", "available_usdc", "usdc_balance", "_usdc_balance"),
+    }
+    for quote, attrs in scalar_attrs.items():
+        for attr in attrs:
+            try:
+                value = getattr(broker, attr, None)
+                if value is not None:
+                    balances[quote] = max(balances.get(quote, 0.0), float(value or 0.0))
+            except (TypeError, ValueError):
+                continue
+    return balances
+
+
+def _should_skip_for_quote(broker_name: str, symbol: str, quote: str, balances: Mapping[str, float]) -> tuple[bool, str]:
+    if not quote or not balances:
+        return False, ""
+    quote_key = quote.lower()
+    quote_available = float(balances.get(quote_key, 0.0) or 0.0)
+    # Only enforce the strict mismatch guard on OKX. Other brokers can expose
+    # their buying power through generic USD/trading_balance fields while still
+    # accepting USD pairs; over-filtering those venues would suppress trades.
+    if broker_name == "okx" and quote in {"USDT", "USDC"} and quote_available <= 0.0:
+        usd_available = float(balances.get("usd", 0.0) or balances.get("available_usd", 0.0) or 0.0)
+        if usd_available > 0.0:
+            return True, f"okx_quote_mismatch:{quote}_balance=0 usd_available={usd_available:.2f}"
+    return False, ""
+
+
+def _filter_symbols_for_quote_balance(broker: Any, symbols: Iterable[Any]) -> list[Any]:
+    symbols_list = list(symbols or [])
+    broker_name = _broker_name(broker)
+    balances = _quote_balances_from_broker(broker)
+    kept: list[Any] = []
+    skipped_quote = 0
+    skipped_unknown = 0
+    for symbol in symbols_list:
+        sym_text = str(symbol)
+        quote = _quote_asset(sym_text)
+        if (broker_name, sym_text.upper()) in _UNKNOWN_PAIRS:
+            skipped_unknown += 1
+            logger.info("PAIR_SKIPPED_UNKNOWN broker=%s pair=%s reason=session_quarantine", broker_name, sym_text)
+            continue
+        skip, reason = _should_skip_for_quote(broker_name, sym_text, quote, balances)
+        if skip:
+            skipped_quote += 1
+            logger.info(
+                "PAIR_SKIPPED_QUOTE_MISMATCH broker=%s pair=%s quote=%s reason=%s balances=%s",
+                broker_name,
+                sym_text,
+                quote,
+                reason,
+                {k: round(v, 8) for k, v in balances.items() if k in {"usd", "usdt", "usdc", "available_usd"}},
+            )
+            continue
+        kept.append(symbol)
+    if skipped_quote or skipped_unknown:
+        logger.warning(
+            "SYMBOL_FILTER_SUMMARY broker=%s input=%d kept=%d skipped_quote=%d skipped_unknown=%d",
+            broker_name,
+            len(symbols_list),
+            len(kept),
+            skipped_quote,
+            skipped_unknown,
+        )
+    return kept
+
+
+def _mark_unknown_pair(broker: Any, symbol: Any, error: Any) -> None:
+    msg = str(error or "")
+    if "Unknown asset pair" not in msg and "EQuery:Unknown asset pair" not in msg:
+        return
+    broker_name = _broker_name(broker)
+    sym_text = str(symbol or "").upper()
+    if not sym_text:
+        return
+    _UNKNOWN_PAIRS.add((broker_name, sym_text))
+    logger.warning("PAIR_QUARANTINED_UNKNOWN broker=%s pair=%s error=%s", broker_name, sym_text, msg[:240])
+
+
+def _wrap_run_scan_phase(cls: type) -> None:
+    original = getattr(cls, "run_scan_phase", None)
+    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
+        return
+
+    @wraps(original)
+    def _wrapped(self: Any, broker: Any = None, balance: float = 0.0, symbols: Optional[list[str]] = None, *args: Any, **kwargs: Any):
+        broker_obj = broker if broker is not None else getattr(getattr(self, "apex", None), "broker_client", None)
+        broker_name = _broker_name(broker_obj)
+        symbols_count = len(symbols or []) if symbols is not None else 0
+        cycle_id = f"runtime-{int(time.time() * 1000)}"
+        logger.info(
+            "SCAN_CYCLE_START cycle_id=%s broker=%s symbols=%d balance=%.2f open_positions=%s user_mode=%s",
+            cycle_id,
+            broker_name,
+            symbols_count,
+            float(balance or 0.0),
+            kwargs.get("open_positions_count", args[0] if args else "unknown"),
+            kwargs.get("user_mode", False),
+        )
+        result = original(self, broker, balance, symbols, *args, **kwargs)
+        logger.info(
+            "SCAN_CYCLE_END cycle_id=%s broker=%s symbols_scored=%s entries_taken=%s entries_blocked=%s exits_taken=%s next_interval=%s errors=%s",
+            cycle_id,
+            broker_name,
+            getattr(result, "symbols_scored", None),
+            getattr(result, "entries_taken", None),
+            getattr(result, "entries_blocked", None),
+            getattr(result, "exits_taken", None),
+            getattr(result, "next_interval", None),
+            getattr(result, "errors", None),
+        )
+        return result
+
+    setattr(_wrapped, _PATCHED_ATTR, True)
+    setattr(cls, "run_scan_phase", _wrapped)
+    logger.warning("LIVE_ENTRY_FIXES_RUN_SCAN_WIRED class=%s", cls.__name__)
+
+
+def _wrap_phase3(cls: type) -> None:
+    original = getattr(cls, "_phase3_scan_and_enter", None)
+    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
+        return
+
+    @wraps(original)
+    def _wrapped(self: Any, broker: Any, snapshot: Any, symbols: list[str], available_slots: int, *args: Any, **kwargs: Any):
+        filtered_symbols = _filter_symbols_for_quote_balance(broker, symbols)
+        logger.info(
+            "ENTRY_SCAN_START broker=%s cycle_id=%s symbols_in=%d symbols_after_filter=%d available_slots=%d balance=%.2f",
+            _broker_name(broker),
+            getattr(snapshot, "cycle_id", "n/a"),
+            len(symbols or []),
+            len(filtered_symbols),
+            int(available_slots or 0),
+            float(getattr(snapshot, "balance", 0.0) or 0.0),
+        )
+        return original(self, broker, snapshot, filtered_symbols, available_slots, *args, **kwargs)
+
+    setattr(_wrapped, _PATCHED_ATTR, True)
+    setattr(cls, "_phase3_scan_and_enter", _wrapped)
+    logger.warning("LIVE_ENTRY_FIXES_PHASE3_WIRED class=%s", cls.__name__)
+
+
+def _wrap_fetch_df(cls: type) -> None:
+    original = getattr(cls, "_fetch_df", None)
+    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
+        return
+
+    @wraps(original)
+    def _wrapped(self: Any, broker: Any, symbol: Any, *args: Any, **kwargs: Any):
+        try:
+            return original(self, broker, symbol, *args, **kwargs)
+        except Exception as exc:
+            _mark_unknown_pair(broker, symbol, exc)
+            raise
+
+    setattr(_wrapped, _PATCHED_ATTR, True)
+    setattr(cls, "_fetch_df", _wrapped)
+    logger.warning("LIVE_ENTRY_FIXES_FETCH_DF_WIRED class=%s", cls.__name__)
+
+
+def _wrap_execute_action(cls: type) -> None:
+    original = getattr(cls, "execute_action", None)
+    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
+        return
+
+    @wraps(original)
+    def _wrapped(self: Any, analysis: Any, symbol: str, *args: Any, **kwargs: Any):
+        action = analysis.get("action") if isinstance(analysis, Mapping) else None
+        size = analysis.get("position_size") if isinstance(analysis, Mapping) else None
+        price = analysis.get("entry_price") if isinstance(analysis, Mapping) else None
+        logger.info(
+            "ORDER_SUBMIT_ATTEMPT broker=%s pair=%s action=%s usd_size=%s entry_price=%s",
+            _broker_name(getattr(self, "broker_client", None)),
+            symbol,
+            action,
+            size,
+            price,
+        )
+        result = original(self, analysis, symbol, *args, **kwargs)
+        logger.info(
+            "ORDER_SUBMIT_RESULT broker=%s pair=%s action=%s success=%s",
+            _broker_name(getattr(self, "broker_client", None)),
+            symbol,
+            action,
+            bool(result),
+        )
+        return result
+
+    setattr(_wrapped, _PATCHED_ATTR, True)
+    setattr(cls, "execute_action", _wrapped)
+    logger.warning("LIVE_ENTRY_FIXES_EXECUTE_WIRED class=%s", cls.__name__)
+
+
+def _patch_module(module: Any) -> bool:
+    if module is None:
+        return False
+    patched = False
+    try:
+        core_cls = getattr(module, "NijaCoreLoop", None)
+        if isinstance(core_cls, type):
+            _wrap_run_scan_phase(core_cls)
+            _wrap_phase3(core_cls)
+            _wrap_fetch_df(core_cls)
+            patched = True
+    except Exception as exc:
+        logger.warning("Live entry core-loop patch failed for %s: %s", getattr(module, "__name__", module), exc)
+    try:
+        apex_cls = getattr(module, "NIJAApexStrategyV71", None)
+        if isinstance(apex_cls, type):
+            _wrap_execute_action(apex_cls)
+            patched = True
+    except Exception as exc:
+        logger.warning("Live entry apex patch failed for %s: %s", getattr(module, "__name__", module), exc)
+    return patched
+
+
+def install_import_hook() -> None:
+    if not _truthy("NIJA_LIVE_ENTRY_RUNTIME_FIXES", True):
+        logger.warning("LIVE_ENTRY_FIXES_DISABLED env=NIJA_LIVE_ENTRY_RUNTIME_FIXES")
+        return
+
+    import sys
+
+    for name, module in list(sys.modules.items()):
+        if name.endswith(("nija_core_loop", "nija_apex_strategy_v71")):
+            _patch_module(module)
+
+    if getattr(builtins, "_NIJA_LIVE_ENTRY_RUNTIME_FIXES_HOOK_INSTALLED", False):
+        return
+
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        targets = ("nija_core_loop", "nija_apex_strategy_v71")
+        try:
+            if name.endswith(targets):
+                _patch_module(module)
+            # When importing from a package with fromlist, Python returns the package;
+            # patch submodules if they are already loaded.
+            for loaded_name, loaded_module in list(sys.modules.items()):
+                if loaded_name.endswith(targets):
+                    _patch_module(loaded_module)
+        except Exception as exc:
+            logger.warning("Live entry runtime fixes import hook failed for %s: %s", name, exc)
+        return module
+
+    builtins.__import__ = guarded_import
+    setattr(builtins, "_NIJA_LIVE_ENTRY_RUNTIME_FIXES_HOOK_INSTALLED", True)
+    logger.warning("LIVE_ENTRY_FIXES_INSTALL_COMPLETE")

--- a/bot/position_sizer.py
+++ b/bot/position_sizer.py
@@ -2,197 +2,130 @@
 NIJA Position Sizer
 ===================
 
-Calculates appropriate position sizes for user accounts based on platform account trades.
-Uses equity-based scaling to ensure users trade proportionally to their account size.
-
-Formula:
-    user_size = platform_size * (user_balance / platform_balance)
-
-This ensures:
-- Users with smaller accounts take smaller positions (risk management)
-- Users with larger accounts take larger positions (capital efficiency)
-- All users maintain same risk/reward ratio as platform account
+Single-source position sizing helpers for platform and user accounts.
+This module deliberately avoids importing trading_strategy at import time: that
+import path is circular during startup and caused callers to fall back to a hard
+$10 minimum.  Runtime floors are now resolved directly from environment values.
 """
+
+from __future__ import annotations
 
 import logging
 import math
-from typing import Dict, Optional
+import os
+from typing import Dict, Iterable, Optional
 
-logger = logging.getLogger('nija.position_sizer')
+logger = logging.getLogger("nija.position_sizer")
 
-# Minimum position sizes (exchange-specific)
-# These prevent creating dust positions that can't be sold
-# Updated Apr 2026: Unified to GLOBAL_MIN_TRADE from trading_strategy.py
 
-import os as _os  # needed for COINBASE_MIN_ORDER_USD env override below
+def _float_env(names: Iterable[str], default: float) -> float:
+    for name in names:
+        raw = os.getenv(name)
+        if raw is None or str(raw).strip() == "":
+            continue
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except (TypeError, ValueError):
+            logger.warning("Invalid numeric env %s=%r; ignoring", name, raw)
+    return float(default)
 
-# Import the single source-of-truth minimum from trading_strategy.
-# Fall back to 5.0 if the import is unavailable (e.g. standalone test runs).
-try:
-    from bot.trading_strategy import GLOBAL_MIN_TRADE as _GLOBAL_MIN_TRADE
-except ImportError:
-    try:
-        from trading_strategy import GLOBAL_MIN_TRADE as _GLOBAL_MIN_TRADE
-    except ImportError:
-        _GLOBAL_MIN_TRADE = 10.0  # fallback — $10 for micro-cap / HF scalp mode (Apr 2026)
 
-# KRAKEN: Exchange minimum lowered to $10 for micro-cap / HF scalp mode.
-# KRAKEN_MIN_TRADE_USD is env-overridable via KRAKEN_MIN_NOTIONAL_USD.
-# The fee buffer (+$0.50) covers ~0.4–0.6% taker fees so the net filled value stays ≥$10.
-# Lowered from $10.50 → $10.0 to allow trading with $174 balance (Apr 2026).
-_KRAKEN_EXCHANGE_FLOOR = float(_os.getenv('KRAKEN_MIN_NOTIONAL_USD', '10.0'))  # env-overridable Kraken minimum
-KRAKEN_MIN_TRADE_USD = max(_KRAKEN_EXCHANGE_FLOOR, _GLOBAL_MIN_TRADE)  # never below exchange floor
-
-# COINBASE / default: env-overridable for micro-cap mode.
-# COINBASE_MIN_ORDER_USD=1 (Step 5) lowers the floor to $1 when set.
-COINBASE_MIN_TRADE_USD: float = float(
-    _os.getenv('COINBASE_MIN_ORDER_USD', _os.getenv('COINBASE_MIN_ORDER', str(_GLOBAL_MIN_TRADE)))
+# Single source of truth for micro-cap floors.  The default is intentionally
+# $2.00 to match NIJA's current live micro-cap profile; exchange/order compiler
+# layers can still enforce higher venue-specific minimums when required.
+GLOBAL_MIN_TRADE = _float_env(
+    ("MIN_POSITION_USD", "MIN_TRADE_USD", "MIN_NOTIONAL_OVERRIDE", "GLOBAL_MIN_TRADE"),
+    2.0,
 )
+MIN_POSITION_USD: float = GLOBAL_MIN_TRADE
 
-# Default minimum for other exchanges
-# Lowered to $10 for micro-cap / HF scalp mode with $174 balance (Apr 2026).
-MIN_POSITION_USD = _GLOBAL_MIN_TRADE  # Minimum USD value for any position (avoids dust + rejections)
+KRAKEN_MIN_TRADE_USD: float = max(
+    _float_env(("KRAKEN_MIN_NOTIONAL_USD", "KRAKEN_MIN_ORDER_USD"), GLOBAL_MIN_TRADE),
+    GLOBAL_MIN_TRADE,
+)
+COINBASE_MIN_TRADE_USD: float = _float_env(
+    ("COINBASE_MIN_ORDER_USD", "COINBASE_MIN_ORDER"),
+    GLOBAL_MIN_TRADE,
+)
+OKX_MIN_TRADE_USD: float = _float_env(("OKX_MIN_ORDER_USD", "OKX_MIN_NOTIONAL_USD"), GLOBAL_MIN_TRADE)
+BINANCE_MIN_TRADE_USD: float = _float_env(("BINANCE_MIN_ORDER_USD", "BINANCE_MIN_NOTIONAL_USD"), GLOBAL_MIN_TRADE)
 
-# Fee buffer applied when capping a user position to their available balance.
-# Set conservatively at 2% to cover Coinbase taker fee (~0.6%) and Kraken (~0.26%)
-# plus rounding — matches the 2% pre-flight buffer used by CoinbaseBroker.place_market_order.
 POSITION_SIZE_FEE_BUFFER_FACTOR = 1.02
 
-# Exchange-specific minimums (with fee buffers)
 EXCHANGE_MIN_TRADE_USD = {
-    'kraken': KRAKEN_MIN_TRADE_USD,      # $10.50 (accounts for Kraken $10 min + fees)
-    'coinbase': COINBASE_MIN_TRADE_USD,  # GLOBAL_MIN_TRADE
-    'okx': _GLOBAL_MIN_TRADE,           # aligned to GLOBAL_MIN_TRADE
-    'binance': _GLOBAL_MIN_TRADE,       # aligned to GLOBAL_MIN_TRADE
+    "kraken": KRAKEN_MIN_TRADE_USD,
+    "coinbase": COINBASE_MIN_TRADE_USD,
+    "okx": OKX_MIN_TRADE_USD,
+    "binance": BINANCE_MIN_TRADE_USD,
 }
 
-# Per-symbol exchange minimums — some assets have higher notional floors on
-# specific exchanges.  These take precedence over the exchange-level defaults
-# when the symbol's base currency matches.
-SYMBOL_MIN_TRADE_USD: dict = {
-    # Coinbase/general — symbols that have known higher rejection thresholds
-    'MOVR': 5.0,   # Moonriver — exchange floor makes sub-$5 orders fail
-    'HBAR': 5.0,   # Hedera — sub-$5 orders frequently rejected
-    'DOT':  5.0,   # Polkadot — sub-$5 orders frequently rejected
-    'BAND': 5.0,
-    'NMR':  5.0,
-    'RLC':  5.0,
+SYMBOL_MIN_TRADE_USD: dict[str, float] = {
+    "MOVR": 5.0,
+    "HBAR": 5.0,
+    "DOT": 5.0,
+    "BAND": 5.0,
+    "NMR": 5.0,
+    "RLC": 5.0,
 }
 
 MIN_BASE_SIZES = {
-    # Coinbase minimum order sizes in base currency (updated Mar 2026).
-    # Where Coinbase publishes an explicit minimum, that value is used;
-    # otherwise a conservative estimate is applied.
-    # NOTE: USD values in comments are approximate at Mar 2026 prices.
-
-    # ── Tier 1: Major, high-price assets ───────────────────────────────────
-    'BTC':   0.000001,  # ~$0.06 at $60k BTC  (Coinbase: 0.000001)
-    'ETH':   0.0001,    # ~$0.30 at $3k ETH
-    'BNB':   0.001,     # ~$0.60 at $600 BNB
-
-    # ── Tier 2: Mid-range assets ($50–$500) ────────────────────────────────
-    'SOL':   0.01,      # ~$1.50 at $150 SOL
-    'AVAX':  0.01,      # ~$0.30 at $30 AVAX
-    'LINK':  0.01,      # ~$0.15 at $15 LINK
-    'DOT':   0.01,      # ~$0.07 at $7 DOT
-    'LTC':   0.001,     # ~$0.08 at $80 LTC
-    'BCH':   0.001,     # ~$0.50 at $500 BCH
-    'UNI':   0.01,      # ~$0.10 at $10 UNI
-    'AAVE':  0.001,     # ~$0.10 at $100 AAVE
-    'ATOM':  0.01,      # ~$0.10 at $10 ATOM
-    'FIL':   0.01,      # ~$0.05 at $5 FIL
-    'ICP':   0.01,      # ~$0.10 at $10 ICP
-
-    # ── Tier 3: Sub-$5 assets ──────────────────────────────────────────────
-    'XRP':   1.0,       # ~$0.50 at $0.50 XRP
-    'ADA':   1.0,       # ~$0.40 at $0.40 ADA
-    'DOGE':  1.0,       # ~$0.15 at $0.15 DOGE
-    'MATIC': 1.0,       # ~$0.70 at $0.70 MATIC
-    'XLM':   1.0,       # ~$0.10 at $0.10 XLM
-    'ALGO':  1.0,       # ~$0.15 at $0.15 ALGO
-    'VET':   1.0,       # ~$0.03 at $0.03 VET
-    'HBAR':  1.0,       # ~$0.07 at $0.07 HBAR
-    'EOS':   1.0,       # ~$0.75 at $0.75 EOS
-    'TRX':   1.0,       # ~$0.10 at $0.10 TRX
-    'CHZ':   1.0,       # ~$0.10 at $0.10 CHZ
-
-    # ── Tier 4: Very low-price assets (need large base qty) ───────────────
-    # These coins require a larger minimum unit count due to their small
-    # per-unit price; using the generic 0.0001 fallback would silently allow
-    # dust orders that Coinbase rejects.
-    'XDC':   100.0,     # ~$5 at $0.05 XDC  (Coinbase explicit minimum)
-    'SHIB':  1_000_000, # ~$25 at $0.000025 SHIB
-    'PEPE':  1_000_000, # ~$10 at $0.00001 PEPE
-    'BONK':  1_000_000, # ~$25 at $0.000025 BONK
-    'MANA':  1.0,       # ~$0.40 at $0.40 MANA (Decentraland)
+    "BTC": 0.000001,
+    "ETH": 0.0001,
+    "BNB": 0.001,
+    "SOL": 0.01,
+    "AVAX": 0.01,
+    "LINK": 0.01,
+    "DOT": 0.01,
+    "LTC": 0.001,
+    "BCH": 0.001,
+    "UNI": 0.01,
+    "AAVE": 0.001,
+    "ATOM": 0.01,
+    "FIL": 0.01,
+    "ICP": 0.01,
+    "XRP": 1.0,
+    "ADA": 1.0,
+    "DOGE": 1.0,
+    "MATIC": 1.0,
+    "XLM": 1.0,
+    "ALGO": 1.0,
+    "VET": 1.0,
+    "HBAR": 1.0,
+    "EOS": 1.0,
+    "TRX": 1.0,
+    "CHZ": 1.0,
+    "XDC": 100.0,
+    "SHIB": 1_000_000,
+    "PEPE": 1_000_000,
+    "BONK": 1_000_000,
+    "MANA": 1.0,
 }
 
 
 def _extract_base_currency(symbol: str) -> str:
-    """Extract the base currency from a trading pair symbol.
-
-    Handles dash-style (``"BTC-USD"``, ``"BTC/USD"``) and compact
-    (``"BTCUSD"``) formats.  Quote suffixes are stripped in longest-first
-    order so that ``"USDCUSD"`` → ``"USDC"`` rather than ``"USDC"`` being
-    stripped as ``"USD"``.
-
-    Args:
-        symbol: Trading pair in any common format.
-
-    Returns:
-        Base currency ticker string (e.g. ``"BTC"``).
-    """
-    if '-' in symbol or '/' in symbol:
-        return symbol.split('-')[0].split('/')[0]
-    # Compact format: strip known quote suffixes longest-first to avoid
-    # partial matches (e.g. USDC before USD).
-    for suffix in ('USDT', 'USDC', 'USD', 'BTC', 'ETH'):
+    if not symbol:
+        return ""
+    symbol = str(symbol).upper().strip()
+    if "-" in symbol or "/" in symbol:
+        return symbol.split("-")[0].split("/")[0]
+    for suffix in ("USDT", "USDC", "USD", "BTC", "ETH"):
         if symbol.endswith(suffix) and len(symbol) > len(suffix):
             return symbol[: -len(suffix)]
     return symbol
 
 
 def get_min_base_size(symbol: str) -> float:
-    """Return the minimum base-currency order quantity for *symbol*.
-
-    Handles both dash-style (``"BTC-USD"``, ``"BTC/USD"``) and compact
-    (``"BTCUSD"``) formats so callers don't need to normalise beforehand.
-    Falls back to ``0.0001`` when the base currency is not listed.
-
-    Args:
-        symbol: Trading pair in any common format.
-
-    Returns:
-        Minimum order size in base currency units.
-    """
     return MIN_BASE_SIZES.get(_extract_base_currency(symbol), 0.0001)
 
 
-def get_exchange_min_trade_size(exchange: str = 'coinbase', symbol: str = '') -> float:
-    """
-    Get minimum trade size for a specific exchange (with fee buffer included).
-
-    Also checks per-symbol overrides in SYMBOL_MIN_TRADE_USD so that assets
-    with known higher rejection thresholds (MOVR, HBAR, DOT, …) always return
-    the correct floor regardless of the exchange default.
-
-    Args:
-        exchange: Exchange name (kraken, coinbase, okx, binance, etc.)
-        symbol:   Optional trading pair (e.g. ``"HBAR-USD"``).  When supplied
-                  the per-symbol minimum is checked and the larger of the two
-                  values is returned.
-
-    Returns:
-        Minimum trade size in USD (includes fee buffer)
-    """
-    exchange_lower = exchange.lower()
+def get_exchange_min_trade_size(exchange: str = "coinbase", symbol: str = "") -> float:
+    exchange_lower = str(exchange or "").lower()
     exchange_min = EXCHANGE_MIN_TRADE_USD.get(exchange_lower, MIN_POSITION_USD)
-
     if symbol:
         base = _extract_base_currency(symbol)
-        symbol_min = SYMBOL_MIN_TRADE_USD.get(base, 0.0)
-        return max(exchange_min, symbol_min)
-
+        return max(exchange_min, SYMBOL_MIN_TRADE_USD.get(base, 0.0))
     return exchange_min
 
 
@@ -200,144 +133,56 @@ def calculate_user_position_size(
     platform_size: float,
     platform_balance: float,
     user_balance: float,
-    size_type: str = 'quote',
-    symbol: str = None,
-    min_position_usd: float = MIN_POSITION_USD
+    size_type: str = "quote",
+    symbol: Optional[str] = None,
+    min_position_usd: float = MIN_POSITION_USD,
 ) -> Dict:
-    """
-    Calculate appropriate position size for a user account.
-
-    Args:
-        platform_size: Size of the platform account's trade
-        platform_balance: Total balance of platform account
-        user_balance: Total balance of user account
-        size_type: "quote" (USD amount) or "base" (crypto amount)
-        symbol: Trading pair symbol (e.g., "BTC-USD") - used for minimum size validation
-        min_position_usd: Minimum position size in USD (default: $1.00)
-
-    Returns:
-        Dictionary with:
-            - 'size': Calculated position size for user
-            - 'size_type': Same as input size_type
-            - 'valid': True if position meets minimum requirements
-            - 'reason': Explanation if position is invalid
-            - 'scale_factor': Ratio of user_balance to platform_balance
-
-    Example:
-        Master: $10,000 balance, $500 BTC trade
-        User: $1,000 balance
-        Result: $50 BTC trade (10% of master size, matching 10% account ratio)
-    """
     try:
-        # Validate inputs
         if platform_balance <= 0:
-            logger.error(f"❌ Invalid platform_balance: {platform_balance}")
-            return {
-                'size': 0,
-                'size_type': size_type,
-                'valid': False,
-                'reason': f'Invalid master balance: {platform_balance}',
-                'scale_factor': 0
-            }
-
+            return {"size": 0, "size_type": size_type, "valid": False, "reason": f"Invalid master balance: {platform_balance}", "scale_factor": 0}
         if user_balance <= 0:
-            logger.warning(f"⚠️  User has zero or negative balance: {user_balance}")
-            return {
-                'size': 0,
-                'size_type': size_type,
-                'valid': False,
-                'reason': f'User balance too low: ${user_balance:.2f}',
-                'scale_factor': 0
-            }
-
+            return {"size": 0, "size_type": size_type, "valid": False, "reason": f"User balance too low: ${user_balance:.2f}", "scale_factor": 0}
         if platform_size <= 0:
-            logger.error(f"❌ Invalid platform_size: {platform_size}")
-            return {
-                'size': 0,
-                'size_type': size_type,
-                'valid': False,
-                'reason': f'Invalid master size: {platform_size}',
-                'scale_factor': 0
-            }
+            return {"size": 0, "size_type": size_type, "valid": False, "reason": f"Invalid master size: {platform_size}", "scale_factor": 0}
 
-        # Calculate scale factor (user equity as % of master equity)
         scale_factor = user_balance / platform_balance
-
-        # Calculate scaled position size
         user_size = platform_size * scale_factor
 
-        logger.info(f"📊 Position Sizing Calculation:")
-        logger.info(f"   Platform: ${platform_balance:.2f} balance, {platform_size} size ({size_type})")
-        logger.info(f"   User: ${user_balance:.2f} balance")
-        logger.info(f"   Scale Factor: {scale_factor:.4f} ({scale_factor*100:.2f}%)")
-        logger.info(f"   Calculated User Size: {user_size} ({size_type})")
+        logger.info("📊 Position Sizing Calculation:")
+        logger.info("   Platform: $%.2f balance, %s size (%s)", platform_balance, platform_size, size_type)
+        logger.info("   User: $%.2f balance", user_balance)
+        logger.info("   Scale Factor: %.4f (%.2f%%)", scale_factor, scale_factor * 100)
+        logger.info("   Calculated User Size: %s (%s)", user_size, size_type)
 
-        # ── Fee-aware balance cap ─────────────────────────────────────────────
-        # Ensure the order leaves room for exchange fees (conservative buffer
-        # covers Coinbase taker fee ~0.6% + Kraken ~0.26% + rounding).  Without
-        # this cap the broker pre-flight check may reject orders where fees would
-        # push the total above the available balance.
-        if size_type == 'quote':
+        if size_type == "quote":
             fee_adjusted_cap = math.floor((user_balance / POSITION_SIZE_FEE_BUFFER_FACTOR) * 100) / 100
             if user_size > fee_adjusted_cap:
-                logger.info(
-                    f"   📉 Size capped: ${user_size:.2f} → ${fee_adjusted_cap:.2f} "
-                    f"({(POSITION_SIZE_FEE_BUFFER_FACTOR - 1) * 100:.0f}% fee reserve "
-                    f"on ${user_balance:.2f} balance)"
-                )
+                logger.info("   📉 Size capped: $%.2f → $%.2f", user_size, fee_adjusted_cap)
                 user_size = fee_adjusted_cap
-
-        # Validate minimum position size
-        if size_type == 'quote':
-            # For USD-denominated trades, check against minimum USD
             if user_size < min_position_usd:
-                logger.warning(f"   ⚠️  Position too small: ${user_size:.2f} < ${min_position_usd:.2f} minimum")
                 return {
-                    'size': user_size,
-                    'size_type': size_type,
-                    'valid': False,
-                    'reason': f'Position too small: ${user_size:.2f} < ${min_position_usd:.2f} minimum',
-                    'scale_factor': scale_factor
+                    "size": user_size,
+                    "size_type": size_type,
+                    "valid": False,
+                    "reason": f"Position too small: ${user_size:.2f} < ${min_position_usd:.2f} minimum",
+                    "scale_factor": scale_factor,
                 }
-
-        elif size_type == 'base' and symbol:
-            # For crypto-denominated trades, check against exchange minimums
+        elif size_type == "base" and symbol:
             min_base = get_min_base_size(symbol)
             base_currency = _extract_base_currency(symbol)
-
             if user_size < min_base:
-                logger.warning(f"   ⚠️  Position too small: {user_size} {base_currency} < {min_base} minimum")
                 return {
-                    'size': user_size,
-                    'size_type': size_type,
-                    'valid': False,
-                    'reason': f'Position too small: {user_size} < {min_base} {base_currency} minimum',
-                    'scale_factor': scale_factor
+                    "size": user_size,
+                    "size_type": size_type,
+                    "valid": False,
+                    "reason": f"Position too small: {user_size} < {min_base} {base_currency} minimum",
+                    "scale_factor": scale_factor,
                 }
 
-        logger.info(f"   ✅ Position size valid: {user_size} ({size_type})")
-
-        return {
-            'size': user_size,
-            'size_type': size_type,
-            'valid': True,
-            'reason': 'Position size valid',
-            'scale_factor': scale_factor
-        }
-
-    except Exception as e:
-        logger.error(f"❌ Error calculating position size: {e}")
-        import traceback
-        logger.error(traceback.format_exc())
-        return {
-            'size': 0,
-            'size_type': size_type,
-            'valid': False,
-            'reason': f'Calculation error: {e}',
-            'scale_factor': 0
-        }
-
-
+        return {"size": user_size, "size_type": size_type, "valid": True, "reason": "Position size valid", "scale_factor": scale_factor}
+    except Exception as exc:
+        logger.exception("❌ Error calculating position size: %s", exc)
+        return {"size": 0, "size_type": size_type, "valid": False, "reason": f"Calculation error: {exc}", "scale_factor": 0}
 
 
 def calculate_position_size(
@@ -348,121 +193,57 @@ def calculate_position_size(
     atr_pct: float,
     win_rate: float = 0.55,
     broker: str = "kraken",
-    max_risk_pct: float = 0.01,    # 1% base risk per trade
-    max_position_pct: float = 0.40, # 40% hard cap
+    max_risk_pct: float = 0.01,
+    max_position_pct: float = 0.40,
 ) -> float:
-    """
-    Optimal position size in USD combining four complementary models.
+    min_trade = get_exchange_min_trade_size(broker)
 
-    Models applied (most conservative wins):
-      1. Risk-based sizing     — risk exactly ``max_risk_pct`` of balance on the
-                                 effective stop (stop + execution friction).
-      2. Volatility scalar     — reduce size when ATR > 2%; hold size when calm.
-      3. Conservative Kelly    — fraction of balance suggested by the Kelly
-                                 criterion, capped at 25% to avoid overbetting.
-      4. Hard cap              — never exceed ``max_position_pct`` of balance.
+    fee_rate = 0.0026 * 2
+    spread = 0.004
+    slippage = 0.002
+    total_cost = fee_rate + spread + slippage
 
-    A trade is **vetoed** (returns 0.0) when the expected net profit after fees,
-    spread, and slippage is less than 1.2 %.  This eliminates "death by fees"
-    on thin entries.
-
-    Parameters
-    ----------
-    account_balance : float
-        Current trading balance in USD.
-    entry_price : float
-        Expected fill price (used for base-currency conversion if needed).
-    stop_loss_pct : float
-        Hard stop distance as a decimal (e.g. 0.02 = 2 %).
-    take_profit_pct : float
-        Primary take-profit target as a decimal (e.g. 0.035 = 3.5 %).
-    atr_pct : float
-        Current ATR expressed as a fraction of price (e.g. 0.02 = 2 %).
-    win_rate : float
-        Estimated win rate for Kelly calculation (default 55 %).
-    broker : str
-        Broker name — used to look up exchange-specific minimum trade size.
-    max_risk_pct : float
-        Maximum fraction of balance to risk on one trade (default 1 %).
-    max_position_pct : float
-        Hard ceiling on position size as a fraction of balance (default 40 %).
-
-    Returns
-    -------
-    float
-        Position size in USD rounded down to 2 decimal places.
-        Returns 0.0 when the trade is vetoed by the cost model.
-    """
-    # ── 1. Broker constraints ─────────────────────────────────────────
-    BROKER_MIN_TRADE: Dict[str, float] = {
-        "kraken":   10.5,
-        "coinbase": 1.0,
-        "binance":  10.0,
-        "okx":      1.0,
-    }
-    min_trade = BROKER_MIN_TRADE.get(broker.lower(), 10.0)
-
-    # ── 2. Execution cost model ───────────────────────────────────────
-    fee_rate   = 0.0026 * 2  # taker round-trip ≈ 0.52 %
-    spread     = 0.004        # bid/ask spread  ≈ 0.40 %
-    slippage   = 0.002        # market impact   ≈ 0.20 %
-    total_cost = fee_rate + spread + slippage   # ≈ 1.12 %
-
-    # ── 3. Validate trade viability ───────────────────────────────────
     expected_net_profit = take_profit_pct - total_cost
     if expected_net_profit <= 0.012:
-        # Require at least 1.2 % real profit after friction — veto otherwise.
         logger.info(
-            "calculate_position_size: trade VETOED — net profit %.2f %% ≤ 1.20 %% "
-            "(tp=%.2f %%, cost=%.2f %%)",
-            expected_net_profit * 100, take_profit_pct * 100, total_cost * 100,
+            "calculate_position_size: trade VETOED — net profit %.2f %% ≤ 1.20 %% (tp=%.2f %%, cost=%.2f %%)",
+            expected_net_profit * 100,
+            take_profit_pct * 100,
+            total_cost * 100,
         )
         return 0.0
 
-    # ── 4. Risk-based sizing ──────────────────────────────────────────
-    risk_amount  = account_balance * max_risk_pct
-    effective_sl = stop_loss_pct + total_cost  # widen SL for friction
+    risk_amount = account_balance * max_risk_pct
+    effective_sl = stop_loss_pct + total_cost
     if effective_sl <= 0:
         return 0.0
-    position_size_risk = risk_amount / effective_sl
 
-    # ── 5. Volatility scalar (ATR-based) ─────────────────────────────
-    # Normalise around a 2 % ATR reference; high ATR → smaller size.
-    if atr_pct > 0:
-        volatility_scalar = min(1.0, 0.02 / atr_pct)
-    else:
-        volatility_scalar = 1.0
+    position_size_risk = risk_amount / effective_sl
+    volatility_scalar = min(1.0, 0.02 / atr_pct) if atr_pct > 0 else 1.0
     position_size_vol = position_size_risk * volatility_scalar
 
-    # ── 6. Conservative Kelly fraction ───────────────────────────────
-    edge     = (win_rate * take_profit_pct) - ((1.0 - win_rate) * stop_loss_pct)
+    edge = (win_rate * take_profit_pct) - ((1.0 - win_rate) * stop_loss_pct)
     variance = take_profit_pct ** 2
-    kelly_fraction    = max(0.0, min(edge / variance if variance > 0 else 0.0, 0.25))
+    kelly_fraction = max(0.0, min(edge / variance if variance > 0 else 0.0, 0.25))
     position_size_kelly = account_balance * kelly_fraction
 
-    # ── 7. Combine models — take the most conservative ────────────────
-    raw_size = min(
-        position_size_vol,
-        position_size_kelly,
-        account_balance * max_position_pct,
-    )
-
-    # ── 8. Enforce broker minimum ─────────────────────────────────────
+    raw_size = min(position_size_vol, position_size_kelly, account_balance * max_position_pct)
     final_size = max(raw_size, min_trade)
-
-    # ── 9. Final hard cap ─────────────────────────────────────────────
     cap = account_balance * max_position_pct
     if final_size > cap:
         final_size = cap
-
-    # ── 10. Round down to 2 decimal places for exchange precision ─────
     final_size = math.floor(final_size * 100) / 100
 
     logger.debug(
-        "calculate_position_size: balance=$%.2f tp=%.2f%% sl=%.2f%% atr=%.2f%% "
-        "→ risk=$%.2f vol=$%.2f kelly=$%.2f → final=$%.2f",
-        account_balance, take_profit_pct * 100, stop_loss_pct * 100, atr_pct * 100,
-        position_size_risk, position_size_vol, position_size_kelly, final_size,
+        "calculate_position_size: balance=$%.2f tp=%.2f%% sl=%.2f%% atr=%.2f%% → risk=$%.2f vol=$%.2f kelly=$%.2f → final=$%.2f",
+        account_balance,
+        take_profit_pct * 100,
+        stop_loss_pct * 100,
+        atr_pct * 100,
+        position_size_risk,
+        position_size_vol,
+        position_size_kelly,
+        final_size,
     )
     return final_size
 
@@ -470,94 +251,45 @@ def calculate_position_size(
 def validate_position_size(
     size: float,
     size_type: str,
-    symbol: str = None,
-    min_position_usd: float = MIN_POSITION_USD
+    symbol: Optional[str] = None,
+    min_position_usd: float = MIN_POSITION_USD,
 ) -> Dict:
-    """
-    Validate if a position size meets minimum requirements.
-
-    Args:
-        size: Position size to validate
-        size_type: "quote" (USD) or "base" (crypto)
-        symbol: Trading pair symbol (e.g., "BTC-USD")
-        min_position_usd: Minimum position value in USD
-
-    Returns:
-        Dictionary with 'valid' (bool) and 'reason' (str)
-    """
     try:
         if size <= 0:
-            return {'valid': False, 'reason': 'Size must be positive'}
-
-        if size_type == 'quote':
-            if size < min_position_usd:
-                return {
-                    'valid': False,
-                    'reason': f'Size ${size:.2f} below minimum ${min_position_usd:.2f}'
-                }
-
-        elif size_type == 'base' and symbol:
+            return {"valid": False, "reason": "Size must be positive"}
+        if size_type == "quote" and size < min_position_usd:
+            return {"valid": False, "reason": f"Size ${size:.2f} below minimum ${min_position_usd:.2f}"}
+        if size_type == "base" and symbol:
             min_base = get_min_base_size(symbol)
             base_currency = _extract_base_currency(symbol)
-
             if size < min_base:
-                return {
-                    'valid': False,
-                    'reason': f'Size {size} {base_currency} below minimum {min_base}'
-                }
-
-        return {'valid': True, 'reason': 'Valid position size'}
-
-    except Exception as e:
-        logger.error(f"❌ Error validating position size: {e}")
-        return {'valid': False, 'reason': f'Validation error: {e}'}
+                return {"valid": False, "reason": f"Size {size} {base_currency} below minimum {min_base}"}
+        return {"valid": True, "reason": "Valid position size"}
+    except Exception as exc:
+        logger.error("❌ Error validating position size: %s", exc)
+        return {"valid": False, "reason": f"Validation error: {exc}"}
 
 
-def round_to_exchange_precision(
-    size: float,
-    symbol: str,
-    size_type: str = 'quote'
-) -> float:
-    """
-    Round position size to exchange-specific precision requirements.
-
-    Args:
-        size: Position size to round
-        symbol: Trading pair symbol (e.g., "BTC-USD")
-        size_type: "quote" (USD) or "base" (crypto)
-
-    Returns:
-        Rounded position size
-    """
+def round_to_exchange_precision(size: float, symbol: str, size_type: str = "quote") -> float:
     try:
-        if size_type == 'quote':
-            # USD amounts typically use 2 decimal places
+        if size_type == "quote":
             return round(size, 2)
-
-        elif size_type == 'base' and symbol:
-            # Crypto amounts vary by currency
-            base_currency = symbol.split('-')[0] if '-' in symbol else symbol
-
-            # Precision map based on typical exchange requirements
+        if size_type == "base" and symbol:
+            base_currency = _extract_base_currency(symbol)
             precision_map = {
-                'BTC': 8,
-                'ETH': 6,
-                'SOL': 4,
-                'XRP': 2,
-                'ADA': 2,
-                'DOGE': 2,
-                'AVAX': 4,
-                'DOT': 4,
-                'LINK': 4,
-                'LTC': 8,
+                "BTC": 8,
+                "ETH": 6,
+                "SOL": 4,
+                "XRP": 2,
+                "ADA": 2,
+                "DOGE": 2,
+                "AVAX": 4,
+                "DOT": 4,
+                "LINK": 4,
+                "LTC": 8,
             }
-
-            precision = precision_map.get(base_currency, 4)  # Default to 4 decimals
-            return round(size, precision)
-
-        # Fallback: return original size
+            return round(size, precision_map.get(base_currency, 4))
         return size
-
-    except Exception as e:
-        logger.warning(f"⚠️  Error rounding position size: {e}, returning original")
+    except Exception as exc:
+        logger.warning("⚠️  Error rounding position size: %s, returning original", exc)
         return size


### PR DESCRIPTION
## Summary

Applies the live-entry fixes from the latest NIJA runtime log review:

- Adds a `live_entry_runtime_fixes` startup patch for runtime visibility and guardrails.
- Emits deterministic scan/order telemetry: `SCAN_CYCLE_START`, `SCAN_CYCLE_END`, `ENTRY_SCAN_START`, `ORDER_SUBMIT_ATTEMPT`, and `ORDER_SUBMIT_RESULT`.
- Filters OKX `USDT` / `USDC` symbols when the broker only has USD buying power, preventing scan cycles from evaluating pairs the account cannot fund.
- Quarantines venue-reported unknown asset pairs for the current session so pairs like bad Kraken mappings do not keep wasting scan cycles.
- Makes `position_sizer.py` import-safe by removing the startup-time dependency on `trading_strategy`, preventing the `$10.00` fallback that was blocking micro-cap sizing.
- Aligns startup defaults to the current micro-cap profile: `MIN_TRADE_USD=2`, `MIN_POSITION_USD=2`, `MIN_NOTIONAL_OVERRIDE=2`, `KRAKEN_MIN_NOTIONAL_USD=2`, `OKX_MIN_ORDER_USD=2`, while leaving Coinbase at `$1`.

## Why

The latest runtime log showed the bot reached live/connected/funded state, but lacked clear evidence of a scan-to-order cycle after startup. The code also had a circular/import fallback path that could silently use a hard `$10` minimum even when the live micro-cap profile expected a lower floor.

## Notes

This PR does not disable `FORCE_TRADE` automatically. That remains an operational deployment flag. Once this telemetry confirms natural startup reaches `LIVE_ACTIVE` and scan/order cycles are visible, production should run with `FORCE_TRADE=false` unless intentionally testing.