### PR TITLE
Fix remaining runtime convergence and account isolation failures

### DIFF
--- a/bot/tests/test_runtime_convergence_v2_patch.py
+++ b/bot/tests/test_runtime_convergence_v2_patch.py
@@ -84,4 +84,4 @@ def test_shared_tracker_is_rebound_to_account_scoped_file(tmp_path, monkeypatch)
         position_tracker=Tracker(),
     )
     assert patch._rebind_tracker(broker) is True
-    assert broker.position_tracker.storage_file.endswith("positions_user:daivon_frazier_kraken.json")
+    assert broker.position_tracker.storage_file.endswith("positions_user_daivon_frazier_kraken.json")

--- a/bot/tests/test_runtime_convergence_v2_patch.py
+++ b/bot/tests/test_runtime_convergence_v2_patch.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "runtime_convergence_v2_patch_test_module",
+    ROOT / "runtime_convergence_v2_patch.py",
+)
+assert SPEC and SPEC.loader
+patch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patch)
+
+
+def test_identity_does_not_depend_on_core_loop_object():
+    broker = SimpleNamespace(account_id="USER:tania_gilbert", broker_name="kraken")
+    assert patch._identity(broker) == "user:tania_gilbert:kraken"
+
+
+def test_duplicate_scans_for_same_account_are_blocked(monkeypatch):
+    patch._SCAN_LOCKS.clear()
+    module = ModuleType("bot.nija_core_loop")
+    entered = threading.Event()
+    release = threading.Event()
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, broker):
+            entered.set()
+            release.wait(2)
+            return (1, 0, 1, {})
+
+    module.NijaCoreLoop = NijaCoreLoop
+    monkeypatch.setenv("NIJA_ACCOUNT_SCAN_LOCK_TIMEOUT_S", "0.05")
+    assert patch._patch_core_loop(module) is True
+    broker = SimpleNamespace(account_id="platform", broker_name="kraken")
+    first_result = []
+    first = threading.Thread(target=lambda: first_result.append(NijaCoreLoop().run_scan_phase(broker)))
+    first.start()
+    assert entered.wait(1)
+    second = NijaCoreLoop().run_scan_phase(broker)
+    assert second == (0, 1, 0, {"duplicate_scan": 1})
+    release.set()
+    first.join(1)
+    assert first_result == [(1, 0, 1, {})]
+
+
+def test_coinbase_constructor_normalizes_before_client_creation(monkeypatch):
+    calls: list[str] = []
+    fake_auth = ModuleType("broker_auth_recovery_patch")
+    fake_auth.normalize_coinbase_environment = lambda: calls.append("normalize") or True
+    fake_auth.normalize_okx_environment = lambda: True
+    real_import = patch.importlib.import_module
+    monkeypatch.setattr(
+        patch.importlib,
+        "import_module",
+        lambda name: fake_auth if name == "broker_auth_recovery_patch" else real_import(name),
+    )
+    module = ModuleType("bot.broker_integration")
+
+    class CoinbaseBrokerAdapter:
+        def __init__(self):
+            calls.append("construct")
+            self.position_tracker = None
+
+    module.CoinbaseBrokerAdapter = CoinbaseBrokerAdapter
+    assert patch._patch_broker_classes(module) is True
+    CoinbaseBrokerAdapter()
+    assert calls == ["normalize", "construct"]
+
+
+def test_shared_tracker_is_rebound_to_account_scoped_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("NIJA_POSITION_STATE_DIR", str(tmp_path))
+
+    class Tracker:
+        def __init__(self, storage_file="positions.json"):
+            self.storage_file = storage_file
+
+    broker = SimpleNamespace(
+        account_id="USER:daivon_frazier",
+        broker_name="kraken",
+        position_tracker=Tracker(),
+    )
+    assert patch._rebind_tracker(broker) is True
+    assert broker.position_tracker.storage_file.endswith("positions_user:daivon_frazier_kraken.json")

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -17,6 +17,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_VENUE_READINESS_SOURCE_MARKER",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
+        "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -34,6 +35,7 @@ def test_source_bootstrap_installs_writer_and_convergence_before_broker_activati
         ("prebot_writer_authority_fail_closed", "writer", "install"),
         ("broker_auth_recovery_patch", "auth", "install"),
         ("runtime_convergence_hardening_patch", "convergence", "install"),
