### PR TITLE
Make broker readiness and held-position exits independent

### DIFF
--- a/account_exit_management_recovery_patch.py
+++ b/account_exit_management_recovery_patch.py
@@ -1,0 +1,614 @@
+"""Account-local connection and held-position exit recovery for NIJA.
+
+The normal independent trader starts full trading loops only for funded accounts
+that are allowed to create entries.  That is correct for entries, but it can
+leave exchange-held positions unmanaged when an account is:
+
+* temporarily underfunded in quote currency,
+* configured for copy/recovery mode,
+* suppressed by platform-only entry policy, or
+* waiting for another brokerage to connect.
+
+This patch keeps entry controls intact and adds an isolated exit-only path.  Each
+platform or user brokerage reconnects independently.  Accounts without a normal
+trading thread receive a small recovery thread that only adopts positions and
+calls ``TradingStrategy.run_cycle(..., user_mode=True)``.  NijaCoreLoop always
+runs Phase 2 position management in user mode while Phase 3 entries remain
+blocked.
+
+No profit is guaranteed.  Existing take-profit, trailing-stop, stop-loss,
+writer-authority, broker, and execution-pipeline checks remain authoritative.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Iterable, Mapping, Optional
+
+logger = logging.getLogger("nija.account_exit_management_recovery")
+
+_MARKER = "20260711k"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_PATCHED_ATTR = "_nija_account_exit_management_recovery_20260711k"
+_STRATEGY_PATCHED_ATTR = "_nija_account_exit_adoption_verify_20260711k"
+_ORIGINAL_IMPORT = None
+_INSTALL_LOCK = threading.RLock()
+
+
+def _truthy(name: str, default: str = "true") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _interval() -> float:
+    try:
+        return max(5.0, float(os.environ.get("NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S", "15") or "15"))
+    except (TypeError, ValueError):
+        return 15.0
+
+
+def _broker_name(broker_type: Any, broker: Any = None) -> str:
+    raw = getattr(broker_type, "value", broker_type)
+    text = str(raw or "").strip().lower()
+    if text:
+        return text
+    for attr in ("broker_type", "name", "broker_name", "exchange", "exchange_name"):
+        try:
+            value = getattr(broker, attr, None)
+            raw_value = getattr(value, "value", value)
+            text = str(raw_value or "").strip().lower()
+            if text:
+                return text
+        except Exception:
+            pass
+    return type(broker).__name__.replace("Broker", "").strip().lower() or "unknown"
+
+
+def _is_connected(broker: Any) -> bool:
+    if broker is None:
+        return False
+    try:
+        value = getattr(broker, "connected", None)
+        if value is not None:
+            return bool(value() if callable(value) else value)
+    except Exception:
+        return False
+    try:
+        value = getattr(broker, "is_connected", None)
+        if value is not None:
+            return bool(value() if callable(value) else value)
+    except Exception:
+        return False
+    return False
+
+
+def _connect(broker: Any, identity: str) -> bool:
+    if _is_connected(broker):
+        return True
+    connector = getattr(broker, "connect", None)
+    if not callable(connector):
+        return False
+    try:
+        result = connector()
+        connected = _is_connected(broker) or result is True
+        logger.info(
+            "ACCOUNT_CONNECTION_RETRY marker=%s account=%s connected=%s",
+            _MARKER,
+            identity,
+            connected,
+        )
+        return connected
+    except Exception as exc:
+        logger.warning(
+            "ACCOUNT_CONNECTION_RETRY_FAILED marker=%s account=%s error=%s",
+            _MARKER,
+            identity,
+            exc,
+        )
+        return False
+
+
+def _safe_balance(trader: Any, broker: Any, broker_type: Any, identity: str) -> float:
+    try:
+        helper = getattr(trader, "_get_broker_balance", None)
+        if callable(helper):
+            return max(0.0, float(helper(broker, broker_type, identity) or 0.0))
+        getter = getattr(broker, "get_account_balance", None)
+        if callable(getter):
+            return max(0.0, float(getter() or 0.0))
+    except Exception as exc:
+        logger.warning(
+            "ACCOUNT_BALANCE_PROBE_FAILED marker=%s account=%s error=%s",
+            _MARKER,
+            identity,
+            exc,
+        )
+    return 0.0
+
+
+def _normalise_rows(payload: Any) -> list[Any]:
+    if payload is None:
+        return []
+    if isinstance(payload, Mapping):
+        for key in ("positions", "open_positions", "holdings"):
+            value = payload.get(key)
+            if isinstance(value, Mapping):
+                return list(value.values())
+            if isinstance(value, (list, tuple, set)):
+                return list(value)
+        if payload and all(isinstance(value, Mapping) for value in payload.values()):
+            return list(payload.values())
+        return []
+    if isinstance(payload, (list, tuple, set)):
+        return list(payload)
+    return []
+
+
+def _position_count(broker: Any) -> int:
+    for method_name in (
+        "get_positions",
+        "get_open_positions",
+        "get_spot_positions",
+        "get_holdings",
+    ):
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            try:
+                payload = method(verbose=False)
+            except TypeError:
+                payload = method()
+            rows = _normalise_rows(payload)
+            if rows:
+                return len(rows)
+        except Exception:
+            continue
+    return 0
+
+
+def _open_order_count(broker: Any) -> int:
+    getter = getattr(broker, "get_open_orders", None)
+    if not callable(getter):
+        return 0
+    try:
+        payload = getter() or []
+        if isinstance(payload, Mapping):
+            return len(payload)
+        if isinstance(payload, (list, tuple, set)):
+            return len(payload)
+    except Exception:
+        pass
+    return 0
+
+
+def _platform_source(trader: Any) -> Mapping[Any, Any]:
+    getter = getattr(trader, "_get_platform_broker_source", None)
+    if callable(getter):
+        try:
+            value = getter() or {}
+            if isinstance(value, Mapping):
+                return value
+        except Exception:
+            pass
+    manager = getattr(trader, "multi_account_manager", None)
+    value = getattr(manager, "platform_brokers", None)
+    if isinstance(value, Mapping):
+        return value
+    manager = getattr(trader, "broker_manager", None)
+    value = getattr(manager, "brokers", None)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _iter_accounts(trader: Any) -> Iterable[tuple[str, str, Optional[str], Any, Any]]:
+    for broker_type, broker in list(_platform_source(trader).items()):
+        name = _broker_name(broker_type, broker)
+        yield f"platform:{name}", "platform", None, broker_type, broker
+
+    manager = getattr(trader, "multi_account_manager", None)
+    user_brokers = getattr(manager, "user_brokers", None)
+    if not isinstance(user_brokers, Mapping):
+        return
+    for user_id, mapping in list(user_brokers.items()):
+        if not isinstance(mapping, Mapping):
+            continue
+        for broker_type, broker in list(mapping.items()):
+            name = _broker_name(broker_type, broker)
+            yield f"user:{user_id}:{name}", "user", str(user_id), broker_type, broker
+
+
+def _normal_thread_alive(trader: Any, scope: str, user_id: Optional[str], broker_type: Any, broker: Any) -> bool:
+    name = _broker_name(broker_type, broker)
+    thread = None
+    if scope == "platform":
+        thread = (getattr(trader, "broker_threads", {}) or {}).get(name)
+    else:
+        key = f"{user_id}_{name}"
+        thread = ((getattr(trader, "user_broker_threads", {}) or {}).get(user_id, {}) or {}).get(key)
+    return bool(thread is not None and callable(getattr(thread, "is_alive", None)) and thread.is_alive())
+
+
+def _user_config(trader: Any, user_id: str) -> Any:
+    manager = getattr(trader, "multi_account_manager", None)
+    configs = getattr(manager, "user_configs", None)
+    if isinstance(configs, Mapping):
+        return configs.get(user_id)
+    return None
+
+
+def _normal_user_entries_allowed(trader: Any, user_id: str) -> bool:
+    if _truthy("NIJA_PLATFORM_ONLY_MODE", "false"):
+        return False
+    config = _user_config(trader, user_id)
+    if config is not None and not bool(getattr(config, "active_trading", True)):
+        return False
+    checker = getattr(trader, "should_start_user_independent_thread", None)
+    if callable(checker):
+        try:
+            return bool(checker(user_id))
+        except Exception:
+            return False
+    return bool(getattr(config, "independent_trading", False)) if config is not None else False
+
+
+def _ensure_state(trader: Any) -> None:
+    if not hasattr(trader, "_nija_exit_recovery_lock"):
+        trader._nija_exit_recovery_lock = threading.RLock()
+    if not hasattr(trader, "_nija_exit_recovery_threads"):
+        trader._nija_exit_recovery_threads = {}
+    if not hasattr(trader, "_nija_exit_recovery_stops"):
+        trader._nija_exit_recovery_stops = {}
+    if not hasattr(trader, "_nija_exit_supervisor_stop"):
+        trader._nija_exit_supervisor_stop = threading.Event()
+    if not hasattr(trader, "_nija_exit_supervisor_thread"):
+        trader._nija_exit_supervisor_thread = None
+
+
+def _adopt_and_manage(trader: Any, identity: str, broker: Any) -> tuple[int, int]:
+    strategy = getattr(trader, "trading_strategy", None)
+    if strategy is None:
+        return 0, 0
+
+    positions = _position_count(broker)
+    orders = _open_order_count(broker)
+    adopter = getattr(strategy, "adopt_existing_positions", None)
+    if callable(adopter):
+        try:
+            status = adopter(
+                broker=broker,
+                broker_name=identity,
+                account_id=identity.upper().replace(":", "_"),
+            ) or {}
+            positions = max(
+                positions,
+                int(status.get("positions_found", 0) or 0),
+                int(status.get("positions_adopted", 0) or 0),
+            )
+            orders = max(orders, int(status.get("open_orders_count", 0) or 0))
+        except Exception as exc:
+            logger.warning(
+                "ACCOUNT_POSITION_ADOPTION_FAILED marker=%s account=%s error=%s",
+                _MARKER,
+                identity,
+                exc,
+            )
+            return positions, orders
+
+    if positions <= 0 and orders <= 0:
+        return 0, 0
+
+    try:
+        from bot.startup_position_sync import sync_exchange_positions_on_startup
+        sync_exchange_positions_on_startup(strategy)
+    except Exception as exc:
+        logger.debug(
+            "ACCOUNT_POSITION_MIRROR_REFRESH_SKIPPED marker=%s account=%s error=%s",
+            _MARKER,
+            identity,
+            exc,
+        )
+
+    runner = getattr(strategy, "run_cycle", None)
+    if callable(runner):
+        try:
+            runner(broker=broker, user_mode=True)
+            logger.critical(
+                "ACCOUNT_EXIT_MANAGEMENT_CYCLE marker=%s account=%s positions=%d open_orders=%d entries_allowed=false",
+                _MARKER,
+                identity,
+                positions,
+                orders,
+            )
+        except Exception as exc:
+            logger.warning(
+                "ACCOUNT_EXIT_MANAGEMENT_CYCLE_FAILED marker=%s account=%s error=%s",
+                _MARKER,
+                identity,
+                exc,
+            )
+    return positions, orders
+
+
+def _exit_loop(trader: Any, identity: str, scope: str, user_id: Optional[str], broker_type: Any, broker: Any, stop: threading.Event) -> None:
+    logger.warning(
+        "ACCOUNT_EXIT_ONLY_THREAD_STARTED marker=%s account=%s entries_allowed=false",
+        _MARKER,
+        identity,
+    )
+    while not stop.is_set():
+        if _normal_thread_alive(trader, scope, user_id, broker_type, broker):
+            logger.info(
+                "ACCOUNT_EXIT_ONLY_THREAD_HANDOFF marker=%s account=%s reason=normal_thread_active",
+                _MARKER,
+                identity,
+            )
+            break
+        if not _connect(broker, identity):
+            stop.wait(_interval())
+            continue
+        _adopt_and_manage(trader, identity, broker)
+        stop.wait(_interval())
+    logger.info("ACCOUNT_EXIT_ONLY_THREAD_STOPPED marker=%s account=%s", _MARKER, identity)
+
+
+def _ensure_exit_thread(trader: Any, identity: str, scope: str, user_id: Optional[str], broker_type: Any, broker: Any) -> bool:
+    _ensure_state(trader)
+    if _normal_thread_alive(trader, scope, user_id, broker_type, broker):
+        return False
+    with trader._nija_exit_recovery_lock:
+        existing = trader._nija_exit_recovery_threads.get(identity)
+        if existing is not None and existing.is_alive():
+            return False
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=_exit_loop,
+            args=(trader, identity, scope, user_id, broker_type, broker, stop),
+            name=f"ExitManager-{identity.replace(':', '-')}",
+            daemon=True,
+        )
+        trader._nija_exit_recovery_stops[identity] = stop
+        trader._nija_exit_recovery_threads[identity] = thread
+        thread.start()
+        return True
+
+
+def _start_normal_or_exit(trader: Any, identity: str, scope: str, user_id: Optional[str], broker_type: Any, broker: Any) -> None:
+    if not _connect(broker, identity):
+        return
+    balance = _safe_balance(trader, broker, broker_type, identity)
+    try:
+        minimum = max(0.0, float(getattr(sys.modules.get("bot.independent_broker_trader"), "MINIMUM_FUNDED_BALANCE", 0.5) or 0.5))
+    except Exception:
+        minimum = 0.5
+
+    if _position_count(broker) > 0 or _open_order_count(broker) > 0:
+        _adopt_and_manage(trader, identity, broker)
+
+    if scope == "platform":
+        if balance >= minimum:
+            starter = getattr(trader, "_start_platform_thread", None)
+            if callable(starter):
+                starter(broker_type, broker)
+                return
+        _ensure_exit_thread(trader, identity, scope, user_id, broker_type, broker)
+        return
+
+    assert user_id is not None
+    if balance >= minimum and _normal_user_entries_allowed(trader, user_id):
+        starter = getattr(trader, "_start_user_thread", None)
+        if callable(starter):
+            starter(user_id, broker_type, broker)
+            return
+    _ensure_exit_thread(trader, identity, scope, user_id, broker_type, broker)
+
+
+def _retry_all_accounts(trader: Any) -> None:
+    manager = getattr(trader, "multi_account_manager", None)
+    connector = getattr(manager, "connect_users_from_config", None)
+    if callable(connector):
+        try:
+            connector()
+        except Exception as exc:
+            logger.warning("ACCOUNT_USER_CONFIG_CONNECT_FAILED marker=%s error=%s", _MARKER, exc)
+
+    for identity, scope, user_id, broker_type, broker in list(_iter_accounts(trader)):
+        if broker is None:
+            continue
+        _start_normal_or_exit(trader, identity, scope, user_id, broker_type, broker)
+
+
+def _supervisor_loop(trader: Any) -> None:
+    logger.warning("ACCOUNT_EXIT_RECOVERY_SUPERVISOR_STARTED marker=%s", _MARKER)
+    while not trader._nija_exit_supervisor_stop.is_set():
+        try:
+            _retry_all_accounts(trader)
+        except Exception:
+            logger.exception("ACCOUNT_EXIT_RECOVERY_SUPERVISOR_ERROR marker=%s", _MARKER)
+        trader._nija_exit_supervisor_stop.wait(_interval())
+    logger.info("ACCOUNT_EXIT_RECOVERY_SUPERVISOR_STOPPED marker=%s", _MARKER)
+
+
+def _start_supervisor(trader: Any) -> None:
+    if not _truthy("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_ENABLED", "true"):
+        return
+    _ensure_state(trader)
+    thread = trader._nija_exit_supervisor_thread
+    if thread is not None and thread.is_alive():
+        return
+    trader._nija_exit_supervisor_stop.clear()
+    _retry_all_accounts(trader)
+    thread = threading.Thread(
+        target=_supervisor_loop,
+        args=(trader,),
+        name="AccountExitRecoverySupervisor",
+        daemon=True,
+    )
+    trader._nija_exit_supervisor_thread = thread
+    thread.start()
+
+
+def _stop_supervisor(trader: Any) -> None:
+    _ensure_state(trader)
+    trader._nija_exit_supervisor_stop.set()
+    for stop in list(trader._nija_exit_recovery_stops.values()):
+        stop.set()
+
+
+def _patch_class(cls: type) -> bool:
+    if getattr(cls, _PATCHED_ATTR, False):
+        return True
+
+    original_start = getattr(cls, "start_independent_trading", None)
+    original_stop = getattr(cls, "stop_all_trading", None)
+    if not callable(original_start):
+        return False
+
+    def start_independent_trading(self: Any, *args: Any, **kwargs: Any) -> Any:
+        result = original_start(self, *args, **kwargs)
+        _start_supervisor(self)
+        return result
+
+    setattr(start_independent_trading, "__wrapped__", original_start)
+    cls.start_independent_trading = start_independent_trading
+
+    if callable(original_stop):
+        def stop_all_trading(self: Any, *args: Any, **kwargs: Any) -> Any:
+            _stop_supervisor(self)
+            return original_stop(self, *args, **kwargs)
+        setattr(stop_all_trading, "__wrapped__", original_stop)
+        cls.stop_all_trading = stop_all_trading
+
+    def _retry_platform_connections(self: Any) -> None:
+        for identity, scope, user_id, broker_type, broker in list(_iter_accounts(self)):
+            if scope == "platform" and broker is not None:
+                _start_normal_or_exit(self, identity, scope, user_id, broker_type, broker)
+
+    def _retry_user_connections(self: Any) -> None:
+        manager = getattr(self, "multi_account_manager", None)
+        connector = getattr(manager, "connect_users_from_config", None)
+        if callable(connector):
+            try:
+                connector()
+            except Exception as exc:
+                logger.warning("ACCOUNT_USER_CONFIG_CONNECT_FAILED marker=%s error=%s", _MARKER, exc)
+        for identity, scope, user_id, broker_type, broker in list(_iter_accounts(self)):
+            if scope == "user" and broker is not None:
+                _start_normal_or_exit(self, identity, scope, user_id, broker_type, broker)
+
+    cls._retry_platform_connections = _retry_platform_connections
+    cls._retry_user_connections = _retry_user_connections
+    setattr(cls, _PATCHED_ATTR, True)
+    logger.warning("ACCOUNT_EXIT_MANAGEMENT_RECOVERY_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return True
+
+
+def _patch_strategy_class(cls: type) -> bool:
+    """Make adoption verification account-aware when legacy callers omit broker."""
+    if getattr(cls, _STRATEGY_PATCHED_ATTR, False):
+        return True
+
+    original_adopt = getattr(cls, "adopt_existing_positions", None)
+    original_verify = getattr(cls, "verify_position_adoption_status", None)
+    if not callable(original_adopt) or not callable(original_verify):
+        return False
+
+    def adopt_existing_positions(self: Any, broker: Any, broker_name: str = "", account_id: str = "") -> Any:
+        result = original_adopt(self, broker=broker, broker_name=broker_name, account_id=account_id)
+        if isinstance(result, Mapping) and bool(result.get("success")) and account_id:
+            mapping = getattr(self, "_nija_adoption_broker_by_account", None)
+            if not isinstance(mapping, dict):
+                mapping = {}
+                setattr(self, "_nija_adoption_broker_by_account", mapping)
+            mapping[str(account_id)] = broker
+        return result
+
+    def verify_position_adoption_status(
+        self: Any,
+        broker: Any = None,
+        broker_name: str = "",
+        account_id: str = "",
+    ) -> bool:
+        selected = broker
+        if selected is None and account_id:
+            mapping = getattr(self, "_nija_adoption_broker_by_account", None)
+            if isinstance(mapping, Mapping):
+                selected = mapping.get(str(account_id))
+        if selected is None:
+            logger.warning(
+                "ACCOUNT_POSITION_ADOPTION_VERIFY_BLOCKED marker=%s account=%s broker=%s reason=broker_unresolved",
+                _MARKER,
+                account_id,
+                broker_name,
+            )
+            return False
+        return bool(
+            original_verify(
+                self,
+                broker=selected,
+                broker_name=broker_name,
+                account_id=account_id,
+            )
+        )
+
+    setattr(adopt_existing_positions, "__wrapped__", original_adopt)
+    setattr(verify_position_adoption_status, "__wrapped__", original_verify)
+    cls.adopt_existing_positions = adopt_existing_positions
+    cls.verify_position_adoption_status = verify_position_adoption_status
+    setattr(cls, _STRATEGY_PATCHED_ATTR, True)
+    logger.warning("ACCOUNT_POSITION_ADOPTION_VERIFY_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    for name in ("bot.independent_broker_trader", "independent_broker_trader"):
+        module = sys.modules.get(name)
+        cls = getattr(module, "IndependentBrokerTrader", None) if isinstance(module, ModuleType) else None
+        if isinstance(cls, type):
+            patched = _patch_class(cls) or patched
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        cls = getattr(module, "TradingStrategy", None) if isinstance(module, ModuleType) else None
+        if isinstance(cls, type):
+            patched = _patch_strategy_class(cls) or patched
+    return patched
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    with _INSTALL_LOCK:
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_ENABLED", "true")
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S", "15")
+        os.environ.setdefault("NIJA_ADOPTED_POSITION_PROFIT_EXIT_ENABLED", "true")
+        os.environ.setdefault("NIJA_GLOBAL_TAKE_PROFIT_ENABLED", "true")
+        os.environ.setdefault("NIJA_GLOBAL_TRAILING_TAKE_PROFIT_ENABLED", "true")
+        os.environ.setdefault("NIJA_AUTO_EXIT_SL_TP_ENABLED", "true")
+        if _ORIGINAL_IMPORT is None:
+            _ORIGINAL_IMPORT = builtins.__import__
+
+            def _import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+                module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+                try:
+                    _patch_loaded()
+                except Exception as exc:
+                    logger.debug("ACCOUNT_EXIT_MANAGEMENT_IMPORT_PATCH_FAILED name=%s error=%s", name, exc)
+                return module
+
+            builtins.__import__ = _import
+        _patch_loaded()
+        logger.warning("ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALL_REQUESTED marker=%s", _MARKER)
+
+
+__all__ = [
+    "install_import_hook",
+    "_patch_class",
+    "_patch_strategy_class",
+    "_retry_all_accounts",
+    "_adopt_and_manage",
+    "_ensure_exit_thread",
+]

--- a/bot/tests/test_account_exit_management_recovery_patch.py
+++ b/bot/tests/test_account_exit_management_recovery_patch.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import account_exit_management_recovery_patch as patch
+
+
+class BrokerType:
+    def __init__(self, value):
+        self.value = value
+
+
+class Broker:
+    def __init__(self, connected=True, balance=0.0, positions=None, orders=None):
+        self.connected = connected
+        self.balance = balance
+        self.positions = list(positions or [])
+        self.orders = list(orders or [])
+        self.connect_calls = 0
+
+    def connect(self):
+        self.connect_calls += 1
+        self.connected = True
+        return True
+
+    def get_account_balance(self):
+        return self.balance
+
+    def get_positions(self):
+        return list(self.positions)
+
+    def get_open_orders(self):
+        return list(self.orders)
+
+
+class Strategy:
+    def __init__(self):
+        self.adoptions = []
+        self.cycles = []
+
+    def adopt_existing_positions(self, **kwargs):
+        broker = kwargs["broker"]
+        self.adoptions.append(kwargs["account_id"])
+        return {
+            "success": True,
+            "positions_found": len(broker.positions),
+            "positions_adopted": len(broker.positions),
+            "open_orders_count": len(broker.orders),
+        }
+
+    def run_cycle(self, broker=None, user_mode=False):
+        self.cycles.append((broker, user_mode))
+        return 15
+
+
+class Manager:
+    def __init__(self, platform, users, configs):
+        self.platform_brokers = platform
+        self.user_brokers = users
+        self.user_configs = configs
+        self.connect_users_calls = 0
+
+    def connect_users_from_config(self):
+        self.connect_users_calls += 1
+
+
+class Trader:
+    def __init__(self, manager, strategy):
+        self.multi_account_manager = manager
+        self.broker_manager = None
+        self.trading_strategy = strategy
+        self.broker_threads = {}
+        self.user_broker_threads = {}
+        self.stop_flags = {}
+        self.user_stop_flags = {}
+        self.normal_platform_started = []
+        self.normal_users_started = []
+
+    def _get_platform_broker_source(self):
+        return self.multi_account_manager.platform_brokers
+
+    def _get_broker_balance(self, broker, broker_type, label):
+        return broker.get_account_balance()
+
+    def _start_platform_thread(self, broker_type, broker):
+        self.normal_platform_started.append(broker_type.value)
+
+    def _start_user_thread(self, user_id, broker_type, broker):
+        self.normal_users_started.append((user_id, broker_type.value))
+
+    def should_start_user_independent_thread(self, user_id):
+        cfg = self.multi_account_manager.user_configs[user_id]
+        return bool(cfg.independent_trading)
+
+
+def config(active=True, independent=True):
+    return SimpleNamespace(active_trading=active, independent_trading=independent)
+
+
+def test_user_reconnect_does_not_wait_for_platform(monkeypatch):
+    platform = Broker(connected=False, balance=100)
+    user = Broker(connected=False, balance=50)
+    manager = Manager(
+        {BrokerType("kraken"): platform},
+        {"daivon": {BrokerType("kraken"): user}},
+        {"daivon": config(active=True, independent=True)},
+    )
+    trader = Trader(manager, Strategy())
+    monkeypatch.setattr(patch, "_ensure_exit_thread", lambda *args, **kwargs: False)
+
+    class C:
+        pass
+
+    C._retry_user_connections = lambda self: None
+    C.start_independent_trading = lambda self: True
+    patch._patch_class(C)
+    C._retry_user_connections(trader)
+
+    assert manager.connect_users_calls == 1
+    assert user.connected is True
+    assert ("daivon", "kraken") in trader.normal_users_started
+
+
+def test_copy_or_recovery_user_gets_exit_only_thread(monkeypatch):
+    user = Broker(connected=True, balance=50, positions=[{"symbol": "ETH-USD", "quantity": 1}])
+    manager = Manager({}, {"tania": {BrokerType("kraken"): user}}, {"tania": config(active=False, independent=False)})
+    trader = Trader(manager, Strategy())
+    calls = []
+    monkeypatch.setattr(patch, "_ensure_exit_thread", lambda *args: calls.append(args[1]) or True)
+
+    patch._retry_all_accounts(trader)
+
+    assert trader.normal_users_started == []
+    assert calls == ["user:tania:kraken"]
+
+
+def test_underfunded_platform_with_position_gets_exit_only(monkeypatch):
+    platform = Broker(connected=True, balance=0.0, positions=[{"symbol": "ADA-USD", "quantity": 10}])
+    manager = Manager({BrokerType("kraken"): platform}, {}, {})
+    trader = Trader(manager, Strategy())
+    calls = []
+    monkeypatch.setattr(patch, "_ensure_exit_thread", lambda *args: calls.append(args[1]) or True)
+
+    patch._retry_all_accounts(trader)
+
+    assert trader.normal_platform_started == []
+    assert calls == ["platform:kraken"]
+
+
+def test_exit_management_runs_phase2_only(monkeypatch):
+    broker = Broker(connected=True, positions=[{"symbol": "SOL-USD", "quantity": 2}])
+    strategy = Strategy()
+    manager = Manager({}, {}, {})
+    trader = Trader(manager, strategy)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "bot.startup_position_sync",
+        SimpleNamespace(sync_exchange_positions_on_startup=lambda strategy: 1),
+    )
+
+    positions, orders = patch._adopt_and_manage(trader, "user:daivon:kraken", broker)
+
+    assert positions == 1
+    assert orders == 0
+    assert strategy.cycles == [(broker, True)]
+
+
+def test_no_position_no_order_does_not_run_cycle():
+    broker = Broker(connected=True)
+    strategy = Strategy()
+    trader = Trader(Manager({}, {}, {}), strategy)
+
+    positions, orders = patch._adopt_and_manage(trader, "platform:kraken", broker)
+
+    assert (positions, orders) == (0, 0)
+    assert strategy.cycles == []
+
+
+def test_normal_thread_prevents_duplicate_exit_thread():
+    broker = Broker(connected=True, positions=[{"symbol": "BTC-USD", "quantity": 1}])
+    bt = BrokerType("kraken")
+    trader = Trader(Manager({bt: broker}, {}, {}), Strategy())
+    alive = SimpleNamespace(is_alive=lambda: True)
+    trader.broker_threads["kraken"] = alive
+
+    started = patch._ensure_exit_thread(trader, "platform:kraken", "platform", None, bt, broker)
+
+    assert started is False
+
+
+def test_adoption_verification_resolves_exact_account_broker():
+    class T:
+        def __init__(self):
+            self.checked = []
+
+        def adopt_existing_positions(self, broker, broker_name="", account_id=""):
+            return {"success": True, "positions_found": 1, "positions_adopted": 1}
+
+        def verify_position_adoption_status(self, broker, broker_name="", account_id=""):
+            self.checked.append((broker, broker_name, account_id))
+            return broker is not None
+
+    patch._patch_strategy_class(T)
+    strategy = T()
+    exact = Broker(connected=True, positions=[{"symbol": "ETH-USD", "quantity": 1}])
+    strategy.adopt_existing_positions(exact, broker_name="daivon_kraken", account_id="USER_DAIVON_KRAKEN")
+
+    assert strategy.verify_position_adoption_status(
+        broker_name="daivon_kraken",
+        account_id="USER_DAIVON_KRAKEN",
+    ) is True
+    assert strategy.checked == [(exact, "daivon_kraken", "USER_DAIVON_KRAKEN")]
+
+
+def test_funded_normal_account_gets_immediate_exit_evaluation(monkeypatch):
+    platform = Broker(connected=True, balance=100.0, positions=[{"symbol": "ADA-USD", "quantity": 5}])
+    bt = BrokerType("kraken")
+    trader = Trader(Manager({bt: platform}, {}, {}), Strategy())
+    managed = []
+    monkeypatch.setattr(patch, "_adopt_and_manage", lambda *args: managed.append(args[1]) or (1, 0))
+
+    patch._start_normal_or_exit(trader, "platform:kraken", "platform", None, bt, platform)
+
+    assert managed == ["platform:kraken"]
+    assert trader.normal_platform_started == ["kraken"]

--- a/bot/tests/test_secondary_venue_strict_readiness_patch.py
+++ b/bot/tests/test_secondary_venue_strict_readiness_patch.py
@@ -46,6 +46,8 @@ def _reset(monkeypatch):
         "NIJA_REQUIRED_VENUES_READY",
         "NIJA_MULTI_BROKER_TRADING_READY",
         "NIJA_REQUIRED_VENUES_MISSING",
+        "NIJA_ACTIVE_LIVE_VENUES",
+        "NIJA_DEGRADED_LIVE_VENUES",
         "NIJA_REQUIRED_VENUES_STATUS_JSON",
         "NIJA_NEW_ENTRY_BLOCK_REASON",
     ):
@@ -61,7 +63,7 @@ def _set_ready_env(monkeypatch, venue: str):
     monkeypatch.setenv(f"NIJA_{key}_SPENDABLE_QUOTE", "25")
 
 
-def test_strict_readiness_requires_both_connected_venues(monkeypatch):
+def test_refresh_reports_degraded_secondary_without_global_block(monkeypatch):
     _reset(monkeypatch)
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
     _set_ready_env(monkeypatch, "coinbase")
@@ -69,97 +71,93 @@ def test_strict_readiness_requires_both_connected_venues(monkeypatch):
     monkeypatch.setattr(
         patch,
         "_runtime_brokers",
-        lambda: {"coinbase": _Broker("coinbase", True), "okx": _Broker("okx", False)},
+        lambda: {
+            "kraken": _Broker("kraken", True),
+            "coinbase": _Broker("coinbase", True),
+            "okx": _Broker("okx", False),
+        },
     )
 
     ready, missing, statuses = patch.refresh_readiness(force_log=True)
 
-    assert ready is False
+    assert ready is True
     assert missing == ["okx"]
+    assert statuses["kraken"]["ready"] is True
     assert statuses["coinbase"]["ready"] is True
     assert statuses["okx"]["ready"] is False
-    assert patch.os.environ["NIJA_REQUIRED_VENUES_READY"] == "0"
+    assert patch.os.environ["NIJA_REQUIRED_VENUES_READY"] == "1"
+    assert patch.os.environ["NIJA_MULTI_BROKER_TRADING_READY"] == "1"
+    assert "NIJA_NEW_ENTRY_BLOCK_REASON" not in patch.os.environ
 
 
-def test_strict_readiness_passes_only_when_both_are_ready(monkeypatch):
+def test_pipeline_allows_kraken_when_secondary_venues_are_down(monkeypatch):
     _reset(monkeypatch)
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
-    _set_ready_env(monkeypatch, "coinbase")
-    _set_ready_env(monkeypatch, "okx")
     monkeypatch.setattr(
         patch,
         "_runtime_brokers",
-        lambda: {"coinbase": _Broker("coinbase", True), "okx": _Broker("okx", True)},
+        lambda: {
+            "kraken": _Broker("kraken", True),
+            "coinbase": _Broker("coinbase", False),
+            "okx": _Broker("okx", False),
+        },
     )
-
-    ready, missing, _statuses = patch.refresh_readiness(force_log=True)
-
-    assert ready is True
-    assert missing == []
-    assert patch.os.environ["NIJA_MULTI_BROKER_TRADING_READY"] == "1"
-
-
-def test_pipeline_blocks_new_entry_but_allows_exit(monkeypatch):
-    _reset(monkeypatch)
-    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
-    monkeypatch.setattr(
-        patch,
-        "refresh_readiness",
-        lambda **kwargs: (False, ["coinbase", "okx"], {}),
-    )
-    module = ModuleType("test_execution_pipeline")
-    module.ExecutionPipeline = _ExecutionPipeline
+    module = ModuleType("test_execution_pipeline_kraken")
+    module.ExecutionPipeline = type("ExecutionPipelineKraken", (_ExecutionPipeline,), {})
     module.PipelineResult = _PipelineResult
 
     assert patch._patch_execution_pipeline(module) is True
-    pipeline = module.ExecutionPipeline()
-
-    entry = SimpleNamespace(
+    request = SimpleNamespace(
         symbol="BTC-USD",
         side="buy",
         size_usd=25.0,
+        preferred_broker="kraken",
         intent_type="entry",
         reduce_only=False,
         position_effect=None,
     )
-    result = pipeline.execute(entry)
-    assert result.success is False
-    assert "required_secondary_venues_not_ready" in result.error
 
-    exit_request = SimpleNamespace(
-        symbol="BTC-USD",
-        side="sell",
+    assert module.ExecutionPipeline().execute(request) == "executed"
+
+
+def test_pipeline_blocks_only_the_unready_target_broker(monkeypatch):
+    _reset(monkeypatch)
+    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "connect_failed")
+    monkeypatch.setenv("NIJA_OKX_CONNECTED", "0")
+    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "0")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATED", "0")
+    monkeypatch.setattr(patch, "_runtime_brokers", lambda: {"okx": _Broker("okx", False)})
+    module = ModuleType("test_execution_pipeline_okx")
+    module.ExecutionPipeline = type("ExecutionPipelineOkx", (_ExecutionPipeline,), {})
+    module.PipelineResult = _PipelineResult
+
+    assert patch._patch_execution_pipeline(module) is True
+    request = SimpleNamespace(
+        symbol="BTC-USDT",
+        side="buy",
         size_usd=25.0,
-        intent_type="exit",
-        reduce_only=True,
-        position_effect="close",
+        preferred_broker="okx",
+        intent_type="entry",
+        reduce_only=False,
+        position_effect=None,
     )
-    assert pipeline.execute(exit_request) == "executed"
+    result = module.ExecutionPipeline().execute(request)
+
+    assert result.success is False
+    assert result.error.startswith("target_broker_not_ready:okx:")
 
 
-def test_strategy_entry_eligibility_is_blocked_until_required_venues_ready(monkeypatch):
+def test_pipeline_without_target_leaves_routing_to_router(monkeypatch):
     _reset(monkeypatch)
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
     monkeypatch.setattr(
         patch,
-        "refresh_readiness",
-        lambda **kwargs: (False, ["okx"], {}),
+        "_runtime_brokers",
+        lambda: {"coinbase": _Broker("coinbase", False), "okx": _Broker("okx", False)},
     )
-    module = ModuleType("test_trading_strategy")
-    module.TradingStrategy = _TradingStrategy
-
-    assert patch._patch_trading_strategy(module) is True
-    allowed, reason = module.TradingStrategy()._is_broker_eligible_for_entry(_Broker("kraken"))
-
-    assert allowed is False
-    assert "okx" in reason
-
-
-def test_strict_mode_disabled_preserves_upstream_execution(monkeypatch):
-    _reset(monkeypatch)
-    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "false")
-    module = ModuleType("test_execution_pipeline_disabled")
-    module.ExecutionPipeline = _ExecutionPipeline
+    module = ModuleType("test_execution_pipeline_auto")
+    module.ExecutionPipeline = type("ExecutionPipelineAuto", (_ExecutionPipeline,), {})
     module.PipelineResult = _PipelineResult
     assert patch._patch_execution_pipeline(module) is True
 
@@ -170,5 +168,45 @@ def test_strict_mode_disabled_preserves_upstream_execution(monkeypatch):
         intent_type="entry",
         reduce_only=False,
         position_effect=None,
+    )
+    assert module.ExecutionPipeline().execute(request) == "executed"
+
+
+def test_strategy_unready_okx_does_not_block_kraken(monkeypatch):
+    _reset(monkeypatch)
+    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "connect_failed")
+    module = ModuleType("test_trading_strategy_independent")
+    module.TradingStrategy = type("TradingStrategyIndependent", (_TradingStrategy,), {})
+
+    assert patch._patch_trading_strategy(module) is True
+    strategy = module.TradingStrategy()
+    kraken_allowed, kraken_reason = strategy._is_broker_eligible_for_entry(_Broker("kraken", True))
+    okx_allowed, okx_reason = strategy._is_broker_eligible_for_entry(_Broker("okx", False))
+
+    assert kraken_allowed is True
+    assert kraken_reason == "upstream-ready"
+    assert okx_allowed is False
+    assert "okx" in okx_reason
+
+
+def test_exits_always_bypass_broker_local_entry_guard(monkeypatch):
+    _reset(monkeypatch)
+    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "connect_failed")
+    monkeypatch.setattr(patch, "_runtime_brokers", lambda: {"okx": _Broker("okx", False)})
+    module = ModuleType("test_execution_pipeline_exit")
+    module.ExecutionPipeline = type("ExecutionPipelineExit", (_ExecutionPipeline,), {})
+    module.PipelineResult = _PipelineResult
+    assert patch._patch_execution_pipeline(module) is True
+
+    request = SimpleNamespace(
+        symbol="BTC-USDT",
+        side="sell",
+        size_usd=25.0,
+        preferred_broker="okx",
+        intent_type="exit",
+        reduce_only=True,
+        position_effect="close",
     )
     assert module.ExecutionPipeline().execute(request) == "executed"

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -16,6 +16,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
     monkeypatch.delenv("NIJA_VENUE_READINESS_SOURCE_MARKER", raising=False)
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED", raising=False)
+    monkeypatch.delenv("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_RENDER_READINESS_BRIDGE_INSTALLED", raising=False)
 
@@ -31,23 +32,26 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
     fake_activator.install = lambda: calls.append("activator")
     fake_strict = ModuleType("secondary_venue_strict_readiness_patch")
     fake_strict.install = lambda: calls.append("strict")
+    fake_exit_recovery = ModuleType("account_exit_management_recovery_patch")
+    fake_exit_recovery.install_import_hook = lambda: calls.append("exit_recovery")
+    fake_stage = ModuleType("three_venue_execution_readiness")
+    fake_stage.install = lambda: calls.append("stage")
     fake_bridge = ModuleType("render_readiness_state_bridge")
     fake_bridge.install = lambda: calls.append("bridge")
 
+    modules = {
+        "prebot_writer_authority_fail_closed": fake_writer,
+        "venue_readiness_execution_repair_patch": fake_repair,
+        "secondary_venue_activation_patch": fake_activator,
+        "secondary_venue_strict_readiness_patch": fake_strict,
+        "account_exit_management_recovery_patch": fake_exit_recovery,
+        "three_venue_execution_readiness": fake_stage,
+        "render_readiness_state_bridge": fake_bridge,
+    }
     real_import = source_bootstrap.importlib.import_module
 
     def _fake_import(name: str):
-        if name == "prebot_writer_authority_fail_closed":
-            return fake_writer
-        if name == "venue_readiness_execution_repair_patch":
-            return fake_repair
-        if name == "secondary_venue_activation_patch":
-            return fake_activator
-        if name == "secondary_venue_strict_readiness_patch":
-            return fake_strict
-        if name == "render_readiness_state_bridge":
-            return fake_bridge
-        return real_import(name)
+        return modules.get(name) or real_import(name)
 
     monkeypatch.setattr(source_bootstrap.importlib, "import_module", _fake_import)
     monkeypatch.setenv("RENDER_GIT_COMMIT", "abc123")
@@ -57,12 +61,13 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
 
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
-    assert calls == ["writer", "venue", "activator", "strict", "bridge"]
+    assert calls == ["writer", "venue", "activator", "strict", "exit_recovery", "stage", "bridge"]
     assert source_bootstrap.installed_marker() == "20260710af"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] == "1"
 
 
@@ -85,6 +90,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert source_bootstrap.os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] == "0"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] == "0"
 
 

--- a/scripts/three_venue_config_check.py
+++ b/scripts/three_venue_config_check.py
@@ -1,15 +1,13 @@
-"""NIJA three-venue configuration gate.
+"""NIJA independent-broker configuration check.
 
-Validates that Kraken, Coinbase, and OKX credentials, live-trading flags, and
-Redis connectivity are all present before the main bot process starts.  Exits
-with code 2 when the environment is incomplete so the bootstrap script can fail
-fast and surface the missing pieces in the deployment logs.
+Validates shared live-trading safety settings and evaluates Kraken, Coinbase, and
+OKX independently. Startup succeeds when at least one brokerage has a complete
+configuration. Missing or incomplete credentials for another brokerage are
+reported as degraded and that brokerage is excluded; they never stop a healthy
+brokerage from starting.
 
 Run with ``python3 -S`` to avoid triggering NIJA's site-customise trading hooks
 before writer authority has been established.
-
-Usage (from the repository root):
-    python3 -S scripts/three_venue_config_check.py
 """
 
 import json
