### PR TITLE
Fix Render bootstrap and required user configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,9 @@ COPY scripts/ scripts/
 # Copy application code
 COPY . .
 
-# The verifier is required by production_bootstrap.sh. Keep the source script
-# fail-closed while preserving the verifier's real non-zero status in the image.
-RUN python -S -c 'from pathlib import Path; p=Path("/app/scripts/production_bootstrap.sh"); s=p.read_text(encoding="utf-8"); old="if ! python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    _CHECK_EXIT=$?\n"; new="if python3 -S \"${SCRIPT_DIR}/three_venue_config_check.py\"; then\n    :\nelse\n    _CHECK_EXIT=$?\n"; assert s.count(old) == 1, "unexpected three-venue bootstrap block"; p.write_text(s.replace(old, new, 1), encoding="utf-8")' && \
-    bash -n /app/scripts/production_bootstrap.sh
+# Validate the committed bootstrap directly. Never rewrite source inside the
+# image build: the repository version is the single source of truth.
+RUN bash -n /app/scripts/production_bootstrap.sh
 
 # Fail the image build immediately if entrypoint Python files or startup guards
 # are syntactically invalid.

--- a/bot/tests/test_production_bootstrap_money_helpers.py
+++ b/bot/tests/test_production_bootstrap_money_helpers.py
@@ -64,13 +64,12 @@ def test_three_venue_verifier_is_included_in_docker_context() -> None:
     assert include_index > exclude_index
 
 
-def test_docker_image_validates_and_repairs_three_venue_bootstrap() -> None:
+def test_docker_image_validates_committed_three_venue_bootstrap() -> None:
     root = Path(__file__).resolve().parents[2]
     dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
 
     assert "test -f /app/scripts/three_venue_config_check.py" in dockerfile
     assert "/app/scripts/three_venue_config_check.py" in dockerfile
-    assert 'old="if ! python3 -S' in dockerfile
-    assert 'new="if python3 -S' in dockerfile
-    assert "unexpected three-venue bootstrap block" in dockerfile
     assert "bash -n /app/scripts/production_bootstrap.sh" in dockerfile
+    assert "unexpected three-venue bootstrap block" not in dockerfile
+    assert "p.write_text(s.replace" not in dockerfile

--- a/config/users/daivon_frazier.json
+++ b/config/users/daivon_frazier.json
@@ -4,7 +4,6 @@
   "role": "user",
   "enabled": true,
   "copy_from_platform": false,
-  "copy_from_platform": true,
   "independent_trading": true,
   "active_trading": true,
   "risk_multiplier": 1.0,
@@ -14,5 +13,4 @@
   "mode": "normal",
   "_reactivated_reason": "Kraken startup nonce resync now advances Redis per-key counters before user connection",
   "_operational_model": "Independent per-account strategy evaluation; no copy trading or signal distribution"
-  "_reactivated_reason": "Kraken startup nonce resync now advances Redis per-key counters before user connection"
 }

--- a/config/users/tania_gilbert.json
+++ b/config/users/tania_gilbert.json
@@ -13,5 +13,4 @@
   "mode": "normal",
   "_reactivated_reason": "Kraken startup nonce resync now advances Redis per-key counters before user connection",
   "_operational_model": "Independent per-account strategy evaluation; no copy trading or signal distribution"
-  "_reactivated_reason": "Kraken startup nonce resync now advances Redis per-key counters before user connection"
 }


### PR DESCRIPTION
## Root causes found
1. Render fails at Docker step 9 because the Dockerfile tries to rewrite an obsolete exact text block in `scripts/production_bootstrap.sh`. The committed bootstrap has already changed, so the assertion aborts every image build.
2. Both required user configuration files were invalid JSON. They contained duplicate fields, missing commas, and contradictory copy-trading settings, which could prevent Daivon and Tania from loading after startup.

## Fixes
- Remove all Docker-time source mutation.
- Validate the committed bootstrap directly with `bash -n`.
- Continue requiring and compiling `scripts/three_venue_config_check.py`.
- Update regression coverage to forbid future Docker-time bootstrap rewriting.
- Repair `config/users/daivon_frazier.json` and `config/users/tania_gilbert.json`.
- Enforce independent user trading with `copy_from_platform: false`.

## Three-broker audit
The platform configuration enables Kraken, Coinbase, and OKX with strict secondary-venue readiness. The current committed user model is still Kraken-only for Daivon and Tania; Coinbase is documented as future user support and OKX user configuration is not currently defined. This PR removes the deployment and existing-user blockers without falsely claiming unsupported user-broker coverage.