### PR TITLE
Fix missing APEX runtime, Coinbase polling, and OKX patch churn

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -1,0 +1,57 @@
+name: Runtime repair regression tests
+
+on:
+  pull_request:
+    paths:
+      - "bot/bot.py"
+      - "bot/strategy_runtime_integrity_patch.py"
+      - "bot/disconnected_coinbase_balance_guard_patch.py"
+      - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_strategy_runtime_integrity_patch.py"
+      - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
+      - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - ".github/workflows/runtime-repair-regression.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bot/bot.py"
+      - "bot/strategy_runtime_integrity_patch.py"
+      - "bot/disconnected_coinbase_balance_guard_patch.py"
+      - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_strategy_runtime_integrity_patch.py"
+      - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
+      - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - ".github/workflows/runtime-repair-regression.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  focused-runtime-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: python -m pip install --disable-pip-version-check pytest
+
+      - name: Compile repaired runtime modules
+        run: |
+          python -m py_compile \
+            bot/strategy_runtime_integrity_patch.py \
+            bot/disconnected_coinbase_balance_guard_patch.py \
+            bot/okx_patch_churn_guard_patch.py \
+            bot/bot.py
+
+      - name: Run focused regression suite
+        run: |
+          python -m pytest -q \
+            bot/tests/test_strategy_runtime_integrity_patch.py \
+            bot/tests/test_disconnected_coinbase_balance_guard_patch.py \
+            bot/tests/test_okx_patch_churn_guard_patch.py

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -8,6 +8,20 @@ import sys
 logger = logging.getLogger("nija.bot_entrypoint")
 
 try:
