### PR TITLE
Finalize runtime convergence and duplicate-scan safety

### DIFF
--- a/bot/tests/test_final_runtime_convergence_patch.py
+++ b/bot/tests/test_final_runtime_convergence_patch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "final_runtime_convergence_patch_test_module",
+    ROOT / "final_runtime_convergence_patch.py",
+)
+assert SPEC and SPEC.loader
+patch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patch)
+
+
+def test_none_scan_result_is_coerced_to_contract():
+    result = patch._coerce_scan_result(None)
+    assert result.symbols_scored == 0
+    assert result.entries_taken == 0
+    assert result.entries_blocked == 1
+    assert result.exits_taken == 0
+    assert result.next_interval >= 5
+    assert result.metadata["duplicate_scan"] is True
+
+
+def test_tuple_scan_result_is_coerced_to_contract():
+    result = patch._coerce_scan_result((2, 1, 1, {"next_interval": 30, "exits_taken": 1}))
+    assert result.symbols_scored == 2
+    assert result.entries_blocked == 1
+    assert result.entries_taken == 1
+    assert result.exits_taken == 1
+    assert result.next_interval == 30
+
+
+def test_auth_repair_uses_loaded_module_without_import(monkeypatch):
+    calls: list[str] = []
+    auth = ModuleType("broker_auth_recovery_patch")
+    auth.normalize_coinbase_environment = lambda: calls.append("coinbase") or True
+    auth.normalize_okx_environment = lambda: calls.append("okx") or True
+    monkeypatch.setitem(sys.modules, "broker_auth_recovery_patch", auth)
+
+    patch._safe_normalize("coinbase")
+    broker = SimpleNamespace(base_url="https://us.okx.com")
+    monkeypatch.setenv("OKX_BASE_URL", "https://www.okx.com")
+    patch._safe_normalize("okx", broker)
+
+    assert calls == ["coinbase", "okx"]
+    assert broker.base_url == "https://www.okx.com"
+
+
+def test_core_loop_wrapper_never_returns_none():
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return None
+
+    module.NijaCoreLoop = NijaCoreLoop
+    assert patch._patch_core_loop(module) is True
+    result = NijaCoreLoop().run_scan_phase(broker=SimpleNamespace(account_id="platform", broker_name="kraken"))
+    assert result.symbols_scored == 0
+    assert result.entries_blocked == 1
+
+
+def test_okx_endpoint_updates_live_instance(monkeypatch):
+    broker = SimpleNamespace(base_url="https://us.okx.com", endpoint="https://us.okx.com")
+    patch._set_okx_endpoint(broker, "https://www.okx.com")
+    assert os.environ["OKX_BASE_URL"] == "https://www.okx.com"
+    assert broker.base_url == "https://www.okx.com"
+    assert broker.endpoint == "https://www.okx.com"

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -18,6 +18,8 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
+        "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
+        "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -36,6 +38,8 @@ def test_source_bootstrap_installs_writer_and_convergence_before_broker_activati
         ("broker_auth_recovery_patch", "auth", "install"),
         ("runtime_convergence_hardening_patch", "convergence", "install"),
         ("runtime_convergence_v2_patch", "convergence_v2", "install"),
+        ("runtime_auth_recursion_endpoint_repair_patch", "auth_endpoint", "install"),
+        ("final_runtime_convergence_patch", "final_convergence", "install"),
         ("venue_readiness_execution_repair_patch", "venue", "install"),
         ("secondary_venue_activation_patch", "activator", "install"),
         ("secondary_venue_strict_readiness_patch", "strict", "install"),
@@ -64,12 +68,15 @@ def test_source_bootstrap_installs_writer_and_convergence_before_broker_activati
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == [
-        "writer", "auth", "convergence", "convergence_v2", "venue", "activator", "strict",
-        "exit_recovery", "exit_bootstrap", "stage", "bridge",
+        "writer", "auth", "convergence", "convergence_v2", "auth_endpoint",
+        "final_convergence", "venue", "activator", "strict", "exit_recovery",
+        "exit_bootstrap", "stage", "bridge",
     ]
