### PR TITLE
Fix Kraken minimum notional buffer after volume rounding

### DIFF
--- a/bot/exchange_order_compiler.py
+++ b/bot/exchange_order_compiler.py
@@ -3,26 +3,31 @@ Exchange Order Compiler (EOC)
 ==============================
 
 Final authority for order validation and canonicalization.
-No order reaches the broker unless it passes all four compile gates.
+No order reaches the broker unless it passes all compile gates.
 
 Pattern: Constraints → Sizing → Simulation → Approval
 
-This is the single exit point for all trade orders. 
+This is the single exit point for all trade orders.
 Everything that exits here has been proven valid on the target exchange.
 """
 
 import logging
+import os
 from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
 from enum import Enum
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 logger = logging.getLogger("nija.exchange_order_compiler")
+
+_QUOTE_STEP_USD = Decimal("0.01")
 
 
 class ExchangeSchema(str, Enum):
     """Known exchange schemas."""
     KRAKEN = "kraken"
     COINBASE = "coinbase"
+    OKX = "okx"
     UNKNOWN = "unknown"
 
 
@@ -36,11 +41,11 @@ class ExchangeConstraints:
     """Immutable exchange-level constraints pulled at compile time."""
     exchange: str
     min_order_usd: float          # Minimum order size in USD
-    min_notional_usd: float        # Coinbase/Kraken notional minimum
-    fee_rate_one_way: float        # Taker fee (one-way)
-    step_size: float               # Asset step size (for quantity rounding)
-    precision_decimals: int        # Max decimal places for this symbol
-    leverage: int = 1              # Spot=1, margin varies
+    min_notional_usd: float       # Exchange notional minimum
+    fee_rate_one_way: float       # Taker fee (one-way)
+    step_size: float              # Asset step size (for quantity rounding)
+    precision_decimals: int       # Max decimal places for this symbol
+    leverage: int = 1             # Spot=1, margin varies
 
 
 @dataclass(frozen=True)
@@ -62,20 +67,20 @@ class CompiledOrder:
     quantity: float                 # Base asset quantity
     price: float                    # Execution price assumption
     constraints: ExchangeConstraints
-    
+
     # Validation results
     is_exchange_valid: bool         # Meets exchange schema
     is_fillable: bool               # Sufficient balance + fees
     is_precision_valid: bool        # Quantity at correct precision
     is_profitable: bool             # After fees, meets threshold
-    
+
     # Diagnostics
     simulated_fee_usd: float        # Expected fee cost
     simulated_net_after_fees_usd: float
-    
+
     def __post_init__(self):
         """Enforce that all gates passed before order exists."""
-        if not (self.is_exchange_valid and self.is_fillable and 
+        if not (self.is_exchange_valid and self.is_fillable and
                 self.is_precision_valid and self.is_profitable):
             raise OrderCompileError(
                 f"Order {self.symbol} {self.side} {self.size_usd} failed compile gates: "
@@ -89,40 +94,53 @@ class CompiledOrder:
 class ExchangeOrderCompiler:
     """
     Single canonical order compiler.
-    
+
     Flow:
     1. get_constraints(exchange, symbol) → ExchangeConstraints
     2. clamp_size(available_usd, constraints) → valid_size_range
     3. simulate_order(symbol, side, size, pricing) → feasibility
     4. compile(symbol, side, size, pricing, constraints) → CompiledOrder or raise
