### PR TITLE
Make the final execution-stage verifier broker-independent

### DIFF
--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 
 
 class FakeBroker:
-    def __init__(self, balance: float = 25.0) -> None:
-        self.connected = True
+    def __init__(self, balance: float = 25.0, connected: bool = True) -> None:
+        self.connected = connected
         self._balance = balance
 
     def get_account_balance(self):
@@ -71,7 +71,7 @@ def test_all_three_venues_require_every_stage(monkeypatch) -> None:
         assert row.eligible_for_execution
 
 
-def test_missing_one_stage_keeps_venue_fail_closed(monkeypatch) -> None:
+def test_missing_one_stage_keeps_only_that_venue_fail_closed(monkeypatch) -> None:
     module = _module()
     _set_credentials(monkeypatch)
     monkeypatch.setenv("NIJA_COINBASE_ACTIVATION_STATE", "ready")
@@ -89,6 +89,106 @@ def test_missing_one_stage_keeps_venue_fail_closed(monkeypatch) -> None:
     assert "no_spendable_quote" in result.reason
 
 
+def test_one_ready_venue_enables_execution_independently(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token")
+    monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
+
+    kraken = FakeBroker(balance=116.09)
+    manager = SimpleNamespace(
+        _platform_brokers={"kraken": kraken},
+        eligible_brokers={kraken},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
+
+    result = module.evaluate_all()
+
+    assert result["execution_ready"] is True
+    assert result["three_venue_execution_ready"] is True
+    assert result["any_venue_ready"] is True
+    assert result["all_venues_ready"] is False
+    assert result["ready_venues"] == ["kraken"]
+    assert result["degraded_venues"] == ["coinbase", "okx"]
+    assert result["venues"]["kraken"]["ready"] is True
+    assert result["venues"]["coinbase"]["ready"] is False
+    assert result["venues"]["okx"]["ready"] is False
+
+
+def test_publish_sets_independent_compatibility_flags(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "evaluate_all",
+        lambda: {
+            "marker": module.MARKER,
+            "timestamp": 1.0,
+            "pid": 1,
+            "writer_ready": True,
+            "capital_ready": True,
+            "any_venue_ready": True,
+            "all_venues_ready": False,
+            "execution_ready": True,
+            "three_venue_execution_ready": True,
+            "ready_venues": ["kraken"],
+            "degraded_venues": ["coinbase", "okx"],
+            "venues": {
+                "kraken": {
+                    "credentials_loaded": True,
+                    "authentication_succeeded": True,
+                    "balance_fetched": True,
+                    "market_metadata_loaded": True,
+                    "order_adapter_initialized": True,
+                    "venue_marked_ready": True,
+                    "eligible_for_execution": True,
+                    "spendable_quote": 116.09,
+                    "activation_state": "ready",
+                    "reason": "ready",
+                    "ready": True,
+                },
+                "coinbase": {
+                    "credentials_loaded": True,
+                    "authentication_succeeded": False,
+                    "balance_fetched": False,
+                    "market_metadata_loaded": False,
+                    "order_adapter_initialized": True,
+                    "venue_marked_ready": False,
+                    "eligible_for_execution": False,
+                    "spendable_quote": 0.0,
+                    "activation_state": "connect_failed",
+                    "reason": "not_connected",
+                    "ready": False,
+                },
+                "okx": {
+                    "credentials_loaded": True,
+                    "authentication_succeeded": False,
+                    "balance_fetched": False,
+                    "market_metadata_loaded": False,
+                    "order_adapter_initialized": True,
+                    "venue_marked_ready": False,
+                    "eligible_for_execution": False,
+                    "spendable_quote": 0.0,
+                    "activation_state": "connect_failed",
+                    "reason": "not_connected",
+                    "ready": False,
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(module, "_write_state", lambda payload: None)
+    monkeypatch.setattr(module, "_LAST_SIGNATURE", "")
+
+    result = module.publish_once(force=True)
+
+    assert result["execution_ready"] is True
+    assert os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] == "1"
+    assert os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] == "1"
+    assert os.environ["NIJA_EXECUTION_READY_VENUES"] == "kraken"
+    assert os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] == "coinbase,okx"
+
+
 def test_source_bootstrap_installs_definitive_verifier() -> None:
     from pathlib import Path
 
@@ -100,19 +200,17 @@ def test_source_bootstrap_installs_definitive_verifier() -> None:
     assert 'three_venue_stage_verifier=installed' in source
 
 
-def test_ready_contract_contains_required_summary_marker() -> None:
+def test_ready_contract_contains_independent_summary_marker() -> None:
     from pathlib import Path
 
     root = Path(__file__).resolve().parents[2]
     source = (root / "three_venue_execution_readiness.py").read_text(encoding="utf-8")
 
+    assert "BROKER_INDEPENDENT_EXECUTION_%s" in source
     assert "THREE_VENUE_EXECUTION_%s" in source
     assert "THREE_VENUE_STAGE venue=%s" in source
     assert 'NIJA_THREE_VENUE_EXECUTION_READY' in source
-    assert 'credentials_loaded' in source
-    assert 'authentication_succeeded' in source
-    assert 'balance_fetched' in source
-    assert 'market_metadata_loaded' in source
-    assert 'order_adapter_initialized' in source
-    assert 'venue_marked_ready' in source
-    assert 'eligible_for_execution' in source
+    assert 'NIJA_ANY_VENUE_EXECUTION_READY' in source
+    assert 'NIJA_EXECUTION_READY_VENUES' in source
+    assert 'ready_venues' in source
+    assert 'degraded_venues' in source

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -1,10 +1,11 @@
-"""Definitive startup readiness verifier for Kraken, Coinbase, and OKX.
+"""Per-venue execution-readiness verifier for Kraken, Coinbase, and OKX.
 
-This observer reports one stage matrix for every required platform venue without
+This observer reports one stage matrix for every configured platform venue without
 creating brokers, connecting accounts, placing probe orders, fabricating balances,
-or bypassing writer/risk controls.  It watches the canonical broker registry after
-normal startup and publishes a fail-closed readiness flag plus an atomic JSON state
-file for Render diagnostics.
+or bypassing writer/risk controls. Each brokerage remains independent: a degraded
+venue is reported and excluded, but it never disables another venue that is fully
+ready. The legacy ``NIJA_THREE_VENUE_EXECUTION_READY`` flag is retained for
+compatibility and now means that the execution system has at least one ready venue.
 """
 from __future__ import annotations
 
@@ -21,7 +22,7 @@ from types import ModuleType
 from typing import Any, Mapping, Optional
 
 logger = logging.getLogger("nija.three_venue_execution_readiness")
-MARKER = "20260711f"
+MARKER = "20260711n"
 VENUES = ("kraken", "coinbase", "okx")
 STAGES = (
     "credentials_loaded",
@@ -32,7 +33,12 @@ STAGES = (
     "venue_marked_ready",
     "eligible_for_execution",
 )
-_STATE_FILE = Path(os.getenv("NIJA_THREE_VENUE_READINESS_FILE", "/tmp/nija_three_venue_readiness.json"))
+_STATE_FILE = Path(
+    os.getenv(
+        "NIJA_THREE_VENUE_READINESS_FILE",
+        "/tmp/nija_three_venue_readiness.json",
+    )
+)
 _LOCK = threading.RLock()
 _INSTALLED = False
 _LAST_SIGNATURE = ""
@@ -43,13 +49,25 @@ _CREDENTIALS = {
         ("KRAKEN_PLATFORM_API_SECRET", "KRAKEN_API_SECRET"),
     ),
     "coinbase": (
-        ("COINBASE_API_KEY", "COINBASE_PLATFORM_API_KEY", "COINBASE_ADVANCED_API_KEY"),
-        ("COINBASE_API_SECRET", "COINBASE_PLATFORM_API_SECRET", "COINBASE_ADVANCED_API_SECRET"),
+        (
+            "COINBASE_API_KEY",
+            "COINBASE_PLATFORM_API_KEY",
+            "COINBASE_ADVANCED_API_KEY",
+        ),
+        (
+            "COINBASE_API_SECRET",
+            "COINBASE_PLATFORM_API_SECRET",
+            "COINBASE_ADVANCED_API_SECRET",
+        ),
     ),
     "okx": (
         ("OKX_API_KEY", "OKX_PLATFORM_API_KEY"),
         ("OKX_API_SECRET", "OKX_PLATFORM_API_SECRET"),
-        ("OKX_PASSPHRASE", "OKX_API_PASSPHRASE", "OKX_PLATFORM_PASSPHRASE"),
+        (
+            "OKX_PASSPHRASE",
+            "OKX_API_PASSPHRASE",
+            "OKX_PLATFORM_PASSPHRASE",
+        ),
     ),
 }
 
@@ -76,7 +94,14 @@ class VenueReadiness:
 
 
 def _truthy(name: str) -> bool:
-    return str(os.getenv(name, "") or "").strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
+    return str(os.getenv(name, "") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+        "y",
+    }
 
 
 def _credentials_loaded(venue: str) -> tuple[bool, str]:
@@ -88,9 +113,15 @@ def _credentials_loaded(venue: str) -> tuple[bool, str]:
 
 
 def _runtime() -> tuple[Optional[ModuleType], Any]:
-    broker_module = sys.modules.get("bot.broker_manager") or sys.modules.get("broker_manager")
-    mabm_module = sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get("multi_account_broker_manager")
-    if not isinstance(broker_module, ModuleType) or not isinstance(mabm_module, ModuleType):
+    broker_module = sys.modules.get("bot.broker_manager") or sys.modules.get(
+        "broker_manager"
+    )
+    mabm_module = sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get(
+        "multi_account_broker_manager"
+    )
+    if not isinstance(broker_module, ModuleType) or not isinstance(
+        mabm_module, ModuleType
+    ):
         return None, None
     manager = getattr(mabm_module, "multi_account_broker_manager", None)
     if manager is None:
@@ -108,7 +139,11 @@ def _broker(manager: Any, broker_module: ModuleType, venue: str) -> Any:
     for attr in ("_platform_brokers", "platform_brokers", "brokers"):
         mapping = getattr(manager, attr, None)
         if isinstance(mapping, Mapping):
-            candidate = mapping.get(enum_value) or mapping.get(venue) or mapping.get(enum_name)
+            candidate = (
+                mapping.get(enum_value)
+                or mapping.get(venue)
+                or mapping.get(enum_name)
+            )
             if candidate is not None:
                 return candidate
     getter = getattr(broker_module, "get_platform_broker", None)
@@ -148,9 +183,21 @@ def _balance(broker: Any) -> tuple[bool, float, str]:
             if isinstance(payload, (int, float)):
                 return True, max(0.0, float(payload)), method_name
             if isinstance(payload, Mapping):
-                for key in ("trading_balance", "available_balance", "available_usd", "usd", "usdt", "usdc", "total"):
+                for key in (
+                    "trading_balance",
+                    "available_balance",
+                    "available_usd",
+                    "usd",
+                    "usdt",
+                    "usdc",
+                    "total",
+                ):
                     if key in payload:
-                        return True, max(0.0, float(payload.get(key) or 0.0)), f"{method_name}:{key}"
+                        return (
+                            True,
+                            max(0.0, float(payload.get(key) or 0.0)),
+                            f"{method_name}:{key}",
+                        )
                 return True, 0.0, method_name
         except Exception as exc:
             return False, 0.0, f"{method_name}:{type(exc).__name__}"
@@ -160,7 +207,12 @@ def _balance(broker: Any) -> tuple[bool, float, str]:
 def _markets(broker: Any) -> tuple[bool, Optional[int], str]:
     if broker is None:
         return False, None, "broker_missing"
-    for method_name in ("get_available_markets", "get_all_products", "get_tradable_symbols", "get_tradable_universe"):
+    for method_name in (
+        "get_available_markets",
+        "get_all_products",
+        "get_tradable_symbols",
+        "get_tradable_universe",
+    ):
         method = getattr(broker, method_name, None)
         if not callable(method):
             continue
@@ -175,18 +227,29 @@ def _markets(broker: Any) -> tuple[bool, Optional[int], str]:
             return count > 0, count, method_name
         except Exception as exc:
             return False, 0, f"{method_name}:{type(exc).__name__}"
-    # Some adapters manage markets internally; an explicit ready activation state
-    # is acceptable evidence only for those adapters.
     return False, None, "market_method_missing"
 
 
 def _adapter_ready(broker: Any) -> bool:
-    return broker is not None and any(callable(getattr(broker, name, None)) for name in ("execute_order", "place_market_order", "place_order"))
+    return broker is not None and any(
+        callable(getattr(broker, name, None))
+        for name in ("execute_order", "place_market_order", "place_order")
+    )
 
 
-def _manager_marks_eligible(manager: Any, broker_module: ModuleType, venue: str, broker: Any) -> bool:
+def _manager_marks_eligible(
+    manager: Any,
+    broker_module: ModuleType,
+    venue: str,
+    broker: Any,
+) -> bool:
     enum_value = getattr(getattr(broker_module, "BrokerType", None), venue.upper(), None)
-    for attr in ("_connected_platform_brokers", "connected_platform_brokers", "eligible_brokers", "_eligible_brokers"):
+    for attr in (
+        "_connected_platform_brokers",
+        "connected_platform_brokers",
+        "eligible_brokers",
+        "_eligible_brokers",
+    ):
         value = getattr(manager, attr, None)
         if isinstance(value, Mapping):
             if any(key in value for key in (enum_value, venue, venue.upper())):
@@ -197,10 +260,20 @@ def _manager_marks_eligible(manager: Any, broker_module: ModuleType, venue: str,
     return _connected(broker)
 
 
-def evaluate_venue(venue: str, broker_module: Optional[ModuleType], manager: Any) -> VenueReadiness:
+def evaluate_venue(
+    venue: str,
+    broker_module: Optional[ModuleType],
+    manager: Any,
+) -> VenueReadiness:
     credentials, credential_reason = _credentials_loaded(venue)
-    activation = str(os.getenv(f"NIJA_{venue.upper()}_ACTIVATION_STATE", "") or "").strip().lower()
-    broker = _broker(manager, broker_module, venue) if broker_module is not None and manager is not None else None
+    activation = str(
+        os.getenv(f"NIJA_{venue.upper()}_ACTIVATION_STATE", "") or ""
+    ).strip().lower()
+    broker = (
+        _broker(manager, broker_module, venue)
+        if broker_module is not None and manager is not None
+        else None
+    )
     connected = _connected(broker)
     balance_ok, spendable, balance_reason = _balance(broker)
     market_ok, market_count, market_reason = _markets(broker)
@@ -209,7 +282,9 @@ def evaluate_venue(venue: str, broker_module: Optional[ModuleType], manager: Any
     if venue == "kraken":
         marked_ready = connected and balance_ok and spendable > 0
     else:
-        marked_ready = activation == "ready" and _truthy(f"NIJA_{venue.upper()}_TRADING_READY")
+        marked_ready = activation == "ready" and _truthy(
+            f"NIJA_{venue.upper()}_TRADING_READY"
+        )
         if activation == "ready" and market_count is None:
             market_ok = True
             market_reason = "activation_ready:adapter_managed"
@@ -227,7 +302,15 @@ def evaluate_venue(venue: str, broker_module: Optional[ModuleType], manager: Any
         and _manager_marks_eligible(manager, broker_module, venue, broker)
     )
 
-    reasons = [reason for reason in (credential_reason, balance_reason if not balance_ok else "", market_reason if not market_ok else "") if reason]
+    reasons = [
+        reason
+        for reason in (
+            credential_reason,
+            balance_reason if not balance_ok else "",
+            market_reason if not market_ok else "",
+        )
+        if reason
+    ]
     if not connected:
         reasons.append("not_connected")
     if balance_ok and spendable <= 0:
@@ -258,25 +341,47 @@ def evaluate_venue(venue: str, broker_module: Optional[ModuleType], manager: Any
 
 def evaluate_all() -> dict[str, Any]:
     broker_module, manager = _runtime()
-    venues = [evaluate_venue(name, broker_module, manager) for name in VENUES]
-    writer_ready = _truthy("NIJA_WRITER_LEASE_ACQUIRED") and bool(os.getenv("NIJA_WRITER_FENCING_TOKEN", "").strip())
-    capital_ready = _truthy("CAPITAL_SYSTEM_READY") or _truthy("NIJA_CAPITAL_READY") or str(os.getenv("NIJA_RUNTIME_TRADING_STATE", "")).strip() == "LIVE_ACTIVE"
-    all_ready = writer_ready and capital_ready and all(item.ready for item in venues)
+    rows = [evaluate_venue(name, broker_module, manager) for name in VENUES]
+    ready_venues = [row.venue for row in rows if row.ready]
+    degraded_venues = [row.venue for row in rows if not row.ready]
+    writer_ready = _truthy("NIJA_WRITER_LEASE_ACQUIRED") and bool(
+        os.getenv("NIJA_WRITER_FENCING_TOKEN", "").strip()
+    )
+    capital_ready = (
+        _truthy("CAPITAL_SYSTEM_READY")
+        or _truthy("NIJA_CAPITAL_READY")
+        or str(os.getenv("NIJA_RUNTIME_TRADING_STATE", "")).strip() == "LIVE_ACTIVE"
+    )
+    any_venue_ready = bool(ready_venues)
+    all_venues_ready = len(ready_venues) == len(VENUES)
+    execution_ready = writer_ready and capital_ready and any_venue_ready
+
     return {
         "marker": MARKER,
         "timestamp": time.time(),
         "pid": os.getpid(),
         "writer_ready": writer_ready,
         "capital_ready": capital_ready,
-        "all_venues_ready": all(item.ready for item in venues),
-        "three_venue_execution_ready": all_ready,
-        "venues": {item.venue: {**asdict(item), "ready": item.ready} for item in venues},
+        "any_venue_ready": any_venue_ready,
+        "all_venues_ready": all_venues_ready,
+        "execution_ready": execution_ready,
+        # Backward-compatible legacy key. It no longer requires all three venues.
+        "three_venue_execution_ready": execution_ready,
+        "ready_venues": ready_venues,
+        "degraded_venues": degraded_venues,
+        "venues": {
+            row.venue: {**asdict(row), "ready": row.ready}
+            for row in rows
+        },
     }
 
 
 def _write_state(payload: dict[str, Any]) -> None:
     _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=_STATE_FILE.name + ".", dir=str(_STATE_FILE.parent))
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=_STATE_FILE.name + ".",
+        dir=str(_STATE_FILE.parent),
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
@@ -292,42 +397,101 @@ def _write_state(payload: dict[str, Any]) -> None:
 
 def publish_once(*, force: bool = False) -> dict[str, Any]:
     global _LAST_SIGNATURE
+
     payload = evaluate_all()
-    os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "1" if payload["three_venue_execution_ready"] else "0"
+    enabled = payload["execution_ready"]
+    ready_csv = ",".join(payload["ready_venues"])
+    degraded_csv = ",".join(payload["degraded_venues"])
+
+    # Retain the old flag for compatibility, but give it broker-independent
+    # semantics: at least one venue is ready under valid writer/capital authority.
+    os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "1" if enabled else "0"
+    os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] = "1" if enabled else "0"
+    os.environ["NIJA_EXECUTION_READY_VENUES"] = ready_csv
+    os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] = degraded_csv
     os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_MARKER"] = MARKER
     _write_state(payload)
-    signature = json.dumps({"writer": payload["writer_ready"], "capital": payload["capital_ready"], "venues": payload["venues"]}, sort_keys=True)
+
+    signature = json.dumps(
+        {
+            "writer": payload["writer_ready"],
+            "capital": payload["capital_ready"],
+            "venues": payload["venues"],
+        },
+        sort_keys=True,
+    )
     if force or signature != _LAST_SIGNATURE:
         _LAST_SIGNATURE = signature
         for venue in VENUES:
             item = payload["venues"][venue]
             logger.warning(
-                "THREE_VENUE_STAGE venue=%s credentials=%s authentication=%s balance=%s markets=%s adapter=%s marked_ready=%s eligible=%s spendable=%.2f activation=%s reason=%s marker=%s",
+                "THREE_VENUE_STAGE venue=%s credentials=%s authentication=%s "
+                "balance=%s markets=%s adapter=%s marked_ready=%s eligible=%s "
+                "spendable=%.2f activation=%s reason=%s marker=%s",
                 venue,
-                item["credentials_loaded"], item["authentication_succeeded"], item["balance_fetched"],
-                item["market_metadata_loaded"], item["order_adapter_initialized"], item["venue_marked_ready"],
-                item["eligible_for_execution"], item["spendable_quote"], item["activation_state"], item["reason"], MARKER,
+                item["credentials_loaded"],
+                item["authentication_succeeded"],
+                item["balance_fetched"],
+                item["market_metadata_loaded"],
+                item["order_adapter_initialized"],
+                item["venue_marked_ready"],
+                item["eligible_for_execution"],
+                item["spendable_quote"],
+                item["activation_state"],
+                item["reason"],
+                MARKER,
             )
-        level = logging.CRITICAL if payload["three_venue_execution_ready"] else logging.WARNING
+
+        level = logging.CRITICAL if enabled else logging.WARNING
         logger.log(
             level,
-            "THREE_VENUE_EXECUTION_%s marker=%s writer_ready=%s capital_ready=%s kraken=%s coinbase=%s okx=%s execution_enabled=%s",
-            "READY" if payload["three_venue_execution_ready"] else "WAITING",
-            MARKER, payload["writer_ready"], payload["capital_ready"],
-            payload["venues"]["kraken"]["ready"], payload["venues"]["coinbase"]["ready"],
-            payload["venues"]["okx"]["ready"], payload["three_venue_execution_ready"],
+            "BROKER_INDEPENDENT_EXECUTION_%s marker=%s writer_ready=%s "
+            "capital_ready=%s ready_venues=%s degraded_venues=%s "
+            "all_venues_ready=%s execution_enabled=%s",
+            "READY" if enabled else "WAITING",
+            MARKER,
+            payload["writer_ready"],
+            payload["capital_ready"],
+            ready_csv or "none",
+            degraded_csv or "none",
+            payload["all_venues_ready"],
+            enabled,
+        )
+        # Keep the historic summary marker for dashboards that parse it.
+        logger.log(
+            level,
+            "THREE_VENUE_EXECUTION_%s marker=%s writer_ready=%s "
+            "capital_ready=%s kraken=%s coinbase=%s okx=%s "
+            "execution_enabled=%s mode=independent_any_ready",
+            "READY" if enabled else "WAITING",
+            MARKER,
+            payload["writer_ready"],
+            payload["capital_ready"],
+            payload["venues"]["kraken"]["ready"],
+            payload["venues"]["coinbase"]["ready"],
+            payload["venues"]["okx"]["ready"],
+            enabled,
         )
     return payload
 
 
 def _monitor() -> None:
-    interval = max(2.0, float(os.getenv("NIJA_THREE_VENUE_VERIFY_INTERVAL_S", "5") or 5))
+    interval = max(
+        2.0,
+        float(os.getenv("NIJA_THREE_VENUE_VERIFY_INTERVAL_S", "5") or 5),
+    )
     while True:
         try:
             publish_once()
         except Exception as exc:
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
-            logger.exception("THREE_VENUE_EXECUTION_VERIFIER_ERROR marker=%s error=%s", MARKER, exc)
+            os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] = "0"
+            os.environ["NIJA_EXECUTION_READY_VENUES"] = ""
+            logger.exception(
+                "THREE_VENUE_EXECUTION_VERIFIER_ERROR marker=%s error=%s",
+                MARKER,
+                exc,
+            )
         time.sleep(interval)
 
 
@@ -338,9 +502,30 @@ def install() -> None:
             return
         _INSTALLED = True
         os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
-        thread = threading.Thread(target=_monitor, name="three-venue-execution-readiness", daemon=True)
+        os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] = "0"
+        os.environ["NIJA_EXECUTION_READY_VENUES"] = ""
+        os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] = ",".join(VENUES)
+        thread = threading.Thread(
+            target=_monitor,
+            name="three-venue-execution-readiness",
+            daemon=True,
+        )
         thread.start()
-        logger.warning("THREE_VENUE_EXECUTION_VERIFIER_INSTALLED marker=%s thread_alive=%s fail_closed=true", MARKER, thread.is_alive())
+        logger.warning(
+            "THREE_VENUE_EXECUTION_VERIFIER_INSTALLED marker=%s "
+            "thread_alive=%s mode=independent_any_ready fail_closed_per_venue=true",
+            MARKER,
+            thread.is_alive(),
+        )
 
 
-__all__ = ["MARKER", "STAGES", "VENUES", "VenueReadiness", "evaluate_venue", "evaluate_all", "publish_once", "install"]
+__all__ = [
+    "MARKER",
+    "STAGES",
+    "VENUES",
+    "VenueReadiness",
+    "evaluate_venue",
+    "evaluate_all",
+    "publish_once",
+    "install",
+]


### PR DESCRIPTION
## Runtime evidence

The July 12 deployment now reaches `RUNNING_SUPERVISED`, has `execution_authority=True`, starts `TradingLoop`, and adopts two Kraken positions. Kraken is fully ready with spendable capital, while Coinbase fails PEM authentication and OKX returns `50111 Invalid OK-ACCESS-KEY`.

Despite Kraken being ready, `three_venue_execution_readiness.py` still published:

`THREE_VENUE_EXECUTION_WAITING ... kraken=True coinbase=False okx=False execution_enabled=False`

That summary contradicted NIJA's independent-broker architecture.

## Fix

- Keep every brokerage's seven readiness stages fail-closed locally.
- Compute system execution readiness from writer authority, capital readiness, and **at least one fully ready venue**.
- Preserve `all_venues_ready` as diagnostic information only.
- Publish `ready_venues` and `degraded_venues` independently.
- Retain `NIJA_THREE_VENUE_EXECUTION_READY` for compatibility, but give it independent-any-ready semantics.
- Add `NIJA_ANY_VENUE_EXECUTION_READY`, `NIJA_EXECUTION_READY_VENUES`, and `NIJA_EXECUTION_DEGRADED_VENUES`.
- Add deterministic `BROKER_INDEPENDENT_EXECUTION_READY/WAITING` telemetry.

## Expected runtime result

With the current deployment state:

- `ready_venues=kraken`
- `degraded_venues=coinbase,okx`
- `execution_enabled=True`
- `all_venues_ready=False`

Coinbase and OKX remain unable to execute until their own credentials are repaired, but neither can disable Kraken.

## Validation

- Python compilation passed.
- Focused stage-verifier suite: **6 passed**.
- Tests cover all-three-ready, local venue failure, Kraken-only execution readiness, compatibility environment flags, and startup contract markers.
