### PR TITLE
Guard USDT venue routing and expose raw Kraken errors

### DIFF
--- a/bot/kraken_error_taxonomy.py
+++ b/bot/kraken_error_taxonomy.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import logging
 import re
 from typing import Iterable, Pattern
+
+logger = logging.getLogger("nija.kraken_error_taxonomy")
 
 
 class KrakenErrorCategory(str, Enum):
@@ -206,6 +209,7 @@ def classify_kraken_error(error_text: object) -> KrakenErrorTaxonomy:
     raw = "" if error_text is None else str(error_text)
     text = raw.strip()
     if not text:
+        logger.warning("KRAKEN_RAW_ERROR_EMPTY_BEFORE_CLASSIFICATION raw=%r", error_text)
         return _UNKNOWN
 
     matches: list[_Rule] = []
@@ -214,9 +218,17 @@ def classify_kraken_error(error_text: object) -> KrakenErrorTaxonomy:
             matches.append(rule)
 
     if not matches:
+        logger.error("KRAKEN_RAW_ERROR_UNCLASSIFIED raw=%r", raw)
         return KrakenErrorTaxonomy(**{**_UNKNOWN.__dict__, "raw_error": raw})
 
     selected = min(matches, key=lambda rule: _ESC_PRIORITY.get(rule.category, 99))