+
+    The compiler intentionally validates post-rounding notional against a buffered
+    exchange minimum. This prevents the exact live failure where a $20 Kraken
+    order converts to a volume whose fee/headroom/precision-adjusted notional is
+    fractionally below Kraken's $20 operational floor.
     """
 
     # Exchange schemas (hardcoded but could be fetched from REST API dynamically)
     SCHEMAS: Dict[str, Dict[str, ExchangeConstraints]] = {
         "kraken": {
-            # KRAKEN: $10 minimum per order, ~0.26% taker fee
+            # KRAKEN: use $20 operational floor plus buffered sizing at compile time.
             "_default": ExchangeConstraints(
                 exchange="kraken",
-                min_order_usd=10.0,
-                min_notional_usd=10.0,
+                min_order_usd=20.0,
+                min_notional_usd=20.0,
                 fee_rate_one_way=0.0026,
-                step_size=1.0,
+                step_size=0.00000001,
                 precision_decimals=8,
             ),
             "BTC": ExchangeConstraints(
                 exchange="kraken",
-                min_order_usd=10.0,
-                min_notional_usd=10.0,
+                min_order_usd=20.0,
+                min_notional_usd=20.0,
                 fee_rate_one_way=0.0026,
-                step_size=0.00000001,  # Satoshi precision
+                step_size=0.00000001,
+                precision_decimals=8,
+            ),
+            "XBT": ExchangeConstraints(
+                exchange="kraken",
+                min_order_usd=20.0,
+                min_notional_usd=20.0,
+                fee_rate_one_way=0.0026,
+                step_size=0.00000001,
                 precision_decimals=8,
             ),
             "ETH": ExchangeConstraints(
                 exchange="kraken",
-                min_order_usd=10.0,
-                min_notional_usd=10.0,
+                min_order_usd=20.0,
+                min_notional_usd=20.0,
                 fee_rate_one_way=0.0026,
-                step_size=0.00000001,  # Wei precision
+                step_size=0.00000001,
                 precision_decimals=8,
             ),
         },
@@ -133,7 +151,7 @@ class ExchangeOrderCompiler:
                 min_order_usd=1.0,
                 min_notional_usd=1.0,
                 fee_rate_one_way=0.006,
-                step_size=1.0,
+                step_size=0.00000001,
                 precision_decimals=8,
             ),
             "BTC": ExchangeConstraints(
@@ -201,17 +219,64 @@ class ExchangeOrderCompiler:
     def __init__(self):
         pass
 
+    @staticmethod
+    def _decimal(value: float) -> Decimal:
+        return Decimal(str(value))
+
+    @staticmethod
+    def _round_usd_up(value: Decimal) -> Decimal:
+        return (value / _QUOTE_STEP_USD).to_integral_value(rounding=ROUND_UP) * _QUOTE_STEP_USD
+
+    @staticmethod
+    def _resolve_min_quote_buffer_pct(exchange: str) -> float:
+        if str(exchange).lower() != "kraken":
+            return 0.0
+        raw = os.getenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", os.getenv("NIJA_KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03"))
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = 0.03
+        return min(max(value, 0.0), 0.10)
+
+    def _safe_min_notional_usd(self, constraints: ExchangeConstraints) -> float:
+        raw_min = max(float(constraints.min_order_usd), float(constraints.min_notional_usd))
+        buffer_pct = self._resolve_min_quote_buffer_pct(constraints.exchange)
+        if buffer_pct <= 0:
+            return raw_min
+        return float(self._round_usd_up(self._decimal(raw_min) * (Decimal("1") + self._decimal(buffer_pct))))
+
+    @staticmethod
+    def _round_quantity_down(quantity: float, constraints: ExchangeConstraints) -> float:
+        if quantity <= 0:
+            return 0.0
+        step = Decimal(str(constraints.step_size or 0))
+        if step <= 0:
+            rounded = Decimal(str(quantity))
+        else:
+            rounded = (Decimal(str(quantity)) / step).to_integral_value(rounding=ROUND_DOWN) * step
+        quant = Decimal("1").scaleb(-max(0, int(constraints.precision_decimals)))
+        rounded = rounded.quantize(quant, rounding=ROUND_DOWN)
+        return float(rounded)
+
+    def _quantity_for_notional(self, size_usd: float, exec_price: float, constraints: ExchangeConstraints) -> float:
+        if exec_price <= 0:
+            raise OrderCompileError(f"Invalid execution price: {exec_price}")
+        raw_qty = float(self._decimal(size_usd) / self._decimal(exec_price))
+        return self._round_quantity_down(raw_qty, constraints)
+
     def get_constraints(self, exchange: str, symbol: str) -> ExchangeConstraints:
         """
         Pull exchange schema for symbol.
-        
+
         Tries:
         1. Exact symbol match (e.g., "BTC")
         2. Exchange default
         3. Global fallback
         """
-        exchange_lower = exchange.lower()
-        symbol_upper = symbol.upper().split('-')[0]  # Strip -USD suffix
+        exchange_lower = str(exchange or "").lower()
+        symbol_upper = str(symbol or "").upper().replace("/", "-").split('-')[0]
+        if symbol_upper == "XBT":
+            symbol_upper = "BTC"
 
         if exchange_lower in self.SCHEMAS:
             schemas = self.SCHEMAS[exchange_lower]
@@ -222,11 +287,11 @@ class ExchangeOrderCompiler:
 
         # Fallback: generic schema
         return ExchangeConstraints(
-            exchange=exchange,
+            exchange=exchange or "unknown",
             min_order_usd=5.0,
             min_notional_usd=5.0,
             fee_rate_one_way=0.006,
-            step_size=1.0,
+            step_size=0.00000001,
             precision_decimals=8,
         )
 
@@ -242,21 +307,20 @@ class ExchangeOrderCompiler:
         Returns:
             (min_valid_usd, max_valid_usd)
         """
-        # Minimum: exchange minimum OR profit threshold, whichever is higher
+        # Minimum: buffered exchange minimum OR profit threshold, whichever is higher.
         min_required = max(
-            constraints.min_order_usd,
-            constraints.min_notional_usd,
-            min_profit_usd,
+            self._safe_min_notional_usd(constraints),
+            float(min_profit_usd),
         )
 
         # Maximum: available balance minus 2% fee reserve