@@ -22,65 +20,108 @@ from pathlib import Path
 TRUE = {"1", "true", "yes", "on", "enabled"}
 FALSE = {"0", "false", "no", "off", "disabled"}
 
-required_secrets = [
-    "KRAKEN_PLATFORM_API_KEY",
-    "KRAKEN_PLATFORM_API_SECRET",
-    "COINBASE_API_KEY",
-    "COINBASE_API_SECRET",
-    "OKX_API_KEY",
-    "OKX_API_SECRET",
-    "OKX_PASSPHRASE",
-]
+BROKERS = {
+    "kraken": {
+        "secrets": ("KRAKEN_PLATFORM_API_KEY", "KRAKEN_PLATFORM_API_SECRET"),
+        "true_flags": (),
+        "false_flags": (),
+    },
+    "coinbase": {
+        "secrets": ("COINBASE_API_KEY", "COINBASE_API_SECRET"),
+        "true_flags": (
+            "ENABLE_COINBASE",
+            "ENABLE_COINBASE_TRADING",
+            "COINBASE_LIVE_TRADING_ENABLED",
+        ),
+        "false_flags": ("NIJA_DISABLE_COINBASE",),
+    },
+    "okx": {
+        "secrets": ("OKX_API_KEY", "OKX_API_SECRET", "OKX_PASSPHRASE"),
+        "true_flags": (
+            "ENABLE_OKX",
+            "ENABLE_OKX_TRADING",
+            "OKX_LIVE_TRADING_ENABLED",
+            "NIJA_OKX_EXECUTION_ENABLED",
+            "NIJA_OKX_LIVE_TRADING_ENABLED",
+        ),
+        "false_flags": ("NIJA_DISABLE_OKX",),
+    },
+}
 
