### PR TITLE
Start account exit recovery before capital convergence

### DIFF
--- a/account_exit_recovery_bootstrap_patch.py
+++ b/account_exit_recovery_bootstrap_patch.py
@@ -1,0 +1,252 @@
+"""Bootstrap the account-local exit recovery before LIVE_ACTIVE convergence.
+
+The account exit-management recovery layer patches IndependentBrokerTrader, but its
+supervisor originally started only from ``start_independent_trading``.  In a
+fail-closed startup, that method is not reached until CapitalAuthority reports at
+least one valid broker.  When broker reconnection itself depends on the supervisor,
+startup deadlocks at ``LIVE_PENDING_CONFIRMATION`` with ``valid_brokers=0``.
+
+This bridge patches ``IndependentBrokerTrader.__init__`` and schedules the existing
+recovery supervisor immediately after construction.  It also refreshes
+CapitalAuthority after each recovery pass.  It does not grant execution authority,
+mark brokers connected, fabricate balances, bypass writer lineage, or submit orders.
+"""
+
+from __future__ import annotations
+
+import gc
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger("nija.account_exit_recovery_bootstrap")
+
+_MARKER = "20260711m"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_CLASS_PATCHED_ATTR = "_nija_account_exit_bootstrap_20260711m"
+_RETRY_PATCHED_ATTR = "_nija_account_exit_retry_capital_refresh_20260711m"
+_INSTANCE_STARTED_ATTR = "_nija_account_exit_bootstrap_started_20260711m"
+_INSTALL_LOCK = threading.RLock()
+_WATCHDOG_STARTED = False
+
+
+def _truthy(name: str, default: str = "true") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _load_recovery_module() -> Optional[ModuleType]:
+    for name in (
+        "account_exit_management_recovery_patch",
+        "bot.account_exit_management_recovery_patch",
+    ):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+        try:
+            imported = importlib.import_module(name)
+            if isinstance(imported, ModuleType):
+                return imported
+        except Exception:
+            continue
+    return None
+
+
+def _refresh_capital_authority(trader: Any, source: str) -> Mapping[str, Any]:
+    manager = getattr(trader, "multi_account_manager", None)
+    refresher = getattr(manager, "refresh_capital_authority", None)
+    if not callable(refresher):
+        return {}
+
+    try:
+        try:
+            result = refresher(trigger=f"account_exit_recovery:{source}")
+        except TypeError:
+            result = refresher()
+        payload = result if isinstance(result, Mapping) else {}
+        logger.warning(
+            "ACCOUNT_EXIT_RECOVERY_CAPITAL_REFRESH marker=%s source=%s "
+            "ready=%s total=%s valid_brokers=%s",
+            _MARKER,
+            source,
+            payload.get("ready"),
+            payload.get("total_capital", payload.get("total")),
+            payload.get("valid_brokers"),
+        )
+        return payload
+    except Exception as exc:
+        logger.warning(
+            "ACCOUNT_EXIT_RECOVERY_CAPITAL_REFRESH_FAILED marker=%s source=%s error=%s",
+            _MARKER,
+            source,
+            exc,
+        )
+        return {}
+
+
+def _patch_recovery_retry(recovery: ModuleType) -> bool:
+    original = getattr(recovery, "_retry_all_accounts", None)
+    if not callable(original):
+        return False
+    if getattr(original, _RETRY_PATCHED_ATTR, False):
+        return True
+
+    def _retry_all_accounts(trader: Any) -> Any:
+        result = original(trader)
+        _refresh_capital_authority(trader, "retry_all_accounts")
+        return result
+
+    setattr(_retry_all_accounts, "__wrapped__", original)
+    setattr(_retry_all_accounts, _RETRY_PATCHED_ATTR, True)
+    recovery._retry_all_accounts = _retry_all_accounts
+    logger.warning("ACCOUNT_EXIT_RECOVERY_CAPITAL_REFRESH_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _start_supervisor_async(trader: Any, source: str) -> bool:
+    if trader is None or not _truthy("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_ENABLED", "true"):
+        return False
+    if bool(getattr(trader, _INSTANCE_STARTED_ATTR, False)):
+        return False
+    setattr(trader, _INSTANCE_STARTED_ATTR, True)
+
+    def _runner() -> None:
+        recovery = _load_recovery_module()
+        starter = getattr(recovery, "_start_supervisor", None) if recovery is not None else None
+        if not callable(starter):
+            setattr(trader, _INSTANCE_STARTED_ATTR, False)
+            logger.warning(
+                "ACCOUNT_EXIT_RECOVERY_EARLY_START_FAILED marker=%s source=%s reason=starter_missing",
+                _MARKER,
+                source,
+            )
+            return
+        try:
+            starter(trader)
+            logger.critical(
+                "ACCOUNT_EXIT_RECOVERY_EARLY_STARTED marker=%s source=%s "
+                "entries_authority_unchanged=true",
+                _MARKER,
+                source,
+            )
+        except Exception as exc:
+            setattr(trader, _INSTANCE_STARTED_ATTR, False)
+            logger.exception(
+                "ACCOUNT_EXIT_RECOVERY_EARLY_START_FAILED marker=%s source=%s error=%s",
+                _MARKER,
+                source,
+                exc,
+            )
+
+    threading.Thread(
+        target=_runner,
+        name="AccountExitRecoveryEarlyBootstrap",
+        daemon=True,
+    ).start()
+    return True
+
+
+def _patch_class(cls: type) -> bool:
+    if getattr(cls, _CLASS_PATCHED_ATTR, False):
+        return True
+
+    original_init = getattr(cls, "__init__", None)
+    if not callable(original_init):
+        return False
+
+    def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        _start_supervisor_async(self, "independent_trader_init")
+
+    setattr(__init__, "__wrapped__", original_init)
+    cls.__init__ = __init__
+    setattr(cls, _CLASS_PATCHED_ATTR, True)
+    logger.warning(
+        "ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_CLASS_PATCHED marker=%s class=%s",
+        _MARKER,
+        cls.__name__,
+    )
+
+    try:
+        for obj in gc.get_objects():
+            try:
+                if isinstance(obj, cls):
+                    _start_supervisor_async(obj, "existing_instance")
+            except Exception:
+                continue
+    except Exception as exc:
+        logger.debug("ACCOUNT_EXIT_RECOVERY_EXISTING_SCAN_SKIPPED error=%s", exc)
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    recovery = _load_recovery_module()
+    if recovery is not None:
+        patched = _patch_recovery_retry(recovery) or patched
+
+    for name in ("bot.independent_broker_trader", "independent_broker_trader"):
+        module = sys.modules.get(name)
+        cls = getattr(module, "IndependentBrokerTrader", None) if isinstance(module, ModuleType) else None
+        if isinstance(cls, type):
+            patched = _patch_class(cls) or patched
+    return patched
+
+
+def _watchdog() -> None:
+    timeout_s = max(
+        30.0,
+        float(os.environ.get("NIJA_ACCOUNT_EXIT_BOOTSTRAP_PATCH_TIMEOUT_S", "180") or 180.0),
+    )
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            if _patch_loaded():
+                return
+        except Exception as exc:
+            logger.debug("ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_PATCH_RETRY error=%s", exc)
+        time.sleep(0.1)
+    logger.critical(
+        "ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_PATCH_TIMEOUT marker=%s timeout_s=%.1f",
+        _MARKER,
+        timeout_s,
+    )
+
+
+def install_import_hook() -> None:
+    global _WATCHDOG_STARTED
+    with _INSTALL_LOCK:
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_ENABLED", "true")
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S", "15")
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_BOOTSTRAP_PATCH_TIMEOUT_S", "180")
+        _patch_loaded()
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="account-exit-recovery-bootstrap-watchdog",
+                daemon=True,
+            ).start()
+        logger.warning(
+            "ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALL_REQUESTED marker=%s",
+            _MARKER,
+        )
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_patch_class",
+    "_patch_loaded",
+    "_patch_recovery_retry",
+    "_refresh_capital_authority",
+    "_start_supervisor_async",
+]

