### PR TITLE
Wire Render-managed Redis into NIJA production

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,22 @@ services:
       - key: ALLOW_CONSUMER_USD
         value: "true"
 
+      # Use the Render private-network connection string from the managed Key
+      # Value service below. This replaces stale Railway/public Redis URLs and
+      # requires no external IP allowlist or TLS downgrade.
+      - key: NIJA_REDIS_URL
+        fromService:
+          type: keyvalue
+          name: nija-redis
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: nija-redis
+          property: connectionString
+      - key: NIJA_REDIS_CONNECT_MAX_TOTAL_WAIT_S
+        value: "12"
+
       # Production-safe small-account order floors. The bootstrap preserves any
       # stricter dashboard value and prevents internally inconsistent limits.
       - key: NIJA_MIN_CASH_RESERVE_USD
@@ -77,3 +93,13 @@ services:
         sync: false
       - key: KRAKEN_USER_TANIA_API_SECRET
         sync: false
+
+  # Private-only Redis-compatible datastore for writer fencing, nonce state,
+  # heartbeats, and distributed runtime coordination. The web service receives
+  # its internal connection string through fromService above.
+  - type: keyvalue
+    name: nija-redis
+    plan: free
+    ipAllowList: []
+    maxmemoryPolicy: noeviction
+    persistenceMode: off


### PR DESCRIPTION
## Root cause

The active Render instance is correctly remaining in fail-closed writer-authority standby, but `NIJA_REDIS_URL` resolves to an unreachable/stale endpoint. `render.yaml` did not define or wire a Render Key Value service.

## Fix

- Add a private-only Render Key Value service named `nija-redis`
- Use the free plan, `noeviction`, and no external IP allowlist
- Inject its private-network `connectionString` into `NIJA_REDIS_URL`
- Also inject the same URL into legacy `REDIS_URL`
- Preserve strict distributed writer authority; no local-lock bypass is enabled

## Expected runtime sequence

`ENTRYPOINT_WRITER_AUTHORITY_READY` → `ENTRYPOINT_WRITER_AUTHORITY_VERIFIED` → self-healing broker bootstrap.

No broker credentials, trading thresholds, or strategy logic are changed.