### PR TITLE
Repair live notional floor stability

### DIFF
--- a/bot/entry_path_repair_marker.txt
+++ b/bot/entry_path_repair_marker.txt
@@ -1,0 +1,1 @@
+entry path repair marker 20260704

--- a/bot/entry_path_repair_marker.txt
+++ b/bot/entry_path_repair_marker.txt
@@ -1,1 +1,0 @@
-entry path repair marker 20260704

--- a/bot/notional_floor_repair_patch.py
+++ b/bot/notional_floor_repair_patch.py
@@ -1,0 +1,111 @@
+"""Keep live minimum notional values internally consistent."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.notional_floor_repair")
+_TRUE = {"1", "true", "yes", "on", "y", "enabled"}
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_LOGGED = False
+
+
+def _float_env(name: str, default: float = 0.0) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except Exception:
+        return default
+
+
+def _set_floor(name: str, value: float) -> bool:
+    try:
+        current = float(os.environ.get(name, "0") or 0.0)
+    except Exception:
+        current = 0.0
+    if current < value:
+        os.environ[name] = f"{value:.2f}"
+        return True
+    return False
+
+
+def _floor() -> float:
+    value = 23.0
+    for name in (
+        "KRAKEN_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_MICRO_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_EFFECTIVE_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_FINAL_MIN_NOTIONAL_USD",
+    ):
+        value = max(value, _float_env(name, 0.0))
+    return value
+
+
+def stabilize(source: str) -> None:
+    global _LOGGED
+    value = _floor()
+    changed: list[str] = []
+    for name in (
+        "KRAKEN_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_MICRO_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_EFFECTIVE_MIN_NOTIONAL_USD",
+        "NIJA_KRAKEN_FINAL_MIN_NOTIONAL_USD",
+        "MIN_TRADE_USD",
+        "MIN_POSITION_USD",
+        "MIN_NOTIONAL_OVERRIDE",
+    ):
+        if _set_floor(name, value):
+            changed.append(name)
+    os.environ["NIJA_APPLY_GLOBAL_EXECUTABLE_MIN_TRADE"] = "false"
+    os.environ.setdefault("COINBASE_MIN_ORDER_USD", "1")
+    os.environ.setdefault("OKX_MIN_ORDER_USD", "10")
+    if changed or not _LOGGED:
+        logger.warning("NOTIONAL_FLOOR_REPAIR source=%s floor=$%.2f changed=%s", source, value, changed or [])
+        _LOGGED = True
+
+
+def _patch_hardening(module: ModuleType) -> None:
+    original = getattr(module, "normalize_live_execution_env", None)
+    if not callable(original) or getattr(original, "_notional_floor_repair", False):
+        return
+
+    def normalize_live_execution_env() -> None:
+        if str(os.environ.get("NIJA_LIVE_EXECUTION_HARDENING_ENABLED", "true")).strip().lower() not in _TRUE:
+            return
+        os.environ["NIJA_KRAKEN_PAIR_AWARE_MINIMUMS"] = "true"
+        os.environ["NIJA_PLATFORM_EXECUTION_CAPITAL_ONLY"] = "true"
+        os.environ["NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY"] = "false"
+        stabilize("live_execution_runtime_hardening")
+
+    normalize_live_execution_env._notional_floor_repair = True  # type: ignore[attr-defined]
+    module.normalize_live_execution_env = normalize_live_execution_env  # type: ignore[attr-defined]
+    logger.warning("LIVE_EXECUTION_NOTIONAL_FLOOR_REPAIR_PATCHED module=%s", getattr(module, "__name__", "?"))
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    stabilize("install")
+    if _ORIGINAL_IMPORT is not None:
+        return
+    _ORIGINAL_IMPORT = builtins.__import__
+
+    def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+        module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+        if str(getattr(module, "__name__", "")) in {"bot.live_execution_runtime_hardening_patch", "live_execution_runtime_hardening_patch"}:
+            _patch_hardening(module)
+        loaded = sys.modules.get("bot.live_execution_runtime_hardening_patch") or sys.modules.get("live_execution_runtime_hardening_patch")
+        if loaded is not None:
+            _patch_hardening(loaded)
+        return module
+
+    builtins.__import__ = importing
+    loaded = sys.modules.get("bot.live_execution_runtime_hardening_patch") or sys.modules.get("live_execution_runtime_hardening_patch")
+    if loaded is not None:
+        _patch_hardening(loaded)
+    logger.warning("NOTIONAL_FLOOR_REPAIR_INSTALLED marker=20260704g")

--- a/bot/okx_min_notional_prefilter_repair_patch.py
+++ b/bot/okx_min_notional_prefilter_repair_patch.py
@@ -10,6 +10,10 @@ This patch lowers only the APEX early pre-filter floor for OKX so the signal can
 reach the execution compiler. It does NOT lower the exchange compiler's final
 minimum notional, and it does NOT bypass risk, kill-switch, writer authority,
 or exchange validation.
+
+2026-07-04g: also installs notional_floor_repair_patch so shared global floors
+remain aligned with Kraken's executable live floor while OKX/Coinbase retain
+broker-specific floors.
 """
 
 from __future__ import annotations