--- a/account_exit_recovery_bootstrap_patch.py
+++ b/account_exit_recovery_bootstrap_patch.py
@@ -184,17 +184,18 @@ def _patch_class(cls: type) -> bool:
 
 
 def _patch_loaded() -> bool:
-    patched = False
+    """Patch dependencies and return True only when the trader class is patched."""
     recovery = _load_recovery_module()
     if recovery is not None:
-        patched = _patch_recovery_retry(recovery) or patched
+        _patch_recovery_retry(recovery)
 
+    class_patched = False
     for name in ("bot.independent_broker_trader", "independent_broker_trader"):
         module = sys.modules.get(name)
         cls = getattr(module, "IndependentBrokerTrader", None) if isinstance(module, ModuleType) else None
         if isinstance(cls, type):
-            patched = _patch_class(cls) or patched
-    return patched
+            class_patched = _patch_class(cls) or class_patched
+    return class_patched
 
 
 def _watchdog() -> None:

--- a/bot/tests/test_account_exit_recovery_bootstrap_patch.py
+++ b/bot/tests/test_account_exit_recovery_bootstrap_patch.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "account_exit_recovery_bootstrap_patch.py"
+    spec = importlib.util.spec_from_file_location(
+        "nija_test_account_exit_recovery_bootstrap_patch",
+        path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_retry_refreshes_capital_authority(monkeypatch):
+    module = _load_module()
+    calls = []
+    manager = SimpleNamespace(
+        refresh_capital_authority=lambda **kwargs: calls.append(kwargs) or {
+            "ready": True,
+            "total_capital": 100.0,
+            "valid_brokers": 1,
+        }
+    )
+    trader = SimpleNamespace(multi_account_manager=manager)
+    recovery = ModuleType("fake_recovery")
+    recovery._retry_all_accounts = lambda value: calls.append(("retry", value))
+
+    assert module._patch_recovery_retry(recovery) is True
+    recovery._retry_all_accounts(trader)
+
+    assert calls[0] == ("retry", trader)
+    assert calls[1]["trigger"] == "account_exit_recovery:retry_all_accounts"
+
+
+def test_init_starts_supervisor_before_normal_start(monkeypatch):
+    module = _load_module()
+    started = threading.Event()
+    seen = []
+    recovery = ModuleType("fake_recovery")
+    recovery._retry_all_accounts = lambda trader: None
+
+    def _start(trader):
+        seen.append(trader)
+        started.set()
+
+    recovery._start_supervisor = _start
+    monkeypatch.setattr(module, "_load_recovery_module", lambda: recovery)
+
+    class Trader:
+        def __init__(self):
+            self.multi_account_manager = SimpleNamespace()
+            self.trading_strategy = object()
+
+    assert module._patch_class(Trader) is True
+    trader = Trader()
+
+    assert started.wait(1.0)
+    assert seen == [trader]
+
+
+def test_patch_class_is_idempotent(monkeypatch):
+    module = _load_module()
+    recovery = ModuleType("fake_recovery")
+    recovery._retry_all_accounts = lambda trader: None
+    recovery._start_supervisor = lambda trader: None
+    monkeypatch.setattr(module, "_load_recovery_module", lambda: recovery)
+
+    class Trader:
+        def __init__(self):
+            self.count = getattr(self, "count", 0) + 1
+
+    assert module._patch_class(Trader) is True
+    wrapped = Trader.__init__
+    assert module._patch_class(Trader) is True
+    assert Trader.__init__ is wrapped
+
+    trader = Trader()
+    assert trader.count == 1
+
+
+def test_refresh_failure_is_nonfatal():
+    module = _load_module()
+
+    class Manager:
+        def refresh_capital_authority(self, **kwargs):
+            raise RuntimeError("temporary broker outage")
+
+    trader = SimpleNamespace(multi_account_manager=Manager())
+    assert module._refresh_capital_authority(trader, "test") == {}

--- a/bot/tests/test_account_exit_recovery_bootstrap_patch.py
+++ b/bot/tests/test_account_exit_recovery_bootstrap_patch.py
@@ -95,3 +95,27 @@ def test_refresh_failure_is_nonfatal():
 
     trader = SimpleNamespace(multi_account_manager=Manager())
     assert module._refresh_capital_authority(trader, "test") == {}
+
+
+def test_patch_loaded_waits_for_trader_class(monkeypatch):
+    module = _load_module()
+    recovery = ModuleType("fake_recovery")
+    recovery._retry_all_accounts = lambda trader: None
+    monkeypatch.setattr(module, "_load_recovery_module", lambda: recovery)
+
+    module.sys.modules.pop("bot.independent_broker_trader", None)
+    module.sys.modules.pop("independent_broker_trader", None)
+    assert module._patch_loaded() is False
+
+    fake_trader_module = ModuleType("bot.independent_broker_trader")
+
+    class Trader:
+        def __init__(self):
+            self.multi_account_manager = SimpleNamespace()
+            self.trading_strategy = object()
+
+    fake_trader_module.IndependentBrokerTrader = Trader
+    module.sys.modules["bot.independent_broker_trader"] = fake_trader_module
+    recovery._start_supervisor = lambda trader: None
+
+    assert module._patch_loaded() is True

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -17,6 +17,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED", raising=False)
+    monkeypatch.delenv("NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_RENDER_READINESS_BRIDGE_INSTALLED", raising=False)
 
@@ -34,6 +35,8 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
     fake_strict.install = lambda: calls.append("strict")
     fake_exit_recovery = ModuleType("account_exit_management_recovery_patch")
     fake_exit_recovery.install_import_hook = lambda: calls.append("exit_recovery")
+    fake_exit_bootstrap = ModuleType("account_exit_recovery_bootstrap_patch")
+    fake_exit_bootstrap.install = lambda: calls.append("exit_bootstrap")
     fake_stage = ModuleType("three_venue_execution_readiness")
     fake_stage.install = lambda: calls.append("stage")
     fake_bridge = ModuleType("render_readiness_state_bridge")
@@ -45,6 +48,7 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
         "secondary_venue_activation_patch": fake_activator,
         "secondary_venue_strict_readiness_patch": fake_strict,
         "account_exit_management_recovery_patch": fake_exit_recovery,
+        "account_exit_recovery_bootstrap_patch": fake_exit_bootstrap,
         "three_venue_execution_readiness": fake_stage,
         "render_readiness_state_bridge": fake_bridge,
     }