+    from bot.okx_patch_churn_guard_patch import install_import_hook as _install_okx_patch_churn_guard
+    _install_okx_patch_churn_guard()
+    logger.warning("OKX_PATCH_CHURN_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
+except Exception as exc:
+    logger.warning("OKX_PATCH_CHURN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+
+try:
+    from bot.disconnected_coinbase_balance_guard_patch import install_import_hook as _install_coinbase_balance_guard
+    _install_coinbase_balance_guard()
+    logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
+except Exception as exc:
+    logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+
+try:
     from bot.live_capital_first_snapshot_latch_patch import install_import_hook as _install_live_capital_first_snapshot_latch
     _install_live_capital_first_snapshot_latch()
     logger.warning("LIVE_CAPITAL_FIRST_SNAPSHOT_LATCH_INSTALL_REQUESTED source=bot_entrypoint")
@@ -34,6 +48,13 @@ try:
     logger.warning("TRADING_ENGINE_STRATEGY_WRAPPER_INSTALL_REQUESTED source=bot_entrypoint")
 except Exception as exc:
     logger.warning("TRADING_ENGINE_STRATEGY_WRAPPER_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+
+try:
+    from bot.strategy_runtime_integrity_patch import install_import_hook as _install_strategy_runtime_integrity
+    _install_strategy_runtime_integrity()
+    logger.warning("STRATEGY_RUNTIME_INTEGRITY_INSTALL_REQUESTED source=bot_entrypoint")
+except Exception as exc:
+    logger.warning("STRATEGY_RUNTIME_INTEGRITY_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
 try:
     from bot.live_entry_scan_adoption_timeout_patch import install_import_hook as _install_scan_adoption_timeout

--- a/bot/disconnected_coinbase_balance_guard_patch.py
+++ b/bot/disconnected_coinbase_balance_guard_patch.py
@@ -14,9 +14,12 @@ _HOOK = "_NIJA_DISCONNECTED_COINBASE_BALANCE_GUARD_HOOK_20260709AV"
 _DETAIL_ATTR = "_nija_disconnected_coinbase_detail_guard_20260709av"
 _PUBLIC_ATTR = "_nija_disconnected_coinbase_public_guard_20260709av"
 _LAST_LOG: dict[int, float] = {}
+_BROKER_MODULES = {"bot.broker_manager", "broker_manager"}
 
 
 def _is_disconnected(instance: Any) -> bool:
+    # This guard is only installed on the concrete CoinbaseBroker implementation,
+    # whose connection contract includes both ``client`` and ``connected``.
     client = getattr(instance, "client", None)
     if client is None:
         return True
@@ -55,9 +58,15 @@ def _log_once(instance: Any, surface: str) -> None:
 
 
 def _patch_class(cls: type) -> bool:
-    changed = False
+    # CoinbaseBrokerAdapter exposes a different balance contract (dict return and
+    # no ``client`` attribute). Requiring the concrete broker's private detailed
+    # reader prevents this patch from ever changing adapter behavior.
     original_detail = getattr(cls, "_get_account_balance_detailed", None)
-    if callable(original_detail) and not getattr(original_detail, _DETAIL_ATTR, False):
+    if not callable(original_detail):
+        return False
+
+    changed = False
+    if not getattr(original_detail, _DETAIL_ATTR, False):
         @wraps(original_detail)
         def _detail(self: Any, *args: Any, **kwargs: Any) -> Any:
             if not _is_disconnected(self):
@@ -97,7 +106,7 @@ def _patch_class(cls: type) -> bool:
 
 def _patch_module(module: ModuleType) -> bool:
     changed = False
-    for name in ("CoinbaseBroker", "CoinbaseAdvancedTradeBroker", "CoinbaseBrokerAdapter"):
+    for name in ("CoinbaseBroker", "CoinbaseAdvancedTradeBroker"):
         cls = getattr(module, name, None)
         if isinstance(cls, type):
             changed = _patch_class(cls) or changed
@@ -108,7 +117,7 @@ def _patch_module(module: ModuleType) -> bool:
 
 def _patch_loaded() -> bool:
     patched = False
-    for name in ("bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"):
+    for name in _BROKER_MODULES:
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
             patched = _patch_module(module) or patched
@@ -123,7 +132,7 @@ def install_import_hook() -> None:
 
     def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
         module = original_import(name, globals, locals, fromlist, level)
-        if str(name) in {"bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"}:
+        if str(name) in _BROKER_MODULES:
             _patch_loaded()
         return module
 

--- a/bot/disconnected_coinbase_balance_guard_patch.py
+++ b/bot/disconnected_coinbase_balance_guard_patch.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.disconnected_coinbase_balance_guard")
+_MARKER = "20260709av"
+_HOOK = "_NIJA_DISCONNECTED_COINBASE_BALANCE_GUARD_HOOK_20260709AV"
+_DETAIL_ATTR = "_nija_disconnected_coinbase_detail_guard_20260709av"
+_PUBLIC_ATTR = "_nija_disconnected_coinbase_public_guard_20260709av"
+_LAST_LOG: dict[int, float] = {}
+
+
+def _is_disconnected(instance: Any) -> bool:
+    client = getattr(instance, "client", None)
+    if client is None:
+        return True
+    connected = getattr(instance, "connected", None)
+    return connected is False
+
+
+def _zero_detail() -> dict[str, Any]:
+    return {
+        "usdc": 0.0,
+        "usd": 0.0,
+        "trading_balance": 0.0,
+        "usd_held": 0.0,
+        "usdc_held": 0.0,
+        "total_held": 0.0,
+        "total_funds": 0.0,
+        "crypto": {},
+        "consumer_usd": 0.0,
+        "consumer_usdc": 0.0,
+    }
+
+
+def _log_once(instance: Any, surface: str) -> None:
+    now = time.monotonic()
+    key = id(instance)
+    if now - _LAST_LOG.get(key, 0.0) < 300.0:
+        return
+    _LAST_LOG[key] = now
+    logger.warning(
+        "COINBASE_BALANCE_DISCONNECTED_SKIPPED marker=%s surface=%s client_present=%s connected=%s",
+        _MARKER,
+        surface,
+        getattr(instance, "client", None) is not None,
+        getattr(instance, "connected", None),
+    )
+
+
+def _patch_class(cls: type) -> bool:
+    changed = False
+    original_detail = getattr(cls, "_get_account_balance_detailed", None)
+    if callable(original_detail) and not getattr(original_detail, _DETAIL_ATTR, False):
+        @wraps(original_detail)
+        def _detail(self: Any, *args: Any, **kwargs: Any) -> Any:
+            if not _is_disconnected(self):
+                return original_detail(self, *args, **kwargs)
+            result = _zero_detail()
+            try:
+                self._balance_cache = result
+                self._balance_cache_time = time.time()
+                self._last_known_balance = 0.0
+            except Exception:
+                pass
+            _log_once(self, "_get_account_balance_detailed")
+            return result
+
+        setattr(_detail, _DETAIL_ATTR, True)
+        setattr(cls, "_get_account_balance_detailed", _detail)
+        changed = True
+
+    original_public = getattr(cls, "get_account_balance", None)
+    if callable(original_public) and not getattr(original_public, _PUBLIC_ATTR, False):
+        @wraps(original_public)
+        def _public(self: Any, *args: Any, **kwargs: Any) -> Any:
+            if not _is_disconnected(self):
+                return original_public(self, *args, **kwargs)
+            try:
+                self._last_known_balance = 0.0
+            except Exception:
+                pass
+            _log_once(self, "get_account_balance")
+            return 0.0
+
+        setattr(_public, _PUBLIC_ATTR, True)
+        setattr(cls, "get_account_balance", _public)
+        changed = True
+    return changed
+
+
+def _patch_module(module: ModuleType) -> bool:
+    changed = False
+    for name in ("CoinbaseBroker", "CoinbaseAdvancedTradeBroker", "CoinbaseBrokerAdapter"):
+        cls = getattr(module, name, None)
+        if isinstance(cls, type):
+            changed = _patch_class(cls) or changed
+    if changed:
+        logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return changed
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    for name in ("bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_module(module) or patched
+    return patched
+
+
+def install_import_hook() -> None:
+    _patch_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if str(name) in {"bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"}:
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+    logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_INSTALL_COMPLETE marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/okx_patch_churn_guard_patch.py
+++ b/bot/okx_patch_churn_guard_patch.py
@@ -5,12 +5,13 @@ import logging
 import sys
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 logger = logging.getLogger("nija.okx_patch_churn_guard")
 _MARKER = "20260709aw"
 _HOOK = "_NIJA_OKX_PATCH_CHURN_GUARD_HOOK_20260709AW"
 _GUARDED = "_nija_okx_patch_churn_guarded_20260709aw"
+_FINAL_MARKER = "_nija_okx_final_order_submission_bridge_order_v20260709d"
 _TARGETS = {
     "bot.broker_manager",
     "broker_manager",
@@ -57,6 +58,16 @@ def _guard_instid_module(module: ModuleType) -> bool:
                 continue
 
             def _make_wrapper(fn: Callable[..., Any], name: str):
+                # The legacy final-order bridge unwraps one layer before replacing a
+                # method. When the current function already guarantees OKX symbol
+                # normalization, persist the instId marker on that retained layer so
+                # the two patches cannot alternate forever.
+                if _has_marker_chain(fn, _FINAL_MARKER):
+                    try:
+                        setattr(fn, marker, True)
+                    except Exception:
+                        pass
+
                 @wraps(fn)
                 def _patched_order(self: Any, symbol: Any, side: Any, quantity: Any, *args: Any, **kwargs: Any) -> Any:
                     before = str(symbol or "")

--- a/bot/okx_patch_churn_guard_patch.py
+++ b/bot/okx_patch_churn_guard_patch.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.okx_patch_churn_guard")
+_MARKER = "20260709aw"
+_HOOK = "_NIJA_OKX_PATCH_CHURN_GUARD_HOOK_20260709AW"
+_GUARDED = "_nija_okx_patch_churn_guarded_20260709aw"
+_TARGETS = {
+    "bot.broker_manager",
+    "broker_manager",
+    "bot.broker_integration",
+    "broker_integration",
+    "bot.multi_account_broker_manager",
+    "multi_account_broker_manager",
+    "bot.multi_broker_execution_router",
+    "multi_broker_execution_router",
+}
+
+
+def _has_marker_chain(fn: Any, marker: str, max_depth: int = 32) -> bool:
+    seen: set[int] = set()
+    current = fn
+    for _ in range(max_depth):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, marker, False)):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
+def _narrow_interesting(name: str) -> bool:
+    lowered = str(name or "").lower()
+    return lowered in _TARGETS or "okx" in lowered
+
+
+def _guard_instid_module(module: ModuleType) -> bool:
+    if getattr(module, _GUARDED, False):
+        return True
+    marker = str(getattr(module, "_ORDER_WRAP_ATTR", ""))
+    normalize = getattr(module, "_normalize_inst_id", None)
+    if not marker or not callable(normalize):
+        return False
+
+    def _wrap_order_class(okx_cls: type, module_name: str) -> bool:
+        patched = False
+        for method_name in ("place_market_order", "execute_order", "place_order"):
+            current = getattr(okx_cls, method_name, None)
+            if not callable(current) or _has_marker_chain(current, marker):
+                continue
+
+            def _make_wrapper(fn: Callable[..., Any], name: str):
+                @wraps(fn)
+                def _patched_order(self: Any, symbol: Any, side: Any, quantity: Any, *args: Any, **kwargs: Any) -> Any:
+                    before = str(symbol or "")
+                    after = normalize(before)
+                    if after != before:
+                        module.logger.critical(
+                            "OKX_ORDER_SYMBOL_NORMALIZED marker=%s method=%s before=%s after=%s",
+                            module._MARKER,
+                            name,
+                            before,
+                            after,
+                        )
+                    return fn(self, after, side, quantity, *args, **kwargs)
+
+                setattr(_patched_order, marker, True)
+                setattr(_patched_order, "__wrapped__", fn)
+                return _patched_order
+
+            setattr(okx_cls, method_name, _make_wrapper(current, method_name))
+            patched = True
+        return patched
+
+    module._wrap_order_class = _wrap_order_class
+    module._interesting_module = _narrow_interesting
+    setattr(module, _GUARDED, True)
+    logger.warning("OKX_PATCH_CHURN_GUARD_APPLIED marker=%s target=instid", _MARKER)
+    return True
+
+
+def _guard_final_module(module: ModuleType) -> bool:
+    if getattr(module, _GUARDED, False):
+        return True
+    marker = str(getattr(module, "_ORDER_WRAP_ATTR", ""))
+    parse = getattr(module, "_parse_order_call", None)
+    normalize = getattr(module, "_normalize_inst_id", None)
+    call_base = getattr(module, "_call_base", None)
+    to_float = getattr(module, "_f", None)
+    if not marker or not all(callable(fn) for fn in (parse, normalize, call_base, to_float)):
+        return False
+
+    def _wrap_order_class(okx_cls: type, module_name: str) -> bool:
+        patched = False
+        for method_name in ("place_market_order", "execute_order", "place_order"):
+            current = getattr(okx_cls, method_name, None)
+            if not callable(current) or _has_marker_chain(current, marker):
+                continue
+
+            def _make_wrapper(fn: Callable[..., Any], name: str):
+                @wraps(fn)
+                def _patched_order(self: Any, *args: Any, **kwargs: Any) -> Any:
+                    symbol, side, quantity, payload, remaining, parsed_kwargs, shape = parse(args, kwargs)
+                    inst_id = normalize(symbol)
+                    order_side = str(side or "").lower().strip()
+                    order_qty = to_float(quantity, 0.0)
+                    if not inst_id or not order_side or order_qty <= 0:
+                        reason = (
+                            f"OKX_CALLSHAPE_BLOCK missing_or_invalid_order_fields method={name} "
+                            f"symbol={symbol!r} side={side!r} quantity={quantity!r} shape={shape}"
+                        )
+                        module.logger.critical("%s marker=%s", reason, module._MARKER)
+                        return {
+                            "status": "error",
+                            "error": reason,
+                            "error_code": "OKX_CALLSHAPE_BLOCK",
+                            "symbol": inst_id,
+                            "side": order_side,
+                            "quantity": quantity,
+                        }
+                    module.logger.critical(
+                        "FINAL_OKX_SUBMIT_CALL marker=%s method=%s symbol=%s side=%s quantity=%s shape=%s",
+                        module._MARKER,
+                        name,
+                        inst_id,
+                        order_side,
+                        order_qty,
+                        shape,
+                    )
+                    return call_base(
+                        fn,
+                        self,
+                        symbol=inst_id,
+                        side=order_side,
+                        quantity=order_qty,
+                        payload=payload,
+                        remaining=remaining,
+                        kwargs=parsed_kwargs,
+                        method_name=name,
+                    )
+
+                setattr(_patched_order, marker, True)
+                setattr(_patched_order, "__wrapped__", fn)
+                return _patched_order
+
+            setattr(okx_cls, method_name, _make_wrapper(current, method_name))
+            try:
+                module._PATCHED_ORDER_CLASSES.add(
+                    f"{getattr(okx_cls, '__module__', '')}.{getattr(okx_cls, '__name__', '')}.{method_name}"
+                )
+            except Exception:
+                pass
+            patched = True
+        return patched
+
+    module._wrap_order_class = _wrap_order_class
+    module._interesting_module = _narrow_interesting
+    setattr(module, _GUARDED, True)
+    logger.warning("OKX_PATCH_CHURN_GUARD_APPLIED marker=%s target=final", _MARKER)
+    return True
+
+
+def _guard_module(name: str, module: ModuleType) -> bool:
+    if name.endswith("okx_order_instid_payload_repair_patch"):
+        return _guard_instid_module(module)
+    if name.endswith("okx_final_order_submission_bridge_patch"):
+        return _guard_final_module(module)
+    return False
+
+
+def _guard_loaded() -> bool:
+    guarded = False
+    for name in (
+        "bot.okx_order_instid_payload_repair_patch",
+        "okx_order_instid_payload_repair_patch",
+        "bot.okx_final_order_submission_bridge_patch",
+        "okx_final_order_submission_bridge_patch",
+    ):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            guarded = _guard_module(name, module) or guarded
+    return guarded
+
+
+def install_import_hook() -> None:
+    _guard_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if str(name).endswith(("okx_order_instid_payload_repair_patch", "okx_final_order_submission_bridge_patch")):
+            _guard_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+    logger.warning("OKX_PATCH_CHURN_GUARD_INSTALL_COMPLETE marker=%s guarded=%s", _MARKER, _guard_loaded())
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/strategy_runtime_integrity_patch.py
+++ b/bot/strategy_runtime_integrity_patch.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import sys
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.strategy_runtime_integrity")
+_MARKER = "20260709au"
+_HOOK = "_NIJA_STRATEGY_RUNTIME_INTEGRITY_HOOK_20260709AU"
+_WRAP_ATTR = "_nija_strategy_runtime_integrity_wrap_20260709au"
+_ENSURE_ATTR = "_nija_strategy_runtime_integrity_ensure_20260709au"
+
+
+def _raw_get(obj: Any, name: str, default: Any = None) -> Any:
+    try:
+        values = object.__getattribute__(obj, "__dict__")
+        if isinstance(values, dict) and name in values:
+            return values.get(name, default)
+    except Exception:
+        pass
+    try:
+        return object.__getattribute__(obj, name)
+    except Exception:
+        return default
+
+
+def _raw_set(obj: Any, name: str, value: Any) -> None:
+    try:
+        object.__setattr__(obj, name, value)
+    except Exception:
+        setattr(obj, name, value)
+
+
+def _is_wired(strategy: Any) -> bool:
+    return _raw_get(strategy, "apex", None) is not None and _raw_get(strategy, "nija_core_loop", None) is not None
+
+
+def _bind_broker(strategy: Any, broker: Any) -> None:
+    _raw_set(strategy, "broker", broker)
+    apex = _raw_get(strategy, "apex", None)
+    if apex is not None:
+        try:
+            update = getattr(apex, "update_broker_client", None)
+            if callable(update):
+                update(broker)
+            else:
+                setattr(apex, "broker_client", broker)
+        except Exception as exc:
+            logger.warning("STRATEGY_RUNTIME_BROKER_BIND_APEX_FAILED marker=%s err=%s", _MARKER, exc)
+    engine = _raw_get(strategy, "execution_engine", None)
+    if engine is None and apex is not None:
+        engine = getattr(apex, "execution_engine", None)
+        if engine is not None:
+            _raw_set(strategy, "execution_engine", engine)
+    if engine is not None:
+        try:
+            setattr(engine, "broker_client", broker)
+        except Exception:
+            pass
+
+
+def _repair_existing(strategy: Any, broker: Any) -> bool:
+    if strategy is None:
+        return False
+    _bind_broker(strategy, broker)
+    if _is_wired(strategy):
+        return True
+
+    ensure = getattr(strategy, "_ensure_nija_wiring", None)
+    if callable(ensure):
+        try:
+            ensure()
+        except Exception as exc:
+            logger.warning("STRATEGY_RUNTIME_EXISTING_ENSURE_FAILED marker=%s err=%s", _MARKER, exc)
+    if _is_wired(strategy):
+        _bind_broker(strategy, broker)
+        return True
+
+    for module_name in ("bot.trading_strategy_apex_wiring_patch", "trading_strategy_apex_wiring_patch"):
+        try:
+            module = importlib.import_module(module_name)
+            hydrate = getattr(module, "_bounded_hydrate_strategy_wiring", None)
+            if callable(hydrate):
+                hydrate(strategy, broker=broker, reason="strategy_runtime_integrity")
+        except Exception as exc:
+            logger.debug("STRATEGY_RUNTIME_HYDRATOR_UNAVAILABLE marker=%s module=%s err=%s", _MARKER, module_name, exc)
+        if _is_wired(strategy):
+            _bind_broker(strategy, broker)
+            return True
+    return False
+
+
+def _patch_module(module: ModuleType) -> bool:
+    original = getattr(module, "_wrap_broker_as_strategy", None)
+    fallback_cls = getattr(module, "_BrokerRuntimeStrategy", None)
+    if not callable(original):
+        return False
+    if getattr(original, _WRAP_ATTR, False):
+        return True
+
+    if isinstance(fallback_cls, type):
+        original_ensure = getattr(fallback_cls, "_ensure_nija_wiring", None)
+        if callable(original_ensure) and not getattr(original_ensure, _ENSURE_ATTR, False):
+            @wraps(original_ensure)
+            def _ensure_runtime(self: Any) -> None:
+                if not _is_wired(self):
+                    wire = getattr(self, "_wire_runtime", None)
+                    if callable(wire):
+                        wire()
+                if not _is_wired(self):
+                    original_ensure(self)
+
+            setattr(_ensure_runtime, _ENSURE_ATTR, True)
+            setattr(fallback_cls, "_ensure_nija_wiring", _ensure_runtime)
+
+    @wraps(original)
+    def _wrap_broker_as_complete_strategy(broker: Any) -> Any:
+        strategy = original(broker)
+        if _repair_existing(strategy, broker):
+            logger.critical(
+                "STRATEGY_RUNTIME_INTEGRITY_READY marker=%s strategy=%s apex=%s core=%s source=primary",
+                _MARKER,
+                type(strategy).__name__,
+                type(_raw_get(strategy, "apex", None)).__name__,
+                type(_raw_get(strategy, "nija_core_loop", None)).__name__,
+            )
+            return strategy
+
+        if isinstance(fallback_cls, type):
+            logger.critical(
+                "STRATEGY_RUNTIME_INTEGRITY_FALLBACK marker=%s primary_strategy=%s reason=incomplete_apex_or_core",
+                _MARKER,
+                type(strategy).__name__ if strategy is not None else "None",
+            )
+            fallback = fallback_cls(broker)
+            if _repair_existing(fallback, broker):
+                logger.critical(
+                    "STRATEGY_RUNTIME_INTEGRITY_READY marker=%s strategy=%s apex=%s core=%s source=fallback",
+                    _MARKER,
+                    type(fallback).__name__,
+                    type(_raw_get(fallback, "apex", None)).__name__,
+                    type(_raw_get(fallback, "nija_core_loop", None)).__name__,
+                )
+                print(
+                    f"[NIJA-PRINT] STRATEGY_RUNTIME_INTEGRITY_READY marker={_MARKER} source=fallback "
+                    f"strategy={type(fallback).__name__}",
+                    flush=True,
+                )
+                return fallback
+
+        raise RuntimeError(
+            "STRATEGY_RUNTIME_INTEGRITY_FAILURE: unable to construct NIJA APEX/CoreLoop runtime; "
+            "refusing to start a live loop that can only emit RUN_CYCLE_BLOCKED_MISSING_REF"
+        )
+
+    setattr(_wrap_broker_as_complete_strategy, _WRAP_ATTR, True)
+    setattr(module, "_wrap_broker_as_strategy", _wrap_broker_as_complete_strategy)
+    logger.warning("STRATEGY_RUNTIME_INTEGRITY_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    for name in ("bot.trading_engine_strategy_wrapper_patch", "trading_engine_strategy_wrapper_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_module(module) or patched
+    return patched
+
+
+def install_import_hook() -> None:
+    _patch_loaded()
+    if getattr(builtins, _HOOK, False):
+        return
+    original_import = builtins.__import__
+
+    def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+        module = original_import(name, globals, locals, fromlist, level)
+        if str(name).endswith("trading_engine_strategy_wrapper_patch"):
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _HOOK, True)
+    logger.warning("STRATEGY_RUNTIME_INTEGRITY_INSTALL_COMPLETE marker=%s patched=%s", _MARKER, _patch_loaded())
+
+
+def install() -> None:
+    install_import_hook()

--- a/bot/tests/test_disconnected_coinbase_balance_guard_patch.py
+++ b/bot/tests/test_disconnected_coinbase_balance_guard_patch.py
@@ -24,6 +24,11 @@ class CoinbaseBroker:
         return 12.5
 
 
+class CoinbaseBrokerAdapter:
+    def get_account_balance(self):
+        return {"USD": 8.0, "USDC": 2.0}
+
+
 def test_disconnected_coinbase_does_not_dereference_missing_client():
     module = SimpleNamespace(__name__="bot.broker_manager", CoinbaseBroker=CoinbaseBroker)
     assert patch._patch_module(module) is True
@@ -49,3 +54,9 @@ def test_connected_coinbase_delegates_to_original_methods():
     assert broker.get_account_balance() == 12.5
     assert broker.detail_calls == 1
     assert broker.public_calls == 1
+
+
+def test_coinbase_adapter_contract_is_not_patched():
+    module = SimpleNamespace(__name__="bot.broker_integration", CoinbaseBrokerAdapter=CoinbaseBrokerAdapter)
+    assert patch._patch_module(module) is False
+    assert module.CoinbaseBrokerAdapter().get_account_balance() == {"USD": 8.0, "USDC": 2.0}

--- a/bot/tests/test_disconnected_coinbase_balance_guard_patch.py
+++ b/bot/tests/test_disconnected_coinbase_balance_guard_patch.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot import disconnected_coinbase_balance_guard_patch as patch
+
+
+class CoinbaseBroker:
+    def __init__(self, *, connected=False, client=None):
+        self.connected = connected
+        self.client = client
+        self.detail_calls = 0
+        self.public_calls = 0
+        self._balance_cache = None
+        self._balance_cache_time = 0.0
+        self._last_known_balance = 99.0
+
+    def _get_account_balance_detailed(self, verbose=False):
+        self.detail_calls += 1
+        return {"trading_balance": 12.5, "total_funds": 12.5}
+
+    def get_account_balance(self):
+        self.public_calls += 1
+        return 12.5
+
+
+def test_disconnected_coinbase_does_not_dereference_missing_client():
+    module = SimpleNamespace(__name__="bot.broker_manager", CoinbaseBroker=CoinbaseBroker)
+    assert patch._patch_module(module) is True
+
+    broker = module.CoinbaseBroker(connected=False, client=None)
+    detail = broker._get_account_balance_detailed()
+
+    assert detail["trading_balance"] == 0.0
+    assert detail["total_funds"] == 0.0
+    assert detail["crypto"] == {}
+    assert broker.get_account_balance() == 0.0
+    assert broker.detail_calls == 0
+    assert broker.public_calls == 0
+    assert broker._last_known_balance == 0.0
+
+
+def test_connected_coinbase_delegates_to_original_methods():
+    module = SimpleNamespace(__name__="bot.broker_manager", CoinbaseBroker=CoinbaseBroker)
+    patch._patch_module(module)
+
+    broker = module.CoinbaseBroker(connected=True, client=object())
+    assert broker._get_account_balance_detailed()["trading_balance"] == 12.5
+    assert broker.get_account_balance() == 12.5
+    assert broker.detail_calls == 1
+    assert broker.public_calls == 1

--- a/bot/tests/test_okx_patch_churn_guard_patch.py
+++ b/bot/tests/test_okx_patch_churn_guard_patch.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from bot import okx_patch_churn_guard_patch as patch
+
+
+def _chain_with_marker(marker: str):
+    def base(self, symbol, side, quantity):
+        return symbol, side, quantity
+
+    def own(self, symbol, side, quantity):
+        return base(self, symbol, side, quantity)
+
+    setattr(own, marker, True)
+    own.__wrapped__ = base
+
+    def foreign(self, symbol, side, quantity):
+        return own(self, symbol, side, quantity)
+
+    foreign.__wrapped__ = own
+    return foreign
+
+
+def test_marker_is_found_below_another_wrapper():
+    marker = "_nija_test_marker"
+    wrapped = _chain_with_marker(marker)
+    assert patch._has_marker_chain(wrapped, marker) is True
+
+
+def test_instid_patch_does_not_rewrap_when_marker_exists_in_chain():
+    marker = "_nija_instid_marker"
+
+    class OKXBroker:
+        place_market_order = _chain_with_marker(marker)
+
+    module = SimpleNamespace(
+        __name__="bot.okx_order_instid_payload_repair_patch",
+        _ORDER_WRAP_ATTR=marker,
+        _MARKER="test",
+        _normalize_inst_id=lambda value: str(value).replace("-USD", "-USDT"),
+        logger=logging.getLogger("test.okx.instid"),
+    )
+
+    assert patch._guard_instid_module(module) is True
+    before = OKXBroker.place_market_order
+    assert module._wrap_order_class(OKXBroker, "bot.broker_manager") is False
+    assert OKXBroker.place_market_order is before
+
+
+def test_unmarked_method_is_wrapped_only_once():
+    marker = "_nija_instid_once"
+
+    class OKXBroker:
+        def place_market_order(self, symbol, side, quantity):
+            return symbol, side, quantity
+
+    module = SimpleNamespace(
+        __name__="bot.okx_order_instid_payload_repair_patch",
+        _ORDER_WRAP_ATTR=marker,
+        _MARKER="test",
+        _normalize_inst_id=lambda value: str(value).replace("-USD", "-USDT"),
+        logger=logging.getLogger("test.okx.once"),
+    )
+
+    patch._guard_instid_module(module)
+    assert module._wrap_order_class(OKXBroker, "bot.broker_manager") is True
+    first = OKXBroker.place_market_order
+    assert module._wrap_order_class(OKXBroker, "bot.broker_manager") is False
+    assert OKXBroker.place_market_order is first
+    assert OKXBroker().place_market_order("APT-USD", "buy", 10) == ("APT-USDT", "buy", 10)
+
+
+def test_generic_broker_module_names_no_longer_trigger_full_rescan():
+    assert patch._narrow_interesting("bot.broker_manager") is True
+    assert patch._narrow_interesting("bot.some_unrelated_broker_helper") is False
+    assert patch._narrow_interesting("bot.okx_client") is True

--- a/bot/tests/test_strategy_runtime_integrity_patch.py
+++ b/bot/tests/test_strategy_runtime_integrity_patch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot import strategy_runtime_integrity_patch as patch
+
+
+class Broker:
+    connected = True
+
+
+class BrokenStrategy:
+    def __init__(self):
+        self.broker = None
+        self.apex = None
+        self.nija_core_loop = None
+        self.execution_engine = None
+
+    def _ensure_nija_wiring(self):
+        return None
+
+
+class Apex:
+    def __init__(self):
+        self.broker_client = None
+        self.execution_engine = SimpleNamespace(broker_client=None)
+
+    def update_broker_client(self, broker):
+        self.broker_client = broker
+
+
+class FallbackStrategy:
+    def __init__(self, broker):
+        self.broker = broker
+        self.apex = Apex()
+        self.nija_core_loop = SimpleNamespace(apex=self.apex)
+        self.execution_engine = self.apex.execution_engine
+
+    def _ensure_nija_wiring(self):
+        return None
+
+
+def test_incomplete_primary_strategy_is_replaced_by_wired_fallback(monkeypatch):
+    module = SimpleNamespace(
+        __name__="bot.trading_engine_strategy_wrapper_patch",
+        _BrokerRuntimeStrategy=FallbackStrategy,
+        _wrap_broker_as_strategy=lambda broker: BrokenStrategy(),
+    )
+    monkeypatch.setattr(patch.importlib, "import_module", lambda name: (_ for _ in ()).throw(ImportError(name)))
+
+    assert patch._patch_module(module) is True
+    broker = Broker()
+    strategy = module._wrap_broker_as_strategy(broker)
+
+    assert isinstance(strategy, FallbackStrategy)
+    assert strategy.broker is broker
+    assert strategy.apex is not None
+    assert strategy.nija_core_loop is not None
+    assert strategy.apex.broker_client is broker
+    assert strategy.execution_engine.broker_client is broker
+
+
+def test_wired_primary_strategy_is_preserved():
+    broker = Broker()
+    primary = FallbackStrategy(broker)
+    module = SimpleNamespace(
+        __name__="bot.trading_engine_strategy_wrapper_patch",
+        _BrokerRuntimeStrategy=FallbackStrategy,
+        _wrap_broker_as_strategy=lambda supplied: primary,
+    )
+
+    assert patch._patch_module(module) is True
+    assert module._wrap_broker_as_strategy(broker) is primary


### PR DESCRIPTION
## Summary

Repairs the active blockers shown in the post-deployment Railway log:

- refuses to start the trading loop with an incomplete strategy runtime
- hydrates or replaces a `TradingStrategy` whose `apex` or `nija_core_loop` is missing
- skips Coinbase balance API calls when the Coinbase client is absent/disconnected
- prevents the OKX submission and instId patches from repeatedly wrapping each other
- narrows OKX import-hook scans so unrelated broker imports do not trigger full rescans
- adds focused regression coverage for all three failure modes

## Runtime effects

- eliminates `RUN_CYCLE_BLOCKED_MISSING_REF reason=apex_is_None`
- stops `NoneType.get_accounts` Coinbase tracebacks
- stops repeated `OKX_FINAL_ORDER_METHOD_PATCHED` / `OKX_ORDER_SYMBOL_METHOD_PATCHED` log floods
- preserves all existing execution authority, risk, ECEL, and broker submission gates

## Validation

- dedicated Runtime repair regression workflow: passed
- repaired-module compilation: passed
- focused pytest suite: passed
- branch policy: passed
- preflight/lint: passed
- remaining import, image, and security workflows are running on the final head