### PR TITLE
Enforce terminal risk hard blocks through live execution

### DIFF
--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -191,7 +191,31 @@ def _try_patch_loaded() -> bool:
     return patched
 
 
+def _install_live_terminal_guards() -> None:
+    """Install non-bypassable terminal-risk guards alongside the broker guard."""
+    for module_name in (
+        "bot.live_execution_terminal_guard_patch",
+        "bot.phase3_force_override_terminal_guard_patch",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+            if callable(installer):
+                installer()
+                logger.warning(
+                    "CORE_LOOP_BROKER_ARGUMENT_GUARD_CHAINED_INSTALL marker=20260705d downstream=%s",
+                    module_name,
+                )
+        except Exception as exc:
+            logger.warning(
+                "CORE_LOOP_BROKER_ARGUMENT_GUARD_CHAINED_INSTALL_FAILED marker=20260705d downstream=%s err=%s",
+                module_name,
+                exc,
+            )
+
+
 def install_import_hook() -> None:
+    _install_live_terminal_guards()
     _try_patch_loaded()
     if getattr(builtins, "_NIJA_CORE_LOOP_BROKER_ARGUMENT_GUARD_HOOK_INSTALLED", False):
         return

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -192,8 +192,9 @@ def _try_patch_loaded() -> bool:
 
 
 def _install_live_terminal_guards() -> None:
-    """Install non-bypassable terminal-risk guards alongside the broker guard."""
+    """Install chained runtime guards alongside the broker guard."""
     for module_name in (
+        "bot.market_data_stability_import_guard_patch",
         "bot.live_execution_terminal_guard_patch",
         "bot.phase3_force_override_terminal_guard_patch",
     ):

--- a/bot/live_execution_terminal_guard_patch.py
+++ b/bot/live_execution_terminal_guard_patch.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.live_execution_terminal_guard")
+
+_MARKER = "LIVE_EXECUTION_TERMINAL_GUARD marker=20260707k"
+_IMPORT_FLAG = "_NIJA_LIVE_EXECUTION_TERMINAL_GUARD_IMPORT_HOOK_V20260707K"
+_TRUTHY = {"1", "true", "yes", "on", "y", "enabled"}
+
+_TARGETS = {
+    "bot.trade_permission_engine",
+    "trade_permission_engine",
+    "bot.execution_pipeline",
+    "execution_pipeline",
+    "bot.multi_broker_execution_router",
+    "multi_broker_execution_router",
+    "bot.ai_intelligence_hub",
+    "ai_intelligence_hub",
+}
+
+
+_TERMINAL_MARKERS = (
+    "terminal_risk_hard_block",
+    "hard_sector_limit_block",
+    "entry_blocked_terminal_risk_hard_block",
+    "portfolio exposure limit reached",
+    "position blocked by risk engine",
+    "sector limit enforcement",
+    "hard sector limit block",
+    "global_exposure_cap",
+    "pretraderiskengine reject",
+)
+
+
+def _truthy_env(name: str, default: str = "true") -> bool:
+    return str(os.environ.get(name, default)).strip().lower() in _TRUTHY
+
+
+def _norm_symbol(value: Any) -> str:
+    return str(value or "").strip().upper().replace("/", "-")
+
+
+def _norm_broker(value: Any) -> str:
+    text = str(value or "").strip().lower().replace(" ", "_")
+    aliases = {
+        "coinbaseadvanced": "coinbase",
+        "coinbase_advanced": "coinbase",
+        "coinbase_advanced_trade": "coinbase",
+        "coinbaseadvancedtrade": "coinbase",
+        "kraken_spot": "kraken",
+        "krakenpro": "kraken",
+        "okxus": "okx",
+        "okx_us": "okx",
+        "okx_spot": "okx",
+    }
+    return aliases.get(text, text)
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _stringify(value: Any, *, _depth: int = 0) -> str:
+    if _depth > 3:
+        return ""
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        parts = []
+        for key, item in value.items():
+            parts.append(str(key))
+            parts.append(_stringify(item, _depth=_depth + 1))
+        return " ".join(parts)
+    if isinstance(value, (list, tuple, set)):
+        return " ".join(_stringify(item, _depth=_depth + 1) for item in value)
+    return str(value)
+
+
+def _contains_terminal_hard_block(value: Any) -> bool:
+    text = _stringify(value).lower()
+    return any(marker in text for marker in _TERMINAL_MARKERS)
+
+
+def _metadata_from_request(request: Any) -> dict[str, Any]:
+    try:
+        meta = getattr(request, "metadata", {}) or {}
+        return dict(meta) if isinstance(meta, dict) else {}
+    except Exception:
+        return {}
+
+
+def _metadata_from_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    meta = kwargs.get("metadata") or {}
+    return dict(meta) if isinstance(meta, dict) else {}
+
+
+def _broker_from_request(request: Any) -> str:
+    meta = _metadata_from_request(request)
+    for value in (
+        getattr(request, "preferred_broker", None),
+        getattr(request, "broker", None),
+        meta.get("broker_name"),
+        meta.get("broker"),
+        meta.get("broker_hint"),
+        meta.get("venue"),
+        meta.get("exchange"),
+    ):
+        broker = _norm_broker(value)
+        if broker:
+            return broker
+    return ""
+
+
+def _broker_from_tpe_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    return _norm_broker(kwargs.get("broker") or (args[8] if len(args) > 8 else ""))
+
+
+def _explicit_zero_allocation(value: Any) -> bool:
+    """Return true only when a request explicitly says the selected route has $0."""
+    if value is None:
+        return False
+    try:
+        return float(value) <= 0.0
+    except Exception:
+        return False
+
+
+def _has_explicit_zero_route(*objects: Any) -> tuple[bool, str]:
+    keys = (
+        "capital_allocated",
+        "allocated_capital",
+        "broker_allocated_capital",
+        "venue_allocated_capital",
+        "selected_broker_capital",
+        "route_capital",
+        "spendable_capital",
+        "usable_capital",
+    )
+    for obj in objects:
+        if obj is None:
+            continue
+        if isinstance(obj, dict):
+            for key in keys:
+                if key in obj and _explicit_zero_allocation(obj.get(key)):
+                    return True, key
+            continue
+        for key in keys:
+            if hasattr(obj, key):
+                value = getattr(obj, key, None)
+                if callable(value):
+                    try:
+                        value = value()
+                    except Exception:
+                        continue
+                if _explicit_zero_allocation(value):
+                    return True, key
+    return False, ""
+
+
+def _request_size_usd(request: Any) -> float:
+    meta = _metadata_from_request(request)
+    for source in (request, meta):
+        if isinstance(source, dict):
+            for key in ("size_usd", "position_size", "notional_usd", "usd_size", "amount_usd"):
+                if key in source:
+                    size = _float(source.get(key), 0.0)
+                    if size > 0.0:
+                        return size
+        else:
+            for key in ("size_usd", "position_size", "notional_usd", "usd_size", "amount_usd"):
+                if hasattr(source, key):
+                    size = _float(getattr(source, key, 0.0), 0.0)
+                    if size > 0.0:
+                        return size
+    return 0.0
+
+
+def _tpe_size_from_kwargs(kwargs: dict[str, Any], meta: dict[str, Any]) -> float:
+    for source in (kwargs, meta):
+        for key in ("position_size", "size_usd", "notional_usd", "usd_size", "amount_usd"):
+            if key in source:
+                size = _float(source.get(key), 0.0)
+                if size > 0.0:
+                    return size
+    return 0.0
+
+
+def _make_tpe_decision(module: ModuleType, *, symbol: str, side: str, score: float, threshold: float, balance: float, broker: str, reason: str):
+    TradeDecision = getattr(module, "TradeDecision", None)
+    if TradeDecision is None:
+        return None
+    try:
+        decision = TradeDecision(
+            symbol=symbol,
+            side=side,
+            signal="NO",
+            signal_score=score,
+            signal_threshold=threshold,
+            signal_bypass=False,
+            regime_label="TERMINAL_RISK",
+            regime_pass=False,
+            regime_bypass=False,
+            capital="PASS" if balance > 0 else "FAIL",
+            capital_balance=balance,
+            capital_threshold=0.0,
+            liquidity="FAIL",
+            liquidity_detail=reason,
+            execution_mode="TERMINAL_GUARD",
+            final_decision="BLOCKED",
+            block_reason=reason,
+            broker=broker,
+            broker_criticality="TERMINAL_GUARD",
+            broker_health="BLOCKED",
+            risk_allowed=False,
+            capital_allocated=0.0,
+            market_regime="TERMINAL_RISK",
+            strategy_name="live_execution_terminal_guard",
+        )
+        return decision
+    except Exception as exc:
+        logger.warning("TERMINAL_GUARD_TPE_DECISION_BUILD_FAILED symbol=%s err=%s", symbol, exc)
+        return None
+
+
+def _patch_trade_permission_engine(module: ModuleType) -> bool:
+    cls = getattr(module, "TradePermissionEngine", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "evaluate", None)
+    if not callable(original) or getattr(original, "_nija_terminal_guard_wrapped", False):
+        return False
+
+    @wraps(original)
+    def evaluate(self: Any, *args: Any, **kwargs: Any):
+        meta = _metadata_from_kwargs(kwargs)
+        symbol = str(kwargs.get("symbol") or (args[0] if args else "UNKNOWN"))
+        side = str(kwargs.get("side") or (args[1] if len(args) > 1 else ""))
+        score = _float(kwargs.get("ai_score") or (args[2] if len(args) > 2 else 0.0), 0.0)
+        threshold = _float(kwargs.get("ai_threshold") or (args[3] if len(args) > 3 else 0.0), 0.0)
+        balance = _float(kwargs.get("balance") or (args[4] if len(args) > 4 else 0.0), 0.0)
+        broker = _broker_from_tpe_args(args, kwargs)
+
+        reason = ""
+        if _contains_terminal_hard_block(meta):
+            reason = "NON_OVERRIDEABLE_TERMINAL_RISK_HARD_BLOCK"
+        zero_route, zero_key = _has_explicit_zero_route(meta)
+        if zero_route:
+            reason = f"NO_FUNDED_BROKER_ROUTE selected_broker={broker or 'unknown'} allocation_key={zero_key}"
+
+        if reason:
+            logger.critical(
+                "TPE_TERMINAL_GUARD_BLOCK marker=20260707k symbol=%s side=%s broker=%s reason=%s",
+                _norm_symbol(symbol),
+                side,
+                broker or "unknown",
+                reason,
+            )
+            decision = _make_tpe_decision(
+                module,
+                symbol=_norm_symbol(symbol),
+                side=side,
+                score=score,
+                threshold=threshold,
+                balance=balance,
+                broker=broker,
+                reason=reason,
+            )
+            if decision is not None:
+                return decision
+
+        decision = original(self, *args, **kwargs)
+        try:
+            decision_text = _stringify(getattr(decision, "to_dict", lambda: vars(decision))())
+        except Exception:
+            decision_text = _stringify(decision)
+        zero_route, zero_key = _has_explicit_zero_route(meta, decision)
+        if _contains_terminal_hard_block(meta) or _contains_terminal_hard_block(decision_text) or zero_route:
+            block_reason = (
+                "NON_OVERRIDEABLE_TERMINAL_RISK_HARD_BLOCK"
+                if (_contains_terminal_hard_block(meta) or _contains_terminal_hard_block(decision_text))
+                else f"NO_FUNDED_BROKER_ROUTE selected_broker={broker or getattr(decision, 'broker', '') or 'unknown'} allocation_key={zero_key}"
+            )
+            for attr, value in (
+                ("final_decision", "BLOCKED"),
+                ("block_reason", block_reason),
+                ("risk_allowed", False),
+                ("capital_allocated", 0.0),
+                ("broker_health", "BLOCKED"),
+                ("broker_criticality", "TERMINAL_GUARD"),
+            ):
+                try:
+                    setattr(decision, attr, value)
+                except Exception:
+                    pass
+            logger.critical(
+                "TPE_EXECUTE_CONVERTED_TO_HOLD marker=20260707k symbol=%s side=%s reason=%s",
+                _norm_symbol(getattr(decision, "symbol", symbol)),
+                getattr(decision, "side", side),
+                block_reason,
+            )
+        return decision
+
+    setattr(evaluate, "_nija_terminal_guard_wrapped", True)
+    setattr(cls, "evaluate", evaluate)
+    logger.warning("%s patched=TradePermissionEngine.evaluate", _MARKER)
+    return True
+
+
+def _pipeline_failure(PipelineResult: Any, request: Any, *, reason: str):
+    symbol = _norm_symbol(getattr(request, "symbol", "UNKNOWN"))
+    side = str(getattr(request, "side", ""))
+    size_usd = _request_size_usd(request)
+    broker = _broker_from_request(request) or "terminal_guard"
+    return PipelineResult(
+        success=False,
+        symbol=symbol,
+        side=side,
+        size_usd=size_usd,
+        broker=broker,
+        latency_ms=0.0,
+        error=reason,
+    )
+
+
+def _patch_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    PipelineResult = getattr(module, "PipelineResult", None)
+    if not isinstance(cls, type) or PipelineResult is None:
+        return False
+    original = getattr(cls, "execute", None)
+    if not callable(original) or getattr(original, "_nija_terminal_guard_wrapped", False):
+        return False
+
+    @wraps(original)
+    def execute(self: Any, request: Any):
+        meta = _metadata_from_request(request)
+        symbol = _norm_symbol(getattr(request, "symbol", "UNKNOWN"))
+        side = str(getattr(request, "side", ""))
+        size = _request_size_usd(request)
+        zero_route, zero_key = _has_explicit_zero_route(request, meta)
+        reason = ""
+        if _contains_terminal_hard_block(request) or _contains_terminal_hard_block(meta):
+            reason = "NON_OVERRIDEABLE_TERMINAL_RISK_HARD_BLOCK"
+        elif size <= 0.0:
+            reason = "ZERO_SIZE_ORDER_BLOCKED_BEFORE_BROKER"
+        elif zero_route:
+            reason = f"NO_FUNDED_BROKER_ROUTE allocation_key={zero_key}"
+        if reason:
+            logger.critical(
+                "PIPELINE_TERMINAL_GUARD_BLOCK marker=20260707k symbol=%s side=%s broker=%s size_usd=%.2f reason=%s",
+                symbol,
+                side,
+                _broker_from_request(request) or "unknown",
+                size,
+                reason,
+            )
+            return _pipeline_failure(PipelineResult, request, reason=reason)
+
+        result = original(self, request)
+        error_text = str(getattr(result, "error", "") or "")
+        if "ack_timeout_no_confirmed_fill" in error_text.lower():
+            try:
+                setattr(result, "error", f"ORDER_ACK_UNCONFIRMED_RECONCILIATION_REQUIRED: {error_text}")
+            except Exception:
+                pass
+            logger.critical(
+                "ORDER_ACK_TIMEOUT_NOT_TREATED_AS_FILL marker=20260707k symbol=%s broker=%s error=%s",
+                _norm_symbol(getattr(result, "symbol", symbol)),
+                getattr(result, "broker", ""),
+                error_text[:500],
+            )
+        return result
+
+    setattr(execute, "_nija_terminal_guard_wrapped", True)
+    setattr(cls, "execute", execute)
+    logger.warning("%s patched=ExecutionPipeline.execute", _MARKER)
+    return True
+
+
+def _route_failure(RouteResult: Any, module: ModuleType, request: Any, *, reason: str):
+    symbol = _norm_symbol(getattr(request, "symbol", "UNKNOWN"))
+    side = str(getattr(request, "side", ""))
+    size = _request_size_usd(request)
+    asset_class = str(getattr(request, "asset_class", "") or "crypto")
+    broker = _broker_from_request(request) or "NONE"
+    return RouteResult(
+        success=False,
+        symbol=symbol,
+        side=side,
+        size_usd=size,
+        asset_class=asset_class,
+        broker=broker,
+        fill_price=0.0,
+        filled_size_usd=0.0,
+        order_type=getattr(request, "order_type", None) or "MARKET",
+        latency_ms=0.0,
+        error=reason,
+    )
+
+
+def _patch_multi_broker_router(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiBrokerExecutionRouter", None)
+    RouteResult = getattr(module, "RouteResult", None)
+    if not isinstance(cls, type) or RouteResult is None:
+        return False
+    original = getattr(cls, "route", None)
+    if not callable(original) or getattr(original, "_nija_terminal_guard_wrapped", False):
+        return False
+
+    @wraps(original)
+    def route(self: Any, request: Any):
+        meta = _metadata_from_request(request)
+        symbol = _norm_symbol(getattr(request, "symbol", "UNKNOWN"))
+        side = str(getattr(request, "side", ""))
+        size = _request_size_usd(request)
+        zero_route, zero_key = _has_explicit_zero_route(request, meta)
+        reason = ""
+        if _contains_terminal_hard_block(request) or _contains_terminal_hard_block(meta):
+            reason = "NON_OVERRIDEABLE_TERMINAL_RISK_HARD_BLOCK"
+        elif size <= 0.0:
+            reason = "ZERO_SIZE_ORDER_BLOCKED_BEFORE_ROUTER"
+        elif zero_route:
+            reason = f"NO_FUNDED_BROKER_ROUTE allocation_key={zero_key}"
+
+        if reason:
+            logger.critical(
+                "ROUTER_TERMINAL_GUARD_BLOCK marker=20260707k symbol=%s side=%s broker=%s size_usd=%.2f reason=%s",
+                symbol,
+                side,
+                _broker_from_request(request) or "unknown",
+                size,
+                reason,
+            )
+            return _route_failure(RouteResult, module, request, reason=reason)
+
+        return original(self, request)
+
+    setattr(route, "_nija_terminal_guard_wrapped", True)
+    setattr(cls, "route", route)
+    logger.warning("%s patched=MultiBrokerExecutionRouter.route", _MARKER)
+    return True
+
+
+def _patch_ai_hub(module: ModuleType) -> bool:
+    cls = getattr(module, "AIIntelligenceHub", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "evaluate_trade", None)
+    if not callable(original) or getattr(original, "_nija_terminal_guard_wrapped", False):
+        return False
+
+    @wraps(original)
+    def evaluate_trade(self: Any, *args: Any, **kwargs: Any):
+        result = original(self, *args, **kwargs)
+        text = " ".join(
+            str(getattr(result, attr, "") or "")
+            for attr in ("exposure_rejection_reason", "ai_reason", "reason")
+        )
+        if getattr(result, "exposure_allowed", True) is False or _contains_terminal_hard_block(text):
+            if _contains_terminal_hard_block(text) or "hard" in text.lower() or "sector" in text.lower():
+                reason = f"terminal_risk_hard_block:{text or 'risk engine hard block'}"
+                for attr, value in (
+                    ("exposure_allowed", False),
+                    ("ai_approved", False),
+                    ("approved", False),
+                    ("allowed", False),
+                    ("trade_allowed", False),
+                    ("ai_score", 0.0),
+                    ("allocated_capital", 0.0),
+                ):
+                    try:
+                        setattr(result, attr, value)
+                    except Exception:
+                        pass
+                try:
+                    setattr(result, "ai_reason", reason)
+                    setattr(result, "exposure_rejection_reason", reason)
+                except Exception:
+                    pass
+                logger.critical(
+                    "AI_HUB_TERMINAL_GUARD_BLOCK marker=20260707k symbol=%s side=%s reason=%s",
+                    args[0] if args else kwargs.get("symbol", ""),
+                    args[1] if len(args) > 1 else kwargs.get("side", ""),
+                    reason,
+                )
+        return result
+
+    setattr(evaluate_trade, "_nija_terminal_guard_wrapped", True)
+    setattr(cls, "evaluate_trade", evaluate_trade)
+    logger.warning("%s patched=AIIntelligenceHub.evaluate_trade", _MARKER)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    name = getattr(module, "__name__", "")
+    patched = False
+    try:
+        if name in {"bot.trade_permission_engine", "trade_permission_engine"}:
+            patched = _patch_trade_permission_engine(module) or patched
+        elif name in {"bot.execution_pipeline", "execution_pipeline"}:
+            patched = _patch_execution_pipeline(module) or patched
+        elif name in {"bot.multi_broker_execution_router", "multi_broker_execution_router"}:
+            patched = _patch_multi_broker_router(module) or patched
+        elif name in {"bot.ai_intelligence_hub", "ai_intelligence_hub"}:
+            patched = _patch_ai_hub(module) or patched
+    except Exception as exc:
+        logger.warning("LIVE_EXECUTION_TERMINAL_GUARD_PATCH_FAILED marker=20260707k module=%s err=%s", name, exc)
+    return patched
+
+
+def _try_patch_loaded() -> bool:
+    patched = False
+    for name in tuple(_TARGETS):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_module(module) or patched
+    return patched
+
+
+def install_import_hook() -> None:
+    if not _truthy_env("NIJA_LIVE_EXECUTION_TERMINAL_GUARD", "true"):
+        logger.warning("LIVE_EXECUTION_TERMINAL_GUARD_DISABLED marker=20260707k")
+        return
+
+    _try_patch_loaded()
+    if getattr(builtins, _IMPORT_FLAG, False):
+        return
+
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        try:
+            if name in _TARGETS or any(str(name).endswith(target.split(".")[-1]) for target in _TARGETS):
+                _try_patch_loaded()
+        except Exception as exc:
+            logger.warning("LIVE_EXECUTION_TERMINAL_GUARD_IMPORT_HOOK_FAILED marker=20260707k name=%s err=%s", name, exc)
+        return module
+
+    builtins.__import__ = guarded_import
+    setattr(builtins, _IMPORT_FLAG, True)
+    logger.warning("LIVE_EXECUTION_TERMINAL_GUARD_IMPORT_HOOK_INSTALLED marker=20260707k")
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/live_execution_terminal_guard_patch.py
+++ b/bot/live_execution_terminal_guard_patch.py
@@ -25,7 +25,6 @@ _TARGETS = {
     "ai_intelligence_hub",
 }
 
-
 _TERMINAL_MARKERS = (
     "terminal_risk_hard_block",
     "hard_sector_limit_block",
@@ -126,7 +125,7 @@ def _broker_from_tpe_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
 
 
 def _explicit_zero_allocation(value: Any) -> bool:
-    """Return true only when a request explicitly says the selected route has $0."""
+    """Return true only when a live route/request explicitly says $0 is allocated."""
     if value is None:
         return False
     try:
@@ -148,6 +147,11 @@ def _has_explicit_zero_route(*objects: Any) -> tuple[bool, str]:
     )
     for obj in objects:
         if obj is None:
+            continue
+        # TradeDecision.capital_allocated defaults to 0.0 and is only diagnostic.
+        # Do not treat that default as a live route allocation unless it was in
+        # request metadata or an execution request object.
+        if obj.__class__.__name__ == "TradeDecision":
             continue
         if isinstance(obj, dict):
             for key in keys:
@@ -185,22 +189,12 @@ def _request_size_usd(request: Any) -> float:
     return 0.0
 
 
-def _tpe_size_from_kwargs(kwargs: dict[str, Any], meta: dict[str, Any]) -> float:
-    for source in (kwargs, meta):
-        for key in ("position_size", "size_usd", "notional_usd", "usd_size", "amount_usd"):
-            if key in source:
-                size = _float(source.get(key), 0.0)
-                if size > 0.0:
-                    return size
-    return 0.0
-
-
 def _make_tpe_decision(module: ModuleType, *, symbol: str, side: str, score: float, threshold: float, balance: float, broker: str, reason: str):
     TradeDecision = getattr(module, "TradeDecision", None)
     if TradeDecision is None:
         return None
     try:
-        decision = TradeDecision(
+        return TradeDecision(
             symbol=symbol,
             side=side,
             signal="NO",
@@ -226,7 +220,6 @@ def _make_tpe_decision(module: ModuleType, *, symbol: str, side: str, score: flo
             market_regime="TERMINAL_RISK",
             strategy_name="live_execution_terminal_guard",
         )
-        return decision
     except Exception as exc:
         logger.warning("TERMINAL_GUARD_TPE_DECISION_BUILD_FAILED symbol=%s err=%s", symbol, exc)
         return None
@@ -283,7 +276,7 @@ def _patch_trade_permission_engine(module: ModuleType) -> bool:
             decision_text = _stringify(getattr(decision, "to_dict", lambda: vars(decision))())
         except Exception:
             decision_text = _stringify(decision)
-        zero_route, zero_key = _has_explicit_zero_route(meta, decision)
+        zero_route, zero_key = _has_explicit_zero_route(meta)
         if _contains_terminal_hard_block(meta) or _contains_terminal_hard_block(decision_text) or zero_route:
             block_reason = (
                 "NON_OVERRIDEABLE_TERMINAL_RISK_HARD_BLOCK"

--- a/bot/market_data_stability_import_guard_patch.py
+++ b/bot/market_data_stability_import_guard_patch.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.market_data_stability_import_guard")
+_MARKER = "MARKET_DATA_STABILITY_IMPORT_GUARD marker=20260707a"
+_HOOK_FLAG = "_NIJA_MARKET_DATA_STABILITY_IMPORT_GUARD_20260707A"
+_LOCK = threading.Lock()
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+
+
+def _broker_loaded() -> bool:
+    for name in ("bot.broker_integration", "broker_integration"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and hasattr(module, "KrakenBrokerAdapter"):
+            return True
+    return False
+
+
+def _force_install_market_data_patch(reason: str) -> bool:
+    if not _broker_loaded():
+        logger.debug("%s waiting_for_broker_integration reason=%s", _MARKER, reason)
+        return False
+    try:
+        patch = importlib.import_module("bot.market_data_stability_runtime_patch")
+    except Exception:
+        try:
+            patch = importlib.import_module("market_data_stability_runtime_patch")
+        except Exception as exc:
+            logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_IMPORT_FAILED marker=20260707a reason=%s err=%s", reason, exc)
+            return False
+
+    installer = getattr(patch, "_install_kraken_market_data_patch", None)
+    if not callable(installer):
+        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_NO_INSTALLER marker=20260707a module=%s", getattr(patch, "__name__", "unknown"))
+        return False
+    try:
+        installer()
+        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason=%s", reason)
+        print(f"[NIJA-PRINT] MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason={reason}", flush=True)
+        return True
+    except Exception as exc:
+        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLY_FAILED marker=20260707a reason=%s err=%s", reason, exc)
+        return False
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    with _LOCK:
+        _force_install_market_data_patch("install_start")
+        if getattr(builtins, _HOOK_FLAG, False):
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            try:
+                if "broker_integration" in str(name):
+                    _force_install_market_data_patch(f"import:{name}")
+                else:
+                    _force_install_market_data_patch("import_poll")
+            except Exception as exc:
+                logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_HOOK_FAILED marker=20260707a name=%s err=%s", name, exc)
+            return module
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, _HOOK_FLAG, True)
+        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_HOOK_INSTALLED marker=20260707a")
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/market_data_stability_import_guard_patch.py
+++ b/bot/market_data_stability_import_guard_patch.py
@@ -13,6 +13,7 @@ _MARKER = "MARKET_DATA_STABILITY_IMPORT_GUARD marker=20260707a"
 _HOOK_FLAG = "_NIJA_MARKET_DATA_STABILITY_IMPORT_GUARD_20260707A"
 _LOCK = threading.Lock()
 _ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_INSTALLING = False
 
 
 def _broker_loaded() -> bool:
@@ -24,30 +25,37 @@ def _broker_loaded() -> bool:
 
 
 def _force_install_market_data_patch(reason: str) -> bool:
+    global _INSTALLING
+    if _INSTALLING:
+        return False
     if not _broker_loaded():
         logger.debug("%s waiting_for_broker_integration reason=%s", _MARKER, reason)
         return False
+    _INSTALLING = True
     try:
-        patch = importlib.import_module("bot.market_data_stability_runtime_patch")
-    except Exception:
         try:
-            patch = importlib.import_module("market_data_stability_runtime_patch")
-        except Exception as exc:
-            logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_IMPORT_FAILED marker=20260707a reason=%s err=%s", reason, exc)
-            return False
+            patch = importlib.import_module("bot.market_data_stability_runtime_patch")
+        except Exception:
+            try:
+                patch = importlib.import_module("market_data_stability_runtime_patch")
+            except Exception as exc:
+                logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_IMPORT_FAILED marker=20260707a reason=%s err=%s", reason, exc)
+                return False
 
-    installer = getattr(patch, "_install_kraken_market_data_patch", None)
-    if not callable(installer):
-        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_NO_INSTALLER marker=20260707a module=%s", getattr(patch, "__name__", "unknown"))
-        return False
-    try:
-        installer()
-        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason=%s", reason)
-        print(f"[NIJA-PRINT] MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason={reason}", flush=True)
-        return True
-    except Exception as exc:
-        logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLY_FAILED marker=20260707a reason=%s err=%s", reason, exc)
-        return False
+        installer = getattr(patch, "_install_kraken_market_data_patch", None)
+        if not callable(installer):
+            logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_NO_INSTALLER marker=20260707a module=%s", getattr(patch, "__name__", "unknown"))
+            return False
+        try:
+            installer()
+            logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason=%s", reason)
+            print(f"[NIJA-PRINT] MARKET_DATA_STABILITY_IMPORT_GUARD_APPLIED marker=20260707a reason={reason}", flush=True)
+            return True
+        except Exception as exc:
+            logger.warning("MARKET_DATA_STABILITY_IMPORT_GUARD_APPLY_FAILED marker=20260707a reason=%s err=%s", reason, exc)
+            return False
+    finally:
+        _INSTALLING = False
 
 
 def install_import_hook() -> None:

--- a/bot/phase3_force_override_terminal_guard_patch.py
+++ b/bot/phase3_force_override_terminal_guard_patch.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import logging
+import os
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.phase3_force_override_terminal_guard")
+
+_MARKER = "PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_PATCHED marker=20260707k"
+_PATCHED_ATTR = "_nija_phase3_force_override_terminal_guard_20260707k"
+_CANONICAL_CORE_LOOP_MODULE = "bot.nija_core_loop"
+_ORIGINAL_IMPORT_MODULE: Optional[Callable[..., Any]] = None
+_INSTALL_LOCK = threading.Lock()
+_MONITOR_STARTED = False
+_PATCHED_CLASSES: set[str] = set()
+_TRUTHY = {"1", "true", "yes", "on", "y", "enabled"}
+
+_NON_OVERRIDEABLE_MARKERS = (
+    "terminal_risk_hard_block",
+    "hard_sector_limit_block",
+    "entry_blocked_terminal_risk_hard_block",
+    "portfolio exposure limit reached",
+    "position blocked by risk engine",
+    "sector limit enforcement",
+    "hard sector limit block",
+    "global_exposure_cap",
+    "pretraderiskengine reject",
+    "no_funded_broker_route",
+    "zero_size_order",
+    "zero_size_order_blocked",
+)
+
+
+def _env_truthy(name: str, default: str = "false") -> bool:
+    return str(os.getenv(name, default)).strip().lower() in _TRUTHY
+
+
+def _nija_phase3_non_overrideable_reason(reason: Any) -> bool:
+    text = str(reason or "").strip().lower()
+    return any(marker in text for marker in _NON_OVERRIDEABLE_MARKERS)
+
+
+def _is_core_loop_module(module: ModuleType) -> bool:
+    return str(getattr(module, "__name__", "")) == _CANONICAL_CORE_LOOP_MODULE
+
+
+def _function_source_from_file(module: ModuleType, func_name: str) -> tuple[str, int]:
+    path = Path(str(getattr(module, "__file__", "")))
+    if not path.exists():
+        raise FileNotFoundError(f"module file not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            segment = ast.get_source_segment(text, node)
+            if not segment:
+                raise RuntimeError(f"source segment missing for {func_name}")
+            return textwrap.dedent(segment), int(getattr(node, "lineno", 0) or 0)
+    raise RuntimeError(f"function {func_name} not found in {path}")
+
+
+def _phase3_hold_skip_block() -> str:
+    for module_name in ("bot.phase3_fallback_hold_skip_patch", "phase3_fallback_hold_skip_patch"):
+        try:
+            module = importlib.import_module(module_name)
+            block = getattr(module, "_SKIP_BLOCK", "")
+            if isinstance(block, str) and "PHASE3_FALLBACK_HOLD_SKIP_APPLIED" in block:
+                return block
+        except Exception:
+            continue
+    return ""
+
+
+def _install_terminal_guard() -> bool:
+    for module_name in ("bot.live_execution_terminal_guard_patch", "live_execution_terminal_guard_patch"):
+        try:
+            module = importlib.import_module(module_name)
+            installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+            if callable(installer):
+                installer()
+                logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_INSTALLED_DOWNSTREAM marker=20260707k module=%s", module_name)
+                return True
+        except Exception as exc:
+            logger.debug("terminal guard install attempt failed module=%s err=%s", module_name, exc)
+    logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_DOWNSTREAM_UNAVAILABLE marker=20260707k")
+    return False
+
+
+def _patch_core_loop(module: ModuleType) -> bool:
+    if not _is_core_loop_module(module):
+        return False
+    cls = getattr(module, "NijaCoreLoop", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "_phase3_scan_and_enter", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCHED_ATTR, False):
+        _PATCHED_CLASSES.add(f"{getattr(module, '__name__', '')}.{cls.__name__}")
+        return True
+
+    try:
+        source, lineno = _function_source_from_file(module, "_phase3_scan_and_enter")
+    except Exception as exc:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_SOURCE_FAILED marker=20260707k err=%s", exc)
+        return False
+
+    patched_source = source
+    changes: list[str] = []
+
+    override_needle = "                            if _force_tpe_bypass:\n"
+    override_replacement = "                            if _force_tpe_bypass and not _nija_phase3_non_overrideable_reason(_tpe_reason):\n"
+    if override_needle in patched_source:
+        patched_source = patched_source.replace(override_needle, override_replacement, 1)
+        changes.append("tpe_force_override_non_overrideable_guard")
+    else:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_TPE_NEEDLE_MISSING marker=20260707k")
+
+    direct_needle = "        if _force_direct_bypass and entries == 0 and _best_volume_symbol:\n"
+    direct_replacement = '        if _force_direct_bypass and entries == 0 and _best_volume_symbol and _env_truthy("NIJA_ALLOW_FORCE_TRADE_DIRECT_FALLBACK", "false"):\n'
+    if direct_needle in patched_source:
+        patched_source = patched_source.replace(direct_needle, direct_replacement, 1)
+        changes.append("force_trade_direct_opt_in_guard")
+    else:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_DIRECT_NEEDLE_MISSING marker=20260707k")
+
+    skip_block = _phase3_hold_skip_block()
+    skip_needle = 'logger.critical(\n                    "✅ [Phase3] SIGNAL PASSED all gates | symbol=%s action=%s "'
+    if skip_block and "PHASE3_FALLBACK_HOLD_SKIP_APPLIED" not in patched_source and skip_needle in patched_source:
+        patched_source = patched_source.replace(skip_needle, skip_block + "                " + skip_needle, 1)
+        changes.append("fallback_hold_skip_preserved")
+    elif skip_block and "PHASE3_FALLBACK_HOLD_SKIP_APPLIED" in patched_source:
+        changes.append("fallback_hold_skip_already_present")
+    elif not skip_block:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_SKIP_BLOCK_UNAVAILABLE marker=20260707k")
+    else:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_SKIP_NEEDLE_MISSING marker=20260707k")
+
+    if not changes:
+        return False
+
+    namespace = dict(vars(module))
+    for key, value in getattr(current, "__globals__", {}).items():
+        namespace.setdefault(key, value)
+    namespace.setdefault("_env_truthy", getattr(module, "_env_truthy", _env_truthy))
+    namespace["_nija_phase3_non_overrideable_reason"] = _nija_phase3_non_overrideable_reason
+    namespace.setdefault("logger", getattr(module, "logger", logging.getLogger("nija.core_loop")))
+
+    try:
+        exec(compile(patched_source, "<phase3_force_override_terminal_guard>", "exec"), namespace, namespace)
+        patched = namespace.get("_phase3_scan_and_enter")
+        if not callable(patched):
+            raise RuntimeError("patched function not produced")
+    except Exception as exc:
+        logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_COMPILE_FAILED marker=20260707k err=%s", exc)
+        return False
+
+    setattr(patched, _PATCHED_ATTR, True)
+    setattr(patched, "__wrapped__", current)
+    setattr(cls, "_phase3_scan_and_enter", patched)
+    key = f"{getattr(module, '__name__', '')}.{cls.__name__}"
+    _PATCHED_CLASSES.add(key)
+    logger.warning(
+        "%s class=%s source=file line=%s changes=%s direct_fallback_requires=NIJA_ALLOW_FORCE_TRADE_DIRECT_FALLBACK",
+        _MARKER,
+        key,
+        lineno,
+        ",".join(changes),
+    )
+    print(
+        f"[NIJA-PRINT] PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_PATCHED marker=20260707k class={key} changes={','.join(changes)}",
+        flush=True,
+    )
+    return True
+
+
+def _try_patch_loaded() -> bool:
+    module = sys.modules.get(_CANONICAL_CORE_LOOP_MODULE)
+    if isinstance(module, ModuleType):
+        return _patch_core_loop(module)
+    return False
+
+
+def _start_monitor() -> None:
+    global _MONITOR_STARTED
+    if _MONITOR_STARTED:
+        return
+    _MONITOR_STARTED = True
+
+    def _monitor() -> None:
+        deadline = time.time() + float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "240") or "240")
+        patched_any = False
+        while time.time() < deadline:
+            patched_any = _try_patch_loaded() or patched_any
+            if patched_any:
+                break
+            time.sleep(1.0)
+        logger.warning(
+            "PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_MONITOR_COMPLETE marker=20260707k patched_any=%s patched_classes=%s",
+            patched_any,
+            sorted(_PATCHED_CLASSES),
+        )
+
+    threading.Thread(target=_monitor, name="phase3-force-override-terminal-guard", daemon=True).start()
+    logger.warning("PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_MONITOR_STARTED marker=20260707k")
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT_MODULE
+    with _INSTALL_LOCK:
+        _install_terminal_guard()
+        _try_patch_loaded()
+        _start_monitor()
+        if _ORIGINAL_IMPORT_MODULE is not None:
+            return
+        _ORIGINAL_IMPORT_MODULE = importlib.import_module
+
+        def _wrapped_import_module(name: str, package: str | None = None):
+            module = _ORIGINAL_IMPORT_MODULE(name, package)  # type: ignore[misc]
+            if name == _CANONICAL_CORE_LOOP_MODULE:
+                _patch_core_loop(module)
+            return module
+
+        importlib.import_module = _wrapped_import_module  # type: ignore[assignment]
+        logger.warning(
+            "PHASE3_FORCE_OVERRIDE_TERMINAL_GUARD_INSTALL_COMPLETE marker=20260707k patched_classes=%s",
+            sorted(_PATCHED_CLASSES),
+        )
+
+
+def install() -> None:
+    install_import_hook()


### PR DESCRIPTION
Summary:
- Enforce terminal risk hard blocks through TPE, AI Hub, pipeline, and router.
- Block zero-size and explicit no-funded-route orders before broker submission.
- Stop FORCE_TRADE from bypassing terminal risk/no-funded-route/zero-size blocks.
- Add market-data stability guard for Kraken candle fetching.
- Main branch follow-up commit de494bad makes the market-data import guard one-shot and broker-import-only so it no longer logs/applies on every import poll.

Safety intent: risk controls are not weakened. EXECUTE remains reserved for broker-ready, funded, risk-approved orders.