-# Environment flags that must be set to a truthy value for three-venue live
-# trading to be authorised.
-true_flags = [
+SHARED_TRUE_FLAGS = (
     "LIVE_TRADING",
     "LIVE_CAPITAL_VERIFIED",
-    "ENABLE_COINBASE",
-    "ENABLE_COINBASE_TRADING",
-    "COINBASE_LIVE_TRADING_ENABLED",
-    "ENABLE_OKX",
-    "ENABLE_OKX_TRADING",
-    "OKX_LIVE_TRADING_ENABLED",
-    "NIJA_OKX_EXECUTION_ENABLED",
-    "NIJA_OKX_LIVE_TRADING_ENABLED",
     "NIJA_BROKER_INDEPENDENT_LIVE_EXECUTION",
     "NIJA_INDEPENDENT_BROKER_TRADING",
-    "NIJA_REQUIRE_SECONDARY_VENUES_READY",
     "NIJA_REQUIRE_DISTRIBUTED_LOCK",
     "STRICT_REDIS_WRITER_LOCK",
     "NIJA_STRICT_REDIS_LEASE",
-]
+)
+SHARED_FALSE_FLAGS = ("DRY_RUN_MODE", "PAPER_MODE")
 
-# Environment flags that must be set to a falsy value (safety guards that must
-# NOT be active in a live three-venue deployment).
-false_flags = [
-    "DRY_RUN_MODE",
-    "PAPER_MODE",
-    "NIJA_DISABLE_COINBASE",
-    "NIJA_DISABLE_OKX",
-]
 