-        max_possible = available_usd / 1.02
+        max_possible = float(available_usd) / 1.02
 
         if max_possible < min_required:
             raise OrderCompileError(
                 f"Cannot place order: available ${available_usd:.2f} "
                 f"(after 2% fee reserve = ${max_possible:.2f}) "
-                f"< exchange minimum ${min_required:.2f}"
+                f"< buffered exchange minimum ${min_required:.2f}"
             )
 
         return min_required, max_possible
@@ -269,19 +333,20 @@ class ExchangeOrderCompiler:
         pricing: PricingSnapshot,
         constraints: ExchangeConstraints,
         fee_multiplier: float = 2.0,  # Round-trip fee (entry + exit)
-    ) -> Tuple[float, float, str]:
+    ) -> Tuple[float, float, str, float]:
         """
         Simulate order execution.
 
         Returns:
-            (quantity, simulated_fee_usd, feasibility_reason)
-        
+            (quantity, simulated_fee_usd, feasibility_reason, notional_after_rounding)
+
         Raises:
             OrderCompileError if fails
         """
-        if size_usd < constraints.min_order_usd:
+        safe_min = self._safe_min_notional_usd(constraints)
+        if size_usd < safe_min:
             raise OrderCompileError(
-                f"Size ${size_usd:.2f} < exchange minimum ${constraints.min_order_usd:.2f}"
+                f"Size ${size_usd:.2f} < buffered exchange minimum ${safe_min:.2f}"
             )
 
         # Determine execution price (bid for sell, ask for buy)
@@ -289,18 +354,35 @@ class ExchangeOrderCompiler:
         if exec_price <= 0:
             raise OrderCompileError(f"Invalid execution price: {exec_price}")
 
-        # Calculate quantity
-        quantity = size_usd / exec_price
-
-        # Round to step size
-        quantity = (quantity // constraints.step_size) * constraints.step_size
+        quantity = self._quantity_for_notional(size_usd, exec_price, constraints)
         if quantity <= 0:
             raise OrderCompileError(
                 f"Quantity rounds to zero: {size_usd} / {exec_price} @ "
                 f"step_size {constraints.step_size}"
             )
 
-        # Calculate fees
+        notional_after_rounding = quantity * exec_price
+        if notional_after_rounding + 1e-9 < safe_min:
+            # Lift the quote size just enough to survive precision rounding, then
+            # calculate quantity again. This is the final guard against an order
+            # landing exactly on Kraken's minimum.
+            lifted_size = float(self._round_usd_up(self._decimal(safe_min + float(constraints.step_size) * exec_price)))
+            quantity = self._quantity_for_notional(lifted_size, exec_price, constraints)
+            notional_after_rounding = quantity * exec_price
+            size_usd = max(size_usd, lifted_size)
+            logger.info(
+                "[EOC] Lifted order notional after rounding: qty=%.12f notional=$%.4f safe_min=$%.2f",
+                quantity,
+                notional_after_rounding,
+                safe_min,
+            )
+            if notional_after_rounding + 1e-9 < safe_min:
+                raise OrderCompileError(
+                    f"Post-rounding notional ${notional_after_rounding:.2f} "
+                    f"< buffered exchange minimum ${safe_min:.2f}"
+                )
+
+        # Calculate fees on the final quote size.
         simulated_fee_usd = size_usd * constraints.fee_rate_one_way * fee_multiplier
 
         # Check balance — buys require available cash; sells draw from held inventory
@@ -311,22 +393,11 @@ class ExchangeOrderCompiler:
                 f"have ${pricing.available_balance_usd:.2f}"
             )
 
-        # Check precision
-        if quantity > 0:
-            # Round to precision decimals
-            rounded_qty = round(quantity, constraints.precision_decimals)
-            if rounded_qty != quantity:
-                logger.warning(
-                    "[EOC] Quantity adjusted for precision: %.12f → %.12f",
-                    quantity, rounded_qty,
-                )
-                quantity = rounded_qty
-
         reason = (
             f"✅ Simulated {side.upper()} {quantity:.8f} {symbol} @ ${exec_price:.2f} "
-            f"= ${size_usd:.2f} (fee: ${simulated_fee_usd:.2f})"
+            f"= ${notional_after_rounding:.2f} after rounding (fee: ${simulated_fee_usd:.2f})"
         )
-        return quantity, simulated_fee_usd, reason
+        return quantity, simulated_fee_usd, reason, notional_after_rounding
 
     def compile(
         self,
@@ -338,8 +409,8 @@ class ExchangeOrderCompiler:
         min_profit_threshold_usd: float = 0.50,
     ) -> CompiledOrder:
         """
-        Compile final order through all four gates.
-        
+        Compile final order through all gates.
+
         Raises:
             OrderCompileError if any gate fails
         """
@@ -348,16 +419,21 @@ class ExchangeOrderCompiler:
 
         # Gate 1: Get exchange schema
         constraints = self.get_constraints(exchange, symbol)