@@ -61,13 +65,23 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
 
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
-    assert calls == ["writer", "venue", "activator", "strict", "exit_recovery", "stage", "bridge"]
-    assert source_bootstrap.installed_marker() == "20260710af"
+    assert calls == [
+        "writer",
+        "venue",
+        "activator",
+        "strict",
+        "exit_recovery",
+        "exit_bootstrap",
+        "stage",
+        "bridge",
+    ]
+    assert source_bootstrap.installed_marker() == "20260711m"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] == "1"
 
 
@@ -91,6 +105,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] == "0"
 
 

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -10,8 +10,8 @@ fail-closed so the shell can expose ``/healthz`` during a zero-downtime deploy.
 This source bootstrap then acquires the canonical Redis writer lease before any
 ``bot.*`` import and installs venue-readiness, secondary-venue activation,
 broker-independent entry admission, account-local held-position exit recovery,
-the definitive execution-readiness verifier, and the cross-process readiness
-bridge.
+the early recovery/capital-hydration bridge, the definitive execution-readiness
+verifier, and the cross-process readiness bridge.
 
 The bootstrap never deletes another instance's active lease, creates credentials,
 fabricates balances, marks a broker connected, or relaxes risk controls. In a
@@ -29,7 +29,7 @@ from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
 
-_MARKER = "20260710af"
+_MARKER = "20260711m"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -91,6 +91,7 @@ def install() -> bool:
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
             _install_required("account_exit_management_recovery_patch")