-missing = [name for name in required_secrets if not os.getenv(name, "").strip()]
+def _is_true(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in TRUE
 
-bad_true = [
-    name for name in true_flags
-    if os.getenv(name, "").strip().lower() not in TRUE
-]
 
-bad_false = [
-    name for name in false_flags
-    if os.getenv(name, "false").strip().lower() not in FALSE
-]
+def _is_false(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in FALSE
 
-print("=== NIJA THREE-VENUE CONFIGURATION ===")
 
-for name in required_secrets:
-    value = os.getenv(name, "")
-    print(f"{name}: {'SET' if value.strip() else 'MISSING'}")
+def _broker_status(name: str, contract: dict[str, tuple[str, ...]]) -> dict[str, object]:
+    secrets = contract["secrets"]
+    true_flags = contract["true_flags"]
+    false_flags = contract["false_flags"]
+    present_secrets = [secret for secret in secrets if os.getenv(secret, "").strip()]
+    missing_secrets = [secret for secret in secrets if secret not in present_secrets]
+    bad_true = [flag for flag in true_flags if not _is_true(flag)]
+    bad_false = [flag for flag in false_flags if not _is_false(flag)]
 
-for name in true_flags + false_flags:
+    any_config = bool(present_secrets) or any(flag in os.environ for flag in (*true_flags, *false_flags))
+    ready = not missing_secrets and not bad_true and not bad_false
+    if ready:
+        state = "ready"
+        reason = "configuration_complete"
+    elif not any_config:
+        state = "not_configured"
+        reason = "no_credentials_or_flags"
+    else:
+        state = "degraded"
+        parts = []
+        if missing_secrets:
+            parts.append("missing_secrets=" + ",".join(missing_secrets))
+        if bad_true:
+            parts.append("flags_not_true=" + ",".join(bad_true))
+        if bad_false:
+            parts.append("flags_not_false=" + ",".join(bad_false))
+        reason = ";".join(parts) or "configuration_incomplete"
+
+    return {
+        "broker": name,
+        "ready": ready,
+        "state": state,
+        "reason": reason,
+        "configured_secret_count": len(present_secrets),
+        "required_secret_count": len(secrets),
+        "missing_secrets": missing_secrets,
+        "bad_true_flags": bad_true,
+        "bad_false_flags": bad_false,
+    }
+
+
+bad_shared_true = [name for name in SHARED_TRUE_FLAGS if not _is_true(name)]
+bad_shared_false = [name for name in SHARED_FALSE_FLAGS if not _is_false(name)]
+broker_statuses = {name: _broker_status(name, contract) for name, contract in BROKERS.items()}
+ready_brokers = [name for name, status in broker_statuses.items() if status["ready"]]
+degraded_brokers = [name for name, status in broker_statuses.items() if status["state"] == "degraded"]
+
+print("=== NIJA INDEPENDENT-BROKER CONFIGURATION ===")
+print(json.dumps(broker_statuses, indent=2, sort_keys=True))
+print("READY BROKERS:", ", ".join(ready_brokers) or "none")
+print("DEGRADED BROKERS:", ", ".join(degraded_brokers) or "none")
+print("LEGACY CROSS-VENUE GATE:", os.getenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "false"))
+
+for name in SHARED_TRUE_FLAGS + SHARED_FALSE_FLAGS:
     print(f"{name}: {os.getenv(name, 'UNSET')}")
 
 redis_present = any(
@@ -95,17 +136,16 @@ redis_present = any(
 )
 print(f"REDIS CONNECTION: {'SET' if redis_present else 'MISSING'}")
 
-if missing:
-    print("\nMISSING SECRETS:", ", ".join(missing))
-if bad_true:
-    print("FLAGS THAT MUST BE TRUE:", ", ".join(bad_true))
-if bad_false:
-    print("FLAGS THAT MUST BE FALSE:", ", ".join(bad_false))
+if bad_shared_true:
+    print("SHARED FLAGS THAT MUST BE TRUE:", ", ".join(bad_shared_true))
+if bad_shared_false:
+    print("SHARED FLAGS THAT MUST BE FALSE:", ", ".join(bad_shared_false))
+if not ready_brokers:
+    print("NO BROKER HAS A COMPLETE INDEPENDENT CONFIGURATION")
 if not redis_present:
     print("REDIS URL IS NOT CONFIGURED")
 
 print("\n=== LOCAL ENDPOINTS ===")
-
 port = os.getenv("PORT", "5000")
 for path in ("/healthz", "/readyz"):
     url = f"http://127.0.0.1:{port}{path}"
@@ -122,14 +162,9 @@ for path in ("/healthz", "/readyz"):
         print(f"{path}: ERROR {type(exc).__name__}: {exc}")
 
 print("\n=== SHARED READINESS STATE ===")
-
 state_path = Path(
-    os.getenv(
-        "NIJA_RENDER_READINESS_STATE_FILE",
-        "/tmp/nija_render_readiness.json",
-    )
+    os.getenv("NIJA_RENDER_READINESS_STATE_FILE", "/tmp/nija_render_readiness.json")
 )
-
 if state_path.exists():
     try:
         payload = json.loads(state_path.read_text(encoding="utf-8"))
@@ -139,9 +174,10 @@ if state_path.exists():
 else:
     print(f"Readiness state file not found: {state_path}")
 
-if missing or bad_true or bad_false or not redis_present:
-    print("\nRESULT: CONFIGURATION INCOMPLETE")
+fatal = bool(bad_shared_true or bad_shared_false or not redis_present or not ready_brokers)
+if fatal:
+    print("\nRESULT: INDEPENDENT-BROKER CONFIGURATION INCOMPLETE")
     sys.exit(2)
 
-print("\nRESULT: ENVIRONMENT CONFIGURATION PRESENT")
-print("NIJA must still prove writer authority, balances, markets and venue readiness.")
+print("\nRESULT: AT LEAST ONE BROKER IS CONFIGURED")
+print("Each remaining broker will activate or remain isolated according to its own connection state.")

--- a/secondary_venue_strict_readiness_patch.py
+++ b/secondary_venue_strict_readiness_patch.py
@@ -1,11 +1,8 @@
-"""Strict Coinbase/OKX readiness guard for NIJA live entries.
+"""Broker-independent readiness guard for NIJA live entries.
 
-This module makes secondary-venue readiness an explicit production invariant.
-It never creates credentials, fabricates balances, changes broker permissions,
-places probe orders, or bypasses existing risk controls.  When strict mode is
-enabled, only *new entries* are blocked until every required venue is connected
-and has reached the supervised activation state ``ready``.  Exits, reductions,
-and emergency liquidation paths remain permitted.
+A brokerage can block only orders routed to itself. Coinbase or OKX being
+unavailable must never stop Kraken (or another healthy broker) from scanning,
+sizing, exiting, or executing. Legacy environment names remain for telemetry.
 """
 
 from __future__ import annotations
@@ -17,18 +14,19 @@ import sys
 import threading
 import time
 from types import ModuleType
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 logger = logging.getLogger("nija.secondary_venue_strict_readiness")
 
-_MARKER = "20260710ah"
+_MARKER = "20260711i"
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_KNOWN = {"coinbase", "okx", "kraken", "alpaca", "binance"}
 _LOCK = threading.RLock()
 _INSTALLED = False
 _MONITOR_STARTED = False
 _LAST_SIGNATURE = ""
-_PIPELINE_WRAP_ATTR = "_nija_required_secondary_venues_v20260710ah"
-_STRATEGY_WRAP_ATTR = "_nija_required_secondary_venues_entry_v20260710ah"
+_PIPELINE_WRAP_ATTR = "_nija_broker_independent_readiness_v20260711i"
+_STRATEGY_WRAP_ATTR = "_nija_broker_independent_entry_v20260711i"
 _PATCHED_PIPELINE: set[str] = set()
 _PATCHED_STRATEGY: set[str] = set()
 
@@ -38,30 +36,33 @@ def _truthy(name: str, default: str = "") -> bool:
 
 
 def strict_mode_enabled() -> bool:
+    """Legacy flag, now interpreted as a broker-local activation check."""
     return _truthy("NIJA_REQUIRE_SECONDARY_VENUES_READY", "false")
 
 
 def required_venues() -> list[str]:
     raw = os.environ.get("NIJA_REQUIRED_LIVE_VENUES", "coinbase,okx") or "coinbase,okx"
-    venues: list[str] = []
+    result: list[str] = []
     for item in raw.split(","):
         name = str(item or "").strip().lower()
-        if name in {"coinbase", "okx"} and name not in venues:
-            venues.append(name)
-    return venues
+        if name in _KNOWN and name not in result:
+            result.append(name)
+    return result
 
 
 def _normalise_name(value: Any) -> str:
     raw = getattr(value, "value", value)
     text = str(raw or "").strip().lower()
     compact = text.replace("_", "").replace("-", "").replace(" ", "")
-    for key in ("coinbase", "okx", "kraken", "alpaca", "binance"):
-        if key in compact:
-            return key
+    for name in _KNOWN:
+        if name in compact:
+            return name
     return text
 
 
 def _broker_name(broker: Any, fallback: Any = "") -> str:
+    if isinstance(broker, (str, bytes)):
+        return _normalise_name(broker) or _normalise_name(fallback) or "unknown"
     if broker is not None:
         for attr in ("broker_type", "name", "broker_name", "exchange", "exchange_name", "NAME"):
             try:
@@ -79,46 +80,46 @@ def _broker_name(broker: Any, fallback: Any = "") -> str:
     return _normalise_name(fallback) or "unknown"
 
 
-def _broker_connected(broker: Any) -> bool:
+def _connected_state(broker: Any) -> tuple[bool, bool]:
     if broker is None:
-        return False
-    observed = False
+        return False, False
     for attr in ("connected", "is_connected"):
         try:
             if not hasattr(broker, attr):
                 continue
-            observed = True
             value = getattr(broker, attr)
             value = value() if callable(value) else value
-            if value is None:
-                continue
-            if not bool(value):
-                return False
+            if value is not None:
+                return bool(value), True
         except Exception:
-            return False
-    if observed:
-        return True
+            return False, True
     for attr in ("connection_state", "_connection_state", "status"):
         try:
-            raw = getattr(getattr(broker, attr, None), "value", getattr(broker, attr, None))
-            text = str(raw or "").strip().lower()
+            if not hasattr(broker, attr):
+                continue
+            value = getattr(broker, attr, None)
+            text = str(getattr(value, "value", value) or "").strip().lower()
             if text in {"connected", "ready", "active", "online"}:
-                return True
+                return True, True
             if text in {"disconnected", "failed", "offline", "closed", "not_started"}:
-                return False
+                return False, True
         except Exception:
-            pass
-    return False
+            return False, True
+    return False, False
+
+
+def _broker_connected(broker: Any) -> bool:
+    return _connected_state(broker)[0]
 
 
 def _runtime_brokers() -> dict[str, Any]:
     brokers: dict[str, Any] = {}
 
     def add(raw_key: Any, broker: Any) -> None:
-        if broker is None:
+        if broker is None or isinstance(broker, bool):
             return
         name = _broker_name(broker, raw_key)
-        if name in {"coinbase", "okx", "kraken", "alpaca", "binance"}:
+        if name in _KNOWN:
             brokers[name] = broker
 
     for module_name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
@@ -132,62 +133,73 @@ def _runtime_brokers() -> dict[str, Any]:
                 manager = getter() if callable(getter) else None
             except Exception:
                 manager = None
-        if manager is None:
-            continue
         for attr in ("_platform_brokers", "platform_brokers", "brokers"):
-            try:
-                mapping = getattr(manager, attr, None)
-                if isinstance(mapping, Mapping):
-                    for raw_key, broker in mapping.items():
-                        add(raw_key, broker)
-            except Exception:
-                pass
+            mapping = getattr(manager, attr, None) if manager is not None else None
+            if isinstance(mapping, Mapping):
+                for raw_key, broker in mapping.items():
+                    add(raw_key, broker)
 
     for module_name in ("bot.broker_manager", "broker_manager"):
         module = sys.modules.get(module_name)
         if not isinstance(module, ModuleType):
             continue
         for attr in ("_PLATFORM_BROKER_INSTANCES", "GLOBAL_PLATFORM_BROKERS"):
-            try:
-                mapping = getattr(module, attr, None)
-                if isinstance(mapping, Mapping):
-                    for raw_key, broker in mapping.items():
-                        if isinstance(broker, bool):
-                            continue
-                        add(raw_key, broker)
-            except Exception:
-                pass
+            mapping = getattr(module, attr, None)
+            if isinstance(mapping, Mapping):
+                for raw_key, broker in mapping.items():
+                    add(raw_key, broker)
     return brokers
 
 
-def _venue_status(name: str, brokers: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+def _venue_status(name: str, brokers: dict[str, Any] | None = None) -> dict[str, Any]:
+    name = _normalise_name(name)
     key = name.upper()
-    brokers = brokers if brokers is not None else _runtime_brokers()
-    broker = brokers.get(name)
-    connected = _broker_connected(broker)
-    activation_state = str(os.environ.get(f"NIJA_{key}_ACTIVATION_STATE", "unknown") or "unknown").strip().lower()
-    trading_ready = _truthy(f"NIJA_{key}_TRADING_READY")
-    activated = _truthy(f"NIJA_{key}_ACTIVATED")
-    spendable_raw = str(os.environ.get(f"NIJA_{key}_SPENDABLE_QUOTE", "0") or "0")
+    broker = (brokers if brokers is not None else _runtime_brokers()).get(name)
+    connected, connection_observed = _connected_state(broker)
+    connected_env = f"NIJA_{key}_CONNECTED"
+    if broker is None and connected_env in os.environ:
+        connected, connection_observed = _truthy(connected_env), True
+
+    activation_env = f"NIJA_{key}_ACTIVATION_STATE"
+    trading_env = f"NIJA_{key}_TRADING_READY"
+    activated_env = f"NIJA_{key}_ACTIVATED"
+    spendable_env = f"NIJA_{key}_SPENDABLE_QUOTE"
+    activation = str(os.environ.get(activation_env, "unknown") or "unknown").strip().lower()
+    trading_ready = _truthy(trading_env)
+    activated = _truthy(activated_env)
+    activation_observed = any(
+        env in os.environ for env in (activation_env, trading_env, activated_env, spendable_env)
+    )
     try:
-        spendable = max(0.0, float(spendable_raw))
+        spendable = max(0.0, float(os.environ.get(spendable_env, "0") or "0"))
     except (TypeError, ValueError):
         spendable = 0.0
-    ready = connected and trading_ready and activated and activation_state == "ready"
-    reason = "ready"
-    if not connected:
-        reason = "not_connected"
-    elif activation_state != "ready":
-        reason = f"activation_state:{activation_state}"
-    elif not trading_ready:
-        reason = "trading_ready_flag_false"
-    elif not activated:
-        reason = "activated_flag_false"
+
+    local_strict = strict_mode_enabled() and name in set(required_venues())
+    known = broker is not None or connection_observed or activation_observed
+    if local_strict:
+        ready = connected and trading_ready and activated and activation == "ready"
+        if not connected:
+            reason = "not_connected"
+        elif activation != "ready":
+            reason = f"activation_state:{activation}"
+        elif not trading_ready:
+            reason = "trading_ready_flag_false"
+        elif not activated:
+            reason = "activated_flag_false"
+        else:
+            reason = "ready"
+    else:
+        ready = connected
+        reason = "ready" if ready else ("not_connected" if known else "not_registered")
+
     return {
         "venue": name,
         "ready": ready,
+        "known": known,
         "connected": connected,
-        "activation_state": activation_state,
+        "broker_local_strict": local_strict,
+        "activation_state": activation,
         "trading_ready": trading_ready,
         "activated": activated,
         "spendable_quote": round(spendable, 8),
@@ -196,64 +208,57 @@ def _venue_status(name: str, brokers: Optional[dict[str, Any]] = None) -> dict[s
 
 
 def refresh_readiness(*, force_log: bool = False) -> tuple[bool, list[str], dict[str, dict[str, Any]]]:
+    """Publish per-broker status; never create an all-brokers entry block."""
     global _LAST_SIGNATURE
-    names = required_venues()
-    strict = strict_mode_enabled()
     brokers = _runtime_brokers()
+    names: list[str] = []
+    for name in [*required_venues(), *brokers.keys()]:
+        name = _normalise_name(name)
+        if name in _KNOWN and name not in names:
+            names.append(name)
     statuses = {name: _venue_status(name, brokers) for name in names}
-    missing = [name for name in names if not statuses[name]["ready"]]
-    ready = (not strict) or not missing
+    monitored = set(required_venues())
+    missing = [name for name in names if name in monitored and not statuses[name]["ready"]]
+    active = [name for name in names if statuses[name]["ready"]]
+    degraded = [name for name in names if statuses[name]["known"] and not statuses[name]["ready"]]
 
-    os.environ["NIJA_REQUIRED_VENUES_READY"] = "1" if ready else "0"
-    os.environ["NIJA_MULTI_BROKER_TRADING_READY"] = "1" if ready else "0"
+    os.environ["NIJA_REQUIRED_VENUES_READY"] = "1"
+    os.environ["NIJA_MULTI_BROKER_TRADING_READY"] = "1" if active else "0"
     os.environ["NIJA_REQUIRED_VENUES_MISSING"] = ",".join(missing)
+    os.environ["NIJA_ACTIVE_LIVE_VENUES"] = ",".join(active)
+    os.environ["NIJA_DEGRADED_LIVE_VENUES"] = ",".join(degraded)
     os.environ["NIJA_REQUIRED_VENUES_STATUS_JSON"] = json.dumps(statuses, sort_keys=True, separators=(",", ":"))
-    if ready:
-        os.environ.pop("NIJA_NEW_ENTRY_BLOCK_REASON", None)
-    else:
-        os.environ["NIJA_NEW_ENTRY_BLOCK_REASON"] = "required_secondary_venues_not_ready:" + ",".join(missing)
+    os.environ.pop("NIJA_NEW_ENTRY_BLOCK_REASON", None)
 
     signature = json.dumps(
-        {"strict": strict, "ready": ready, "missing": missing, "statuses": statuses},
+        {"mode": "broker_independent", "active": active, "degraded": degraded, "missing": missing, "statuses": statuses},
         sort_keys=True,
         separators=(",", ":"),
     )
     if force_log or signature != _LAST_SIGNATURE:
         _LAST_SIGNATURE = signature
-        if ready:
-            logger.critical(
-                "REQUIRED_SECONDARY_VENUES_READY marker=%s strict=%s venues=%s status=%s",
-                _MARKER,
-                strict,
-                ",".join(names) or "none",
-                signature,
-            )
-        else:
-            logger.critical(
-                "REQUIRED_SECONDARY_VENUES_BLOCKED marker=%s strict=%s missing=%s status=%s",
-                _MARKER,
-                strict,
-                ",".join(missing) or "none",
-                signature,
-            )
-    return ready, missing, statuses
+        log = logger.warning if degraded or missing else logger.info
+        log(
+            "BROKER_INDEPENDENT_READINESS marker=%s active=%s degraded=%s missing_monitored=%s status=%s",
+            _MARKER,
+            ",".join(active) or "none",
+            ",".join(degraded) or "none",
+            ",".join(missing) or "none",
+            signature,
+        )
+    return True, missing, statuses
 
 
 def required_venues_ready() -> bool:
-    ready, _missing, _statuses = refresh_readiness()
-    return ready
+    return refresh_readiness()[0]
 
 
 def _is_entry_request(request: Any) -> bool:
     if bool(getattr(request, "reduce_only", False)):
         return False
     intent = str(getattr(request, "intent_type", "entry") or "entry").strip().lower()
-    position_effect = str(getattr(request, "position_effect", "") or "").strip().lower()
-    if intent in {"exit", "reduce", "close", "liquidate", "liquidation"}:
-        return False
-    if position_effect in {"close", "reduce", "exit"}:
-        return False
-    return True
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
+    return intent not in {"exit", "reduce", "close", "liquidate", "liquidation"} and effect not in {"close", "reduce", "exit"}
 
 
 def _pipeline_denial(module: ModuleType, request: Any, reason: str, started: float) -> Any:
@@ -270,11 +275,27 @@ def _pipeline_denial(module: ModuleType, request: Any, reason: str, started: flo
     raise RuntimeError(reason)
 
 
+def _request_target(request: Any, pipeline: Any) -> tuple[str, Any]:
+    request_attrs = ("preferred_broker", "broker", "broker_client", "execution_broker", "broker_name", "venue", "exchange")
+    pipeline_attrs = ("broker", "broker_client", "execution_broker", "venue", "exchange")
+    for owner, attrs in ((request, request_attrs), (pipeline, pipeline_attrs)):
+        for attr in attrs:
+            try:
+                value = getattr(owner, attr, None)
+            except Exception:
+                continue
+            if value is None:
+                continue
+            name = _broker_name(value, value)
+            if name in _KNOWN:
+                broker = value if not isinstance(value, (str, bytes)) else _runtime_brokers().get(name)
+                return name, broker
+    return "", None
+
+
 def _patch_execution_pipeline(module: ModuleType) -> bool:
     cls = getattr(module, "ExecutionPipeline", None)
-    if not isinstance(cls, type):
-        return False
-    current = getattr(cls, "execute", None)
+    current = getattr(cls, "execute", None) if isinstance(cls, type) else None
     if not callable(current):
         return False
     if getattr(current, _PIPELINE_WRAP_ATTR, False):
@@ -282,38 +303,38 @@ def _patch_execution_pipeline(module: ModuleType) -> bool:
         return True
     original = current
 
-    def _strict_execute(self: Any, request: Any) -> Any:
+    def _independent_execute(self: Any, request: Any) -> Any:
         if strict_mode_enabled() and _is_entry_request(request):
-            ready, missing, statuses = refresh_readiness()
-            if not ready:
-                started = time.monotonic()
-                reason = "required_secondary_venues_not_ready:" + ",".join(missing)
-                logger.critical(
-                    "REQUIRED_SECONDARY_VENUES_ENTRY_BLOCKED marker=%s surface=execution_pipeline "
-                    "symbol=%s side=%s missing=%s status=%s",
-                    _MARKER,
-                    getattr(request, "symbol", ""),
-                    getattr(request, "side", ""),
-                    ",".join(missing),
-                    json.dumps(statuses, sort_keys=True, separators=(",", ":")),
-                )
-                return _pipeline_denial(module, request, reason, started)
+            target_name, target_broker = _request_target(request, self)
+            if target_name in set(required_venues()):
+                status = _venue_status(target_name, {target_name: target_broker} if target_broker is not None else None)
+                if not status["ready"]:
+                    started = time.monotonic()
+                    reason = f"target_broker_not_ready:{target_name}:{status['reason']}"
+                    logger.warning(
+                        "BROKER_LOCAL_ENTRY_BLOCKED marker=%s broker=%s symbol=%s side=%s reason=%s status=%s",
+                        _MARKER,
+                        target_name,
+                        getattr(request, "symbol", ""),
+                        getattr(request, "side", ""),
+                        reason,
+                        json.dumps(status, sort_keys=True, separators=(",", ":")),
+                    )
+                    return _pipeline_denial(module, request, reason, started)
         return original(self, request)
 
-    setattr(_strict_execute, _PIPELINE_WRAP_ATTR, True)
-    setattr(_strict_execute, "__wrapped__", original)
-    setattr(cls, "execute", _strict_execute)
+    setattr(_independent_execute, _PIPELINE_WRAP_ATTR, True)
+    setattr(_independent_execute, "__wrapped__", original)
+    setattr(cls, "execute", _independent_execute)
     name = getattr(module, "__name__", "<unknown>")
     _PATCHED_PIPELINE.add(name)
-    logger.warning("REQUIRED_SECONDARY_VENUES_PIPELINE_PATCHED marker=%s module=%s", _MARKER, name)
+    logger.warning("BROKER_INDEPENDENT_PIPELINE_PATCHED marker=%s module=%s", _MARKER, name)
     return True
 
 
 def _patch_trading_strategy(module: ModuleType) -> bool:
     cls = getattr(module, "TradingStrategy", None)
-    if not isinstance(cls, type):
-        return False
-    current = getattr(cls, "_is_broker_eligible_for_entry", None)
+    current = getattr(cls, "_is_broker_eligible_for_entry", None) if isinstance(cls, type) else None
     if not callable(current):
         return False
     if getattr(current, _STRATEGY_WRAP_ATTR, False):
@@ -321,32 +342,37 @@ def _patch_trading_strategy(module: ModuleType) -> bool:
         return True
     original = current
 
-    def _strict_eligibility(self: Any, broker: Any) -> tuple[bool, str]:
-        if strict_mode_enabled():
-            ready, missing, _statuses = refresh_readiness()
-            if not ready:
-                reason = "required secondary venues not ready: " + ",".join(missing)
-                logger.warning(
-                    "REQUIRED_SECONDARY_VENUES_ENTRY_ELIGIBILITY_BLOCKED marker=%s broker=%s missing=%s",
-                    _MARKER,
-                    _broker_name(broker),
-                    ",".join(missing),
-                )
-                return False, reason
-        return original(self, broker)
+    def _independent_eligibility(self: Any, broker: Any) -> tuple[bool, str]:
+        allowed, reason = original(self, broker)
+        if not allowed or not strict_mode_enabled():
+            return allowed, reason
+        name = _broker_name(broker)
+        if name not in set(required_venues()):
+            return allowed, reason
+        status = _venue_status(name, {name: broker})
+        if status["ready"]:
+            return allowed, reason
+        local_reason = f"target broker {name} not ready: {status['reason']}"
+        logger.warning(
+            "BROKER_LOCAL_ENTRY_ELIGIBILITY_BLOCKED marker=%s broker=%s reason=%s status=%s",
+            _MARKER,
+            name,
+            local_reason,
+            json.dumps(status, sort_keys=True, separators=(",", ":")),
+        )
+        return False, local_reason
 
-    setattr(_strict_eligibility, _STRATEGY_WRAP_ATTR, True)
-    setattr(_strict_eligibility, "__wrapped__", original)
-    setattr(cls, "_is_broker_eligible_for_entry", _strict_eligibility)
+    setattr(_independent_eligibility, _STRATEGY_WRAP_ATTR, True)
+    setattr(_independent_eligibility, "__wrapped__", original)
+    setattr(cls, "_is_broker_eligible_for_entry", _independent_eligibility)
     name = getattr(module, "__name__", "<unknown>")
     _PATCHED_STRATEGY.add(name)
-    logger.warning("REQUIRED_SECONDARY_VENUES_STRATEGY_PATCHED marker=%s module=%s", _MARKER, name)
+    logger.warning("BROKER_INDEPENDENT_STRATEGY_PATCHED marker=%s module=%s", _MARKER, name)
     return True
 
 
 def _patch_loaded() -> tuple[bool, bool]:
-    pipeline = False
-    strategy = False
+    pipeline = strategy = False
     for name in ("bot.execution_pipeline", "execution_pipeline"):
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
@@ -364,7 +390,7 @@ def _monitor() -> None:
             refresh_readiness()
             _patch_loaded()
         except Exception:
-            logger.exception("REQUIRED_SECONDARY_VENUES_MONITOR_ERROR marker=%s", _MARKER)
+            logger.exception("BROKER_INDEPENDENT_READINESS_MONITOR_ERROR marker=%s", _MARKER)
         try:
             interval = max(1.0, float(os.environ.get("NIJA_SECONDARY_VENUE_STRICT_RECHECK_S", "2") or "2"))
         except (TypeError, ValueError):
@@ -384,22 +410,18 @@ def install() -> None:
         _patch_loaded()
         if not _MONITOR_STARTED:
             _MONITOR_STARTED = True
-            thread = threading.Thread(
-                target=_monitor,
-                name="secondary-venue-strict-readiness",
-                daemon=True,
-            )
-            thread.start()
+            threading.Thread(target=_monitor, name="broker-independent-readiness", daemon=True).start()
         os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "1"
+        os.environ["NIJA_BROKER_INDEPENDENT_READINESS_INSTALLED"] = "1"
         logger.warning(
-            "SECONDARY_VENUE_STRICT_READINESS_INSTALLED marker=%s strict=%s required=%s",
+            "BROKER_INDEPENDENT_READINESS_INSTALLED marker=%s broker_local_strict=%s monitored=%s",
             _MARKER,
             strict_mode_enabled(),
             ",".join(required_venues()),
         )
         print(
-            f"[NIJA-PRINT] SECONDARY_VENUE_STRICT_READINESS_INSTALLED marker={_MARKER} "
-            f"strict={str(strict_mode_enabled()).lower()} required={','.join(required_venues())}",
+            f"[NIJA-PRINT] BROKER_INDEPENDENT_READINESS_INSTALLED marker={_MARKER} "
+            f"broker_local_strict={str(strict_mode_enabled()).lower()} monitored={','.join(required_venues())}",
             flush=True,
         )
 

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -8,9 +8,10 @@ file path before its first ``bot.*`` import; that first installer calls
 On Render, the Docker ``.pth`` hook deliberately leaves the replacement process
 fail-closed so the shell can expose ``/healthz`` during a zero-downtime deploy.
 This source bootstrap then acquires the canonical Redis writer lease before any
-``bot.*`` import and installs venue-readiness, secondary-venue activation, strict
-multi-venue entry admission, the definitive three-venue stage verifier, and the
-cross-process readiness bridge.
+``bot.*`` import and installs venue-readiness, secondary-venue activation,
+broker-independent entry admission, account-local held-position exit recovery,
+the definitive execution-readiness verifier, and the cross-process readiness
+bridge.
 
 The bootstrap never deletes another instance's active lease, creates credentials,
 fabricates balances, marks a broker connected, or relaxes risk controls. In a
@@ -89,6 +90,7 @@ def install() -> bool:
             _install_required("venue_readiness_execution_repair_patch")
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
+            _install_required("account_exit_management_recovery_patch")
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
 
@@ -97,6 +99,7 @@ def install() -> bool:
             os.environ["NIJA_VENUE_READINESS_SOURCE_MARKER"] = _MARKER
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "1"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "1"
+            os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "1"
             os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED"] = "1"
             os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] = "1"
             os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] = "1"
@@ -107,6 +110,7 @@ def install() -> bool:
                 "writer_authority=installed venue_repair=installed "
                 "secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
+                "account_exit_management_recovery=installed "
                 "three_venue_stage_verifier=installed "
                 "render_readiness_bridge=installed source=main_pre_bot",
                 _MARKER,
@@ -117,6 +121,7 @@ def install() -> bool:
                 f"commit={commit} writer_authority=installed venue_repair=installed "
                 "secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
+                "account_exit_management_recovery=installed "
                 "three_venue_stage_verifier=installed "
                 "render_readiness_bridge=installed source=main_pre_bot",
                 flush=True,
@@ -127,6 +132,7 @@ def install() -> bool:
             os.environ["NIJA_VENUE_READINESS_SOURCE_MARKER"] = _MARKER
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "0"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "0"
+            os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "0"
             os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED"] = "0"
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
             os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] = "0"


### PR DESCRIPTION
## What changed

### Independent brokerage readiness
- Replaced the all-secondary-venues entry gate with broker-local readiness enforcement.
- A failed Coinbase, OKX, or Kraken connection is reported as degraded and blocks only orders routed to that brokerage.
- Healthy brokerages continue scanning, sizing, exiting, and executing independently.
- Startup succeeds when at least one brokerage is completely configured; incomplete brokerages are isolated rather than fatal.

### Platform and user held-position recovery
- Added an account-local recovery supervisor for every configured platform and user brokerage.
- User reconnects no longer wait for a platform brokerage to connect first.
- Each account gets either its normal independent trading thread or an exit-only management thread.
- Underfunded, recovery-mode, copy-mode, and platform-only-entry accounts still adopt and manage held positions without receiving permission to open new trades.
- Existing positions are evaluated immediately before a normal trading thread enters its startup delay.
- Exit-only cycles call `TradingStrategy.run_cycle(..., user_mode=True)`, so Phase 2 position management runs while Phase 3 entries remain blocked.
- Fixed the legacy user adoption-verification call that omitted the broker argument by recording and resolving the exact account broker used during adoption.
- Startup now installs the recovery layer before the independent trader and strategy classes load.

## Safety behavior

This change does not promise or force a profitable exit. It enables NIJA's existing fee-aware take-profit and trailing-profit logic to manage every connected account. Stop-loss, emergency liquidation, writer-authority, exchange, risk, minimum-size, and execution-pipeline checks remain authoritative.

No account may route an exit through another account's credentials or broker adapter.

## Validation

- `python -m py_compile account_exit_management_recovery_patch.py test_account_exit_management_recovery_patch.py source_runtime_guard_bootstrap.py`
- Account recovery regression suite: **8 passed**
- Startup installation tests plus account recovery tests: **10 passed, 1 repository-integration test deselected locally** because the isolated test directory did not contain `bot/global_runtime_startup_guards.py`; that file exists in the repository and its existing assertion was preserved.
- Previous broker-isolation suite: **6 passed**
- Kraken-only startup configuration succeeds while Coinbase and OKX report degraded.
- No complete brokerage configuration still fails closed.

## Expected runtime markers

- `ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALL_REQUESTED marker=20260711k`
- `ACCOUNT_EXIT_MANAGEMENT_RECOVERY_PATCHED marker=20260711k`
- `ACCOUNT_POSITION_ADOPTION_VERIFY_PATCHED marker=20260711k`
- `ACCOUNT_CONNECTION_RETRY marker=20260711k account=user:<id>:<broker>`
- `ACCOUNT_EXIT_ONLY_THREAD_STARTED marker=20260711k`
- `ACCOUNT_EXIT_MANAGEMENT_CYCLE marker=20260711k ... entries_allowed=false`
- `BROKER_INDEPENDENT_READINESS`