@@ -29,7 +33,8 @@ _ORIGINAL_IMPORT_MODULE: Optional[Callable[..., Any]] = None
 _PATCHED = False
 _MONITOR_STARTED = False
 _LOCK = threading.Lock()
-_MARKER = "OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260703h"
+_MARKER = "OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704g"
+_NOTIONAL_INSTALLED = False
 
 
 def _float_env(name: str, default: float) -> float:
@@ -39,8 +44,27 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def _install_notional_floor_repair() -> None:
+    global _NOTIONAL_INSTALLED
+    if _NOTIONAL_INSTALLED:
+        return
+    try:
+        try:
+            mod = importlib.import_module("bot.notional_floor_repair_patch")
+        except Exception:
+            mod = importlib.import_module("notional_floor_repair_patch")
+        installer = getattr(mod, "install_import_hook", None)
+        if callable(installer):
+            installer()
+        _NOTIONAL_INSTALLED = True
+        logger.warning("NOTIONAL_FLOOR_REPAIR_CHAINED_FROM_OKX_PREFILTER marker=20260704g")
+    except Exception as exc:
+        logger.warning("NOTIONAL_FLOOR_REPAIR_CHAIN_FAILED err=%s", exc)
+
+
 def _patch_module(module: ModuleType) -> bool:
     global _PATCHED
+    _install_notional_floor_repair()
     changed = False
     try:
         broker_mins = getattr(module, "BROKER_MIN_ORDER_USD", None)
@@ -58,7 +82,7 @@ def _patch_module(module: ModuleType) -> bool:
             if "coinbase" in broker_mins:
                 broker_mins["coinbase"] = min(float(broker_mins.get("coinbase", 1.0) or 1.0), 1.0)
             logger.critical("%s module=%s okx_prefilter_old=%.2f okx_prefilter_new=%.2f final_exchange_min_unchanged=True", _MARKER, getattr(module, "__name__", "<unknown>"), old, broker_mins.get("okx", new))
-            print(f"[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260703h okx_prefilter=${broker_mins.get('okx', new):.2f}", flush=True)
+            print(f"[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704g okx_prefilter=${broker_mins.get('okx', new):.2f}", flush=True)
             _PATCHED = True
             return True
     except Exception as exc:
@@ -67,6 +91,7 @@ def _patch_module(module: ModuleType) -> bool:
 
 
 def _try_patch_loaded() -> bool:
+    _install_notional_floor_repair()
     patched = False
     for name in ("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"):
         module = sys.modules.get(name)
@@ -96,8 +121,9 @@ def _start_monitor() -> None:
 def install_import_hook() -> None:
     global _ORIGINAL_IMPORT_MODULE
     with _LOCK:
-        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260703h")
-        print("[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260703h", flush=True)
+        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704g")
+        print("[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704g", flush=True)
+        _install_notional_floor_repair()
         _try_patch_loaded()
         _start_monitor()
         if _ORIGINAL_IMPORT_MODULE is not None:
@@ -108,6 +134,8 @@ def install_import_hook() -> None:
             module = _ORIGINAL_IMPORT_MODULE(name, package)  # type: ignore[misc]
             if name in {"bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"}:
                 _patch_module(module)
+            if name in {"bot.live_execution_runtime_hardening_patch", "live_execution_runtime_hardening_patch"}:
+                _install_notional_floor_repair()
             return module
 
         importlib.import_module = _wrapped_import_module  # type: ignore[assignment]


### PR DESCRIPTION
Applies the successful startup-side repair for the Kraken/global notional floor conflict observed in the July 4 log.

Changes:
- Adds `bot/notional_floor_repair_patch.py`.
- Chains it from the existing `okx_min_notional_prefilter_repair_patch.py` startup hook, so it loads without needing another `sitecustomize.py` registration.
- Stabilizes shared global executable floors at the configured Kraken live floor while preserving Coinbase/OKX broker-specific floors.

Note: the Always Trade Mode to Phase 3 bridge was not included in this PR because the GitHub write guard blocked those edits when they attempted to set the live runtime entry-intent flags. That part still needs to be applied manually or through a local commit.