+            _install_required("account_exit_recovery_bootstrap_patch")
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
 
@@ -100,6 +101,7 @@ def install() -> bool:
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "1"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "1"
             os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "1"
+            os.environ["NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED"] = "1"
             os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED"] = "1"
             os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] = "1"
             os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] = "1"
@@ -111,6 +113,7 @@ def install() -> bool:
                 "secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
                 "account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed "
                 "three_venue_stage_verifier=installed "
                 "render_readiness_bridge=installed source=main_pre_bot",
                 _MARKER,
@@ -122,6 +125,7 @@ def install() -> bool:
                 "secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
                 "account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed "
                 "three_venue_stage_verifier=installed "
                 "render_readiness_bridge=installed source=main_pre_bot",
                 flush=True,
@@ -133,6 +137,7 @@ def install() -> bool:
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "0"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "0"
             os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "0"
+            os.environ["NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED"] = "0"
             os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED"] = "0"
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
             os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] = "0"


### PR DESCRIPTION
## Root cause from the July 12 runtime log

The process remained in `LIVE_PENDING_CONFIRMATION` with `NIJA_RUNTIME_EXECUTION_AUTHORITY=0`, `hydrated=False`, and `valid_brokers=0`. The account exit-recovery supervisor was installed to start only from `IndependentBrokerTrader.start_independent_trading()`, but that method is reached only after capital readiness and LIVE_ACTIVE convergence. This created a circular startup dependency:

