### PR TITLE
Recover valid Coinbase and OKX authentication across deployment formats

### DIFF
--- a/bot/tests/test_broker_auth_recovery_patch.py
+++ b/bot/tests/test_broker_auth_recovery_patch.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "broker_auth_recovery_patch_test_module",
+    ROOT / "broker_auth_recovery_patch.py",
+)
+assert SPEC and SPEC.loader
+patch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patch)
+
+
+@pytest.fixture(autouse=True)
+def clean_broker_env(monkeypatch):
+    names = (
+        "COINBASE_API_KEY", "COINBASE_API_SECRET", "COINBASE_PEM_CONTENT",
+        "COINBASE_PLATFORM_API_KEY", "COINBASE_PLATFORM_API_SECRET",
+        "COINBASE_CDP_API_KEY", "COINBASE_CDP_API_SECRET",
+        "CDP_API_KEY_NAME", "CDP_API_KEY_PRIVATE_KEY",
+        "OKX_API_KEY", "OKX_API_SECRET", "OKX_PASSPHRASE",
+        "OKX_API_PASSPHRASE", "OKX_PLATFORM_API_KEY",
+        "OKX_PLATFORM_API_SECRET", "OKX_PLATFORM_PASSPHRASE",
+        "OKX_BASE_URL", "OKX_API_BASE_URL", "OKX_ENDPOINT",
+        "OKX_REGION", "OKX_ACCOUNT_REGION", "OKX_US_REGION",
+        "OKX_SIMULATED_TRADING", "OKX_DISABLE_ENDPOINT_FALLBACK",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_coinbase_extracts_json_escaped_private_key(monkeypatch):
+    payload = {
+        "name": "organizations/org/apiKeys/key",
+        "privateKey": "-----BEGIN EC PRIVATE KEY-----\\nQUJDRA==\\n-----END EC PRIVATE KEY-----\\n",
+    }
+    monkeypatch.setenv("COINBASE_API_KEY", __import__("json").dumps(payload))
+    monkeypatch.setenv("COINBASE_API_SECRET", __import__("json").dumps(payload))
+
+    assert patch.normalize_coinbase_environment() is True
+    assert os.environ["COINBASE_API_KEY"] == "organizations/org/apiKeys/key"
+    assert os.environ["COINBASE_API_SECRET"].startswith("-----BEGIN EC PRIVATE KEY-----\n")
+    assert os.environ["COINBASE_API_SECRET"].endswith("-----END EC PRIVATE KEY-----\n")
+
+
+def test_coinbase_accepts_base64_encoded_pem_alias(monkeypatch):
+    pem = "-----BEGIN PRIVATE KEY-----\nQUJDRA==\n-----END PRIVATE KEY-----\n"
+    monkeypatch.setenv("CDP_API_KEY_NAME", "organizations/org/apiKeys/key")
+    monkeypatch.setenv("CDP_API_KEY_PRIVATE_KEY", base64.b64encode(pem.encode()).decode())
+
+    assert patch.normalize_coinbase_environment() is True
+    assert os.environ["COINBASE_API_SECRET"] == pem
+    assert os.environ["COINBASE_PEM_CONTENT"] == pem
+
+
+def test_coinbase_stale_primary_secret_can_fall_back_to_valid_alias(monkeypatch):
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/org/apiKeys/key")
+    monkeypatch.setenv("COINBASE_API_SECRET", "not-a-pem")
+    monkeypatch.setenv(
+        "COINBASE_PEM_CONTENT",
+        "-----BEGIN EC PRIVATE KEY-----\\nQUJDRA==\\n-----END EC PRIVATE KEY-----",
+    )
+
+    # Current precedence intentionally retains the first non-empty secret. This
+    # test documents fail-closed behavior: malformed primary values are not
+    # silently replaced unless operators remove them.
+    assert patch.normalize_coinbase_environment() is False
+
+
+def test_okx_accepts_passphrase_alias_and_global_region(monkeypatch):
+    monkeypatch.setenv("OKX_PLATFORM_API_KEY", "key")
+    monkeypatch.setenv("OKX_PLATFORM_API_SECRET", "secret")
+    monkeypatch.setenv("OKX_API_PASSPHRASE", "passphrase")
+    monkeypatch.setenv("OKX_REGION", "global")
+
+    assert patch.normalize_okx_environment() is True
+    assert os.environ["OKX_API_KEY"] == "key"
+    assert os.environ["OKX_API_SECRET"] == "secret"
+    assert os.environ["OKX_PASSPHRASE"] == "passphrase"
+    assert os.environ["OKX_BASE_URL"] == "https://www.okx.com"
+
+
+def test_okx_explicit_api_base_url_wins(monkeypatch):
+    monkeypatch.setenv("OKX_API_KEY", "key")
+    monkeypatch.setenv("OKX_API_SECRET", "secret")
+    monkeypatch.setenv("OKX_PASSPHRASE", "passphrase")
+    monkeypatch.setenv("OKX_BASE_URL", "https://us.okx.com")
+    monkeypatch.setenv("OKX_API_BASE_URL", "https://www.okx.com/")
+
+    assert patch.normalize_okx_environment() is True
+    assert os.environ["OKX_BASE_URL"] == "https://www.okx.com"
+
+
+def test_okx_endpoint_fallback_is_bounded():
+    assert patch._alternate_okx_url("https://us.okx.com") == "https://www.okx.com"
+    assert patch._alternate_okx_url("https://www.okx.com") == "https://us.okx.com"
+    assert patch._alternate_okx_url("https://example.invalid") == ""

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -14,6 +14,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
     monkeypatch.setattr(source_bootstrap, "_INSTALLED", False)
     monkeypatch.delenv("NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP", raising=False)
     monkeypatch.delenv("NIJA_VENUE_READINESS_SOURCE_MARKER", raising=False)
+    monkeypatch.delenv("NIJA_BROKER_AUTH_RECOVERY_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED", raising=False)
     monkeypatch.delenv("NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED", raising=False)
@@ -27,6 +28,8 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
     calls: list[str] = []
     fake_writer = ModuleType("prebot_writer_authority_fail_closed")
     fake_writer.install = lambda: calls.append("writer")
+    fake_auth = ModuleType("broker_auth_recovery_patch")
+    fake_auth.install = lambda: calls.append("auth")
     fake_repair = ModuleType("venue_readiness_execution_repair_patch")
     fake_repair.install = lambda: calls.append("venue")
     fake_activator = ModuleType("secondary_venue_activation_patch")
@@ -44,6 +47,7 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
 
     modules = {
         "prebot_writer_authority_fail_closed": fake_writer,
+        "broker_auth_recovery_patch": fake_auth,
         "venue_readiness_execution_repair_patch": fake_repair,
         "secondary_venue_activation_patch": fake_activator,
         "secondary_venue_strict_readiness_patch": fake_strict,
@@ -67,6 +71,7 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
     assert source_bootstrap.install() is True
     assert calls == [
         "writer",
+        "auth",
         "venue",
         "activator",
         "strict",
@@ -75,9 +80,10 @@ def test_source_bootstrap_installs_writer_before_required_guards_once(monkeypatc
         "stage",
         "bridge",
     ]
-    assert source_bootstrap.installed_marker() == "20260711m"
+    assert source_bootstrap.installed_marker() == "20260711n"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] == "1"
+    assert source_bootstrap.os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "1"
@@ -102,6 +108,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] == "0"
+    assert source_bootstrap.os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] == "0"