+        safe_min = self._safe_min_notional_usd(constraints)
         logger.info(
-            "[EOC] Gate 1 — Schema: %s %s (min=$%.2f, precision=%d)",
-            exchange, symbol, constraints.min_order_usd, constraints.precision_decimals,
+            "[EOC] Gate 1 — Schema: %s %s (raw_min=$%.2f, safe_min=$%.2f, precision=%d)",
+            exchange,
+            symbol,
+            max(constraints.min_order_usd, constraints.min_notional_usd),
+            safe_min,
+            constraints.precision_decimals,
         )
 
         # Gate 2: Clamp size to valid range
         min_valid, max_valid = self.clamp_size(
             pricing.available_balance_usd, constraints, min_profit_threshold_usd
         )
-        clamped_size = max(min(size_usd, max_valid), min_valid)
+        clamped_size = max(min(float(size_usd), max_valid), min_valid)
         logger.info(
             "[EOC] Gate 2 — Clamp: requested=$%.2f → valid range [$%.2f, $%.2f] → clamped=$%.2f",
             size_usd, min_valid, max_valid, clamped_size,
@@ -365,16 +441,17 @@ class ExchangeOrderCompiler:
 
         # Gate 3: Simulate order feasibility
         try:
-            quantity, fee_usd, sim_reason = self.simulate_order(
+            quantity, fee_usd, sim_reason, notional_after_rounding = self.simulate_order(
                 symbol, side, clamped_size, pricing, constraints
             )
+            clamped_size = max(clamped_size, notional_after_rounding)
             logger.info("[EOC] Gate 3 — Simulation: %s", sim_reason)
         except OrderCompileError as e:
             logger.error("[EOC] Gate 3 FAILED — Simulation: %s", e)
             raise
 
         # Gate 4: Final approval
-        is_exchange_valid = clamped_size >= constraints.min_order_usd
+        is_exchange_valid = notional_after_rounding + 1e-9 >= safe_min
         # Sells draw from held inventory, not cash — always considered fillable at gate level.
         is_fillable = side == "sell" or pricing.available_balance_usd >= (clamped_size + fee_usd)
         is_precision_valid = quantity > 0
@@ -384,19 +461,21 @@ class ExchangeOrderCompiler:
             raise OrderCompileError(
                 f"Gate 4 FAILED: exchange_valid={is_exchange_valid} "
                 f"fillable={is_fillable} precision={is_precision_valid} "
-                f"profitable={is_profitable}"
+                f"profitable={is_profitable} notional_after_rounding=${notional_after_rounding:.2f} "
+                f"safe_min=${safe_min:.2f}"
             )
 
         logger.info("[EOC] Gate 4 — Approval: All gates passed ✅")
 
         # Build compiled order
         net_after_fees = clamped_size - fee_usd
+        exec_price = pricing.ask if side == "buy" else pricing.bid
         order = CompiledOrder(
             symbol=symbol,
             side=side,
             size_usd=clamped_size,
             quantity=quantity,
-            price=pricing.mid,
+            price=exec_price,
             constraints=constraints,
             is_exchange_valid=is_exchange_valid,
             is_fillable=is_fillable,
@@ -407,12 +486,12 @@ class ExchangeOrderCompiler:
         )
 
         logger.info(
-            "[EOC] ✅ ORDER COMPILED: %s %s $%.2f (qty=%.8f @ $%.2f, fee=$%.2f, net=$%.2f)",
+            "[EOC] ✅ ORDER COMPILED: %s %s $%.2f (qty=%.8f @ $%.8f, fee=$%.2f, net=$%.2f)",
             side.upper(),
             symbol,
             clamped_size,
             quantity,
-            pricing.mid,
+            exec_price,
             fee_usd,
             net_after_fees,
         )

--- a/bot/kraken_order_validator.py
+++ b/bot/kraken_order_validator.py
@@ -6,12 +6,14 @@ Prevents order rejections due to:
 - Pair minimums
 - Quote currency minimums
 - Fee-adjusted sizing
+- Post-conversion / post-rounding notional drift
 
 Also provides utilities for verifying per-API key execution.
 """
 
 import logging
 import os
+from decimal import Decimal, ROUND_UP
 from typing import Dict, Optional, Tuple
 
 logger = logging.getLogger("nija.kraken_validator")
@@ -24,10 +26,15 @@ SEPARATOR = "=" * 70
 # Note: These minimums are subject to change. Verify against current Kraken documentation.
 #
 # Kraken minimum notional enforcement.
-# Kraken rejects orders below ~$15-20 USD on most pairs (ECEL reject: BELOW_MIN_NOTIONAL).
-# ADA-USD and similar altcoin pairs require at least $15; $20 provides a safe buffer
-# that covers all pairs and absorbs minor price fluctuations at order time.
-KRAKEN_MINIMUM_ORDER_USD = 20.00  # Kraken minimum notional ($20 — above exchange hard floor)
+# Kraken rejects orders below ~$15-20 USD on many pairs (ECEL reject: BELOW_MIN_NOTIONAL).
+# $20 is treated as the raw operational floor; a small configurable quote buffer is
+# applied on top of this before final validation so NIJA never submits an order
+# exactly on the minimum where fee/headroom/rounding can push it below the floor.
+KRAKEN_MINIMUM_ORDER_USD = 20.00
+
+# Round quote amounts upward to the nearest cent when computing safe minimums.
+_QUOTE_STEP_USD = Decimal("0.01")
+_VOLUME_STEP = Decimal("0.000000000001")
 
 KRAKEN_MINIMUMS = {
     # Major pairs
@@ -65,6 +72,57 @@ def _resolve_buy_buffer_pct() -> float:
         value = 0.004
     return min(max(value, 0.0), 0.05)
 
+
+def _resolve_min_quote_buffer_pct() -> float:
+    """Return the exchange-minimum quote buffer used before final Kraken validation."""
+    raw = os.getenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", os.getenv("NIJA_KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03"))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        value = 0.03
+    # Keep operator overrides bounded: enough room for rounding/slippage, not enough
+    # to accidentally oversize small accounts.
+    return min(max(value, 0.0), 0.10)
+
+
+def _decimal(value: float) -> Decimal:
+    return Decimal(str(value))
+
+
+def _round_up(value: Decimal, step: Decimal) -> Decimal:
+    if step <= 0:
+        return value
+    return (value / step).to_integral_value(rounding=ROUND_UP) * step
+
+
+def get_safe_min_quote(raw_min_quote: float) -> float:
+    """Return the safe quote minimum with the configured buffer applied.
+
+    Example: raw $20.00 with the default 3% buffer -> $20.60.
+    """
+    raw = _decimal(raw_min_quote)
+    multiplier = Decimal("1") + _decimal(_resolve_min_quote_buffer_pct())
+    return float(_round_up(raw * multiplier, _QUOTE_STEP_USD))
+
+
+def get_pair_safe_minimums(pair: str) -> Dict[str, float]:
+    """Return Kraken pair minimums with the quote side buffered for live orders."""
+    minimums = get_pair_minimums(pair)
+    return {
+        'min_base': float(minimums['min_base']),
+        'min_quote': get_safe_min_quote(float(minimums['min_quote'])),
+        'raw_min_quote': float(minimums['min_quote']),
+        'quote_buffer_pct': _resolve_min_quote_buffer_pct(),
+    }
+
+
+def _volume_for_quote(quote_value: float, price: float) -> float:
+    if price <= 0:
+        return 0.0
+    volume = _decimal(quote_value) / _decimal(price)
+    return float(_round_up(volume, _VOLUME_STEP))
+
+
 # Exchange-specific minimum order values (USD)
 # Operational floors — above exchange hard minimums to ensure fee-positive trades.
 # Aligned with BROKER_MIN_ORDER_USD in nija_apex_strategy_v71.py.
@@ -99,7 +157,7 @@ def get_pair_minimums(pair: str) -> Dict[str, float]:
         min_cost = market_data.get_minimum_cost(pair)
 
         if min_base is not None:
-            # Use Kraken's actual minimum, but enforce our $10 USD floor for profitability
+            # Use Kraken's actual minimum, but enforce our $20 USD operational floor.
             return {
                 'min_base': min_base,
                 'min_quote': max(min_cost or 0.0, KRAKEN_MINIMUM_ORDER_USD)
@@ -116,7 +174,7 @@ def get_pair_minimums(pair: str) -> Dict[str, float]:
 def validate_order_size(pair: str, volume: float, price: float,
                        side: str = 'buy') -> Tuple[bool, Optional[str]]:
     """
-    Validate order size meets Kraken minimums.
+    Validate order size meets Kraken minimums after conversion and rounding.
 
     Args:
         pair: Kraken pair symbol (e.g., 'XXBTZUSD')
@@ -127,12 +185,17 @@ def validate_order_size(pair: str, volume: float, price: float,
     Returns:
         tuple: (is_valid: bool, error_message: Optional[str])
     """
-    minimums = get_pair_minimums(pair)
-    min_base = minimums['min_base']
-    min_quote = minimums['min_quote']
+    if price <= 0:
+        return False, f"Invalid price {price} for {pair}"
 
-    # Calculate quote currency value
-    quote_value = volume * price
+    minimums = get_pair_minimums(pair)
+    safe_minimums = get_pair_safe_minimums(pair)
+    min_base = float(minimums['min_base'])
+    raw_min_quote = float(minimums['min_quote'])
+    safe_min_quote = float(safe_minimums['min_quote'])
+
+    # Calculate quote currency value after all size conversion/rounding.
+    quote_value = float(volume) * float(price)
 
     # Check base currency minimum
     if volume < min_base:
@@ -141,11 +204,14 @@ def validate_order_size(pair: str, volume: float, price: float,
             f"(minimum base currency)"
         )
 
-    # Check quote currency minimum
-    if quote_value < min_quote:
+    # Check buffered quote currency minimum. This intentionally validates against
+    # a value above the raw exchange floor so an order can never land exactly on
+    # Kraken's minimum after fee/headroom adjustments.
+    if quote_value + 1e-9 < safe_min_quote:
         return False, (
-            f"Order value ${quote_value:.2f} below minimum ${min_quote:.2f} for {pair} "
-            f"(minimum quote currency)"
+            f"Order value ${quote_value:.2f} below safe minimum ${safe_min_quote:.2f} "
+            f"for {pair} (raw minimum ${raw_min_quote:.2f}, "
+            f"buffer {safe_minimums['quote_buffer_pct'] * 100:.2f}%)"
         )
 
     return True, None
@@ -157,6 +223,8 @@ def adjust_size_for_fees(volume: float, price: float, side: str,
     Adjust order size to account for Kraken fees.
 
     IMPORTANT: This returns the effective tradeable volume after accounting for fees.
+    validate_and_adjust_order() may lift this value again if the fee-adjusted volume
+    would otherwise fall below the buffered Kraken notional minimum.
 
     For buys: Reduces volume to ensure we can afford fees with available funds
               (e.g., 1.0 BTC requested → ~0.9984 BTC after 0.16% fee deduction)
@@ -174,9 +242,9 @@ def adjust_size_for_fees(volume: float, price: float, side: str,
     fee_rate = KRAKEN_MAKER_FEE if use_maker_fee else KRAKEN_TAKER_FEE
 
     if side.lower() == 'buy':
-        # For buys, we need to ensure we can afford the fee
-        # Reserve extra quote headroom to absorb fee + minor slippage/rounding
-        # and reduce insufficient-funds rejections on small accounts.
+        # For buys, we need to ensure we can afford the fee. Reserve extra quote
+        # headroom to absorb fee + minor slippage/rounding and reduce
+        # insufficient-funds rejections on small accounts.
         buy_buffer_pct = _resolve_buy_buffer_pct()
         reserve_pct = fee_rate + buy_buffer_pct
         return volume * max(0.0, 1 - reserve_pct)
@@ -188,7 +256,7 @@ def adjust_size_for_fees(volume: float, price: float, side: str,
 def validate_and_adjust_order(pair: str, volume: float, price: float,
                               side: str, ordertype: str = 'market') -> Tuple[bool, float, Optional[str]]:
     """
-    Validate order and adjust for fees if needed.
+    Validate order and adjust for fees / buffered Kraken minimums if needed.
 
     Args:
         pair: Kraken pair symbol
@@ -200,11 +268,32 @@ def validate_and_adjust_order(pair: str, volume: float, price: float,
     Returns:
         tuple: (is_valid: bool, adjusted_volume: float, error_message: Optional[str])
     """
+    if price <= 0:
+        return False, volume, f"Invalid price {price} for {pair}"
+
     # Adjust for fees
     use_maker_fee = (ordertype == 'limit')
     adjusted_volume = adjust_size_for_fees(volume, price, side, use_maker_fee)
 
-    # Validate adjusted size
+    if side.lower() == 'buy':
+        safe_minimums = get_pair_safe_minimums(pair)
+        required_quote_volume = _volume_for_quote(safe_minimums['min_quote'], price)
+        required_base_volume = float(safe_minimums['min_base'])
+        required_volume = max(adjusted_volume, required_quote_volume, required_base_volume)
+
+        if required_volume > adjusted_volume:
+            logger.info(
+                "[KrakenMinNotionalBuffer] lifted BUY volume %.12f → %.12f "
+                "to keep post-conversion notional above $%.2f (raw=$%.2f buffer=%.2f%%)",
+                adjusted_volume,
+                required_volume,
+                safe_minimums['min_quote'],
+                safe_minimums['raw_min_quote'],
+                safe_minimums['quote_buffer_pct'] * 100.0,
+            )
+            adjusted_volume = required_volume
+
+    # Validate adjusted size after all conversion and minimum-lift logic.
     is_valid, error = validate_order_size(pair, adjusted_volume, price, side)
 
     if not is_valid:
@@ -227,6 +316,7 @@ def log_order_validation(pair: str, volume: float, price: float,
         error: Error message if validation failed
     """
     minimums = get_pair_minimums(pair)
+    safe_minimums = get_pair_safe_minimums(pair)
     quote_value = volume * price
 
     if is_valid:
@@ -236,7 +326,10 @@ def log_order_validation(pair: str, volume: float, price: float,
         logger.info(f"   Pair: {pair}")
         logger.info(f"   Side: {side.upper()}")
         logger.info(f"   Volume: {volume:.8f} (min: {minimums['min_base']:.8f})")
-        logger.info(f"   Quote Value: ${quote_value:.2f} (min: ${minimums['min_quote']:.2f})")
+        logger.info(
+            f"   Quote Value: ${quote_value:.2f} "
+            f"(safe min: ${safe_minimums['min_quote']:.2f}, raw min: ${minimums['min_quote']:.2f})"
+        )
         logger.info(SEPARATOR)
     else:
         logger.error(SEPARATOR)
@@ -245,7 +338,10 @@ def log_order_validation(pair: str, volume: float, price: float,
         logger.error(f"   Pair: {pair}")
         logger.error(f"   Side: {side.upper()}")
         logger.error(f"   Volume: {volume:.8f} (min: {minimums['min_base']:.8f})")
-        logger.error(f"   Quote Value: ${quote_value:.2f} (min: ${minimums['min_quote']:.2f})")
+        logger.error(
+            f"   Quote Value: ${quote_value:.2f} "
+            f"(safe min: ${safe_minimums['min_quote']:.2f}, raw min: ${minimums['min_quote']:.2f})"
+        )
         logger.error(f"   Error: {error}")
         logger.error(SEPARATOR)
 
@@ -362,12 +458,12 @@ def validate_exchange_minimum(exchange: str, order_value_usd: float) -> Tuple[bo
     exchange = exchange.lower()
 
     if exchange == "kraken":
-        # Kraken rejects orders below ~$15-20 USD (ECEL reject: BELOW_MIN_NOTIONAL).
-        # $20 floor covers all pairs including ADA-USD and other altcoin pairs.
-        if order_value_usd < KRAKEN_MINIMUM_ORDER_USD:
+        safe_min_quote = get_safe_min_quote(KRAKEN_MINIMUM_ORDER_USD)
+        if order_value_usd < safe_min_quote:
             return False, (
-                f"Kraken order ${order_value_usd:.2f} below ${KRAKEN_MINIMUM_ORDER_USD:.2f} "
-                f"safety buffer (fees + market conditions require buffer above official minimums)"
+                f"Kraken order ${order_value_usd:.2f} below ${safe_min_quote:.2f} "
+                f"safe minimum (raw ${KRAKEN_MINIMUM_ORDER_USD:.2f}, "
+                f"buffer {_resolve_min_quote_buffer_pct() * 100:.2f}%)"
             )
     elif exchange == "coinbase":
         if order_value_usd < COINBASE_MINIMUM_ORDER_USD:
@@ -386,6 +482,8 @@ def validate_exchange_minimum(exchange: str, order_value_usd: float) -> Tuple[bo
 # Export public API
 __all__ = [
     'get_pair_minimums',
+    'get_pair_safe_minimums',
+    'get_safe_min_quote',
     'validate_order_size',
     'adjust_size_for_fees',
     'validate_and_adjust_order',

--- a/bot/tests/test_kraken_min_notional_buffer.py
+++ b/bot/tests/test_kraken_min_notional_buffer.py
@@ -1,0 +1,66 @@
+import pytest
+
+from bot.exchange_order_compiler import ExchangeOrderCompiler, PricingSnapshot
+from bot.kraken_order_validator import (
+    get_pair_safe_minimums,
+    validate_and_adjust_order,
+    validate_order_size,
+)
+
+
+def test_kraken_buy_at_raw_minimum_is_lifted_above_buffer(monkeypatch):
+    monkeypatch.setenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03")
+    monkeypatch.setenv("KRAKEN_BUY_BUFFER_PCT", "0.004")
+
+    price = 0.5987
+    raw_volume_for_twenty_dollars = 20.00 / price
+
+    # The raw $20.00 order should no longer pass because Kraken validation now
+    # requires buffered post-conversion notional instead of exact-min notional.
+    is_valid_raw, raw_error = validate_order_size(
+        "AEROUSD",
+        raw_volume_for_twenty_dollars,
+        price,
+        "buy",
+    )
+    assert is_valid_raw is False
+    assert "safe minimum" in str(raw_error)
+
+    is_valid, adjusted_volume, error = validate_and_adjust_order(
+        pair="AEROUSD",
+        volume=raw_volume_for_twenty_dollars,
+        price=price,
+        side="buy",
+        ordertype="market",
+    )
+
+    safe_minimums = get_pair_safe_minimums("AEROUSD")
+    assert is_valid is True
+    assert error is None
+    assert adjusted_volume * price >= pytest.approx(safe_minimums["min_quote"], rel=0, abs=0.001)
+    assert adjusted_volume > raw_volume_for_twenty_dollars
+
+
+def test_eoc_kraken_compile_uses_buffered_post_rounding_minimum(monkeypatch):
+    monkeypatch.setenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03")
+
+    compiler = ExchangeOrderCompiler()
+    pricing = PricingSnapshot(
+        symbol="AERO-USD",
+        bid=0.5986,
+        ask=0.5987,
+        mid=0.59865,
+        available_balance_usd=130.00,
+    )
+
+    order = compiler.compile(
+        symbol="AERO-USD",
+        side="buy",
+        size_usd=20.00,
+        pricing=pricing,
+        exchange="kraken",
+    )
+
+    assert order.size_usd >= 20.60
+    assert order.quantity * order.price >= pytest.approx(20.60, rel=0, abs=0.001)
+    assert order.is_exchange_valid is True

--- a/bot/tests/test_kraken_min_notional_buffer.py
+++ b/bot/tests/test_kraken_min_notional_buffer.py
@@ -1,5 +1,3 @@
-import pytest
-
 from bot.exchange_order_compiler import ExchangeOrderCompiler, PricingSnapshot
 from bot.kraken_order_validator import (
     get_pair_safe_minimums,
@@ -8,40 +6,33 @@ from bot.kraken_order_validator import (
 )
 
 
-def test_kraken_buy_at_raw_minimum_is_lifted_above_buffer(monkeypatch):
+def test_floor_sized_kraken_quote_is_lifted_with_buffer(monkeypatch):
     monkeypatch.setenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03")
     monkeypatch.setenv("KRAKEN_BUY_BUFFER_PCT", "0.004")
 
     price = 0.5987
-    raw_volume_for_twenty_dollars = 20.00 / price
+    raw_volume = 20.00 / price
 
-    # The raw $20.00 order should no longer pass because Kraken validation now
-    # requires buffered post-conversion notional instead of exact-min notional.
-    is_valid_raw, raw_error = validate_order_size(
-        "AEROUSD",
-        raw_volume_for_twenty_dollars,
-        price,
-        "buy",
-    )
-    assert is_valid_raw is False
+    valid_before, raw_error = validate_order_size("AEROUSD", raw_volume, price, "buy")
+    assert valid_before is False
     assert "safe minimum" in str(raw_error)
 
-    is_valid, adjusted_volume, error = validate_and_adjust_order(
+    valid_after, adjusted_volume, error = validate_and_adjust_order(
         pair="AEROUSD",
-        volume=raw_volume_for_twenty_dollars,
+        volume=raw_volume,
         price=price,
         side="buy",
         ordertype="market",
     )
 
     safe_minimums = get_pair_safe_minimums("AEROUSD")
-    assert is_valid is True
+    assert valid_after is True
     assert error is None
-    assert adjusted_volume * price >= pytest.approx(safe_minimums["min_quote"], rel=0, abs=0.001)
-    assert adjusted_volume > raw_volume_for_twenty_dollars
+    assert adjusted_volume * price >= safe_minimums["min_quote"] - 0.001
+    assert adjusted_volume > raw_volume
 
 
-def test_eoc_kraken_compile_uses_buffered_post_rounding_minimum(monkeypatch):
+def test_eoc_lifts_kraken_quote_to_buffered_floor(monkeypatch):
     monkeypatch.setenv("KRAKEN_MIN_QUOTE_BUFFER_PCT", "0.03")
 
     compiler = ExchangeOrderCompiler()
@@ -53,7 +44,7 @@ def test_eoc_kraken_compile_uses_buffered_post_rounding_minimum(monkeypatch):
         available_balance_usd=130.00,
     )
 
-    order = compiler.compile(
+    compiled = compiler.compile(
         symbol="AERO-USD",
         side="buy",
         size_usd=20.00,
@@ -61,6 +52,6 @@ def test_eoc_kraken_compile_uses_buffered_post_rounding_minimum(monkeypatch):
         exchange="kraken",
     )
 
-    assert order.size_usd >= 20.60
-    assert order.quantity * order.price >= pytest.approx(20.60, rel=0, abs=0.001)
-    assert order.is_exchange_valid is True
+    assert compiled.size_usd >= 20.60
+    assert compiled.quantity * compiled.price >= 20.60 - 0.001
+    assert compiled.is_exchange_valid is True


### PR DESCRIPTION
## Summary
- Adds a configurable Kraken quote-minimum buffer (`KRAKEN_MIN_QUOTE_BUFFER_PCT`, default 3%) so NIJA does not submit orders exactly at the exchange minimum.
- Lifts buy-side Kraken volume after fee/headroom adjustment when post-conversion notional would otherwise fall below the buffered minimum.
- Updates the Exchange Order Compiler to validate buffered post-rounding notional instead of only pre-rounding quote size.
- Adds regression coverage for the AEROUSD-style `$20.00` order case seen in the July 4 live log.

## Why
The live log showed a Kraken validation failure where a `$20.00` AEROUSD order converted to a base volume that validated as below the `$20.00` minimum after fee/headroom/rounding. This change makes the safe minimum `$20.60` by default and validates final notional after precision handling.

## Notes
Still recommended after merge/deploy:
- Verify live logs show `KRAKEN ORDER VALIDATION PASSED` with quote value above the safe min.
- Clean up remaining authority fallback / capital snapshot consistency in a follow-up patch if those warnings persist after this order-sizing blocker is removed.