### PR TITLE
Fix live-capital startup convergence and repeated patch noise

### DIFF
--- a/bot/post_lock_capital_refresh_patch.py
+++ b/bot/post_lock_capital_refresh_patch.py
@@ -1,20 +1,151 @@
-"""Post-lock capital refresh hook.
+"""Post-lock readiness, live-capital convergence, and startup log hardening.
 
-Imported by ``bot.__init__``.  It records startup readiness from real successful
-runtime events so the readiness table is not dependent on a timer path.
+This module is imported early by ``bot.__init__``. It never enables live trading
+by itself. ``LIVE_CAPITAL_VERIFIED`` remains an explicit operator-controlled
+master switch. The patch only:
+
+* normalizes an explicitly configured boolean value (including quoted Railway
+  values such as ``\"true\"``);
+* observes real, positive, fresh broker-backed capital and then asks the normal
+  runtime-authority convergence path to re-evaluate;
+* installs the final execution contract before the long startup patch chain;
+* marks readiness from successful runtime events; and
+* suppresses duplicate patch-install chatter without hiding execution failures.
 """
 
 from __future__ import annotations
 
 import builtins
+import importlib
 import logging
+import os
 import sys
+import threading
+import time
+from collections.abc import Mapping
 from functools import wraps
 from typing import Any
 
 logger = logging.getLogger("nija.post_lock_capital_refresh")
 _INSTALLED = False
 _PATCHED = "__nija_post_lock_capital_refresh_patch__"
+_MONITOR_STARTED = False
+_MONITOR_LOCK = threading.Lock()
+_CONVERGENCE_LOCK = threading.Lock()
+_LAST_CONVERGENCE_SIGNATURE = ""
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_FALSE = {"0", "false", "no", "off", "disabled", "n"}
+
+
+class _PatchNoiseFilter(logging.Filter):
+    """Throttle repeated installation markers while preserving the first event."""
+
+    _MARKERS = (
+        "SPENDABLE_QUOTE_ROUTING_PATCHED",
+        "LIVE_ENTRY_FIXES_RUN_SCAN_WIRED",
+        "LIVE_ENTRY_FIXES_PHASE3_WIRED",
+        "TRADING_STATE_DISPATCH_LATCH_REPAIR_PATCHED",
+        "LIVE_ACTIVE_EXECUTION_GATE_FINAL_PATCHED",
+        "EXCHANGE_ORDER_COMPILER_KRAKEN_ENTRY_TARGET_PATCHED",
+        "POSITION_SIZER_KRAKEN_ENTRY_TARGET_PATCHED",
+        "ECEL_KRAKEN_ENTRY_TARGET_PATCHED",
+    )
+    _lock = threading.Lock()
+    _last_seen: dict[str, float] = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        marker = next((token for token in self._MARKERS if token in message), "")
+        if not marker:
+            return True
+        now = time.monotonic()
+        interval = max(5.0, _float_env("NIJA_PATCH_INSTALL_LOG_THROTTLE_S", 60.0))
+        with self._lock:
+            previous = self._last_seen.get(marker, 0.0)
+            if now - previous < interval:
+                return False
+            self._last_seen[marker] = now
+        return True
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except Exception:
+        return default
+
+
+def _clean_env_value(value: Any) -> str:
+    text = str(value or "").strip().lstrip("\ufeff")
+    while len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        text = text[1:-1].strip()
+    return text.strip().lower()
+
+
+def _truthy_env(name: str) -> bool:
+    return _clean_env_value(os.environ.get(name, "")) in _TRUE
+
+
+def _normalize_explicit_boolean(name: str) -> tuple[bool, str, str]:
+    """Normalize a present boolean variable without creating or enabling it."""
+
+    if name not in os.environ:
+        return False, "missing", ""
+    raw = str(os.environ.get(name, ""))
+    cleaned = _clean_env_value(raw)
+    if cleaned in _TRUE:
+        canonical = "true"
+    elif cleaned in _FALSE:
+        canonical = "false"
+    else:
+        return False, "invalid", cleaned
+    changed = raw != canonical
+    os.environ[name] = canonical
+    return changed, canonical, cleaned
+
+
+def _normalize_explicit_controls() -> None:
+    statuses: list[str] = []
+    for name in (
+        "LIVE_CAPITAL_VERIFIED",
+        "DRY_RUN_MODE",
+        "PAPER_MODE",
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY",
+    ):
+        changed, state, _cleaned = _normalize_explicit_boolean(name)
+        statuses.append(f"{name}={state}{':normalized' if changed else ''}")
+    logger.warning("LIVE_CONTROL_ENV_STATUS %s", " ".join(statuses))
+    if not _truthy_env("LIVE_CAPITAL_VERIFIED"):
+        logger.warning(
+            "LIVE_CAPITAL_OPERATOR_SWITCH_OFF trading_disabled=true "
+            "action=set LIVE_CAPITAL_VERIFIED=true in Railway only after intentional approval"
+        )
+
+
+def _install_noise_filter() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if getattr(handler, "_nija_patch_noise_filter_20260710b", False):
+            continue
+        handler.addFilter(_PatchNoiseFilter())
+        setattr(handler, "_nija_patch_noise_filter_20260710b", True)
+    logger.warning(
+        "PATCH_INSTALL_LOG_THROTTLE_ENABLED interval_s=%.1f",
+        _float_env("NIJA_PATCH_INSTALL_LOG_THROTTLE_S", 60.0),
+    )
+
+
+def _install_final_execution_contract() -> None:
+    """Install the immutable execution contract before later patch modules load."""
+
+    try:
+        module = importlib.import_module("bot.execution_pipeline_runtime_patch")
+        installer = getattr(module, "install_import_hook", None)
+        if callable(installer):
+            installer()
+        logger.warning("FINAL_EXECUTION_CONTRACT_EARLY_INSTALL_CONFIRMED marker=20260710a")
+    except Exception as exc:
+        logger.warning("FINAL_EXECUTION_CONTRACT_EARLY_INSTALL_FAILED err=%s", exc)
 
 
 def _mark(component: str, reason: str) -> None:
@@ -56,8 +187,147 @@ def _maybe_mark_bootstrap(reason: str) -> None:
         "execution_ready",
         "nonce_ready",
     )
-    if all(table.get(k) is True for k in required):
+    if all(table.get(key) is True for key in required):
         _mark("bootstrap_ready", reason)
+
+
+def _number(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+        return result if result == result else default
+    except Exception:
+        return default
+
+
+def _capital_result(result: Any) -> dict[str, Any]:
+    if isinstance(result, Mapping):
+        return dict(result)
+    out: dict[str, Any] = {}
+    for name in (
+        "ready",
+        "total_capital",
+        "real_capital",
+        "valid_brokers",
+        "broker_count",
+        "kraken_capital",
+        "snapshot_source",
+        "bootstrap_seed",
+    ):
+        try:
+            value = getattr(result, name)
+        except Exception:
+            continue
+        out[name] = value
+    return out
+
+
+def _capital_authority_proof() -> tuple[bool, str]:
+    try:
+        from bot.capital_authority import get_capital_authority, get_capital_system_gate
+
+        authority = get_capital_authority()
+        hydrated = bool(getattr(authority, "is_hydrated", False))
+        real = _number(getattr(authority, "real_capital", 0.0))
+        getter = getattr(authority, "get_real_capital", None)
+        if callable(getter):
+            real = max(real, _number(getter()))
+        fresh = True
+        fresh_getter = getattr(authority, "is_fresh", None)
+        if callable(fresh_getter):
+            try:
+                fresh = bool(fresh_getter(ttl_s=180.0))
+            except TypeError:
+                fresh = bool(fresh_getter())
+        gate = get_capital_system_gate()
+        gate_ready = bool(gate.is_set())
+        ok = hydrated and real > 0.0 and fresh and gate_ready
+        return ok, f"hydrated={hydrated} real={real:.2f} fresh={fresh} capital_gate={gate_ready}"
+    except Exception as exc:
+        return False, f"capital_authority_probe_failed:{exc}"
+
+
+def _request_safe_convergence(source: str, result: Any = None) -> bool:
+    """Re-evaluate normal authority gates after verified capital becomes ready."""
+
+    global _LAST_CONVERGENCE_SIGNATURE
+    if not _truthy_env("LIVE_CAPITAL_VERIFIED"):
+        return False
+    if _truthy_env("DRY_RUN_MODE") or _truthy_env("PAPER_MODE"):
+        return False
+
+    payload = _capital_result(result)
+    if payload:
+        ready = bool(_number(payload.get("ready")))
+        total = max(_number(payload.get("total_capital")), _number(payload.get("real_capital")))
+        valid = max(
+            int(_number(payload.get("valid_brokers"))),
+            int(_number(payload.get("broker_count"))),
+        )
+        source_name = str(payload.get("snapshot_source") or "").strip().lower()
+        bootstrap_seed = bool(_number(payload.get("bootstrap_seed")))
+        live_source = source_name == "live_exchange" or bootstrap_seed
+        if not (ready and total > 0.0 and valid > 0 and live_source):
+            return False
+    else:
+        total = 0.0
+        valid = 0
+        source_name = "capital_system_gate"
+
+    proof_ok, proof = _capital_authority_proof()
+    if not proof_ok:
+        logger.info("POST_LOCK_CAPITAL_CONVERGENCE_WAITING source=%s proof=%s", source, proof)
+        return False
+
+    signature = f"{source}:{source_name}:{total:.2f}:{valid}:{proof}"
+    with _CONVERGENCE_LOCK:
+        if signature == _LAST_CONVERGENCE_SIGNATURE:
+            return False
+        _LAST_CONVERGENCE_SIGNATURE = signature
+
+    _mark_many(("broker_connected", "balance_hydrated", "capital_ready"), signature)
+    converged = False
+    try:
+        module = importlib.import_module("bot.runtime_authority_convergence_repair_patch")
+        converge = getattr(module, "converge_runtime_authority", None)
+        if callable(converge):
+            converged = bool(converge(f"post_lock_capital:{source}"))
+    except Exception as exc:
+        logger.warning("POST_LOCK_CAPITAL_CONVERGENCE_CALL_FAILED source=%s err=%s", source, exc)
+    logger.critical(
+        "POST_LOCK_LIVE_CAPITAL_VERIFIED source=%s snapshot_source=%s total=%.2f "
+        "valid_brokers=%d proof=%s convergence_triggered=%s",
+        source,
+        source_name,
+        total,
+        valid,
+        proof,
+        converged,
+    )
+    return True
+
+
+def _start_capital_gate_monitor() -> None:
+    global _MONITOR_STARTED
+    with _MONITOR_LOCK:
+        if _MONITOR_STARTED:
+            return
+        _MONITOR_STARTED = True
+
+    def _monitor() -> None:
+        if not _truthy_env("LIVE_CAPITAL_VERIFIED"):
+            return
+        timeout_s = max(30.0, _float_env("NIJA_POST_LOCK_CAPITAL_MONITOR_SECONDS", 300.0))
+        try:
+            from bot.capital_authority import get_capital_system_gate
+
+            if not get_capital_system_gate().wait(timeout=timeout_s):
+                logger.warning("POST_LOCK_CAPITAL_GATE_MONITOR_TIMEOUT timeout_s=%.1f", timeout_s)
+                return
+            _request_safe_convergence("capital_system_gate")
+        except Exception as exc:
+            logger.warning("POST_LOCK_CAPITAL_GATE_MONITOR_FAILED err=%s", exc)
+
+    threading.Thread(target=_monitor, name="post-lock-capital-gate-monitor", daemon=True).start()
 
 
 def _patch_nonce_module(module: Any) -> None:
@@ -72,6 +342,7 @@ def _patch_nonce_module(module: Any) -> None:
     def wrapper(self: Any, api_key_id: str, *args: Any, **kwargs: Any):
         result = original(self, api_key_id, *args, **kwargs)
         _mark_many(("authority_ready", "nonce_ready"), f"writer_lock:{api_key_id}")
+        _request_safe_convergence("writer_lock")
         return result
 
     setattr(wrapper, _PATCHED, True)
@@ -90,15 +361,19 @@ def _patch_mabm_module(module: Any) -> None:
     @wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any):
         result = original(self, *args, **kwargs)
-        if isinstance(result, dict):
-            ready = bool(float(result.get("ready", 0.0) or 0.0))
-            total = float(result.get("total_capital", 0.0) or 0.0)
-            valid = int(float(result.get("valid_brokers", 0.0) or 0.0))
-            if ready and total > 0.0 and valid > 0:
-                _mark_many(
-                    ("broker_connected", "balance_hydrated", "capital_ready"),
-                    f"capital_refresh:total={total:.2f}:brokers={valid}",
-                )
+        payload = _capital_result(result)
+        ready = bool(_number(payload.get("ready")))
+        total = max(_number(payload.get("total_capital")), _number(payload.get("real_capital")))
+        valid = max(
+            int(_number(payload.get("valid_brokers"))),
+            int(_number(payload.get("broker_count"))),
+        )
+        if ready and total > 0.0 and valid > 0:
+            _mark_many(
+                ("broker_connected", "balance_hydrated", "capital_ready"),
+                f"capital_refresh:total={total:.2f}:brokers={valid}",
+            )
+            _request_safe_convergence("refresh_capital_authority", result)
         return result
 
     setattr(wrapper, _PATCHED, True)
@@ -111,11 +386,13 @@ def _patch_strategy_module(module: Any) -> None:
     if isinstance(cls, type):
         original = getattr(cls, "__init__", None)
         if callable(original) and not getattr(original, _PATCHED, False):
+
             @wraps(original)
             def wrapper(self: Any, *args: Any, **kwargs: Any):
                 result = original(self, *args, **kwargs)
                 _mark_many(("risk_ready", "strategy_ready"), "TradingStrategy.__init__")
                 return result
+
             setattr(wrapper, _PATCHED, True)
             setattr(cls, "__init__", wrapper)
             logger.warning("POST_LOCK_CAPITAL_REFRESH_PATCHED TradingStrategy.__init__")
@@ -139,6 +416,9 @@ def install_import_hook() -> None:
     if _INSTALLED:
         return
     _INSTALLED = True
+    _normalize_explicit_controls()
+    _install_noise_filter()
+    _install_final_execution_contract()
     for module in list(sys.modules.values()):
         try:
             _patch_module(module)
@@ -156,4 +436,5 @@ def install_import_hook() -> None:
         return module
 
     builtins.__import__ = guarded_import
-    logger.warning("POST_LOCK_CAPITAL_REFRESH_INSTALL_COMPLETE")
+    _start_capital_gate_monitor()
+    logger.warning("POST_LOCK_CAPITAL_REFRESH_INSTALL_COMPLETE marker=20260710b")

--- a/bot/tests/test_post_lock_capital_refresh_patch.py
+++ b/bot/tests/test_post_lock_capital_refresh_patch.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "post_lock_capital_refresh_patch.py"
+
+
+def _load_patch(name: str = "test_post_lock_capital_refresh_patch_module"):
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_explicit_quoted_true_is_normalized_without_enabling_missing_switches(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    patch = _load_patch("post_lock_normalization")
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", ' "TRUE" ')
+    monkeypatch.delenv("DRY_RUN_MODE", raising=False)
+
+    changed, state, _ = patch._normalize_explicit_boolean("LIVE_CAPITAL_VERIFIED")
+    missing_changed, missing_state, _ = patch._normalize_explicit_boolean("DRY_RUN_MODE")
+
+    assert changed is True
+    assert state == "true"
+    assert os.environ["LIVE_CAPITAL_VERIFIED"] == "true"
+    assert missing_changed is False
+    assert missing_state == "missing"
+    assert "DRY_RUN_MODE" not in os.environ
+
+
+def test_invalid_live_switch_remains_fail_closed(monkeypatch: pytest.MonkeyPatch):
+    patch = _load_patch("post_lock_invalid")
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "maybe")
+
+    changed, state, cleaned = patch._normalize_explicit_boolean("LIVE_CAPITAL_VERIFIED")
+
+    assert changed is False
+    assert state == "invalid"
+    assert cleaned == "maybe"
+    assert os.environ["LIVE_CAPITAL_VERIFIED"] == "maybe"
+    assert patch._truthy_env("LIVE_CAPITAL_VERIFIED") is False
+
+
+def test_capital_result_accepts_object_and_mapping_shapes():
+    patch = _load_patch("post_lock_capital_result")
+
+    class Snapshot:
+        ready = 1
+        total_capital = 125.50
+        valid_brokers = 2
+        snapshot_source = "live_exchange"
+
+    object_result = patch._capital_result(Snapshot())
+    mapping_result = patch._capital_result(
+        {"ready": 1.0, "total_capital": 88.0, "valid_brokers": 1}
+    )
+
+    assert object_result["total_capital"] == 125.50
+    assert object_result["valid_brokers"] == 2
+    assert object_result["snapshot_source"] == "live_exchange"
+    assert mapping_result["total_capital"] == 88.0
+
+
+def test_patch_noise_filter_keeps_first_and_suppresses_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    patch = _load_patch("post_lock_noise")
+    monkeypatch.setenv("NIJA_PATCH_INSTALL_LOG_THROTTLE_S", "60")
+    patch._PatchNoiseFilter._last_seen.clear()
+    filter_ = patch._PatchNoiseFilter()
+    first = logging.LogRecord(
+        "one",
+        logging.WARNING,
+        __file__,
+        1,
+        "SPENDABLE_QUOTE_ROUTING_PATCHED marker=20260706a",
+        (),
+        None,
+    )
+    second = logging.LogRecord(
+        "two",
+        logging.WARNING,
+        __file__,
+        2,
+        "SPENDABLE_QUOTE_ROUTING_PATCHED marker=20260706a",
+        (),
+        None,
+    )
+
+    assert filter_.filter(first) is True
+    assert filter_.filter(second) is False
+
+
+def test_verified_live_capital_requests_existing_safe_convergence(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    patch = _load_patch("post_lock_convergence")
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+
+    class CapitalAuthority:
+        is_hydrated = True
+        real_capital = 125.50
+
+        def get_real_capital(self):
+            return self.real_capital
+
+        def is_fresh(self, ttl_s=180.0):
+            return True
+
+    gate = threading.Event()
+    gate.set()
+    capital_module = types.ModuleType("bot.capital_authority")
+    capital_module.get_capital_authority = lambda: CapitalAuthority()
+    capital_module.get_capital_system_gate = lambda: gate
+    runtime_module = types.ModuleType("bot.runtime_authority_convergence_repair_patch")
+    calls: list[str] = []
+    runtime_module.converge_runtime_authority = lambda source: calls.append(source) or True
+    bot_module = types.ModuleType("bot")
+    bot_module.__path__ = []
+
+    monkeypatch.setitem(sys.modules, "bot", bot_module)
+    monkeypatch.setitem(sys.modules, "bot.capital_authority", capital_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.runtime_authority_convergence_repair_patch",
+        runtime_module,
+    )
+    original_import_module = patch.importlib.import_module
+
+    def fake_import(name: str, package=None):
+        if name == "bot.runtime_authority_convergence_repair_patch":
+            return runtime_module
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(patch.importlib, "import_module", fake_import)
+    result = {
+        "ready": 1.0,
+        "total_capital": 125.50,
+        "valid_brokers": 2,
+        "snapshot_source": "live_exchange",
+    }
+
+    assert patch._request_safe_convergence("test", result) is True
+    assert calls == ["post_lock_capital:test"]
+
+
+def test_convergence_never_enables_operator_switch(monkeypatch: pytest.MonkeyPatch):
+    patch = _load_patch("post_lock_switch_off")
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "false")
+    result = {
+        "ready": 1.0,
+        "total_capital": 125.50,
+        "valid_brokers": 2,
+        "snapshot_source": "live_exchange",
+    }
+
+    assert patch._request_safe_convergence("test", result) is False
+    assert os.environ["LIVE_CAPITAL_VERIFIED"] == "false"
+
+
+def test_placeholder_or_dedup_snapshot_cannot_trigger_convergence(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    patch = _load_patch("post_lock_placeholder")
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setattr(patch, "_capital_authority_proof", lambda: (True, "proof"))
+
+    assert patch._request_safe_convergence(
+        "placeholder",
+        {
+            "ready": 1.0,
+            "total_capital": 125.50,
+            "valid_brokers": 2,
+            "snapshot_source": "placeholder",
+        },
+    ) is False
+    assert patch._request_safe_convergence(
+        "dedup",
+        {
+            "ready": 1.0,
+            "total_capital": 0.0,
+            "valid_brokers": 2,
+            "dedup": 1.0,
+        },
+    ) is False


### PR DESCRIPTION
## Summary

This repair addresses the remaining startup behavior shown in the July 10 Railway log without weakening NIJA's real-money safety controls.

### Fixes

- Preserves `LIVE_CAPITAL_VERIFIED` as an explicit operator-controlled master kill switch.
- Normalizes explicitly configured quoted/BOM/whitespace boolean values such as `"true"` into canonical values so Railway formatting cannot create a false `live_capital_not_verified` state.
- Never creates or automatically enables a missing/false/invalid live-capital switch.
- Accepts both mapping and object-shaped CapitalAuthority refresh results.
- Requires a ready, positive, broker-backed `live_exchange`/bootstrap-seed snapshot plus hydrated, fresh CapitalAuthority state and the capital-system gate before requesting convergence.
- Calls the existing fail-closed runtime-authority convergence path after verified capital becomes ready; writer, heartbeat, nonce, kill-switch, and bootstrap gates remain authoritative.
- Installs the final immutable execution contract earlier in startup and emits `FINAL_EXECUTION_CONTRACT_EARLY_INSTALL_CONFIRMED marker=20260710a`.
- Adds startup diagnostics that clearly distinguish an operator switch being off from broker-capital hydration still being pending.
- Throttles repeated patch-install messages for spendable routing, live-entry wiring, trading-state latch, live-active gate, and Kraken sizing modules while preserving the first message and all execution failures.

## Validation

Added focused regression coverage for:

1. Quoted explicit `true` normalization.
2. Missing switch remains missing and disabled.
3. Invalid switch remains fail-closed.
4. Mapping and object-shaped capital results.
5. Duplicate patch-install log throttling.
6. Verified live-capital convergence through the existing safe authority path.
7. No automatic enabling of the operator switch.
8. Placeholder/dedup snapshots cannot trigger convergence.

Local syntax validation passed and eight focused assertions passed.