### PR TITLE
Fix Render three-venue bootstrap packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -106,6 +106,7 @@ scripts/*
 !scripts/redis_connectivity_check.sh
 !scripts/debug_startup_safe_mode.sh
 !scripts/production_bootstrap.sh
+!scripts/three_venue_config_check.py
 !scripts/render_entrypoint.sh
 check_*.py
 verify_*.py

--- a/.github/workflows/entrypoint-writer-authority-tests.yml
+++ b/.github/workflows/entrypoint-writer-authority-tests.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     paths:
       - 'Dockerfile'
+      - '.dockerignore'
       - 'render.yaml'
       - 'scripts/production_bootstrap.sh'
+      - 'scripts/three_venue_config_check.py'
       - 'render_liveness_server.py'
       - 'render_readiness_state_bridge.py'
       - 'prebot_writer_authority_bootstrap.py'
@@ -39,8 +41,10 @@ on:
     branches: [main]
     paths:
       - 'Dockerfile'
+      - '.dockerignore'
       - 'render.yaml'
       - 'scripts/production_bootstrap.sh'
+      - 'scripts/three_venue_config_check.py'
       - 'render_liveness_server.py'
       - 'render_readiness_state_bridge.py'
       - 'prebot_writer_authority_bootstrap.py'
@@ -122,24 +126,34 @@ jobs:
             bot/activation_pending_commit_monitor_patch.py \
             bot/writer_lock_release_guard.py \
             bot/entrypoint_writer_authority.py \
-            bot/bot_main.py
+            bot/bot_main.py \
+            scripts/three_venue_config_check.py
 
-      - name: Run focused deployment safety tests
-        env:
-          PYTHONUNBUFFERED: '1'
-        run: |
-          python -m pytest -q \
-            bot/tests/test_three_venue_execution_readiness.py \
-            bot/tests/test_import_hook_chain_compactor.py \
-            bot/tests/test_activation_pending_startup_order.py \
-            bot/tests/test_production_bootstrap_money_helpers.py \
-            bot/tests/test_writer_lock_release_guard.py \
-            bot/tests/test_writer_release_heartbeat_quiesce.py \
-            bot/tests/test_entrypoint_writer_authority.py \
-            bot/tests/test_entrypoint_writer_heartbeat.py \
-            bot/tests/test_prebot_writer_authority_bootstrap.py \
-            bot/tests/test_render_prebot_writer_handoff.py \
-            bot/tests/test_render_liveness_launcher.py \
-            bot/tests/test_render_liveness_readiness.py \
-            bot/tests/test_source_runtime_guard_bootstrap.py \
-            bot/tests/test_docker_pth_startup_paths.py
+      - name: Test three-venue readiness
+        run: python -m pytest -q bot/tests/test_three_venue_execution_readiness.py
+      - name: Test import-hook compactor
+        run: python -m pytest -q bot/tests/test_import_hook_chain_compactor.py
+      - name: Test activation startup order
+        run: python -m pytest -q bot/tests/test_activation_pending_startup_order.py
+      - name: Test production bootstrap helpers
+        run: python -m pytest -q bot/tests/test_production_bootstrap_money_helpers.py
+      - name: Test writer-lock release guard
+        run: python -m pytest -q bot/tests/test_writer_lock_release_guard.py
+      - name: Test heartbeat quiescence
+        run: python -m pytest -q bot/tests/test_writer_release_heartbeat_quiesce.py
+      - name: Test entrypoint writer authority
+        run: python -m pytest -q bot/tests/test_entrypoint_writer_authority.py
+      - name: Test entrypoint writer heartbeat
+        run: python -m pytest -q bot/tests/test_entrypoint_writer_heartbeat.py
+      - name: Test prebot writer authority
+        run: python -m pytest -q bot/tests/test_prebot_writer_authority_bootstrap.py
+      - name: Test Render writer handoff
+        run: python -m pytest -q bot/tests/test_render_prebot_writer_handoff.py
+      - name: Test Render liveness launcher
+        run: python -m pytest -q bot/tests/test_render_liveness_launcher.py
+      - name: Test Render liveness readiness
+        run: python -m pytest -q bot/tests/test_render_liveness_readiness.py
+      - name: Test source runtime guard
+        run: python -m pytest -q bot/tests/test_source_runtime_guard_bootstrap.py
+      - name: Test Docker PTH startup paths
+        run: python -m pytest -q bot/tests/test_docker_pth_startup_paths.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ COPY scripts/ scripts/
 # Copy application code
 COPY . .
 
+# The verifier is required by production_bootstrap.sh. Keep the source script
+# fail-closed while preserving the verifier's real non-zero status in the image.
+RUN python -S -c 'from pathlib import Path; p=Path("/app/scripts/production_bootstrap.sh"); s=p.read_text(encoding="utf-8"); old="if ! python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    _CHECK_EXIT=$?\n"; new="if python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    :\nelse\n    _CHECK_EXIT=$?\n"; assert s.count(old) == 1, "unexpected three-venue bootstrap block"; p.write_text(s.replace(old, new, 1), encoding="utf-8")' && \
+    bash -n /app/scripts/production_bootstrap.sh
+
 # Fail the image build immediately if entrypoint Python files or startup guards
 # are syntactically invalid.
 RUN python -m py_compile \
@@ -38,7 +43,8 @@ RUN python -m py_compile \
         /app/bot/writer_lock_release_guard.py \
         /app/bot/global_runtime_startup_guards.py \
         /app/import_hook_recursion_shield_patch.py \
-        /app/disconnected_broker_execution_guard_patch.py
+        /app/disconnected_broker_execution_guard_patch.py \
+        /app/scripts/three_venue_config_check.py
 
 # Install startup guards before sitecustomize executes. Python processes .pth
 # files before the entry script directory is reliably importable, so every hook
@@ -57,6 +63,7 @@ RUN cd /tmp && python -c "import prebot_writer_authority_fail_closed, import_hoo
 # Ensure Redis connectivity and production bootstrap scripts are present and executable.
 RUN test -f /app/scripts/redis_connectivity_check.sh && \
     test -f /app/scripts/production_bootstrap.sh && \
+    test -f /app/scripts/three_venue_config_check.py && \
     test -f /app/scripts/render_entrypoint.sh && \
     chmod +x /app/scripts/redis_connectivity_check.sh \
              /app/scripts/production_bootstrap.sh \

--- a/bot/tests/test_production_bootstrap_money_helpers.py
+++ b/bot/tests/test_production_bootstrap_money_helpers.py
@@ -53,3 +53,23 @@ printf '%s\n' "${value}"
     assert completed.returncode == 0, completed.stdout
     assert completed.stdout.strip() == "23.10"
     assert "SHOULD_NOT_APPEAR" not in completed.stdout
+
+
+def test_three_venue_verifier_is_included_in_docker_context() -> None:
+    root = Path(__file__).resolve().parents[2]
+    rules = (root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+
+    exclude_index = rules.index("scripts/*")
+    include_index = rules.index("!scripts/three_venue_config_check.py")
+    assert include_index > exclude_index
+
+
+def test_docker_image_validates_and_repairs_three_venue_bootstrap() -> None:
+    root = Path(__file__).resolve().parents[2]
+    dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "/app/scripts/three_venue_config_check.py" in dockerfile
+    assert "test -f /app/scripts/three_venue_config_check.py" in dockerfile
+    assert "unexpected three-venue bootstrap block" in dockerfile
+    assert "bash -n /app/scripts/production_bootstrap.sh" in dockerfile
+    assert 'new="if python3 -S \\"${SCRIPT_DIR}/three_venue_config_check.py\\"; then\\n    :\\nelse\\n    _CHECK_EXIT=$?\\n"' in dockerfile

--- a/bot/tests/test_production_bootstrap_money_helpers.py
+++ b/bot/tests/test_production_bootstrap_money_helpers.py
@@ -68,8 +68,9 @@ def test_docker_image_validates_and_repairs_three_venue_bootstrap() -> None:
     root = Path(__file__).resolve().parents[2]
     dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
 
-    assert "/app/scripts/three_venue_config_check.py" in dockerfile
     assert "test -f /app/scripts/three_venue_config_check.py" in dockerfile
+    assert "/app/scripts/three_venue_config_check.py" in dockerfile
+    assert 'old="if ! python3 -S' in dockerfile
+    assert 'new="if python3 -S' in dockerfile
     assert "unexpected three-venue bootstrap block" in dockerfile
     assert "bash -n /app/scripts/production_bootstrap.sh" in dockerfile
-    assert 'new="if python3 -S \\"${SCRIPT_DIR}/three_venue_config_check.py\\"; then\\n    :\\nelse\\n    _CHECK_EXIT=$?\\n"' in dockerfile


### PR DESCRIPTION
## What changed
- Re-includes `scripts/three_venue_config_check.py` in the Docker build context.
- Makes the Docker image fail during build if the verifier is missing or invalid.
- Repairs the bootstrap's `! command` status inversion inside the built image so failures preserve the real nonzero verifier exit code.
- Adds regression coverage to the existing production-bootstrap test suite.

## Root cause
`.dockerignore` excluded every file under `scripts/` except a small shell-script allowlist, so the committed Python verifier never reached `/app/scripts` in the Render image. The bootstrap also captured `$?` after `! python3 ...`, which yielded `0` instead of the verifier's failure status.

## Validation
- Packaging assertions pass.
- The Dockerfile transformation was executed against the failing block and the repaired script passes `bash -n`.
- The image build now checks file presence and runs `py_compile` on the verifier.