### PR TITLE
Prefer Render private Redis over stale Railway URL

### DIFF
--- a/bot/redis_env.py
+++ b/bot/redis_env.py
@@ -23,8 +23,7 @@ _REDIS_URL_ENV_NAMES = (
     "REDIS_TLS_URL",
 )
 
-_RENDER_RUNTIME_ENV_NAMES = (
-    "RENDER",
+_RENDER_RUNTIME_METADATA_ENV_NAMES = (
     "RENDER_SERVICE_ID",
     "RENDER_SERVICE_NAME",
     "RENDER_INSTANCE_ID",
@@ -83,8 +82,14 @@ def _is_railway_public_proxy_host(host: str) -> bool:
 
 
 def _is_render_runtime() -> bool:
-    """Return True when Render runtime metadata is present."""
-    return any(_strip_wrapping_quotes(os.getenv(name, "")) for name in _RENDER_RUNTIME_ENV_NAMES)
+    """Return True for a truthy Render flag or concrete Render metadata."""
+    render_flag = _strip_wrapping_quotes(os.getenv("RENDER", ""))
+    if render_flag and _is_truthy(render_flag):
+        return True
+    return any(
+        _strip_wrapping_quotes(os.getenv(name, ""))
+        for name in _RENDER_RUNTIME_METADATA_ENV_NAMES
+    )
 
 
 def _is_render_private_redis_url(url: str) -> bool:

--- a/bot/redis_env.py
+++ b/bot/redis_env.py
@@ -98,13 +98,14 @@ def _is_render_private_redis_url(url: str) -> bool:
         parsed = urlparse((url or "").strip())
         host = (parsed.hostname or "").lower()
         scheme = (parsed.scheme or "").lower()
-    except Exception:
+        port = parsed.port
+    except (TypeError, ValueError):
         return False
     return bool(
         scheme == "redis"
         and host.startswith("red-")
         and "." not in host
-        and parsed.port == 6379
+        and port == 6379
     )
 
 

--- a/bot/redis_env.py
+++ b/bot/redis_env.py
@@ -23,6 +23,15 @@ _REDIS_URL_ENV_NAMES = (
     "REDIS_TLS_URL",
 )
 
+_RENDER_RUNTIME_ENV_NAMES = (
+    "RENDER",
+    "RENDER_SERVICE_ID",
+    "RENDER_SERVICE_NAME",
+    "RENDER_INSTANCE_ID",
+    "RENDER_GIT_BRANCH",
+    "RENDER_GIT_COMMIT",
+)
+
 _REDIS_COMPONENT_HOST_ENV_NAMES = (
     "RAILWAY_TCP_PROXY_DOMAIN",
     "REDISHOST",
@@ -71,6 +80,57 @@ def _is_railway_public_proxy_host(host: str) -> bool:
     """
     h = host.lower()
     return ".proxy.rlwy.net" in h or h.endswith(".up.railway.app")
+
+
+def _is_render_runtime() -> bool:
+    """Return True when Render runtime metadata is present."""
+    return any(_strip_wrapping_quotes(os.getenv(name, "")) for name in _RENDER_RUNTIME_ENV_NAMES)
+
+
+def _is_render_private_redis_url(url: str) -> bool:
+    """Return True for Render private-network Key Value connection URLs.
+
+    Render internal Key Value hosts use an unqualified ``red-...`` service host
+    over plain ``redis://`` inside the same region. Public/external endpoints
+    include a DNS suffix and are intentionally not classified as private here.
+    """
+    try:
+        parsed = urlparse((url or "").strip())
+        host = (parsed.hostname or "").lower()
+        scheme = (parsed.scheme or "").lower()
+    except Exception:
+        return False
+    return bool(
+        scheme == "redis"
+        and host.startswith("red-")
+        and "." not in host
+        and parsed.port == 6379
+    )
+
+
+def _prioritize_runtime_redis_urls(
+    configured: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """Apply provider-local Redis priority without weakening explicit safety.
+
+    On Render, a stale manually configured ``NIJA_REDIS_URL`` may still point at
+    a Railway public proxy while the Blueprint-provided ``REDIS_URL`` contains
+    the valid Render private-network connection string. Prefer the Render-private
+    endpoint only when Render runtime metadata is present. Outside Render, retain
+    the historical explicit environment-variable priority unchanged.
+    """
+    if not _is_render_runtime():
+        return configured
+
+    render_private = [
+        item for item in configured if _is_render_private_redis_url(item[1])
+    ]
+    if not render_private:
+        return configured
+
+    return render_private + [
+        item for item in configured if not _is_render_private_redis_url(item[1])
+    ]
 
 
 def _build_component_redis_url() -> tuple[str, dict[str, object]]:
@@ -202,7 +262,7 @@ def _iter_configured_redis_urls() -> list[tuple[str, str]]:
     if component_url:
         component_source = str(component_diag.get("component_source") or "components")
         configured.append((f"COMPONENTS[{component_source}]", component_url))
-    return configured
+    return _prioritize_runtime_redis_urls(configured)
 
 
 def get_redis_url_source() -> str:
@@ -228,6 +288,7 @@ def get_redis_resolution_diagnostics() -> dict[str, object]:
     scheme = (parsed.scheme or "").lower() if parsed else ""
     is_railway_proxy = _is_railway_public_proxy_host(hostname)
     is_railway_internal = ".railway.internal" in hostname
+    is_render_private = _is_render_private_redis_url(resolved_url)
     tls_required_hint = bool(is_railway_proxy)
     tls_configured = scheme == "rediss"
     tls_mismatch = bool(resolved_url) and tls_required_hint and not tls_configured
@@ -246,6 +307,8 @@ def get_redis_resolution_diagnostics() -> dict[str, object]:
         "resolved_host": hostname or None,
         "is_railway_proxy": is_railway_proxy,
         "is_railway_internal": is_railway_internal,
+        "is_render_runtime": _is_render_runtime(),
+        "is_render_private": is_render_private,
         "tls_required_hint": tls_required_hint,
         "tls_configured": tls_configured,
         "tls_mismatch": tls_mismatch,

--- a/bot/tests/test_redis_env_priority.py
+++ b/bot/tests/test_redis_env_priority.py
@@ -67,6 +67,22 @@ class TestRedisEnvPriority(unittest.TestCase):
             self.assertTrue(diagnostics["is_render_private"])
             self.assertEqual(diagnostics["resolved_source"], "REDIS_URL")
 
+    def test_false_render_flag_does_not_change_priority(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RENDER": "false",
+                "NIJA_REDIS_URL": "redis://redis-production-e747.up.railway.app:6379",
+                "REDIS_URL": "redis://red-d98dsl5aeets73fpb0hg:6379",
+            },
+            clear=True,
+        ):
+            self.assertEqual(get_redis_url_source(), "NIJA_REDIS_URL")
+            self.assertEqual(
+                get_redis_url(),
+                "rediss://redis-production-e747.up.railway.app:6379",
+            )
+
     def test_stale_railway_nija_url_keeps_priority_outside_render(self):
         with patch.dict(
             os.environ,

--- a/bot/tests/test_redis_env_priority.py
+++ b/bot/tests/test_redis_env_priority.py
@@ -2,7 +2,12 @@ import os
 import unittest
 from unittest.mock import patch
 
-from bot.redis_env import get_all_redis_urls, get_redis_url, get_redis_url_source
+from bot.redis_env import (
+    get_all_redis_urls,
+    get_redis_resolution_diagnostics,
+    get_redis_url,
+    get_redis_url_source,
+)
 
 
 class TestRedisEnvPriority(unittest.TestCase):
@@ -37,6 +42,45 @@ class TestRedisEnvPriority(unittest.TestCase):
         ):
             self.assertEqual(get_redis_url_source(), "REDIS_URL")
             self.assertEqual(get_redis_url(), "rediss://default:pw@redis-production-e747.up.railway.app:6379/0")
+
+    def test_render_private_url_beats_stale_railway_nija_url_on_render(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RENDER": "true",
+                "NIJA_REDIS_URL": "redis://redis-production-e747.up.railway.app:6379",
+                "REDIS_URL": "redis://red-d98dsl5aeets73fpb0hg:6379",
+            },
+            clear=True,
+        ):
+            self.assertEqual(get_redis_url_source(), "REDIS_URL")
+            self.assertEqual(get_redis_url(), "redis://red-d98dsl5aeets73fpb0hg:6379")
+            self.assertEqual(
+                get_all_redis_urls(),
+                [
+                    ("REDIS_URL", "redis://red-d98dsl5aeets73fpb0hg:6379"),
+                    ("NIJA_REDIS_URL", "rediss://redis-production-e747.up.railway.app:6379"),
+                ],
+            )
+            diagnostics = get_redis_resolution_diagnostics()
+            self.assertTrue(diagnostics["is_render_runtime"])
+            self.assertTrue(diagnostics["is_render_private"])
+            self.assertEqual(diagnostics["resolved_source"], "REDIS_URL")
+
+    def test_stale_railway_nija_url_keeps_priority_outside_render(self):
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_REDIS_URL": "redis://redis-production-e747.up.railway.app:6379",
+                "REDIS_URL": "redis://red-d98dsl5aeets73fpb0hg:6379",
+            },
+            clear=True,
+        ):
+            self.assertEqual(get_redis_url_source(), "NIJA_REDIS_URL")
+            self.assertEqual(
+                get_redis_url(),
+                "rediss://redis-production-e747.up.railway.app:6379",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

The deployed Render service had both Redis variables configured, but `bot.redis_env` always prioritized `NIJA_REDIS_URL`. That variable still contained the stale Railway proxy, while Blueprint-managed `REDIS_URL` contained the valid Render-private `redis://red-...:6379` endpoint.

## Fix

- Detect Render runtime metadata
- Detect Render private Key Value URLs (`redis://red-...:6379`)
- Prefer the Render-private URL only while running on Render
- Preserve historical environment priority outside Render
- Add diagnostics for Render runtime/private endpoint selection
- Add regression tests for stale Railway + valid Render URL coexistence

## Safety

No lock bypass, broker credential, trading threshold, strategy, or risk-limit changes are included.