+        ("runtime_convergence_v2_patch", "convergence_v2", "install"),
         ("venue_readiness_execution_repair_patch", "venue", "install"),
         ("secondary_venue_activation_patch", "activator", "install"),
         ("secondary_venue_strict_readiness_patch", "strict", "install"),
@@ -62,11 +64,12 @@ def test_source_bootstrap_installs_writer_and_convergence_before_broker_activati
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == [
-        "writer", "auth", "convergence", "venue", "activator", "strict",
+        "writer", "auth", "convergence", "convergence_v2", "venue", "activator", "strict",
         "exit_recovery", "exit_bootstrap", "stage", "bridge",
     ]
-    assert source_bootstrap.installed_marker() == "20260712a"
+    assert source_bootstrap.installed_marker() == "20260712b"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
@@ -87,6 +90,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
 
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/runtime_convergence_v2_patch.py
+++ b/runtime_convergence_v2_patch.py
@@ -1,0 +1,219 @@
+"""Targeted follow-up hardening for NIJA runtime convergence.
+
+This module fixes gaps left by the first convergence guard without bypassing
+broker authentication, writer authority, risk controls, or exchange validation.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.runtime_convergence_v2")
+MARKER = "20260712b"
+_LOCK = threading.RLock()
+_SCAN_LOCKS: dict[str, threading.Lock] = {}
+_SCAN_GUARD = threading.RLock()
+_STARTED = False
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip().lower().replace(" ", "_")
+
+
+def _broker_name(obj: Any) -> str:
+    if obj is None:
+        return "unknown"
+    text = " ".join(
+        str(getattr(obj, attr, "") or "")
+        for attr in ("broker_type", "broker_name", "name", "exchange", "exchange_name")
+    ).lower() + " " + type(obj).__name__.lower()
+    for name in ("kraken", "coinbase", "okx", "alpaca", "binance"):
+        if name in text:
+            return name
+    return "unknown"
+
+
+def _account_id(obj: Any) -> str:
+    if obj is None:
+        return "platform"
+    for attr in ("account_id", "user_id", "account_name", "owner_id"):
+        value = getattr(obj, attr, None)
+        if value:
+            return _clean(value)
+    account_type = getattr(obj, "account_type", None)
+    value = getattr(account_type, "value", account_type)
+    return _clean(value) if value else "platform"
+
+
+def _identity(obj: Any) -> str:
+    identity = f"{_account_id(obj)}:{_broker_name(obj)}"
+    if identity == "platform:unknown":
+        identity = f"platform:unknown:{id(obj)}"
+    return identity
+
+
+def _normalize_auth(venue: str) -> None:
+    auth = importlib.import_module("broker_auth_recovery_patch")
+    if venue == "coinbase":
+        auth.normalize_coinbase_environment()
+    elif venue == "okx":
+        auth.normalize_okx_environment()
+
+
+def _rebind_tracker(instance: Any) -> bool:
+    tracker = getattr(instance, "position_tracker", None)
+    if tracker is None:
+        return False
+    current = str(getattr(tracker, "storage_file", "") or "")
+    if current and Path(current).name != "positions.json":
+        return False
+    identity = _identity(instance).replace(":", "_")
+    scoped = str(Path(os.getenv("NIJA_POSITION_STATE_DIR", "data")) / f"positions_{identity}.json")
+    try:
+        setattr(instance, "position_tracker", type(tracker)(scoped))
+        logger.warning(
+            "POSITION_TRACKER_REBOUND marker=%s identity=%s old=%s new=%s",
+            MARKER, identity, current or "unset", scoped,
+        )
+        return True
+    except Exception as exc:
+        logger.error(
+            "POSITION_TRACKER_REBOUND_FAILED marker=%s identity=%s err=%s",
+            MARKER, identity, exc,
+        )
+        return False
+
+
+def _patch_broker_classes(module: ModuleType) -> bool:
+    patched = False
+    for class_name in dir(module):
+        cls = getattr(module, class_name, None)
+        if not isinstance(cls, type) or "broker" not in class_name.lower():
+            continue
+        lower = class_name.lower()
+        venue = "coinbase" if "coinbase" in lower else "okx" if "okx" in lower else ""
+        original = getattr(cls, "__init__", None)
+        if callable(original) and not getattr(original, "_nija_convergence_v2", False):
+            def init(self: Any, *args: Any, __original: Callable[..., Any] = original,
+                     __venue: str = venue, **kwargs: Any) -> None:
+                if __venue:
+                    _normalize_auth(__venue)
+                __original(self, *args, **kwargs)
+                _rebind_tracker(self)
+            init._nija_convergence_v2 = True  # type: ignore[attr-defined]
+            init.__wrapped__ = original  # type: ignore[attr-defined]
+            setattr(cls, "__init__", init)
+            patched = True
+            logger.warning(
+                "BROKER_CONSTRUCTOR_CONVERGENCE_PATCHED marker=%s module=%s class=%s venue=%s",
+                MARKER, module.__name__, class_name, venue or "other",
+            )
+        for method_name in ("connect", "verify_connection", "test_connection"):
+            method = getattr(cls, method_name, None)
+            if not venue or not callable(method) or getattr(method, "_nija_auth_v2", False):
+                continue
+            def wrapped(self: Any, *args: Any, __method: Callable[..., Any] = method,
+                        __venue: str = venue, **kwargs: Any) -> Any:
+                _normalize_auth(__venue)
+                result = __method(self, *args, **kwargs)
+                _rebind_tracker(self)
+                return result
+            wrapped._nija_auth_v2 = True  # type: ignore[attr-defined]
+            wrapped.__wrapped__ = method  # type: ignore[attr-defined]
+            setattr(cls, method_name, wrapped)
+            patched = True
+    return patched
+
+
+def _patch_core_loop(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "run_scan_phase", None)
+    if not callable(original) or getattr(original, "_nija_scan_identity_lock_v2", False):
+        return False
+
+    def run_scan_phase(self: Any, *args: Any, **kwargs: Any) -> Any:
+        broker = kwargs.get("broker") or (args[0] if args else None)
+        key = _identity(broker)
+        with _SCAN_GUARD:
+            lock = _SCAN_LOCKS.setdefault(key, threading.Lock())
+        timeout = max(0.01, float(os.getenv("NIJA_ACCOUNT_SCAN_LOCK_TIMEOUT_S", "0.25") or 0.25))
+        if not lock.acquire(timeout=timeout):
+            logger.critical(
+                "DUPLICATE_SCAN_BLOCKED marker=%s identity=%s timeout_s=%.2f",
+                MARKER, key, timeout,
+            )
+            return (0, 1, 0, {"duplicate_scan": 1})
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            lock.release()
+
+    run_scan_phase._nija_scan_identity_lock_v2 = True  # type: ignore[attr-defined]
+    run_scan_phase.__wrapped__ = original  # type: ignore[attr-defined]
+    setattr(cls, "run_scan_phase", run_scan_phase)
+    logger.warning("ACCOUNT_SCAN_IDENTITY_LOCK_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    for name in (
+        "bot.broker_manager", "broker_manager",
+        "bot.broker_integration", "broker_integration",
+        "bot.multi_account_broker_manager", "multi_account_broker_manager",
+        "bot.nija_core_loop", "nija_core_loop",
+    ):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        patched = _patch_broker_classes(module) or patched
+        patched = _patch_core_loop(module) or patched
+    return patched
+
+
+def _watchdog() -> None:
+    deadline = time.monotonic() + max(30.0, float(os.getenv("NIJA_RUNTIME_PATCH_WATCHDOG_S", "180") or 180))
+    while time.monotonic() < deadline:
+        try:
+            _patch_loaded()
+        except Exception as exc:
+            logger.debug("RUNTIME_CONVERGENCE_V2_RETRY marker=%s err=%s", MARKER, exc)
+        time.sleep(0.25)
+
+
+def install() -> None:
+    global _STARTED
+    with _LOCK:
+        os.environ.setdefault("NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S", "5")
+        os.environ.setdefault("NIJA_ACCOUNT_SCAN_LOCK_TIMEOUT_S", "0.25")
+        for name in (
+            "bot.broker_manager", "bot.broker_integration",
+            "bot.multi_account_broker_manager", "bot.nija_core_loop",
+        ):
+            try:
+                module = importlib.import_module(name)
+                _patch_broker_classes(module)
+                _patch_core_loop(module)
+            except Exception as exc:
+                logger.debug("RUNTIME_CONVERGENCE_V2_EAGER_IMPORT marker=%s module=%s err=%s", MARKER, name, exc)
+        _patch_loaded()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="RuntimeConvergenceV2Watchdog", daemon=True).start()
+        logger.warning("RUNTIME_CONVERGENCE_V2_INSTALLED marker=%s", MARKER)
+
+
+def installed() -> bool:
+    return _STARTED
+
+
+__all__ = ["install", "installed", "_identity", "_patch_broker_classes", "_patch_core_loop", "_rebind_tracker"]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260712a"
+_MARKER = "20260712b"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -53,6 +53,7 @@ def _set_status(value: str) -> None:
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
+        "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -73,8 +74,8 @@ def install() -> bool:
         try:
             _install_required("prebot_writer_authority_fail_closed")
             _install_required("broker_auth_recovery_patch")
-            # Must precede broker construction, activation and account supervisors.
             _install_required("runtime_convergence_hardening_patch")
+            _install_required("runtime_convergence_v2_patch")
             _install_required("venue_readiness_execution_repair_patch")
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
@@ -89,10 +90,11 @@ def install() -> bool:
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
                 "writer_authority=installed broker_auth_recovery=installed "
-                "runtime_convergence_hardening=installed venue_repair=installed "
-                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed source=main_pre_bot"
+                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
+                "venue_repair=installed secondary_venue_activation=installed "
+                "secondary_venue_strict_readiness=installed account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)


### PR DESCRIPTION
## Summary
- Normalize Coinbase and OKX credentials before broker/adapter constructors create clients, not only during later connect calls.
- Eagerly patch the known broker modules and keep a bounded watchdog for late imports.
- Serialize scans by account+broker identity so duplicate core-loop objects cannot scan the same account concurrently.
- Rebind legacy shared `positions.json` trackers to account-and-broker-scoped files after broker construction.
- Reduce independent held-position exit-management cadence to 5 seconds while preserving all existing TP/SL/trailing/emergency checks.
- Update mandatory bootstrap ordering and add focused regression coverage.

## Runtime failures addressed
- Coinbase still reached `MalformedFraming` without normalization markers.
- Duplicate Kraken scan cycle IDs appeared within milliseconds.
- User cycles could inherit platform position counts.
- A global `positions.json` was loaded across platform and user brokers.
- Held-position management was slower than necessary relative to entry scans.

## Safety
This change does not create credentials, bypass authentication/signatures, fabricate balances/acks/fills, force entries, raise position caps, or weaken writer authority, risk, stop-loss, take-profit, trailing-exit, or exchange validation controls.

## Validation
- Branch is 5 commits ahead of `main` and 0 behind.
- Four files changed: one targeted guard, one new test file, and two bootstrap updates.
- Keep draft until GitHub CI completes.

## Expected deployment markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260712b ... runtime_convergence_v2=installed`
- `RUNTIME_CONVERGENCE_V2_INSTALLED marker=20260712b`
- `BROKER_CONSTRUCTOR_CONVERGENCE_PATCHED marker=20260712b`
- `ACCOUNT_SCAN_IDENTITY_LOCK_PATCHED marker=20260712b`
- `DUPLICATE_SCAN_BLOCKED marker=20260712b` when an overlap is attempted
- `POSITION_TRACKER_REBOUND marker=20260712b identity=...`