+    logger.warning(
+        "KRAKEN_RAW_ERROR_CLASSIFIED code=%s category=%s policy=%s raw=%r",
+        selected.canonical_code,
+        selected.category.value,
+        selected.policy.value,
+        raw,
+    )
     return KrakenErrorTaxonomy(
         category=selected.category,
         policy=selected.policy,

--- a/bot/okx_min_notional_prefilter_repair_patch.py
+++ b/bot/okx_min_notional_prefilter_repair_patch.py
@@ -1,20 +1,4 @@
-"""Repair OKX micro-notional pre-entry blocking.
-
-The APEX strategy has an early affordability pre-filter that compares
-`balance × risk_manager.min_position_pct` with BROKER_MIN_ORDER_USD[broker].
-For OKX, a $222.27 canonical balance at 2% yields $4.45, so the pre-filter
-blocks with "Need $250+ balance" even though the downstream exchange order
-compiler already clamps valid OKX orders to the $5.00 exchange notional.
-
-This patch lowers only the APEX early pre-filter floor for OKX so the signal can
-reach the execution compiler. It does NOT lower the exchange compiler's final
-minimum notional, and it does NOT bypass risk, kill-switch, writer authority,
-or exchange validation.
-
-2026-07-04g: also installs notional_floor_repair_patch so shared global floors
-remain aligned with Kraken's executable live floor while OKX/Coinbase retain
-broker-specific floors.
-"""
+"""Repair OKX micro-notional pre-entry blocking."""
 
 from __future__ import annotations
 
@@ -33,8 +17,9 @@ _ORIGINAL_IMPORT_MODULE: Optional[Callable[..., Any]] = None
 _PATCHED = False
 _MONITOR_STARTED = False
 _LOCK = threading.Lock()
-_MARKER = "OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704g"
+_MARKER = "OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704h"
 _NOTIONAL_INSTALLED = False
+_SIDECAR_INSTALLED = False
 
 
 def _float_env(name: str, default: float) -> float:
@@ -57,32 +42,46 @@ def _install_notional_floor_repair() -> None:
         if callable(installer):
             installer()
         _NOTIONAL_INSTALLED = True
-        logger.warning("NOTIONAL_FLOOR_REPAIR_CHAINED_FROM_OKX_PREFILTER marker=20260704g")
+        logger.warning("NOTIONAL_FLOOR_REPAIR_CHAINED_FROM_OKX_PREFILTER marker=20260704h")
     except Exception as exc:
         logger.warning("NOTIONAL_FLOOR_REPAIR_CHAIN_FAILED err=%s", exc)
+
+
+def _install_sidecar() -> None:
+    global _SIDECAR_INSTALLED
+    if _SIDECAR_INSTALLED:
+        return
+    try:
+        try:
+            mod = importlib.import_module("bot.venue_route_guard_patch")
+        except Exception:
+            mod = importlib.import_module("venue_route_guard_patch")
+        installer = getattr(mod, "install_import_hook", None)
+        if callable(installer):
+            installer()
+        _SIDECAR_INSTALLED = True
+        logger.warning("VENUE_ROUTE_GUARD_CHAINED_FROM_OKX_PREFILTER marker=20260704h")
+    except Exception as exc:
+        logger.warning("VENUE_ROUTE_GUARD_CHAIN_FAILED err=%s", exc)
 
 
 def _patch_module(module: ModuleType) -> bool:
     global _PATCHED
     _install_notional_floor_repair()
+    _install_sidecar()
     changed = False
     try:
         broker_mins = getattr(module, "BROKER_MIN_ORDER_USD", None)
         if isinstance(broker_mins, dict):
             old = float(broker_mins.get("okx", 5.0) or 5.0)
-            # This is only the APEX early affordability pre-filter. The final
-            # ExchangeOrderCompiler still clamps/validates OKX orders to the real
-            # exchange minimum before submit.
             new = min(old, _float_env("NIJA_OKX_APEX_PREFILTER_MIN_USD", 1.0))
             if old != new:
                 broker_mins["okx"] = new
                 changed = True
-            # Keep Coinbase/Kraken micro floors unchanged unless they are higher
-            # than their already established micro-compatible defaults.
             if "coinbase" in broker_mins:
                 broker_mins["coinbase"] = min(float(broker_mins.get("coinbase", 1.0) or 1.0), 1.0)
             logger.critical("%s module=%s okx_prefilter_old=%.2f okx_prefilter_new=%.2f final_exchange_min_unchanged=True", _MARKER, getattr(module, "__name__", "<unknown>"), old, broker_mins.get("okx", new))
-            print(f"[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704g okx_prefilter=${broker_mins.get('okx', new):.2f}", flush=True)
+            print(f"[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_PATCHED marker=20260704h okx_prefilter=${broker_mins.get('okx', new):.2f}", flush=True)
             _PATCHED = True
             return True
     except Exception as exc:
@@ -92,6 +91,7 @@ def _patch_module(module: ModuleType) -> bool:
 
 def _try_patch_loaded() -> bool:
     _install_notional_floor_repair()
+    _install_sidecar()
     patched = False
     for name in ("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"):
         module = sys.modules.get(name)
@@ -121,9 +121,10 @@ def _start_monitor() -> None:
 def install_import_hook() -> None:
     global _ORIGINAL_IMPORT_MODULE
     with _LOCK:
-        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704g")
-        print("[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704g", flush=True)
+        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704h")
+        print("[NIJA-PRINT] OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_START marker=20260704h", flush=True)
         _install_notional_floor_repair()
+        _install_sidecar()
         _try_patch_loaded()
         _start_monitor()
         if _ORIGINAL_IMPORT_MODULE is not None:
@@ -136,7 +137,9 @@ def install_import_hook() -> None:
                 _patch_module(module)
             if name in {"bot.live_execution_runtime_hardening_patch", "live_execution_runtime_hardening_patch"}:
                 _install_notional_floor_repair()
+            if name in {"bot.usdt_kraken_ecel_routing_repair_patch", "usdt_kraken_ecel_routing_repair_patch"}:
+                _install_sidecar()
             return module
 
         importlib.import_module = _wrapped_import_module  # type: ignore[assignment]
-        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_COMPLETE patched=%s", _PATCHED)
+        logger.warning("OKX_MIN_NOTIONAL_PREFILTER_REPAIR_INSTALL_COMPLETE patched=%s sidecar=%s", _PATCHED, _SIDECAR_INSTALLED)

--- a/bot/venue_route_guard_patch.py
+++ b/bot/venue_route_guard_patch.py
@@ -1,0 +1,261 @@
+"""Venue route guard for USDT spot execution.
+
+Prevents the legacy USDT repair from blindly rewriting USDT orders to Kraken.
+Kraken is allowed only when the request is already targeting Kraken, the pair is
+known by the Kraken validator, and the notional is above the effective live floor.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.venue_route_guard")
+
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_PATCHED_USDT_MODULES: set[int] = set()
+_PATCHED_PIPELINES: set[int] = set()
+_PATCHED_ECEL: set[int] = set()
+_MONITOR_STARTED = False
+_LOCK = threading.Lock()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default)).strip().lower() in _TRUE
+
+
+def _float_env(name: str, default: float = 0.0) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except Exception:
+        return default
+
+
+def _is_usdt(symbol: Any) -> bool:
+    return str(symbol or "").strip().upper().replace("/", "-").endswith("-USDT")
+
+
+def _broker(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _symbol_text(value: Any) -> str:
+    return str(value or "").strip().upper().replace("/", "-").replace("_", "-")
+
+
+def _kraken_pair_key(symbol: Any) -> str:
+    text = _symbol_text(symbol)
+    base = text.split("-", 1)[0] if "-" in text else text.replace("USDT", "")
+    if base in {"BTC", "XBT"}:
+        return "XXBTZUSDT"
+    if base in {"ETH", "XETH"}:
+        return "XETHZUSDT"
+    return f"{base}USDT"
+
+
+def _configured_kraken_floor() -> float:
+    return max(
+        23.0,
+        _float_env("KRAKEN_MIN_NOTIONAL_USD", 0.0),
+        _float_env("NIJA_KRAKEN_MIN_NOTIONAL_USD", 0.0),
+        _float_env("NIJA_KRAKEN_EFFECTIVE_MIN_NOTIONAL_USD", 0.0),
+        _float_env("NIJA_KRAKEN_FINAL_MIN_NOTIONAL_USD", 0.0),
+    )
+
+
+def _notional_from(obj: Any) -> float:
+    for name in ("notional_usd", "size_usd", "quote_amount", "amount_usd"):
+        if hasattr(obj, name):
+            value = _float_env("__missing__", 0.0)
+            try:
+                value = float(getattr(obj, name) or 0.0)
+            except Exception:
+                value = 0.0
+            if value > 0:
+                return value
+    if isinstance(obj, dict):
+        for name in ("notional_usd", "size_usd", "quote_amount", "amount_usd"):
+            try:
+                value = float(obj.get(name) or 0.0)
+            except Exception:
+                value = 0.0
+            if value > 0:
+                return value
+    return 0.0
+
+
+def _kraken_pair_validation(symbol: Any, notional: float) -> tuple[bool, str, float, str]:
+    pair = _kraken_pair_key(symbol)
+    floor = _configured_kraken_floor()
+    try:
+        try:
+            validator = importlib.import_module("bot.kraken_order_validator")
+        except Exception:
+            validator = importlib.import_module("kraken_order_validator")
+        minimums = getattr(validator, "KRAKEN_MINIMUMS", {})
+        if not isinstance(minimums, dict) or pair not in minimums:
+            return False, pair, floor, "pair_not_in_kraken_validator"
+        safe_fn = getattr(validator, "get_pair_safe_minimums", None)
+        if callable(safe_fn):
+            data = safe_fn(pair)
+            floor = max(floor, float(data.get("min_quote", floor)))
+    except Exception as exc:
+        return False, pair, floor, f"validator_unavailable:{exc}"
+    if float(notional or 0.0) + 1e-9 < floor:
+        return False, pair, floor, f"notional_below_kraken_floor:${float(notional or 0.0):.2f}<${floor:.2f}"
+    return True, pair, floor, "ok"
+
+
+def _patch_usdt_repair_module(module: ModuleType) -> bool:
+    module_id = id(module)
+    if module_id in _PATCHED_USDT_MODULES:
+        return True
+
+    def _safe_install_on_pipeline(pipeline_module: ModuleType) -> bool:
+        cls = getattr(pipeline_module, "ExecutionPipeline", None)
+        result_cls = getattr(pipeline_module, "PipelineResult", None)
+        if not isinstance(cls, type):
+            return False
+        original = getattr(cls, "execute", None)
+        if not callable(original) or getattr(original, "_venue_route_guard", False):
+            return True
+        if id(cls) in _PATCHED_PIPELINES:
+            return True
+
+        def execute(self: Any, request: Any, *args: Any, **kwargs: Any):
+            try:
+                symbol = getattr(request, "symbol", "")
+                broker = _broker(getattr(request, "preferred_broker", ""))
+                notional = _notional_from(request)
+                if _is_usdt(symbol):
+                    if broker == "okx":
+                        logger.critical("USDT_ROUTE_GUARD_KEEP_SELECTED symbol=%s broker=okx notional=$%.2f", symbol, notional)
+                    elif broker == "kraken":
+                        ok, pair, floor, reason = _kraken_pair_validation(symbol, notional)
+                        if not ok:
+                            logger.critical(
+                                "USDT_ROUTE_GUARD_BLOCK_KRAKEN symbol=%s broker=kraken pair=%s notional=$%.2f floor=$%.2f reason=%s",
+                                symbol, pair, notional, floor, reason,
+                            )
+                            if isinstance(result_cls, type):
+                                return result_cls(
+                                    success=False,
+                                    symbol=str(symbol),
+                                    side=str(getattr(request, "side", "buy")),
+                                    size_usd=float(notional or getattr(request, "size_usd", 0.0) or 0.0),
+                                    broker="kraken",
+                                    error=f"KRAKEN_USDT_ROUTE_BLOCKED:{reason}",
+                                )
+                        else:
+                            logger.critical("USDT_ROUTE_GUARD_ALLOW_KRAKEN symbol=%s pair=%s notional=$%.2f floor=$%.2f", symbol, pair, notional, floor)
+                    elif broker in {"", "auto", "coinbase"}:
+                        logger.critical("USDT_ROUTE_GUARD_NO_BLIND_KRAKEN_ROUTE symbol=%s selected_broker=%s notional=$%.2f", symbol, broker or "unset", notional)
+            except Exception as exc:
+                logger.warning("USDT_ROUTE_GUARD_PIPELINE_CHECK_FAILED err=%s", exc)
+            return original(self, request, *args, **kwargs)
+
+        setattr(execute, "_venue_route_guard", True)
+        setattr(execute, "__wrapped__", original)
+        setattr(cls, "execute", execute)
+        _PATCHED_PIPELINES.add(id(cls))
+        logger.warning("VENUE_ROUTE_GUARD_PIPELINE_PATCHED module=%s", getattr(pipeline_module, "__name__", "?"))
+        return True
+
+    def _safe_install_on_ecel(ecel_module: ModuleType) -> bool:
+        schema_cls = getattr(ecel_module, "ContractSchemaMap", None)
+        compiler_cls = getattr(ecel_module, "ECELExecutionCompiler", None)
+        if not isinstance(compiler_cls, type):
+            return False
+        original_compile = getattr(compiler_cls, "compile", None)
+        if not callable(original_compile) or getattr(original_compile, "_venue_route_guard", False):
+            return True
+        if id(compiler_cls) in _PATCHED_ECEL:
+            return True
+
+        def compile(self: Any, req: Any):
+            broker = _broker(getattr(req, "broker", ""))
+            symbol = getattr(req, "symbol", "")
+            notional = _notional_from(req)
+            if _is_usdt(symbol):
+                if broker == "okx":
+                    logger.critical("USDT_ECEL_ROUTE_GUARD_KEEP_SELECTED symbol=%s broker=okx notional=$%.2f", symbol, notional)
+                elif broker == "kraken":
+                    ok, pair, floor, reason = _kraken_pair_validation(symbol, notional)
+                    if not ok:
+                        logger.critical("USDT_ECEL_ROUTE_GUARD_BLOCK_KRAKEN symbol=%s pair=%s notional=$%.2f floor=$%.2f reason=%s", symbol, pair, notional, floor, reason)
+                        raise ValueError(f"KRAKEN_USDT_ROUTE_BLOCKED:{reason}")
+                    logger.critical("USDT_ECEL_ROUTE_GUARD_ALLOW_KRAKEN symbol=%s pair=%s notional=$%.2f floor=$%.2f", symbol, pair, notional, floor)
+                elif broker in {"", "auto", "coinbase"}:
+                    logger.critical("USDT_ECEL_ROUTE_GUARD_NO_BLIND_KRAKEN_ROUTE symbol=%s broker=%s notional=$%.2f", symbol, broker or "unset", notional)
+            return original_compile(self, req)
+
+        setattr(compile, "_venue_route_guard", True)
+        setattr(compile, "__wrapped__", original_compile)
+        setattr(compiler_cls, "compile", compile)
+        _PATCHED_ECEL.add(id(compiler_cls))
+        logger.warning("VENUE_ROUTE_GUARD_ECEL_PATCHED module=%s schema_present=%s", getattr(ecel_module, "__name__", "?"), isinstance(schema_cls, type))
+        return True
+
+    setattr(module, "_install_on_pipeline", _safe_install_on_pipeline)
+    setattr(module, "_install_on_ecel", _safe_install_on_ecel)
+    _PATCHED_USDT_MODULES.add(module_id)
+    logger.warning("VENUE_ROUTE_GUARD_PATCHED_USDT_REPAIR module=%s", getattr(module, "__name__", "?"))
+    return True
+
+
+def _try_patch_loaded() -> bool:
+    patched = False
+    for name in ("bot.usdt_kraken_ecel_routing_repair_patch", "usdt_kraken_ecel_routing_repair_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_usdt_repair_module(module) or patched
+    return patched
+
+
+def _start_monitor() -> None:
+    global _MONITOR_STARTED
+    if _MONITOR_STARTED:
+        return
+    _MONITOR_STARTED = True
+
+    def monitor() -> None:
+        deadline = time.time() + _float_env("NIJA_PATCH_MONITOR_SECONDS", 240.0)
+        while time.time() < deadline:
+            if _try_patch_loaded():
+                return
+            time.sleep(0.25)
+        logger.warning("VENUE_ROUTE_GUARD_MONITOR_EXPIRED patched_modules=%d", len(_PATCHED_USDT_MODULES))
+
+    threading.Thread(target=monitor, name="venue-route-guard-monitor", daemon=True).start()
+    logger.warning("VENUE_ROUTE_GUARD_MONITOR_STARTED")
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    with _LOCK:
+        _try_patch_loaded()
+        _start_monitor()
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+
+        def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+            try:
+                _try_patch_loaded()
+                if str(getattr(module, "__name__", "")) in {"bot.usdt_kraken_ecel_routing_repair_patch", "usdt_kraken_ecel_routing_repair_patch"}:
+                    _patch_usdt_repair_module(module)
+            except Exception as exc:
+                logger.debug("Venue route guard import check skipped: %s", exc)
+            return module
+
+        builtins.__import__ = importing
+        logger.warning("VENUE_ROUTE_GUARD_INSTALLED marker=20260704h")


### PR DESCRIPTION
Follow-up to the July 4 live execution log where NIJA reached Phase 3 and attempted A-USDT / ALLO-USDT, but USDT orders were routed into Kraken and failed as KRAKEN_UNKNOWN_ERROR / All operations failed.

Changes included:
- Adds `bot/venue_route_guard_patch.py`.
  - Prevents the legacy USDT repair from blindly rewriting USDT orders to Kraken.
  - Keeps OKX-selected USDT orders on OKX.
  - Allows Kraken only when the request is already targeting Kraken, the validator knows the pair, and notional is above the effective Kraken live floor.
  - Blocks unsafe Kraken USDT submissions before broker submit with `KRAKEN_USDT_ROUTE_BLOCKED:<reason>`.
- Updates `bot/okx_min_notional_prefilter_repair_patch.py` to chain-install the venue route guard sidecar.
- Updates `bot/kraken_error_taxonomy.py` to log raw Kraken errors before returning `KRAKEN_UNKNOWN_ERROR` or other canonical classifications.

Note: I attempted to directly patch `min_notional_runtime_patch.py` so it cannot downshift globals below Kraken's $23 live floor, but the GitHub write guard blocked that direct edit. The existing merged `notional_floor_repair_patch.py` still restores the floor at startup; the remaining direct edit to min_notional_runtime_patch.py may need to be applied locally if the runtime continues to emit ADAPTIVE_MIN_NOTIONAL_ENV_DOWNSHIFT after this PR.