-    assert source_bootstrap.installed_marker() == "20260712b"
+    assert source_bootstrap.installed_marker() == "20260712d"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
@@ -91,6 +98,8 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/final_runtime_convergence_patch.py
+++ b/final_runtime_convergence_patch.py
@@ -1,0 +1,203 @@
+"""Final convergence repair for duplicate scans and auth hook recursion.
+
+This patch is intentionally narrow. It preserves broker authentication, writer
+lineage, risk controls, exchange validation, and all exit protections.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.final_runtime_convergence")
+MARKER = "20260712d"
+_LOCK = threading.RLock()
+_PATCHED = False
+
+
+def _auth_module() -> ModuleType | None:
+    module = sys.modules.get("broker_auth_recovery_patch")
+    return module if isinstance(module, ModuleType) else None
+
+
+def _set_okx_endpoint(instance: Any, url: str) -> None:
+    normalized = str(url or "").strip().rstrip("/")
+    if not normalized:
+        return
+    os.environ["OKX_BASE_URL"] = normalized
+    for attr in ("base_url", "api_base_url", "endpoint", "api_url", "rest_url"):
+        try:
+            if hasattr(instance, attr):
+                setattr(instance, attr, normalized)
+        except Exception:
+            pass
+
+
+def _safe_normalize(venue: str, instance: Any | None = None) -> None:
+    auth = _auth_module()
+    if auth is None:
+        return
+    normalizer = getattr(auth, f"normalize_{venue}_environment", None)
+    if callable(normalizer):
+        normalizer()
+    if venue == "okx" and instance is not None:
+        _set_okx_endpoint(instance, os.environ.get("OKX_BASE_URL", ""))
+
+
+def _replace_recursive_auth_hooks() -> bool:
+    patched = False
+    legacy = sys.modules.get("runtime_convergence_hardening_patch")
+    if isinstance(legacy, ModuleType):
+        def safe_patch_auth_surface(target: ModuleType) -> bool:
+            changed = False
+            for class_name in dir(target):
+                cls = getattr(target, class_name, None)
+                if not isinstance(cls, type):
+                    continue
+                lowered = class_name.lower()
+                venue = "coinbase" if "coinbase" in lowered else "okx" if "okx" in lowered else ""
+                if not venue:
+                    continue
+                for method_name in ("connect", "verify_connection", "test_connection"):
+                    original = getattr(cls, method_name, None)
+                    if not callable(original) or getattr(original, "_nija_final_auth_safe", False):
+                        continue
+
+                    def wrapped(self: Any, *args: Any, __original: Callable[..., Any] = original,
+                                __venue: str = venue, **kwargs: Any) -> Any:
+                        _safe_normalize(__venue, self)
+                        return __original(self, *args, **kwargs)
+
+                    wrapped._nija_final_auth_safe = True  # type: ignore[attr-defined]
+                    wrapped.__wrapped__ = original  # type: ignore[attr-defined]
+                    setattr(cls, method_name, wrapped)
+                    changed = True
+            return changed
+
+        legacy._patch_auth_surface = safe_patch_auth_surface
+        patched = True
+
+    v2 = sys.modules.get("runtime_convergence_v2_patch")
+    if isinstance(v2, ModuleType):
+        v2._normalize_auth = lambda venue: _safe_normalize(str(venue))
+        patched = True
+
+    if patched:
+        logger.warning("AUTH_IMPORT_RECURSION_REMOVED marker=%s", MARKER)
+    return patched
+
+
+def _duplicate_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        symbols_scored=0,
+        entries_taken=0,
+        entries_blocked=1,
+        exits_taken=0,
+        next_interval=max(5, int(float(os.getenv("NIJA_DUPLICATE_SCAN_NEXT_INTERVAL_S", "15") or 15))),
+        errors=["duplicate_scan_suppressed"],
+        metadata={"duplicate_scan": True},
+    )
+
+
+def _coerce_scan_result(result: Any) -> Any:
+    if result is None:
+        return _duplicate_result()
+    if isinstance(result, tuple):
+        scored = int(result[0] or 0) if len(result) > 0 else 0
+        blocked = int(result[1] or 0) if len(result) > 1 else 0
+        entered = int(result[2] or 0) if len(result) > 2 else 0
+        meta = result[3] if len(result) > 3 and isinstance(result[3], dict) else {}
+        return SimpleNamespace(
+            symbols_scored=scored,
+            entries_taken=entered,
+            entries_blocked=blocked,
+            exits_taken=int(meta.get("exits_taken", 0) or 0),
+            next_interval=int(meta.get("next_interval", 15) or 15),
+            errors=list(meta.get("errors", [])),
+            metadata=meta,
+        )
+    return result
+
+
+def _patch_core_loop(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "run_scan_phase", None)
+    if not callable(original) or getattr(original, "_nija_final_result_contract", False):
+        return False
+
+    def run_scan_phase(self: Any, *args: Any, **kwargs: Any) -> Any:
+        result = original(self, *args, **kwargs)
+        coerced = _coerce_scan_result(result)
+        if coerced is not result:
+            logger.warning(
+                "DUPLICATE_SCAN_RESULT_CONTRACT_REPAIRED marker=%s result_type=%s",
+                MARKER, type(result).__name__,
+            )
+        return coerced
+
+    run_scan_phase._nija_final_result_contract = True  # type: ignore[attr-defined]
+    run_scan_phase.__wrapped__ = original  # type: ignore[attr-defined]
+    setattr(cls, "run_scan_phase", run_scan_phase)
+    logger.warning("SCAN_RESULT_CONTRACT_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _patch_okx_classes() -> bool:
+    changed = False
+    for module_name in (
+        "bot.broker_manager", "broker_manager",
+        "bot.broker_integration", "broker_integration",
+        "bot.multi_account_broker_manager", "multi_account_broker_manager",
+    ):
+        module = sys.modules.get(module_name)
+        if not isinstance(module, ModuleType):
+            continue
+        for class_name in dir(module):
+            cls = getattr(module, class_name, None)
+            if not isinstance(cls, type) or "okx" not in class_name.lower():
+                continue
+            original = getattr(cls, "connect", None)
+            if not callable(original) or getattr(original, "_nija_final_okx_endpoint", False):
+                continue
+
+            def connect(self: Any, *args: Any, __original: Callable[..., Any] = original, **kwargs: Any) -> Any:
+                _safe_normalize("okx", self)
+                before = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
+                result = __original(self, *args, **kwargs)
+                after = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
+                if after and after != before:
+                    _set_okx_endpoint(self, after)
+                return result
+
+            connect._nija_final_okx_endpoint = True  # type: ignore[attr-defined]
+            connect.__wrapped__ = original  # type: ignore[attr-defined]
+            setattr(cls, "connect", connect)
+            changed = True
+    if changed:
+        logger.warning("OKX_LIVE_ENDPOINT_CONVERGENCE_PATCHED marker=%s", MARKER)
+    return changed
+
+
+def install() -> None:
+    global _PATCHED
+    with _LOCK:
+        changed = _replace_recursive_auth_hooks()
+        for name in ("bot.nija_core_loop", "nija_core_loop"):
+            module = sys.modules.get(name)
+            if isinstance(module, ModuleType):
+                changed = _patch_core_loop(module) or changed
+        changed = _patch_okx_classes() or changed
+        _PATCHED = _PATCHED or changed
+        logger.warning("FINAL_RUNTIME_CONVERGENCE_INSTALLED marker=%s patched=%s", MARKER, _PATCHED)
+
+
+def installed() -> bool:
+    return _PATCHED
+
+
+__all__ = ["install", "installed", "_coerce_scan_result", "_duplicate_result"]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260712c"
+_MARKER = "20260712d"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -55,6 +55,7 @@ def _set_status(value: str) -> None:
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
+        "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -78,6 +79,7 @@ def install() -> bool:
             _install_required("runtime_convergence_hardening_patch")
             _install_required("runtime_convergence_v2_patch")
             _install_required("runtime_auth_recursion_endpoint_repair_patch")
+            _install_required("final_runtime_convergence_patch")
             _install_required("venue_readiness_execution_repair_patch")
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
@@ -93,10 +95,11 @@ def install() -> bool:
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
                 "writer_authority=installed broker_auth_recovery=installed "
                 "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
-                "runtime_auth_endpoint_repair=installed venue_repair=installed "
-                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed source=main_pre_bot"
+                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
+                "venue_repair=installed secondary_venue_activation=installed "
+                "secondary_venue_strict_readiness=installed account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)


### PR DESCRIPTION
## Summary
- Guarantee duplicate-scan suppression always returns the normal core-loop result contract instead of `None` or a raw tuple.
- Replace the remaining recursive authentication hook lookups with `sys.modules` access.
- Keep Coinbase/OKX normalization attached without recursively invoking wrapped import machinery.
- Propagate OKX endpoint changes to live broker-instance URL fields.
- Install the final guard before venue activation and account recovery.
- Add focused regression coverage for `None`/tuple scan results, non-recursive auth lookup, live OKX endpoint updates, and bootstrap ordering.

## Runtime failures addressed
- `AttributeError: 'NoneType' object has no attribute 'symbols_scored'` after `DUPLICATE_SCAN_BLOCKED`.
- `RUNTIME_CONVERGENCE_AUTH_IMPORT_FAILED ... maximum recursion depth exceeded`.
- OKX fallback environment changed while the active broker continued reporting the old `base_url`.

## Safety
This change does not fabricate credentials, balances, broker acknowledgements, fills, or profitability. It does not force entries, raise position caps, bypass writer authority, or weaken TP/SL/trailing/emergency/exchange validation controls.

## Expected deployment markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260712d ... final_runtime_convergence=installed`
- `AUTH_IMPORT_RECURSION_REMOVED marker=20260712d`
- `SCAN_RESULT_CONTRACT_PATCHED marker=20260712d`
- `DUPLICATE_SCAN_RESULT_CONTRACT_REPAIRED marker=20260712d` when overlap is suppressed
- `OKX_LIVE_ENDPOINT_CONVERGENCE_PATCHED marker=20260712d`
- The `NoneType ... symbols_scored` and recursion-depth errors must disappear.
