### PR TITLE
Prevent pre-execution emergency-clear amplification

### DIFF
--- a/bot/operator_emergency_stop_preexec_clear_patch.py
+++ b/bot/operator_emergency_stop_preexec_clear_patch.py
@@ -2,44 +2,134 @@ from __future__ import annotations
 
 import builtins
 import logging
+import os
 import sys
+import threading
 from functools import wraps
 from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.operator_emergency_stop_preexec_clear")
-_MARKER = "20260709ai"
-_HOOK_FLAG = "_NIJA_OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_HOOK_20260709AI"
-_EXEC_PATCH_ATTR = "_nija_operator_emergency_clear_pre_execute_20260709ai"
-_KILL_PATCH_ATTR = "_nija_operator_emergency_clear_kill_switch_20260709ai"
+_MARKER = "20260710t"
+_HOOK_FLAG = "_NIJA_OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_HOOK_20260710T"
+_EXEC_PATCH_ATTR = "_nija_operator_emergency_clear_pre_execute_20260710t"
+_KILL_PATCH_ATTR = "_nija_operator_emergency_clear_kill_switch_20260710t"
+_CLEAR_LOCK = threading.Lock()
+_TRUTHY = {"1", "true", "yes", "on", "y", "enabled"}
+
+
+def _truthy_env(name: str) -> bool:
+    return str(os.environ.get(name, "")).strip().lower() in _TRUTHY
+
+
+def _clear_patch_module() -> ModuleType:
+    try:
+        from bot import operator_emergency_stop_clear_patch as clear_patch
+    except ImportError:
+        import operator_emergency_stop_clear_patch as clear_patch  # type: ignore[import]
+    return clear_patch
+
+
+def _operator_clear_candidate_present() -> tuple[bool, str]:
+    """Return true only when an actual operator/emergency latch may need clearing.
+
+    KillSwitch.is_active() is called frequently throughout startup and normal
+    execution. Running filesystem/env clear logic on every probe amplifies any
+    detector defect and can recursively flood authority-convergence diagnostics.
+    Normal fail-closed state (OFF with authority=0) is deliberately not a clear
+    candidate.
+    """
+
+    if _truthy_env("NIJA_OPERATOR_CLEAR_EMERGENCY_STOP"):
+        return True, "explicit_operator_request"
+
+    try:
+        clear_patch = _clear_patch_module()
+    except Exception as exc:
+        return False, f"clear_patch_unavailable:{type(exc).__name__}"
+
+    for getter_name, reason in (
+        ("_kill_files", "kill_file_present"),
+        ("_state_files", "state_file_present"),
+    ):
+        getter = getattr(clear_patch, getter_name, None)
+        if callable(getter):
+            try:
+                if getter():
+                    return True, reason
+            except Exception:
+                # The canonical run_once path owns detailed path-check logging.
+                pass
+
+    detector = getattr(clear_patch, "_env_only_stop_present", None)
+    if callable(detector):
+        try:
+            present, detail = detector()
+            if bool(present):
+                return True, f"env_latch:{detail}"
+            return False, f"no_emergency_latch:{detail}"
+        except Exception as exc:
+            return False, f"env_probe_failed:{type(exc).__name__}"
+
+    # Fail closed: without a canonical detector, do not mutate emergency state
+    # from a hot-path is_active() probe.
+    return False, "canonical_detector_missing"
 
 
 def _run_operator_clear(source: str) -> int:
-    try:
-        try:
-            from bot.operator_emergency_stop_clear_patch import run_once
-        except ImportError:
-            from operator_emergency_stop_clear_patch import run_once  # type: ignore[import]
-        try:
-            result = int(run_once(source) or 0)
-        except TypeError:
-            result = int(run_once() or 0)
-    except Exception as exc:
-        logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_FAILED marker=%s source=%s err=%s", _MARKER, source, exc)
+    candidate, candidate_reason = _operator_clear_candidate_present()
+    if not candidate:
         return 0
 