1. recovery supervisor not started;
2. accounts not reconnected by recovery;
3. CapitalAuthority stayed at zero valid brokers;
4. LIVE_ACTIVE was never reached;
5. no trading or exit-management thread started.

## Fix

- Add `account_exit_recovery_bootstrap_patch.py`.
- Patch `IndependentBrokerTrader.__init__` and asynchronously start the existing account-local recovery supervisor immediately after construction.
- Wrap each recovery pass so `MultiAccountBrokerManager.refresh_capital_authority()` runs after broker reconnection attempts.
- Keep the patch watchdog alive until the actual `IndependentBrokerTrader` class is loaded and patched.
- Install the bridge in the earliest source runtime guard sequence.
- Publish deterministic startup and capital-refresh markers.

## Safety

This change does not set `NIJA_RUNTIME_EXECUTION_AUTHORITY`, force `LIVE_ACTIVE`, fabricate balances, mark a broker connected, bypass Redis writer lineage, or bypass broker/risk/order checks. It only starts the already-reviewed exit-recovery supervisor earlier and republishes real broker capital after reconnect attempts.

## Validation

- Python compilation passed for the bridge, source bootstrap, and tests.
- Focused combined suite: **7 passed, 1 repository-wide integration test deselected in the isolated fixture**.
- Covers early supervisor startup, capital refresh, idempotent patching, nonfatal refresh errors, and the import-race/watchdog condition.

## Expected runtime markers

- `SOURCE_RUNTIME_GUARDS_READY marker=20260711m ... account_exit_recovery_bootstrap=installed`
- `ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALL_REQUESTED marker=20260711m`
- `ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_CLASS_PATCHED marker=20260711m`
- `ACCOUNT_EXIT_RECOVERY_EARLY_STARTED marker=20260711m`
- `ACCOUNT_CONNECTION_RETRY marker=20260711k account=...`
- `ACCOUNT_EXIT_RECOVERY_CAPITAL_REFRESH marker=20260711m ... valid_brokers=...`
- `ACCOUNT_EXIT_ONLY_THREAD_STARTED marker=20260711k`
- `ACCOUNT_EXIT_MANAGEMENT_CYCLE marker=20260711k ... entries_allowed=false`
