### PR TITLE
Fix live execution context, broker routing, and ACK safety

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -13,13 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAX_BRANCH_AGE_DAYS: "90"
-      BRANCH_NAME_REGEX: "^(feature|fix|copilot|chore|docs|refactor|test|release|hotfix)\\/[a-z0-9._-]+$"
+      BRANCH_NAME_REGEX: "^(feature|fix|copilot|chore|docs|refactor|test|release|hotfix)\/[a-z0-9._-]+$"
     steps:
       - name: Validate branch naming and age
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const branch = context.payload.pull_request?.head?.ref;

--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAX_BRANCH_AGE_DAYS: "90"
-      BRANCH_NAME_REGEX: "^(feature|fix|copilot|chore|docs|refactor|test|release|hotfix)\/[a-z0-9._-]+$"
+      BRANCH_NAME_REGEX: '^(feature|fix|copilot|chore|docs|refactor|test|release|hotfix)/[a-z0-9._-]+$'
     steps:
       - name: Validate branch naming and age
         uses: actions/github-script@v7

--- a/bot/broker_scoped_hardening_repair_patch.py
+++ b/bot/broker_scoped_hardening_repair_patch.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.broker_scoped_hardening_repair")
+_MARKER = "20260709at"
+_HOOK = "_NIJA_BROKER_SCOPED_HARDENING_HOOK_20260709AT"
+_VALIDATE = "_nija_broker_scoped_validation_20260709at"
+_GETTER = "_nija_broker_scoped_getter_20260709at"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default)).strip().lower() in _TRUE
+
+
+def _num(value: Any) -> float:
+    try:
+        result = float(value)
+        return result if result == result else 0.0
+    except Exception:
+        return 0.0
+
+
+def _broker(value: Any) -> str:
+    text = str(getattr(value, "value", value) or "").lower().strip().split(":", 1)[0]
+    compact = text.replace("_", "").replace("-", "").replace(" ", "")
+    for name in ("coinbase", "kraken", "okx", "alpaca", "binance"):
+        if name in compact:
+            return name
+    return text
+
+
+def _authority() -> Any:
+    for name in ("bot.capital_authority", "capital_authority"):
+        try:
+            module = sys.modules.get(name) or __import__(name, fromlist=["*"])
+            getter = getattr(module, "get_capital_authority", None)
+            if callable(getter):
+                return getter()
+        except Exception:
+            pass
+    return None
+
+
+def _registered_count() -> int:
+    authority = _authority()
+    if authority is None:
+        return 0
+    for attr in ("registered_broker_count", "valid_broker_count"):
+        count = int(_num(getattr(authority, attr, 0)))
+        if count:
+            return count
+    return 0
+
+
+def _broker_equity(name: str) -> float:
+    authority = _authority()
+    reader = getattr(authority, "get_per_broker", None) if authority is not None else None
+    if callable(reader):
+        for key in (name, name.upper()):
+            try:
+                value = _num(reader(key))
+                if value > 0:
+                    return value
+            except Exception:
+                pass
+    return 0.0
+
+
+def _position_broker(position: Any) -> str:
+    if not isinstance(position, dict):
+        return ""
+    for key in ("broker", "broker_name", "exchange", "venue", "selected_broker", "execution_broker", "source_broker"):
+        name = _broker(position.get(key))
+        if name:
+            return name
+    source = str(position.get("position_source") or "").lower()
+    for name in ("coinbase", "kraken", "okx", "alpaca", "binance"):
+        if name in source:
+            return name
+    return ""
+
+
+def _scope_positions(positions: Any, broker_name: str) -> list[Any]:
+    raw = list(positions or [])
+    include_unscoped = _truthy("NIJA_POSITION_CAP_INCLUDE_UNSCOPED", "false") or _registered_count() <= 1
+    return [
+        position
+        for position in raw
+        if _position_broker(position) == broker_name
+        or (not _position_broker(position) and include_unscoped)
+    ]
+
+
+def _patch(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionLayerHardening", None)
+    if not isinstance(cls, type):
+        return False
+    changed = False
+    original_validate = getattr(cls, "validate_order_hardening", None)
+    if callable(original_validate) and not getattr(original_validate, _VALIDATE, False):
+        @wraps(original_validate)
+        def validate(self: Any, symbol: str, side: str, position_size_usd: float, balance: float,
+                     current_positions: Any, user_id: Any = None, force_liquidate: bool = False):
+            broker_name = _broker(getattr(self, "broker_type", "")) or "coinbase"
+            raw = list(current_positions or [])
+            scoped = _scope_positions(raw, broker_name)
+            cash = _num(balance)
+            equity = _broker_equity(broker_name)
+            tier_balance = max(cash, equity)
+            result = original_validate(
+                self,
+                symbol=symbol,
+                side=side,
+                position_size_usd=position_size_usd,
+                balance=tier_balance,
+                current_positions=scoped,
+                user_id=user_id,
+                force_liquidate=force_liquidate,
+            )
+            try:
+                passed, reason, details = result
+                if isinstance(details, dict):
+                    details.update({
+                        "broker": broker_name,
+                        "raw_position_count": len(raw),
+                        "scoped_position_count": len(scoped),
+                        "input_cash_balance": cash,
+                        "broker_equity_for_tier": equity,
+                        "effective_tier_balance": tier_balance,
+                    })
+                if len(raw) != len(scoped) or tier_balance != cash:
+                    logger.warning(
+                        "BROKER_SCOPED_HARDENING_APPLIED marker=%s broker=%s positions=%s->%s balance=$%.2f->$%.2f",
+                        _MARKER, broker_name, len(raw), len(scoped), cash, tier_balance,
+                    )
+                return passed, reason, details
+            except Exception:
+                return result
+
+        setattr(validate, _VALIDATE, True)
+        setattr(cls, "validate_order_hardening", validate)
+        changed = True
+
+    original_getter = getattr(module, "get_execution_layer_hardening", None)
+    if callable(original_getter) and not getattr(original_getter, _GETTER, False):
+        instances: dict[tuple[Any, ...], Any] = {}
+        lock = threading.Lock()
+
+        @wraps(original_getter)
+        def getter(broker_type: str = "coinbase", enable_position_cap: bool = True,
+                   enable_minimum_size: bool = True, enable_average_monitor: bool = True,
+                   enable_dust_prevention: bool = True):
+            broker_name = _broker(broker_type) or "coinbase"
+            key = (broker_name, enable_position_cap, enable_minimum_size, enable_average_monitor, enable_dust_prevention)
+            with lock:
+                if key not in instances:
+                    instances[key] = cls(
+                        broker_type=broker_name,
+                        enable_position_cap=enable_position_cap,
+                        enable_minimum_size=enable_minimum_size,
+                        enable_average_monitor=enable_average_monitor,
+                        enable_dust_prevention=enable_dust_prevention,
+                    )
+                module._hardening_instance = instances[key]
+                module._hardening_instances_by_broker = instances
+                return instances[key]
+
+        setattr(getter, _GETTER, True)
+        setattr(module, "get_execution_layer_hardening", getter)
+        changed = True
+    if changed:
+        logger.warning("BROKER_SCOPED_HARDENING_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for name in ("bot.execution_layer_hardening", "execution_layer_hardening"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch(module)
+
+
+def install_import_hook() -> None:
+    os.environ.setdefault("NIJA_POSITION_CAP_INCLUDE_UNSCOPED", "false")
+    _patch_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if "execution_layer_hardening" in str(name):
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+    logger.warning("BROKER_SCOPED_HARDENING_INSTALL_COMPLETE marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/dispatch_scope_bridge_safety_patch.py
+++ b/bot/dispatch_scope_bridge_safety_patch.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.dispatch_scope_bridge_safety")
+_MARKER = "20260709at"
+_HOOK = "_NIJA_DISPATCH_SCOPE_BRIDGE_SAFETY_HOOK_20260709AT"
+_PATCHED = "_nija_dispatch_scope_bridge_safety_20260709at"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _enabled() -> bool:
+    return str(os.environ.get("NIJA_ALLOW_DISPATCH_SCOPE_BRIDGE", "false")).strip().lower() in _TRUE
+
+
+def _patch(module: ModuleType) -> bool:
+    original = getattr(module, "_dispatch_scope_only_block", None)
+    if not callable(original) or getattr(original, _PATCHED, False):
+        return bool(getattr(original, _PATCHED, False))
+
+    @wraps(original)
+    def gated(decision: Any) -> bool:
+        return bool(original(decision)) if _enabled() else False
+
+    setattr(gated, _PATCHED, True)
+    setattr(module, "_dispatch_scope_only_block", gated)
+    logger.warning("DISPATCH_SCOPE_BRIDGE_SAFETY_GATED marker=%s enabled=%s", _MARKER, _enabled())
+    return True
+
+
+def _patch_loaded() -> None:
+    for name in ("bot.dispatch_scope_bridge_patch", "dispatch_scope_bridge_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch(module)
+
+
+def install_import_hook() -> None:
+    os.environ.setdefault("NIJA_ALLOW_DISPATCH_SCOPE_BRIDGE", "false")
+    _patch_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if "dispatch_scope_bridge_patch" in str(name):
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/execution_ack_timeout_failover_patch.py
+++ b/bot/execution_ack_timeout_failover_patch.py
@@ -11,11 +11,6 @@ from typing import Any
 logger = logging.getLogger("nija.execution_ack_timeout_failover")
 _MARKER = "20260709ab"
 _PATCHED_ATTR = "_nija_execution_ack_timeout_failover_20260709ab"
-_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
-
-
-def _truthy(name: str, default: str = "true") -> bool:
-    return str(os.environ.get(name, default)).strip().lower() in _TRUE
 
 
 def _is_ack_timeout_result(result: Any) -> bool:
@@ -23,6 +18,17 @@ def _is_ack_timeout_result(result: Any) -> bool:
         return False
     error = str(getattr(result, "error", "") or "").lower()
     return "ack_timeout" in error or "ack timeout" in error
+
+
+def _mark_uncertain(request: Any) -> None:
+    try:
+        metadata = dict(getattr(request, "metadata", {}) or {})
+        metadata["ack_state"] = "uncertain"
+        metadata["ack_retry_suppressed"] = True
+        metadata["ack_safety_marker"] = _MARKER
+        setattr(request, "metadata", metadata)
+    except Exception:
+        pass
 
 
 def _patch_module(module: ModuleType) -> bool:
@@ -34,75 +40,43 @@ def _patch_module(module: ModuleType) -> bool:
         return bool(getattr(original, _PATCHED_ATTR, False))
 
     @wraps(original)
-    def _dispatch_with_ack_failover(self: Any, request: Any, t_start: float, *args: Any, **kwargs: Any):
+    def _dispatch_with_safe_ack_handling(self: Any, request: Any, t_start: float, *args: Any, **kwargs: Any):
+        # Submit exactly once. An ACK timeout is an unknown broker state, not proof
+        # that the exchange rejected the order. Retrying through another router or
+        # broker can create duplicate live positions.
         result = original(self, request, t_start, *args, **kwargs)
-        if not _truthy("NIJA_ACK_TIMEOUT_SINGLE_ROUTER_FAILOVER", "true"):
-            return result
         if not _is_ack_timeout_result(result):
             return result
 
-        multi_router = getattr(self, "_multi_router", None)
-        single_router = getattr(self, "_router", None)
-        if multi_router is None or single_router is None:
-            logger.warning(
-                "EXECUTION_ACK_TIMEOUT_FAILOVER_UNAVAILABLE marker=%s symbol=%s multi_router=%s single_router=%s error=%s",
-                _MARKER,
-                getattr(request, "symbol", "unknown"),
-                multi_router is not None,
-                single_router is not None,
-                getattr(result, "error", ""),
-            )
-            return result
-
+        _mark_uncertain(request)
+        broker = str(getattr(request, "preferred_broker", "") or getattr(result, "broker", "") or "unknown")
+        intent_id = str(getattr(request, "intent_id", "") or getattr(request, "request_id", "") or "unknown")
         logger.critical(
-            "EXECUTION_ACK_TIMEOUT_FAILOVER_TRIGGERED marker=%s symbol=%s side=%s size_usd=%.2f broker_hint=%s original_error=%s action=temporary_single_router_retry",
+            "EXECUTION_ACK_TIMEOUT_UNCERTAIN_NO_RETRY marker=%s symbol=%s side=%s size_usd=%.2f "
+            "broker=%s intent_id=%s action=do_not_resubmit_reconcile_next_cycle",
             _MARKER,
             getattr(request, "symbol", "unknown"),
             getattr(request, "side", "unknown"),
             float(getattr(request, "size_usd", 0.0) or 0.0),
-            getattr(request, "preferred_broker", "") or "auto",
-            getattr(result, "error", ""),
+            broker,
+            intent_id,
         )
         print(
-            f"[NIJA-PRINT] EXECUTION_ACK_TIMEOUT_FAILOVER_TRIGGERED marker={_MARKER} symbol={getattr(request, 'symbol', 'unknown')} action=single_router_retry",
+            f"[NIJA-PRINT] EXECUTION_ACK_TIMEOUT_UNCERTAIN_NO_RETRY marker={_MARKER} "
+            f"symbol={getattr(request, 'symbol', 'unknown')} broker={broker} intent_id={intent_id}",
             flush=True,
         )
-
         try:
-            setattr(self, "_multi_router", None)
-            retry = original(self, request, t_start, *args, **kwargs)
-        except Exception as exc:
-            logger.warning(
-                "EXECUTION_ACK_TIMEOUT_FAILOVER_EXCEPTION marker=%s symbol=%s err=%s",
-                _MARKER,
-                getattr(request, "symbol", "unknown"),
-                exc,
-            )
-            return result
-        finally:
-            try:
-                setattr(self, "_multi_router", multi_router)
-            except Exception:
-                pass
+            old_error = str(getattr(result, "error", "") or "ack timeout")
+            setattr(result, "error", f"{old_error}; uncertain broker state; retry suppressed")
+        except Exception:
+            pass
+        return result
 
-        logger.critical(
-            "EXECUTION_ACK_TIMEOUT_FAILOVER_RESULT marker=%s symbol=%s success=%s broker=%s error=%s",
-            _MARKER,
-            getattr(request, "symbol", "unknown"),
-            bool(getattr(retry, "success", False)),
-            getattr(retry, "broker", "") or "unknown",
-            getattr(retry, "error", "") or "",
-        )
-        print(
-            f"[NIJA-PRINT] EXECUTION_ACK_TIMEOUT_FAILOVER_RESULT marker={_MARKER} symbol={getattr(request, 'symbol', 'unknown')} success={bool(getattr(retry, 'success', False))}",
-            flush=True,
-        )
-        return retry
-
-    setattr(_dispatch_with_ack_failover, _PATCHED_ATTR, True)
-    setattr(cls, "_dispatch", _dispatch_with_ack_failover)
-    logger.warning("EXECUTION_ACK_TIMEOUT_FAILOVER_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
-    print(f"[NIJA-PRINT] EXECUTION_ACK_TIMEOUT_FAILOVER_PATCHED marker={_MARKER}", flush=True)
+    setattr(_dispatch_with_safe_ack_handling, _PATCHED_ATTR, True)
+    setattr(cls, "_dispatch", _dispatch_with_safe_ack_handling)
+    logger.warning("EXECUTION_ACK_TIMEOUT_SAFE_HANDLING_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
+    print(f"[NIJA-PRINT] EXECUTION_ACK_TIMEOUT_SAFE_HANDLING_PATCHED marker={_MARKER}", flush=True)
     return True
 
 
@@ -113,12 +87,16 @@ def _patch_loaded() -> None:
             try:
                 _patch_module(module)
             except Exception as exc:
-                logger.warning("EXECUTION_ACK_TIMEOUT_FAILOVER_PATCH_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.warning("EXECUTION_ACK_TIMEOUT_SAFE_HANDLING_PATCH_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
 
 
 def install_import_hook() -> None:
+    # Keep the legacy environment variable for compatibility, but force the unsafe
+    # cross-router retry path off. Broker reconciliation must happen before a retry.
+    os.environ["NIJA_ACK_TIMEOUT_SINGLE_ROUTER_FAILOVER"] = "false"
     _patch_loaded()
-    if getattr(builtins, "_NIJA_EXECUTION_ACK_TIMEOUT_FAILOVER_HOOK_20260709AB", False):
+    flag = "_NIJA_EXECUTION_ACK_TIMEOUT_FAILOVER_HOOK_20260709AB"
+    if getattr(builtins, flag, False):
         return
     original_import = builtins.__import__
 
@@ -129,8 +107,8 @@ def install_import_hook() -> None:
         return module
 
     builtins.__import__ = importing
-    setattr(builtins, "_NIJA_EXECUTION_ACK_TIMEOUT_FAILOVER_HOOK_20260709AB", True)
-    logger.warning("EXECUTION_ACK_TIMEOUT_FAILOVER_IMPORT_HOOK marker=%s installed=true", _MARKER)
+    setattr(builtins, flag, True)
+    logger.warning("EXECUTION_ACK_TIMEOUT_SAFE_HANDLING_IMPORT_HOOK marker=%s installed=true", _MARKER)
 
 
 def install() -> None:

--- a/bot/execution_entry_timeout_guard_patch.py
+++ b/bot/execution_entry_timeout_guard_patch.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 import os
-import queue
-import threading
+import sys
 import time
 from functools import wraps
 from types import ModuleType
@@ -40,17 +39,10 @@ def _timeout_s() -> float:
         raw = os.environ.get("NIJA_EXECUTION_ENTRY_TIMEOUT_SECONDS")
         if raw not in (None, ""):
             requested = max(5.0, float(raw or "0"))
-            if requested < floor:
-                logger.warning(
-                    "EXECUTION_ENTRY_TIMEOUT_CLAMPED marker=20260709ae requested_s=%.1f floor_s=%.1f ack_timeout_s=%.1f reason=explicit_env_below_ack_safe_floor",
-                    requested,
-                    floor,
-                    _float_env("NIJA_ACK_TIMEOUT_S", 30.0),
-                )
             return max(requested, floor)
-        return floor
     except Exception:
-        return floor
+        pass
+    return floor
 
 
 def _symbol_from(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
@@ -90,86 +82,97 @@ def _patch_module(module: ModuleType) -> bool:
         if not _truthy("NIJA_EXECUTION_ENTRY_TIMEOUT_GUARD_ENABLED", "true"):
             return original(self, *args, **kwargs)
 
+        # Do not move live execution into a daemon thread. Context variables that
+        # carry dispatch authority are thread-local, and Python cannot safely cancel
+        # a timed-out worker. The former implementation returned while the worker
+        # could still submit an order, creating orphaned and duplicate executions.
         timeout = _timeout_s()
         symbol = _symbol_from(args, kwargs)
         side = _side_from(args, kwargs)
         size = _size_from(args, kwargs)
-        result_queue: "queue.Queue[tuple[str, Any]]" = queue.Queue(maxsize=1)
-
-        def _runner() -> None:
-            try:
-                result_queue.put(("result", original(self, *args, **kwargs)), block=False)
-            except BaseException as exc:  # noqa: BLE001 - must return exceptions across thread boundary
-                try:
-                    result_queue.put(("error", exc), block=False)
-                except Exception:
-                    pass
-
-        worker = threading.Thread(
-            target=_runner,
-            name=f"nija-execute-entry-timeout-{symbol or 'unknown'}",
-            daemon=True,
-        )
-        started = time.time()
-        worker.start()
-        worker.join(timeout)
-
-        if worker.is_alive():
-            logger.critical(
-                "EXECUTION_ENTRY_TIMEOUT_GUARD_TIMEOUT marker=20260709ae symbol=%s side=%s size_usd=%.2f timeout_s=%.1f ack_timeout_s=%.1f action=return_false_loop_continue",
+        started = time.monotonic()
+        try:
+            result = original(self, *args, **kwargs)
+        except BaseException:
+            logger.exception(
+                "EXECUTION_ENTRY_INLINE_EXCEPTION marker=20260709ae symbol=%s side=%s size_usd=%.2f",
                 symbol,
                 side,
                 size,
-                timeout,
-                _float_env("NIJA_ACK_TIMEOUT_S", 30.0),
             )
-            print(
-                f"[NIJA-PRINT] EXECUTION_ENTRY_TIMEOUT_GUARD_TIMEOUT marker=20260709ae symbol={symbol} side={side} size=${size:.2f} timeout_s={timeout:.1f}",
-                flush=True,
-            )
-            return None
+            raise
 
-        try:
-            kind, payload = result_queue.get_nowait()
-        except queue.Empty:
-            logger.warning(
-                "EXECUTION_ENTRY_TIMEOUT_GUARD_EMPTY_RESULT marker=20260709ae symbol=%s side=%s elapsed_ms=%.0f",
+        elapsed = time.monotonic() - started
+        if elapsed > timeout:
+            logger.critical(
+                "EXECUTION_ENTRY_SLOW_COMPLETION marker=20260709ae symbol=%s side=%s size_usd=%.2f "
+                "elapsed_s=%.1f threshold_s=%.1f action=completed_inline_no_orphan_no_retry",
                 symbol,
                 side,
-                (time.time() - started) * 1000,
+                size,
+                elapsed,
+                timeout,
             )
-            return None
-
-        if kind == "error":
-            raise payload
-        return payload
+            print(
+                f"[NIJA-PRINT] EXECUTION_ENTRY_SLOW_COMPLETION marker=20260709ae "
+                f"symbol={symbol} side={side} size=${size:.2f} elapsed_s={elapsed:.1f}",
+                flush=True,
+            )
+        return result
 
     setattr(execute_entry, _WRAP_ATTR, True)
     setattr(cls, "execute_entry", execute_entry)
-    logger.warning("%s class=ExecutionEngine timeout_s=%.1f ack_timeout_s=%.1f", _MARKER, _timeout_s(), _float_env("NIJA_ACK_TIMEOUT_S", 30.0))
-    print("[NIJA-PRINT] EXECUTION_ENTRY_TIMEOUT_GUARD_PATCHED marker=20260709ae", flush=True)
+    logger.warning(
+        "%s class=ExecutionEngine mode=inline_context_preserving threshold_s=%.1f ack_timeout_s=%.1f",
+        _MARKER,
+        _timeout_s(),
+        _float_env("NIJA_ACK_TIMEOUT_S", 30.0),
+    )
+    print("[NIJA-PRINT] EXECUTION_ENTRY_TIMEOUT_GUARD_PATCHED marker=20260709ae mode=inline_context_preserving", flush=True)
     return True
 
 
 def _try_patch_loaded() -> bool:
     patched = False
     for name in ("bot.execution_engine", "execution_engine"):
-        try:
-            import sys
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            try:
                 patched = _patch_module(module) or patched
-        except Exception:
-            continue
+            except Exception:
+                continue
     return patched
+
+
+def _install_context_integrity_repair() -> None:
+    module_names = (
+        "broker_scoped_hardening_repair_patch",
+        "execution_route_context_integrity_patch",
+        "dispatch_scope_bridge_safety_patch",
+    )
+    for short_name in module_names:
+        installed = False
+        for name in (f"bot.{short_name}", short_name):
+            try:
+                module = __import__(name, fromlist=["*"])
+                installer = getattr(module, "install_import_hook", None)
+                if callable(installer):
+                    installer()
+                installed = True
+                break
+            except Exception:
+                continue
+        if not installed:
+            logger.warning(
+                "EXECUTION_CONTEXT_INTEGRITY_REPAIR_IMPORT_FAILED marker=20260709at module=%s",
+                short_name,
+            )
 
 
 def install_import_hook() -> None:
     os.environ.setdefault("NIJA_EXECUTION_ENTRY_TIMEOUT_GUARD_ENABLED", "true")
-    # Do not set NIJA_EXECUTION_ENTRY_TIMEOUT_SECONDS here.  Railway may still
-    # carry an old explicit 25s value; _timeout_s() clamps any explicit value
-    # below the ACK-safe floor instead of trusting it.
     _try_patch_loaded()
+    _install_context_integrity_repair()
     if getattr(builtins, _IMPORT_FLAG, False):
         return
     original_import = builtins.__import__
@@ -185,7 +188,10 @@ def install_import_hook() -> None:
 
     builtins.__import__ = guarded_import
     setattr(builtins, _IMPORT_FLAG, True)
-    logger.warning("EXECUTION_ENTRY_TIMEOUT_GUARD_IMPORT_HOOK marker=20260709ae installed=true timeout_s=%.1f", _timeout_s())
+    logger.warning(
+        "EXECUTION_ENTRY_TIMEOUT_GUARD_IMPORT_HOOK marker=20260709ae installed=true mode=inline_context_preserving threshold_s=%.1f",
+        _timeout_s(),
+    )
 
 
 def install() -> None:

--- a/bot/execution_route_context_integrity_patch.py
+++ b/bot/execution_route_context_integrity_patch.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import uuid
+from dataclasses import is_dataclass, replace
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.execution_route_context_integrity")
+_MARKER = "20260709at"
+_HOOK = "_NIJA_EXECUTION_ROUTE_CONTEXT_HOOK_20260709AT"
+_PATCHED = "_nija_execution_route_context_20260709at"
+
+
+def _broker(value: Any) -> str:
+    text = str(getattr(value, "value", value) or "").lower().strip().split(":", 1)[0]
+    compact = text.replace("_", "").replace("-", "").replace(" ", "")
+    for name in ("coinbase", "kraken", "okx", "alpaca", "binance"):
+        if name in compact:
+            return name
+    return text
+
+
+def _symbol(value: Any) -> str:
+    return str(value or "").strip().upper().replace("/", "-").replace("_", "-").replace(":", "-")
+
+
+def _native_symbol(value: Any, broker_name: str) -> str:
+    symbol = _symbol(value)
+    if "-" not in symbol:
+        return symbol
+    base, quote = symbol.rsplit("-", 1)
+    if broker_name == "okx" and quote == "USD":
+        return f"{base}-USDT"
+    if broker_name in {"coinbase", "kraken"} and quote in {"USDT", "USDC"}:
+        return f"{base}-USD"
+    return symbol
+
+
+def _client_broker(client: Any) -> str:
+    if client is None:
+        return ""
+    for value in (
+        getattr(getattr(client, "broker_type", None), "value", None),
+        getattr(client, "broker_type", None), getattr(client, "broker_name", None),
+        getattr(client, "exchange", None), client.__class__.__name__, client.__class__.__module__,
+    ):
+        name = _broker(value)
+        if name in {"coinbase", "kraken", "okx", "alpaca", "binance"}:
+            return name
+    return ""
+
+
+def _authoritative_broker(request: Any) -> str:
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    route = metadata.get("execution_route")
+    for value in (
+        getattr(route, "selected_broker", None), getattr(request, "preferred_broker", None),
+        metadata.get("preferred_broker"), metadata.get("selected_broker"),
+        metadata.get("execution_broker"), metadata.get("dispatch_broker"), metadata.get("broker_name"),
+    ):
+        name = _broker(value)
+        if name:
+            return name
+    return ""
+
+
+def _replace_request(request: Any, **changes: Any) -> Any:
+    try:
+        if is_dataclass(request):
+            return replace(request, **changes)
+    except Exception:
+        pass
+    for key, value in changes.items():
+        try:
+            setattr(request, key, value)
+        except Exception:
+            pass
+    return request
+
+
+def _resolve_client(pipeline: Any, broker_name: str) -> Any:
+    for module_name in ("bot.final_stage_venue_routing_repair_patch", "final_stage_venue_routing_repair_patch"):
+        try:
+            module = sys.modules.get(module_name) or __import__(module_name, fromlist=["*"])
+            resolver = getattr(module, "_resolve_live_client", None)
+            if callable(resolver):
+                for seed in (getattr(pipeline, "_multi_router", None), getattr(pipeline, "_router", None), pipeline):
+                    client = resolver(seed, broker_name)
+                    if _client_broker(client) == broker_name:
+                        return client
+        except Exception:
+            pass
+    return None
+
+
+def _repair_request(pipeline: Any, request: Any) -> tuple[Any, str]:
+    broker_name = _authoritative_broker(request)
+    if not broker_name:
+        return request, ""
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    old_symbol = _symbol(getattr(request, "symbol", ""))
+    new_symbol = _native_symbol(old_symbol, broker_name)
+    for key in ("preferred_broker", "broker_name", "selected_broker", "execution_broker",
+                "dispatch_broker", "symbol_broker", "balance_broker"):
+        metadata[key] = broker_name
+    route = metadata.get("execution_route")
+    try:
+        metadata["execution_route"] = replace(route, selected_broker=broker_name, symbol=new_symbol)
+    except Exception:
+        pass
+    client = metadata.get("broker_client") or metadata.get("broker_adapter")
+    if _client_broker(client) != broker_name:
+        metadata.pop("broker_client", None)
+        metadata.pop("broker_adapter", None)
+        resolved = _resolve_client(pipeline, broker_name)
+        if resolved is not None:
+            metadata["broker_client"] = resolved
+    request_id = str(getattr(request, "request_id", "") or metadata.get("request_id") or uuid.uuid4())
+    intent_id = str(getattr(request, "intent_id", "") or metadata.get("intent_id") or request_id)
+    metadata.update({"request_id": request_id, "intent_id": intent_id, "route_consistency_marker": _MARKER})
+    repaired = _replace_request(
+        request, symbol=new_symbol, preferred_broker=broker_name,
+        request_id=request_id, intent_id=intent_id, metadata=metadata,
+    )
+    if old_symbol != new_symbol or (_client_broker(client) and _client_broker(client) != broker_name):
+        logger.warning(
+            "EXECUTION_ROUTE_CONTEXT_REPAIRED marker=%s broker=%s symbol=%s->%s client=%s",
+            _MARKER, broker_name, old_symbol, new_symbol, _client_broker(client) or "none",
+        )
+    return repaired, broker_name
+
+
+def _patch(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    result_cls = getattr(module, "PipelineResult", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "_dispatch", None)
+    if not callable(original) or getattr(original, _PATCHED, False):
+        return bool(getattr(original, _PATCHED, False))
+
+    @wraps(original)
+    def dispatch(self: Any, request: Any, t_start: float, *args: Any, **kwargs: Any):
+        request, expected = _repair_request(self, request)
+        intent_id = str(getattr(request, "intent_id", "") or "")
+        key = f"{expected}:{intent_id}" if intent_id else ""
+        lock = getattr(self, "_nija_route_lock", None) or threading.Lock()
+        setattr(self, "_nija_route_lock", lock)
+        inflight = getattr(self, "_nija_route_inflight", None)
+        if inflight is None:
+            inflight = set()
+            setattr(self, "_nija_route_inflight", inflight)
+        if key:
+            with lock:
+                if key in inflight:
+                    message = f"duplicate in-flight dispatch blocked: {key}"
+                    logger.critical("EXECUTION_DUPLICATE_INFLIGHT_BLOCKED marker=%s key=%s", _MARKER, key)
+                    if result_cls is not None:
+                        return result_cls(
+                            success=False, symbol=request.symbol, side=request.side,
+                            size_usd=float(request.size_usd or 0), broker=expected, error=message,
+                        )
+                    return None
+                inflight.add(key)
+        try:
+            result = original(self, request, t_start, *args, **kwargs)
+        finally:
+            if key:
+                with lock:
+                    inflight.discard(key)
+        actual = _broker(getattr(result, "broker", ""))
+        if expected and actual and actual != expected:
+            logger.critical(
+                "EXECUTION_ROUTE_MISMATCH marker=%s expected=%s actual=%s success=%s symbol=%s action=no_retry",
+                _MARKER, expected, actual, bool(getattr(result, "success", False)), request.symbol,
+            )
+            if not bool(getattr(result, "success", False)):
+                try:
+                    result.error = f"route mismatch expected={expected} actual={actual}; {result.error}"
+                except Exception:
+                    pass
+        return result
+
+    setattr(dispatch, _PATCHED, True)
+    setattr(cls, "_dispatch", dispatch)
+    logger.warning("EXECUTION_ROUTE_CONTEXT_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return True
+
+
+def _patch_loaded() -> None:
+    for name in ("bot.execution_pipeline", "execution_pipeline"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch(module)
+
+
+def install_import_hook() -> None:
+    os.environ["NIJA_ACK_TIMEOUT_SINGLE_ROUTER_FAILOVER"] = "false"
+    _patch_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if "execution_pipeline" in str(name):
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+    logger.warning("EXECUTION_ROUTE_CONTEXT_INSTALL_COMPLETE marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/tests/test_broker_scoped_hardening_repair_patch.py
+++ b/bot/tests/test_broker_scoped_hardening_repair_patch.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+from bot import broker_scoped_hardening_repair_patch as patch
+
+
+class FakeHardening:
+    def __init__(self, broker_type="coinbase", **kwargs):
+        self.broker_type = broker_type
+        self.kwargs = kwargs
+
+    def validate_order_hardening(
+        self,
+        symbol,
+        side,
+        position_size_usd,
+        balance,
+        current_positions,
+        user_id=None,
+        force_liquidate=False,
+    ):
+        return True, "ok", {
+            "balance": balance,
+            "positions": list(current_positions),
+        }
+
+
+def test_scopes_positions_and_uses_selected_broker_equity(monkeypatch):
+    authority_module = ModuleType("bot.capital_authority")
+    authority = SimpleNamespace(
+        registered_broker_count=3,
+        get_per_broker=lambda broker: {
+            "coinbase": 71.45,
+            "kraken": 333.40,
+            "okx": 146.27,
+        }.get(str(broker).lower(), 0.0),
+    )
+    authority_module.get_capital_authority = lambda: authority
+    monkeypatch.setitem(sys.modules, "bot.capital_authority", authority_module)
+
+    hardening_module = ModuleType("bot.execution_layer_hardening")
+    hardening_module.ExecutionLayerHardening = FakeHardening
+    hardening_module.get_execution_layer_hardening = (
+        lambda broker_type="coinbase", **kwargs: FakeHardening(broker_type, **kwargs)
+    )
+
+    assert patch._patch(hardening_module) is True
+    kraken = hardening_module.get_execution_layer_hardening("kraken")
+    coinbase = hardening_module.get_execution_layer_hardening("coinbase")
+
+    assert kraken is not coinbase
+    passed, reason, details = kraken.validate_order_hardening(
+        symbol="APT-USD",
+        side="BUY",
+        position_size_usd=27.56,
+        balance=116.09,
+        current_positions=[
+            {"symbol": "ADA-USD", "broker": "kraken"},
+            {"symbol": "ETH-USD", "broker": "kraken"},
+            {"symbol": "SOL-USD", "broker": "coinbase"},
+            {"symbol": "UNKNOWN-USD"},
+        ],
+    )
+
+    assert passed is True
+    assert reason == "ok"
+    assert details["effective_tier_balance"] == 333.40
+    assert details["raw_position_count"] == 4
+    assert details["scoped_position_count"] == 2
+    assert [position["symbol"] for position in details["positions"]] == [
+        "ADA-USD",
+        "ETH-USD",
+    ]

--- a/bot/tests/test_execution_ack_timeout_failover_patch.py
+++ b/bot/tests/test_execution_ack_timeout_failover_patch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 
 from bot import execution_ack_timeout_failover_patch as patch
@@ -9,41 +9,50 @@ from bot import execution_ack_timeout_failover_patch as patch
 @dataclass
 class FakeResult:
     success: bool
-    symbol: str = "ALLO-USD"
+    symbol: str = "ALLO-USDT"
     side: str = "buy"
     size_usd: float = 35.47
-    broker: str = ""
+    broker: str = "okx"
     error: str = ""
+
+
+@dataclass
+class FakeRequest:
+    symbol: str = "ALLO-USDT"
+    side: str = "buy"
+    size_usd: float = 35.47
+    preferred_broker: str = "okx"
+    request_id: str = "request-1"
+    intent_id: str = "intent-1"
+    metadata: dict = field(default_factory=dict)
 
 
 class FakePipeline:
     def __init__(self):
-        self._multi_router = object()
-        self._router = object()
         self.calls = 0
 
     def _dispatch(self, request, t_start):
         self.calls += 1
-        if self._multi_router is not None:
-            return FakeResult(False, error="confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s")
-        return FakeResult(True, broker="single-router")
+        return FakeResult(False, error="confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s")
 
 
-def test_ack_timeout_failover_retries_single_router():
+def test_ack_timeout_is_not_resubmitted_and_is_marked_uncertain():
     module = SimpleNamespace(ExecutionPipeline=FakePipeline, __name__="bot.execution_pipeline")
     assert patch._patch_module(module) is True
     pipeline = module.ExecutionPipeline()
-    request = SimpleNamespace(symbol="ALLO-USD", side="buy", size_usd=35.47, preferred_broker="okx")
+    request = FakeRequest()
 
     result = pipeline._dispatch(request, 0.0)
 
-    assert result.success is True
-    assert result.broker == "single-router"
-    assert pipeline.calls == 2
-    assert pipeline._multi_router is not None
+    assert result.success is False
+    assert pipeline.calls == 1
+    assert result.broker == "okx"
+    assert request.metadata["ack_state"] == "uncertain"
+    assert request.metadata["ack_retry_suppressed"] is True
+    assert "retry suppressed" in result.error
 
 
-def test_ack_timeout_failover_does_not_retry_non_timeout():
+def test_non_timeout_failure_is_returned_without_mutation():
     class NonTimeoutPipeline(FakePipeline):
         def _dispatch(self, request, t_start):
             self.calls += 1
@@ -52,10 +61,11 @@ def test_ack_timeout_failover_does_not_retry_non_timeout():
     module = SimpleNamespace(ExecutionPipeline=NonTimeoutPipeline, __name__="bot.execution_pipeline")
     assert patch._patch_module(module) is True
     pipeline = module.ExecutionPipeline()
-    request = SimpleNamespace(symbol="ALLO-USD", side="buy", size_usd=35.47, preferred_broker="okx")
+    request = FakeRequest()
 
     result = pipeline._dispatch(request, 0.0)
 
     assert result.success is False
     assert result.error == "confirmed_order_rejected:insufficient_funds"
     assert pipeline.calls == 1
+    assert request.metadata == {}

--- a/bot/tests/test_execution_context_and_dispatch_bridge_safety.py
+++ b/bot/tests/test_execution_context_and_dispatch_bridge_safety.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import contextvars
+from types import SimpleNamespace
+
+from bot import dispatch_scope_bridge_safety_patch as bridge_patch
+from bot import execution_entry_timeout_guard_patch as timeout_patch
+
+
+def test_execute_entry_runs_inline_and_preserves_authority_context():
+    authority = contextvars.ContextVar("authority", default="missing")
+
+    class Engine:
+        def execute_entry(self, symbol, side, position_size):
+            return authority.get()
+
+    module = SimpleNamespace(ExecutionEngine=Engine, __name__="bot.execution_engine")
+    assert timeout_patch._patch_module(module) is True
+
+    token = authority.set("dispatch-enabled")
+    try:
+        result = module.ExecutionEngine().execute_entry("APT-USDT", "buy", 27.56)
+    finally:
+        authority.reset(token)
+
+    assert result == "dispatch-enabled"
+
+
+def test_dispatch_scope_bridge_is_disabled_by_default(monkeypatch):
+    module = SimpleNamespace(
+        _dispatch_scope_only_block=lambda decision: True,
+        __name__="bot.dispatch_scope_bridge_patch",
+    )
+    monkeypatch.delenv("NIJA_ALLOW_DISPATCH_SCOPE_BRIDGE", raising=False)
+
+    assert bridge_patch._patch(module) is True
+    assert module._dispatch_scope_only_block(SimpleNamespace()) is False
+
+    monkeypatch.setenv("NIJA_ALLOW_DISPATCH_SCOPE_BRIDGE", "true")
+    assert module._dispatch_scope_only_block(SimpleNamespace()) is True

--- a/bot/tests/test_execution_route_context_integrity_patch.py
+++ b/bot/tests/test_execution_route_context_integrity_patch.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+from bot import execution_route_context_integrity_patch as patch
+
+
+@dataclass(frozen=True)
+class Route:
+    selected_broker: str
+    symbol: str
+
+
+@dataclass
+class Request:
+    symbol: str
+    side: str
+    size_usd: float
+    preferred_broker: str = ""
+    request_id: str = ""
+    intent_id: str = ""
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class Result:
+    success: bool
+    symbol: str
+    side: str
+    size_usd: float
+    broker: str = ""
+    error: str = ""
+
+
+class FakePipeline:
+    def __init__(self):
+        self.seen = None
+
+    def _dispatch(self, request, t_start):
+        self.seen = request
+        return Result(
+            True,
+            request.symbol,
+            request.side,
+            request.size_usd,
+            broker=request.preferred_broker,
+        )
+
+
+def test_preserves_okx_route_and_normalizes_native_symbol():
+    module = SimpleNamespace(
+        ExecutionPipeline=FakePipeline,
+        PipelineResult=Result,
+        __name__="bot.execution_pipeline",
+    )
+    assert patch._patch(module) is True
+
+    pipeline = module.ExecutionPipeline()
+    request = Request(
+        symbol="APT-USD",
+        side="buy",
+        size_usd=27.56,
+        preferred_broker="okx",
+        metadata={
+            "execution_route": Route(selected_broker="okx", symbol="APT-USD"),
+            "broker_name": "coinbase",
+            "broker_client": SimpleNamespace(broker_type="coinbase"),
+        },
+    )
+
+    result = pipeline._dispatch(request, 0.0)
+
+    assert result.success is True
+    assert result.broker == "okx"
+    assert pipeline.seen.symbol == "APT-USDT"
+    assert pipeline.seen.preferred_broker == "okx"
+    assert pipeline.seen.metadata["broker_name"] == "okx"
+    assert pipeline.seen.metadata["selected_broker"] == "okx"
+    assert pipeline.seen.metadata["execution_route"].selected_broker == "okx"
+    assert pipeline.seen.metadata["execution_route"].symbol == "APT-USDT"
+    assert pipeline.seen.request_id
+    assert pipeline.seen.intent_id == pipeline.seen.request_id
+    assert "broker_client" not in pipeline.seen.metadata


### PR DESCRIPTION
## Summary

Repairs the live execution failures shown in the July 10 runtime log:

- preserves execution-authority context by removing orphan daemon timeout workers
- makes ACK timeouts single-submit and marks broker state uncertain instead of resubmitting
- scopes hardening and position counts to the selected broker
- uses selected-broker equity for tier enforcement instead of unrelated available cash
- locks broker and native symbol metadata through final dispatch
- disables the dispatch-scope bridge unless explicitly opted in
- adds focused regression tests for each repair

## Safety invariants

- no automatic retry after an unknown broker ACK state
- no cross-broker position-cap contamination
- no silent broker drift after route selection
- no timeout return while a live worker continues submitting
- no dispatch authorization bridge by default

## Validation

Focused local regression suite: 4 passed.
Python compilation passed for all modified and added runtime modules.