-    if result > 0:
+    # Kill-switch probes can arrive concurrently. Only one thread may perform
+    # the mutating clear/convergence sequence; all others continue to the
+    # original safety check without waiting.
+    if not _CLEAR_LOCK.acquire(blocking=False):
+        return 0
+
+    try:
         try:
-            try:
-                from bot.runtime_authority_convergence_repair_patch import converge_runtime_authority
-            except ImportError:
-                from runtime_authority_convergence_repair_patch import converge_runtime_authority  # type: ignore[import]
-            converge_runtime_authority(f"operator_preexec_clear:{source}")
+            clear_patch = _clear_patch_module()
+            run_once = getattr(clear_patch, "run_once")
+            result = int(run_once() or 0)
         except Exception as exc:
-            logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_CONVERGENCE_FAILED marker=%s source=%s err=%s", _MARKER, source, exc)
-        logger.critical("OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_APPLIED marker=%s source=%s cleared=%s", _MARKER, source, result)
-        print(f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_APPLIED marker={_MARKER} source={source} cleared={result}", flush=True)
-    return result
+            logger.warning(
+                "OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_FAILED marker=%s source=%s candidate=%s err=%s",
+                _MARKER,
+                source,
+                candidate_reason,
+                exc,
+            )
+            return 0
+
+        if result > 0:
+            try:
+                try:
+                    from bot.runtime_authority_convergence_repair_patch import converge_runtime_authority
+                except ImportError:
+                    from runtime_authority_convergence_repair_patch import converge_runtime_authority  # type: ignore[import]
+                converge_runtime_authority(f"operator_preexec_clear:{source}")
+            except Exception as exc:
+                logger.warning(
+                    "OPERATOR_EMERGENCY_STOP_PREEXEC_CONVERGENCE_FAILED marker=%s source=%s err=%s",
+                    _MARKER,
+                    source,
+                    exc,
+                )
+            logger.critical(
+                "OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_APPLIED marker=%s source=%s candidate=%s cleared=%s",
+                _MARKER,
+                source,
+                candidate_reason,
+                result,
+            )
+            print(
+                f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_CLEAR_APPLIED marker={_MARKER} source={source} cleared={result}",
+                flush=True,
+            )
+        return result
+    finally:
+        _CLEAR_LOCK.release()
 
 
 def _patch_kill_switch_module(module: ModuleType) -> bool:
@@ -57,8 +147,15 @@ def _patch_kill_switch_module(module: ModuleType) -> bool:
 
     setattr(is_active_with_operator_clear, _KILL_PATCH_ATTR, True)
     setattr(cls, "is_active", is_active_with_operator_clear)
-    logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_SWITCH_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
-    print(f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_SWITCH_PATCHED marker={_MARKER}", flush=True)
+    logger.warning(
+        "OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_SWITCH_PATCHED marker=%s module=%s",
+        _MARKER,
+        getattr(module, "__name__", "unknown"),
+    )
+    print(
+        f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_SWITCH_PATCHED marker={_MARKER}",
+        flush=True,
+    )
     return True
 
 
@@ -77,8 +174,15 @@ def _patch_execution_module(module: ModuleType) -> bool:
 
     setattr(execute_entry_with_operator_clear, _EXEC_PATCH_ATTR, True)
     setattr(cls, "execute_entry", execute_entry_with_operator_clear)
-    logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_EXECUTION_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
-    print(f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_EXECUTION_PATCHED marker={_MARKER}", flush=True)
+    logger.warning(
+        "OPERATOR_EMERGENCY_STOP_PREEXEC_EXECUTION_PATCHED marker=%s module=%s",
+        _MARKER,
+        getattr(module, "__name__", "unknown"),
+    )
+    print(
+        f"[NIJA-PRINT] OPERATOR_EMERGENCY_STOP_PREEXEC_EXECUTION_PATCHED marker={_MARKER}",
+        flush=True,
+    )
     return True
 
 
@@ -89,14 +193,24 @@ def _patch_loaded() -> None:
             try:
                 _patch_kill_switch_module(module)
             except Exception as exc:
-                logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_PATCH_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.warning(
+                    "OPERATOR_EMERGENCY_STOP_PREEXEC_KILL_PATCH_FAILED marker=%s module=%s err=%s",
+                    _MARKER,
+                    name,
+                    exc,
+                )
     for name in ("bot.execution_engine", "execution_engine", "bot.execution", "execution"):
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
             try:
                 _patch_execution_module(module)
             except Exception as exc:
-                logger.warning("OPERATOR_EMERGENCY_STOP_PREEXEC_EXEC_PATCH_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.warning(
+                    "OPERATOR_EMERGENCY_STOP_PREEXEC_EXEC_PATCH_FAILED marker=%s module=%s err=%s",
+                    _MARKER,
+                    name,
+                    exc,
+                )
 
 
 def install_import_hook() -> None:

--- a/bot/tests/test_operator_emergency_stop_preexec_clear_patch.py
+++ b/bot/tests/test_operator_emergency_stop_preexec_clear_patch.py
@@ -57,3 +57,39 @@ def test_preexec_bridge_runs_operator_clear_before_kill_switch_check(monkeypatch
     assert kill_switch.is_active() is False
     assert calls == ["kill_switch.is_active"]
     assert kill_switch.checked is True
+
+
+def test_operator_clear_hot_path_skips_without_real_candidate(monkeypatch):
+    clear_module_calls: list[str] = []
+
+    monkeypatch.setattr(
+        patch,
+        "_operator_clear_candidate_present",
+        lambda: (False, "no_emergency_latch:runtime_state=OFF exec_auth=0"),
+    )
+    monkeypatch.setattr(
+        patch,
+        "_clear_patch_module",
+        lambda: clear_module_calls.append("loaded") or SimpleNamespace(run_once=lambda: 1),
+    )
+
+    assert patch._run_operator_clear("kill_switch.is_active") == 0
+    assert clear_module_calls == []
+
+
+def test_operator_clear_candidate_runs_canonical_clear_once(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        patch,
+        "_operator_clear_candidate_present",
+        lambda: (True, "kill_file_present"),
+    )
+    monkeypatch.setattr(
+        patch,
+        "_clear_patch_module",
+        lambda: SimpleNamespace(run_once=lambda: calls.append("run_once") or 0),
+    )
+
+    assert patch._run_operator_clear("kill_switch.is_active") == 0
+    assert calls == ["run_once"]


### PR DESCRIPTION
## Summary

Hardens the emergency-stop pre-execution bridge after the July 10 Render log showed hundreds of repeated clear/convergence calls from `KillSwitch.is_active()`.

## Root cause

The pre-execution patch invoked the canonical emergency clear routine on every kill-switch probe and every entry attempt. Under the previous detector defect, normal fail-closed startup (`state=OFF`, `authority=0`) returned `cleared=1`, so every safety probe re-ran authority convergence and flooded startup.

The underlying false-latch detector was fixed in PR #2133. This change prevents the hot-path bridge from amplifying any future detector regression.

## Fixes

- checks for a real emergency-clear candidate before invoking mutating clear logic
- candidates are limited to an explicit operator request, an existing kill/state file, an explicit emergency reason, or `EMERGENCY_STOP` state
- normal fail-closed `OFF/0` startup is a no-op
- serializes the clear/convergence sequence with a non-blocking process lock
- concurrent kill-switch probes continue through the original safety check without waiting
- removes the legacy attempted `run_once(source)` call shape and uses the canonical `run_once()` interface
- retains execution-entry and kill-switch safety wrappers
- does not force activation or bypass capital, writer, heartbeat, state-machine, or risk gates

## Regression coverage

- normal no-candidate hot path does not load or call the clear module
- a genuine candidate invokes canonical clear once
- execution-entry and kill-switch wrappers preserve original behavior

The uploaded log also uses old marker `20260709z`; the current main fix is marker `20260710s`, confirming that log came from the deployment before PR #2133 was active.