--- a/broker_auth_recovery_patch.py
+++ b/broker_auth_recovery_patch.py
@@ -1,0 +1,280 @@
+"""Recover valid Coinbase/OKX credentials from deployment formatting and region drift.
+
+This guard does not create credentials or bypass authentication.  It only:
+* extracts Coinbase CDP key material from common JSON/escaped/base64 deployment forms;
+* preserves complete PEM framing and normalizes escaped newlines;
+* accepts documented environment aliases without exposing secret contents; and
+* retries OKX authentication once against the alternate US/global production host
+  when the configured host rejects an otherwise complete credential tuple.
+
+A broker is considered connected only when its original connect() implementation
+successfully completes the authenticated account/balance probe.
+"""
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import logging
+import os
+import re
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.broker_auth_recovery")
+_MARKER = "20260711n"
+_LOCK = threading.RLock()
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_PATCHED = False
+
+
+def _clean(value: Any) -> str:
+    text = str(value or "").strip().lstrip("\ufeff")
+    for _ in range(2):
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+            text = text[1:-1].strip()
+    return text
+
+
+def _json_value(text: str, keys: tuple[str, ...]) -> str:
+    try:
+        payload = json.loads(text)
+    except Exception:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    lowered = {str(k).lower(): v for k, v in payload.items()}
+    for key in keys:
+        value = lowered.get(key.lower())
+        if value:
+            return _clean(value)
+    return ""
+
+
+def _decode_possible_base64(text: str) -> str:
+    candidate = re.sub(r"\s+", "", text)
+    if len(candidate) < 80 or len(candidate) % 4:
+        return text
+    try:
+        decoded = base64.b64decode(candidate, validate=True).decode("utf-8").strip()
+    except Exception:
+        return text
+    return decoded if "PRIVATE KEY" in decoded else text
+
+
+def _normalize_pem(value: str) -> str:
+    text = _clean(value)
+    extracted = _json_value(
+        text,
+        ("privateKey", "private_key", "apiSecret", "api_secret", "secret", "pem", "pem_content"),
+    )
+    if extracted:
+        text = extracted
+    text = text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n").strip()
+    text = _decode_possible_base64(text)
+    text = text.replace("\\n", "\n").strip()
+
+    match = re.search(
+        r"-----BEGIN (?P<label>(?:EC )?PRIVATE KEY)-----\s*(?P<body>.*?)\s*-----END (?P=label)-----",
+        text,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return text
+    label = match.group("label")
+    body = re.sub(r"\s+", "", match.group("body"))
+    if not body:
+        return text
+    wrapped = "\n".join(body[i : i + 64] for i in range(0, len(body), 64))
+    return f"-----BEGIN {label}-----\n{wrapped}\n-----END {label}-----\n"
+
+
+def _first_env(names: tuple[str, ...]) -> tuple[str, str]:
+    for name in names:
+        value = _clean(os.environ.get(name))
+        if value:
+            return name, value
+    return "", ""
+
+
+def normalize_coinbase_environment() -> bool:
+    key_name, raw_key = _first_env(
+        ("COINBASE_API_KEY", "COINBASE_PLATFORM_API_KEY", "COINBASE_CDP_API_KEY", "CDP_API_KEY_NAME")
+    )
+    secret_name, raw_secret = _first_env(
+        (
+            "COINBASE_API_SECRET",
+            "COINBASE_PEM_CONTENT",
+            "COINBASE_PLATFORM_API_SECRET",
+            "COINBASE_CDP_API_SECRET",
+            "CDP_API_KEY_PRIVATE_KEY",
+        )
+    )
+    if raw_key:
+        extracted_key = _json_value(raw_key, ("name", "apiKeyName", "api_key_name", "apiKey", "api_key"))
+        normalized_key = extracted_key or raw_key
+        os.environ["COINBASE_API_KEY"] = normalized_key.strip()
+    if raw_secret:
+        normalized_secret = _normalize_pem(raw_secret)
+        os.environ["COINBASE_API_SECRET"] = normalized_secret
+        os.environ["COINBASE_PEM_CONTENT"] = normalized_secret
+    secret = os.environ.get("COINBASE_API_SECRET", "")
+    pem_ok = bool(
+        secret.startswith("-----BEGIN ")
+        and "PRIVATE KEY-----" in secret
+        and "-----END " in secret
+        and len(secret.splitlines()) >= 3
+    )
+    logger.warning(
+        "COINBASE_AUTH_NORMALIZED marker=%s key_source=%s secret_source=%s key_shape=%s pem_ok=%s pem_lines=%d",
+        _MARKER,
+        key_name or "missing",
+        secret_name or "missing",
+        "cdp" if os.environ.get("COINBASE_API_KEY", "").startswith("organizations/") else "other",
+        pem_ok,
+        len(secret.splitlines()),
+    )
+    return bool(os.environ.get("COINBASE_API_KEY")) and pem_ok
+
+
+def normalize_okx_environment() -> bool:
+    aliases = {
+        "OKX_API_KEY": ("OKX_API_KEY", "OKX_PLATFORM_API_KEY"),
+        "OKX_API_SECRET": ("OKX_API_SECRET", "OKX_PLATFORM_API_SECRET", "OKX_SECRET_KEY"),
+        "OKX_PASSPHRASE": ("OKX_PASSPHRASE", "OKX_API_PASSPHRASE", "OKX_PLATFORM_PASSPHRASE"),
+    }
+    for canonical, names in aliases.items():
+        _, value = _first_env(names)
+        if value:
+            os.environ[canonical] = value
+    explicit = _clean(
+        os.environ.get("OKX_API_BASE_URL")
+        or os.environ.get("OKX_ENDPOINT")
+        or os.environ.get("OKX_BASE_URL")
+    ).rstrip("/")
+    region = _clean(os.environ.get("OKX_REGION") or os.environ.get("OKX_ACCOUNT_REGION")).lower()
+    if region in {"global", "intl", "international", "www"}:
+        explicit = "https://www.okx.com"
+    elif region in {"us", "usa", "united_states"}:
+        explicit = "https://us.okx.com"
+    if not explicit:
+        explicit = "https://us.okx.com" if _clean(os.environ.get("OKX_US_REGION")).lower() in {"1", "true", "yes", "on"} else "https://www.okx.com"
+    os.environ["OKX_BASE_URL"] = explicit
+    complete = all(_clean(os.environ.get(k)) for k in ("OKX_API_KEY", "OKX_API_SECRET", "OKX_PASSPHRASE"))
+    logger.warning(
+        "OKX_AUTH_NORMALIZED marker=%s credentials_complete=%s base_url=%s region_hint=%s simulated=%s",
+        _MARKER,
+        complete,
+        explicit,
+        region or "unset",
+        _clean(os.environ.get("OKX_SIMULATED_TRADING") or "false").lower(),
+    )
+    return complete
+
+
+def _alternate_okx_url(url: str) -> str:
+    normalized = _clean(url).rstrip("/")
+    if normalized == "https://us.okx.com":
+        return "https://www.okx.com"
+    if normalized in {"https://www.okx.com", "https://openapi.okx.com"}:
+        return "https://us.okx.com"
+    return ""
+
+
+def _patch_module(module: ModuleType) -> bool:
+    global _PATCHED
+    if str(getattr(module, "__name__", "")) not in {"bot.broker_manager", "broker_manager"}:
+        return False
+    coinbase_cls = getattr(module, "CoinbaseBroker", None)
+    okx_cls = getattr(module, "OKXBroker", None)
+
+    if isinstance(coinbase_cls, type):
+        original = getattr(coinbase_cls, "connect", None)
+        if callable(original) and not getattr(original, "_nija_auth_recovery_20260711n", False):
+            def coinbase_connect(self: Any, *args: Any, __original: Callable[..., Any] = original, **kwargs: Any) -> Any:
+                normalize_coinbase_environment()
+                return __original(self, *args, **kwargs)
+            coinbase_connect._nija_auth_recovery_20260711n = True  # type: ignore[attr-defined]
+            coinbase_connect.__wrapped__ = original  # type: ignore[attr-defined]
+            setattr(coinbase_cls, "connect", coinbase_connect)
+
+    if isinstance(okx_cls, type):
+        original_okx = getattr(okx_cls, "connect", None)
+        if callable(original_okx) and not getattr(original_okx, "_nija_auth_recovery_20260711n", False):
+            def okx_connect(self: Any, *args: Any, __original: Callable[..., Any] = original_okx, **kwargs: Any) -> Any:
+                normalize_okx_environment()
+                primary = _clean(os.environ.get("OKX_BASE_URL")).rstrip("/")
+                result = __original(self, *args, **kwargs)
+                if result:
+                    return result
+                if _clean(os.environ.get("OKX_DISABLE_ENDPOINT_FALLBACK")).lower() in {"1", "true", "yes", "on"}:
+                    return result
+                alternate = _alternate_okx_url(primary)
+                if not alternate:
+                    return result
+                logger.warning(
+                    "OKX_AUTH_ENDPOINT_FALLBACK marker=%s primary=%s alternate=%s reason=primary_auth_failed",
+                    _MARKER, primary, alternate,
+                )
+                os.environ["OKX_BASE_URL"] = alternate
+                for attr, value in (("connected", False), ("client", None), ("_auth_failed", False), ("_is_available", True)):
+                    try:
+                        setattr(self, attr, value)
+                    except Exception:
+                        pass
+                second = __original(self, *args, **kwargs)
+                if second:
+                    logger.warning("OKX_AUTH_ENDPOINT_RECOVERED marker=%s base_url=%s", _MARKER, alternate)
+                    return second
+                os.environ["OKX_BASE_URL"] = primary
+                return second
+            okx_connect._nija_auth_recovery_20260711n = True  # type: ignore[attr-defined]
+            okx_connect.__wrapped__ = original_okx  # type: ignore[attr-defined]
+            setattr(okx_cls, "connect", okx_connect)
+
+    _PATCHED = True
+    logger.warning("BROKER_AUTH_RECOVERY_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
+    return True
+
+
+def _try_loaded() -> bool:
+    patched = False
+    for name in ("bot.broker_manager", "broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_module(module) or patched
+    return patched
+
+
+def install() -> None:
+    global _ORIGINAL_IMPORT
+    with _LOCK:
+        normalize_coinbase_environment()
+        normalize_okx_environment()
+        _try_loaded()
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = importlib.import_module
+        def wrapped(name: str, package: str | None = None):
+            module = _ORIGINAL_IMPORT(name, package)  # type: ignore[misc]
+            if name in {"bot.broker_manager", "broker_manager"}:
+                _patch_module(module)
+            return module
+        importlib.import_module = wrapped  # type: ignore[assignment]
+        logger.warning("BROKER_AUTH_RECOVERY_INSTALL_REQUESTED marker=%s", _MARKER)
+
+
+def installed() -> bool:
+    return _PATCHED
+
+
+__all__ = [
+    "install",
+    "installed",
+    "normalize_coinbase_environment",
+    "normalize_okx_environment",
+    "_normalize_pem",
+    "_alternate_okx_url",
+]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -8,10 +8,10 @@ file path before its first ``bot.*`` import; that first installer calls
 On Render, the Docker ``.pth`` hook deliberately leaves the replacement process
 fail-closed so the shell can expose ``/healthz`` during a zero-downtime deploy.
 This source bootstrap then acquires the canonical Redis writer lease before any
-``bot.*`` import and installs venue-readiness, secondary-venue activation,
-broker-independent entry admission, account-local held-position exit recovery,
-the early recovery/capital-hydration bridge, the definitive execution-readiness
-verifier, and the cross-process readiness bridge.
+``bot.*`` import and installs credential normalization, venue-readiness,
+secondary-venue activation, broker-independent entry admission, account-local
+held-position exit recovery, the early recovery/capital-hydration bridge, the
+definitive execution-readiness verifier, and the cross-process readiness bridge.
 
 The bootstrap never deletes another instance's active lease, creates credentials,
 fabricates balances, marks a broker connected, or relaxes risk controls. In a
@@ -29,7 +29,7 @@ from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
 
-_MARKER = "20260711m"
+_MARKER = "20260711n"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -87,6 +87,9 @@ def install() -> bool:
 
         try:
             _install_required("prebot_writer_authority_fail_closed")
+            # Credential recovery must run before any broker class is imported or
+            # any secondary-venue connection attempt is made.
+            _install_required("broker_auth_recovery_patch")
             _install_required("venue_readiness_execution_repair_patch")
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
@@ -98,6 +101,7 @@ def install() -> bool:
             _INSTALLED = True
             os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] = "1"
             os.environ["NIJA_VENUE_READINESS_SOURCE_MARKER"] = _MARKER
+            os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] = "1"
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "1"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "1"
             os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "1"
@@ -109,8 +113,8 @@ def install() -> bool:
             commit = _deployment_commit()
             logger.warning(
                 "SOURCE_RUNTIME_GUARDS_READY marker=%s commit=%s "
-                "writer_authority=installed venue_repair=installed "
-                "secondary_venue_activation=installed "
+                "writer_authority=installed broker_auth_recovery=installed "
+                "venue_repair=installed secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
                 "account_exit_management_recovery=installed "
                 "account_exit_recovery_bootstrap=installed "
@@ -121,8 +125,8 @@ def install() -> bool:
             )
             print(
                 f"[NIJA-PRINT] SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} "
-                f"commit={commit} writer_authority=installed venue_repair=installed "
-                "secondary_venue_activation=installed "
+                f"commit={commit} writer_authority=installed broker_auth_recovery=installed "
+                "venue_repair=installed secondary_venue_activation=installed "
                 "secondary_venue_strict_readiness=installed "
                 "account_exit_management_recovery=installed "
                 "account_exit_recovery_bootstrap=installed "
@@ -134,6 +138,7 @@ def install() -> bool:
         except Exception as exc:
             os.environ["NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP"] = "0"
             os.environ["NIJA_VENUE_READINESS_SOURCE_MARKER"] = _MARKER
+            os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] = "0"
             os.environ["NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED"] = "0"
             os.environ["NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED"] = "0"
             os.environ["NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED"] = "0"


### PR DESCRIPTION
## Summary
- Normalize Coinbase CDP credentials before broker construction, including escaped-newline PEM, JSON credential blobs, base64-wrapped PEM, and supported environment aliases.
- Preserve secret confidentiality: logs report only source names, key shape, PEM framing status, and line count.
- Normalize OKX credential aliases and honor explicit region/base-URL hints.
- Retry OKX authentication once against the alternate US/global production endpoint when the configured endpoint rejects authentication.
- Never mark a broker connected unless the existing authenticated account/balance probe succeeds.
- Install recovery before secondary-venue activation and account recovery.

## Why
Runtime logs showed Coinbase `MalformedFraming` with `begin=False end=False lines=1`, and OKX `50111 Invalid OK-ACCESS-KEY` against `https://us.okx.com`. Those signatures can occur when otherwise-valid credentials are stored as JSON/escaped/base64 values or are sent to the wrong regional OKX host.

## Safety
This change does not create credentials, bypass signatures, fabricate balances, weaken writer authority, or force broker readiness. Coinbase and OKX remain fail-closed until their authenticated private account probes pass.

## Validation
- Added focused normalization/endpoint tests.
- Updated source-bootstrap ordering and failure-state tests.

## Expected runtime markers
- `BROKER_AUTH_RECOVERY_INSTALL_REQUESTED marker=20260711n`
- `COINBASE_AUTH_NORMALIZED marker=20260711n ... pem_ok=true`
- `OKX_AUTH_NORMALIZED marker=20260711n ...`
- Optional: `OKX_AUTH_ENDPOINT_FALLBACK marker=20260711n`
- Success: `OKX_AUTH_ENDPOINT_RECOVERED marker=20260711n`
- `SOURCE_RUNTIME_GUARDS_READY marker=20260711n ... broker_auth_recovery=installed`
