### PR TITLE
Fix Render writer-authority and capital startup convergence

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -43,7 +43,7 @@ def _copy_first_present_env(canonical: str, aliases: tuple[str, ...]) -> str:
 
 
 def _normalize_credential_aliases(label: str) -> None:
-    """Accept common Railway/user secret aliases and map them to NIJA canonical names."""
+    """Accept common deployment/user secret aliases and map them to NIJA canonical names."""
     alias_map: dict[str, tuple[str, ...]] = {
         "KRAKEN_PLATFORM_API_KEY": ("KRAKEN_API_KEY", "KRAKEN_MASTER_API_KEY", "KRAKEN_MASTER_KEY", "KRAKEN_PLATFORM_KEY"),
         "KRAKEN_PLATFORM_API_SECRET": ("KRAKEN_API_SECRET", "KRAKEN_PRIVATE_KEY", "KRAKEN_SECRET_KEY", "KRAKEN_MASTER_API_SECRET", "KRAKEN_MASTER_SECRET", "KRAKEN_PLATFORM_SECRET"),
@@ -161,6 +161,10 @@ for _key, _value in {
     "NIJA_PLATFORM_EXECUTION_CAPITAL_ONLY": "true",
     "NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY": "false",
     "NIJA_GENERATION_MISMATCH_RECOVERY_COOLDOWN_S": "0",
+    "NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS": "1",
+    "NIJA_RENDER_STARTUP_RECOVERY_ENABLED": "true",
+    "NIJA_RENDER_STARTUP_RECOVERY_INTERVAL_S": "5",
+    "NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS": "60",
     "NIJA_KRAKEN_EFFECTIVE_MIN_NOTIONAL_USD": "23.00",
     "NIJA_KRAKEN_FINAL_MIN_NOTIONAL_USD": "23.00",
     "NIJA_KRAKEN_MIN_QUOTE_BUFFER_PCT": "0.10",
@@ -237,6 +241,7 @@ _PATCH_HOOKS = (
     ("min_notional_runtime_patch", "Adaptive min-notional runtime patch"),
     ("kraken_equity_runtime_patch", "Kraken equity hydration patch"),
     ("capital_balance_propagation_patch", "Capital balance propagation patch"),
+    ("render_startup_convergence_patch", "Render startup authority/capital convergence repair"),
     ("post_lock_capital_refresh_patch", "Post-lock capital refresh patch"),
     ("full_execution_observability_patch", "Full execution observability"),
     ("decision_pipeline_runtime_patch", "Decision pipeline telemetry"),

--- a/bot/render_startup_convergence_patch.py
+++ b/bot/render_startup_convergence_patch.py
@@ -1,0 +1,331 @@
+"""Fail-closed Render startup authority and capital convergence repair.
+
+This module repairs two startup-state problems without granting trading authority:
+
+* Runtime authority is derived state, not an operator setting.  A stale Render
+  environment value such as ``NIJA_RUNTIME_EXECUTION_AUTHORITY=true`` is reset
+  to ``0`` until the current process owns a writer fencing token and lease
+  generation.
+* After writer lineage exists, a bounded monitor asks the already-initialized
+  MultiAccountBrokerManager to re-run its normal capital watchdog refresh.  It
+  never creates brokers, never calls ``initialize()`` from a background thread,
+  and never bypasses capital, heartbeat, writer-lock, kill-switch, or state
+  machine gates.
+
+The platform contract treats Kraken as the required primary broker and Coinbase
+as an optional isolated broker, so runtime convergence defaults to one valid
+broker.  Operators may still configure a stricter value explicitly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from collections.abc import Mapping
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("nija.render_startup_convergence")
+
+_MARKER = "20260710r"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_FALSE = {"0", "false", "no", "off", "disabled", "n", ""}
+_STARTED = False
+_START_LOCK = threading.Lock()
+
+
+def _truthy_value(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _truthy_env(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return _truthy_value(raw)
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default)) or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _live_mode() -> bool:
+    return (
+        _truthy_env("LIVE_CAPITAL_VERIFIED")
+        and not _truthy_env("DRY_RUN_MODE")
+        and not _truthy_env("PAPER_MODE")
+    )
+
+
+def _writer_lineage() -> Tuple[bool, str]:
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip()
+    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")).strip()
+    lease = _truthy_env("NIJA_WRITER_LEASE_ACQUIRED") or bool(token)
+    if not token:
+        return False, "fencing_token_missing"
+    if not generation:
+        return False, "lease_generation_missing"
+    if not lease:
+        return False, "lease_not_acquired"
+    return True, f"lineage_ready generation={generation}"
+
+
+def normalize_derived_runtime_state() -> dict[str, str]:
+    """Canonicalize derived authority flags without granting authority.
+
+    When writer lineage is absent, stale deployment-environment authority is
+    reset to the fail-closed state.  When lineage already exists, recognized
+    boolean spellings are only canonicalized to ``1``/``0``.
+    """
+
+    os.environ.setdefault("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "1")
+
+    lineage_ready, _ = _writer_lineage()
+    raw_auth = str(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "")).strip().lower()
+    raw_state = str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip().upper()
+    changes: dict[str, str] = {}
+
+    if not lineage_ready:
+        if raw_auth != "0":
+            changes["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = f"{raw_auth or 'missing'}->0"
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+
+        if raw_state != "OFF":
+            changes["NIJA_RUNTIME_TRADING_STATE"] = f"{raw_state or 'missing'}->OFF"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+
+        if str(os.environ.get("NIJA_WRITER_LEASE_ACQUIRED", "")).strip() != "0":
+            changes["NIJA_WRITER_LEASE_ACQUIRED"] = "reset->0"
+        os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
+    else:
+        if raw_auth in _TRUE:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"
+            if raw_auth != "1":
+                changes["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = f"{raw_auth}->1"
+        elif raw_auth in _FALSE:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            if raw_auth != "0":
+                changes["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = f"{raw_auth or 'missing'}->0"
+        else:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            changes["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = f"invalid:{raw_auth}->0"
+
+        os.environ.setdefault("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    if changes:
+        logger.warning(
+            "RENDER_STARTUP_DERIVED_STATE_NORMALIZED marker=%s changes=%s",
+            _MARKER,
+            ",".join(f"{key}:{value}" for key, value in sorted(changes.items())),
+        )
+    return changes
+
+
+def _manager_module() -> Optional[Any]:
+    """Return an already-imported MABM module without taking bootstrap ownership."""
+
+    return sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get(
+        "multi_account_broker_manager"
+    )
+
+
+def _result_summary(result: Any) -> str:
+    if isinstance(result, Mapping):
+        total = result.get("total_capital", result.get("real_capital", 0.0))
+        valid = result.get("valid_brokers", result.get("broker_count", 0))
+        ready = result.get("ready", False)
+        return f"ready={bool(ready)} total={total} valid_brokers={valid}"
+    return f"type={type(result).__name__}"
+
+
+def _attempt_recovery_once() -> Tuple[bool, str]:
+    """Run one safe convergence attempt.
+
+    Returns ``(done, reason)``.  ``done`` means the monitor can stop because the
+    service is not in live mode or runtime authority has converged.
+    """
+
+    normalize_derived_runtime_state()
+
+    if not _live_mode():
+        return True, "not_live_mode"
+
+    state = str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip().upper()
+    if state == "LIVE_ACTIVE" and _truthy_env("NIJA_RUNTIME_EXECUTION_AUTHORITY"):
+        return True, "already_live_active"
+
+    lineage_ready, lineage_reason = _writer_lineage()
+    if not lineage_ready:
+        return False, lineage_reason
+
+    module = _manager_module()
+    if module is None:
+        return False, "broker_manager_module_not_loaded"
+
+    getter = getattr(module, "get_broker_manager", None)
+    if not callable(getter):
+        return False, "broker_manager_getter_missing"
+
+    try:
+        manager = getter()
+    except Exception as exc:
+        return False, f"broker_manager_unavailable:{type(exc).__name__}"
+
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        return False, "broker_manager_not_initialized"
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    if not callable(has_sources) or not bool(has_sources()):
+        return False, "no_registered_platform_source"
+
+    attempted = getattr(manager, "has_attempted_connections", None)
+    if not callable(attempted) or not bool(attempted()):
+        return False, "broker_registration_not_finalized"
+
+    watchdog_start = getattr(manager, "_start_capital_watchdog", None)
+    if callable(watchdog_start):
+        watchdog_start()
+
+    refresh = getattr(manager, "refresh_capital_authority", None)
+    if not callable(refresh):
+        return False, "capital_refresh_unavailable"
+
+    try:
+        trigger = str(getattr(manager, "WATCHDOG_REFRESH_TRIGGER", "watchdog") or "watchdog")
+        result = refresh(trigger=trigger)
+    except Exception as exc:
+        logger.warning(
+            "RENDER_STARTUP_CAPITAL_REFRESH_FAILED marker=%s err=%s",
+            _MARKER,
+            exc,
+        )
+        return False, f"capital_refresh_failed:{type(exc).__name__}"
+
+    converged = False
+    try:
+        convergence = importlib.import_module("bot.runtime_authority_convergence_repair_patch")
+        converge = getattr(convergence, "converge_runtime_authority", None)
+        if callable(converge):
+            converged = bool(converge("render_post_lock_recovery"))
+    except Exception as exc:
+        logger.warning(
+            "RENDER_STARTUP_CONVERGENCE_CALL_FAILED marker=%s err=%s",
+            _MARKER,
+            exc,
+        )
+
+    state = str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip().upper()
+    authority = _truthy_env("NIJA_RUNTIME_EXECUTION_AUTHORITY")
+    logger.warning(
+        "RENDER_STARTUP_CAPITAL_REFRESH marker=%s result=%s converged=%s state=%s authority=%s",
+        _MARKER,
+        _result_summary(result),
+        converged,
+        state or "missing",
+        authority,
+    )
+    if state == "LIVE_ACTIVE" and authority:
+        return True, "converged_live_active"
+    return False, "capital_refreshed_waiting_for_remaining_gates"
+
+
+def _monitor() -> None:
+    interval = max(1.0, _float_env("NIJA_RENDER_STARTUP_RECOVERY_INTERVAL_S", 5.0))
+    max_attempts = max(1, _int_env("NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS", 60))
+    initial_delay = max(0.0, _float_env("NIJA_RENDER_STARTUP_RECOVERY_INITIAL_DELAY_S", 2.0))
+    log_every = max(1, _int_env("NIJA_RENDER_STARTUP_RECOVERY_LOG_EVERY", 3))
+
+    if initial_delay:
+        time.sleep(initial_delay)
+
+    last_reason = ""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            done, reason = _attempt_recovery_once()
+        except Exception as exc:  # pragma: no cover - final defensive boundary
+            done = False
+            reason = f"unexpected:{type(exc).__name__}"
+            logger.exception(
+                "RENDER_STARTUP_RECOVERY_ERROR marker=%s attempt=%d/%d",
+                _MARKER,
+                attempt,
+                max_attempts,
+            )
+
+        if done:
+            logger.warning(
+                "RENDER_STARTUP_RECOVERY_COMPLETE marker=%s attempt=%d/%d reason=%s",
+                _MARKER,
+                attempt,
+                max_attempts,
+                reason,
+            )
+            return
+
+        if reason != last_reason or attempt == 1 or attempt % log_every == 0:
+            logger.warning(
+                "RENDER_STARTUP_RECOVERY_WAITING marker=%s attempt=%d/%d reason=%s",
+                _MARKER,
+                attempt,
+                max_attempts,
+                reason,
+            )
+            last_reason = reason
+
+        time.sleep(interval)
+
+    logger.error(
+        "RENDER_STARTUP_RECOVERY_EXHAUSTED marker=%s attempts=%d last_reason=%s "
+        "trading_remains_fail_closed=true",
+        _MARKER,
+        max_attempts,
+        last_reason or "unknown",
+    )
+
+
+def install_import_hook() -> None:
+    """Install normalization and the bounded recovery monitor exactly once."""
+
+    global _STARTED
+    with _START_LOCK:
+        if _STARTED:
+            return
+        _STARTED = True
+
+    normalize_derived_runtime_state()
+    if not _truthy_env("NIJA_RENDER_STARTUP_RECOVERY_ENABLED", True):
+        logger.warning("RENDER_STARTUP_RECOVERY_DISABLED marker=%s", _MARKER)
+        return
+
+    thread = threading.Thread(
+        target=_monitor,
+        name="render-startup-convergence",
+        daemon=True,
+    )
+    thread.start()
+    logger.warning(
+        "RENDER_STARTUP_RECOVERY_INSTALLED marker=%s thread_alive=%s min_brokers=%s",
+        _MARKER,
+        thread.is_alive(),
+        os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "1"),
+    )
+
+
+__all__ = [
+    "install_import_hook",
+    "normalize_derived_runtime_state",
+    "_attempt_recovery_once",
+]

--- a/bot/tests/test_render_startup_convergence_patch.py
+++ b/bot/tests/test_render_startup_convergence_patch.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "render_startup_convergence_patch.py"
+
+
+def _load_module():
+    name = f"render_startup_convergence_patch_test_{uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _clear_runtime_env(monkeypatch):
+    for key in (
+        "LIVE_CAPITAL_VERIFIED",
+        "DRY_RUN_MODE",
+        "PAPER_MODE",
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY",
+        "NIJA_RUNTIME_TRADING_STATE",
+        "NIJA_WRITER_FENCING_TOKEN",
+        "NIJA_WRITER_LEASE_GENERATION",
+        "NIJA_WRITER_LEASE_ACQUIRED",
+        "NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_stale_render_authority_is_reset_without_writer_lineage(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "true")
+
+    module = _load_module()
+    changes = module.normalize_derived_runtime_state()
+
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"
+    assert os.environ["NIJA_WRITER_LEASE_ACQUIRED"] == "0"
+    assert os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] == "1"
+    assert "NIJA_RUNTIME_EXECUTION_AUTHORITY" in changes
+
+
+def test_truthy_authority_is_canonicalized_after_writer_lineage(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-123")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "7")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+
+    module = _load_module()
+    module.normalize_derived_runtime_state()
+
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "1"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "LIVE_ACTIVE"
+
+
+def test_explicit_stricter_minimum_broker_requirement_is_preserved(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "2")
+
+    module = _load_module()
+    module.normalize_derived_runtime_state()
+
+    assert os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] == "2"
+
+
+def test_recovery_refreshes_existing_manager_and_uses_normal_convergence(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-abc")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "3")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    calls = {"watchdog": 0, "refresh": 0, "converge": 0}
+
+    class FakeManager:
+        _fsm_initialized = True
+        WATCHDOG_REFRESH_TRIGGER = "watchdog"
+
+        @staticmethod
+        def has_registered_sources():
+            return True
+
+        @staticmethod
+        def has_attempted_connections():
+            return True
+
+        @staticmethod
+        def _start_capital_watchdog():
+            calls["watchdog"] += 1
+
+        @staticmethod
+        def refresh_capital_authority(*, trigger: str):
+            calls["refresh"] += 1
+            assert trigger == "watchdog"
+            return {"ready": True, "total_capital": 75.0, "valid_brokers": 1}
+
+    fake_manager_module = SimpleNamespace(get_broker_manager=lambda: FakeManager())
+    monkeypatch.setitem(sys.modules, "bot.multi_account_broker_manager", fake_manager_module)
+
+    fake_convergence_module = SimpleNamespace()
+
+    def converge(source: str):
+        calls["converge"] += 1
+        assert source == "render_post_lock_recovery"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "LIVE_ACTIVE"
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"
+        return True
+
+    fake_convergence_module.converge_runtime_authority = converge
+
+    module = _load_module()
+    original_import_module = module.importlib.import_module
+
+    def import_module(name: str):
+        if name == "bot.runtime_authority_convergence_repair_patch":
+            return fake_convergence_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", import_module)
+
+    done, reason = module._attempt_recovery_once()
+
+    assert done is True
+    assert reason == "converged_live_active"
+    assert calls == {"watchdog": 1, "refresh": 1, "converge": 1}
+
+
+def test_recovery_does_not_import_or_initialize_brokers_before_writer_lineage(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    monkeypatch.delitem(sys.modules, "bot.multi_account_broker_manager", raising=False)
+    monkeypatch.delitem(sys.modules, "multi_account_broker_manager", raising=False)
+
+    module = _load_module()
+    done, reason = module._attempt_recovery_once()
+
+    assert done is False
+    assert reason == "fencing_token_missing"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"

--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,28 @@ services:
       - key: MINIMUM_TRADING_BALANCE
         value: "5.00"
 
+      # Render cold-start convergence. Kraken is the required primary platform
+      # broker; Coinbase is optional and must not be required for activation.
+      - key: NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS
+        value: "1"
+      - key: NIJA_RENDER_STARTUP_RECOVERY_ENABLED
+        value: "true"
+      - key: NIJA_RENDER_STARTUP_RECOVERY_INTERVAL_S
+        value: "5"
+      - key: NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS
+        value: "60"
+      - key: NIJA_CAPITAL_WATCHDOG_INTERVAL_S
+        value: "5"
+      - key: NIJA_CAPITAL_STARTUP_INVARIANT_TIMEOUT_S
+        value: "90"
+      - key: NIJA_WAIT_PLATFORM_TIMEOUT_S
+        value: "90"
+      - key: NIJA_POST_LOCK_CAPITAL_MONITOR_SECONDS
+        value: "300"
+
       # Live-mode intent remains an operator-controlled Render secret/setting.
+      # Runtime execution authority is deliberately absent: it is derived by the
+      # current process only after writer-lock, heartbeat, and capital proof.
       - key: LIVE_TRADING
         sync: false
       - key: LIVE_CAPITAL_VERIFIED

--- a/scripts/production_bootstrap.sh
+++ b/scripts/production_bootstrap.sh
@@ -154,6 +154,36 @@ echo "   Source: ${NIJA_GIT_METADATA_SOURCE}"
 echo "   Branch: ${GIT_BRANCH}"
 echo "   Commit: ${GIT_COMMIT_SHORT}"
 
+# Runtime authority, trading state, fencing tokens, and heartbeat state are
+# process-derived facts. Render dashboard variables must never pre-grant them to
+# a new process. Reset stale values before Python acquires the current writer
+# lease; the normal lock/capital/state-machine path will set them again only
+# after proof succeeds.
+_PREVIOUS_RUNTIME_AUTHORITY="${NIJA_RUNTIME_EXECUTION_AUTHORITY:-unset}"
+_PREVIOUS_RUNTIME_STATE="${NIJA_RUNTIME_TRADING_STATE:-unset}"
+export NIJA_RUNTIME_EXECUTION_AUTHORITY="0"
+export NIJA_RUNTIME_TRADING_STATE="OFF"
+export NIJA_WRITER_LEASE_ACQUIRED="0"
+export NIJA_WRITER_HEARTBEAT_ACTIVE="0"
+unset NIJA_WRITER_FENCING_TOKEN
+unset NIJA_WRITER_LEASE_GENERATION
+unset NIJA_WRITER_HEARTBEAT_ALIVE_TS
+unset NIJA_WRITER_LOCK_ACQUIRED_AT
+
+# Kraken is the required primary platform broker. Coinbase is optional/isolated,
+# so one fresh positive authoritative broker is sufficient by default. Operators
+# can explicitly configure a stricter requirement.
+export NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS="${NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS:-1}"
+export NIJA_RENDER_STARTUP_RECOVERY_ENABLED="${NIJA_RENDER_STARTUP_RECOVERY_ENABLED:-true}"
+export NIJA_RENDER_STARTUP_RECOVERY_INTERVAL_S="${NIJA_RENDER_STARTUP_RECOVERY_INTERVAL_S:-5}"
+export NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS="${NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS:-60}"
+
+echo "🧭 Derived runtime state reset for current process"
+echo "   Previous authority: ${_PREVIOUS_RUNTIME_AUTHORITY} → 0"
+echo "   Previous state: ${_PREVIOUS_RUNTIME_STATE} → OFF"
+echo "   Required valid brokers for convergence: ${NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS}"
+echo ""
+
 _is_positive_money() {
     python - "$1" <<'PY'
 from decimal import Decimal, InvalidOperation


### PR DESCRIPTION
## Summary

Repairs the Render startup state shown in the July 10 logs without bypassing NIJA's real-money safety gates.

## Fixes

- resets stale deployment-provided runtime authority, trading state, writer lease, heartbeat, and lineage values before the current process acquires its writer lease
- preserves `LIVE_CAPITAL_VERIFIED` as the operator-controlled live-capital switch
- treats `NIJA_RUNTIME_EXECUTION_AUTHORITY` and `NIJA_RUNTIME_TRADING_STATE` as process-derived state rather than Render configuration
- defaults runtime convergence to one authoritative broker because Kraken is the required primary broker and Coinbase is optional/isolated
- preserves any explicitly stricter `NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS` setting
- adds a bounded Render startup recovery monitor that waits for current writer lineage, uses the existing initialized broker manager, triggers the existing capital watchdog refresh, and calls the normal fail-closed authority convergence path
- never creates brokers from the monitor and never bypasses writer-lock, heartbeat, capital, kill-switch, or state-machine gates
- extends Render cold-start capital timeouts and increases refresh cadence while keeping a bounded recovery limit

## Regression coverage

- stale `true` authority and `LIVE_ACTIVE` state are reset before writer lineage
- authority is canonicalized to `1` only when current lineage exists
- stricter minimum broker requirements remain preserved
- an existing initialized manager is refreshed through the normal watchdog/convergence path
- recovery refuses to import or initialize brokers before writer lineage

No API secrets or unsafe bypass flags were added.