### PR TITLE
Fix Render three-venue bootstrap packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -106,6 +106,7 @@ scripts/*
 !scripts/redis_connectivity_check.sh
 !scripts/debug_startup_safe_mode.sh
 !scripts/production_bootstrap.sh
+!scripts/three_venue_config_check.py
 !scripts/render_entrypoint.sh
 check_*.py
 verify_*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ COPY scripts/ scripts/
 # Copy application code
 COPY . .
 
+# The verifier is required by production_bootstrap.sh. Keep the source script
+# fail-closed while preserving the verifier's real non-zero status in the image.
+RUN python -S -c 'from pathlib import Path; p=Path("/app/scripts/production_bootstrap.sh"); s=p.read_text(encoding="utf-8"); old="if ! python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    _CHECK_EXIT=$?\n"; new="if python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    :\nelse\n    _CHECK_EXIT=$?\n"; assert s.count(old) == 1, "unexpected three-venue bootstrap block"; p.write_text(s.replace(old, new, 1), encoding="utf-8")' && \
+    bash -n /app/scripts/production_bootstrap.sh
+
 # Fail the image build immediately if entrypoint Python files or startup guards
 # are syntactically invalid.
 RUN python -m py_compile \
@@ -38,7 +43,8 @@ RUN python -m py_compile \
         /app/bot/writer_lock_release_guard.py \
         /app/bot/global_runtime_startup_guards.py \
         /app/import_hook_recursion_shield_patch.py \
-        /app/disconnected_broker_execution_guard_patch.py
+        /app/disconnected_broker_execution_guard_patch.py \
+        /app/scripts/three_venue_config_check.py
 
 # Install startup guards before sitecustomize executes. Python processes .pth
 # files before the entry script directory is reliably importable, so every hook
@@ -57,6 +63,7 @@ RUN cd /tmp && python -c "import prebot_writer_authority_fail_closed, import_hoo
 # Ensure Redis connectivity and production bootstrap scripts are present and executable.
 RUN test -f /app/scripts/redis_connectivity_check.sh && \
     test -f /app/scripts/production_bootstrap.sh && \
+    test -f /app/scripts/three_venue_config_check.py && \
     test -f /app/scripts/render_entrypoint.sh && \
     chmod +x /app/scripts/redis_connectivity_check.sh \
              /app/scripts/production_bootstrap.sh \

--- a/bot/tests/test_production_bootstrap_money_helpers.py
+++ b/bot/tests/test_production_bootstrap_money_helpers.py
@@ -53,3 +53,23 @@ printf '%s\n' "${value}"
     assert completed.returncode == 0, completed.stdout
     assert completed.stdout.strip() == "23.10"
     assert "SHOULD_NOT_APPEAR" not in completed.stdout
+
+
+def test_three_venue_verifier_is_included_in_docker_context() -> None:
+    root = Path(__file__).resolve().parents[2]
+    rules = (root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+
+    exclude_index = rules.index("scripts/*")
+    include_index = rules.index("!scripts/three_venue_config_check.py")
+    assert include_index > exclude_index
+
+
+def test_docker_image_validates_and_repairs_three_venue_bootstrap() -> None:
+    root = Path(__file__).resolve().parents[2]
+    dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "/app/scripts/three_venue_config_check.py" in dockerfile
+    assert "test -f /app/scripts/three_venue_config_check.py" in dockerfile
+    assert "unexpected three-venue bootstrap block" in dockerfile
+    assert "bash -n /app/scripts/production_bootstrap.sh" in dockerfile
+    assert 'new="if python3 -S \\"${SCRIPT_DIR}/three_venue_config_check.py\\"; then\\n    :\\nelse\\n    _CHECK_EXIT=$?\\n"' in dockerfile


### PR DESCRIPTION
## What changed
- Re-includes `scripts/three_venue_config_check.py` in the Docker build context.
- Makes the Docker image fail during build if the verifier is missing or invalid.
- Repairs the bootstrap's `! command` status inversion inside the built image so failures preserve the real nonzero verifier exit code.
- Adds regression coverage to the existing production-bootstrap test suite.

## Root cause
`.dockerignore` excluded every file under `scripts/` except a small shell-script allowlist, so the committed Python verifier never reached `/app/scripts` in the Render image. The bootstrap also captured `$?` after `! python3 ...`, which yielded `0` instead of the verifier's failure status.

## Validation
- Packaging assertions pass.
- The Dockerfile transformation was executed against the failing block and the repaired script passes `bash -n`.
- The image build now checks file presence and runs `py_compile` on the verifier.