### PR TITLE
Scope writer generation to the platform Kraken lease

### DIFF
--- a/bot/tests/test_writer_generation_scope_repair_patch.py
+++ b/bot/tests/test_writer_generation_scope_repair_patch.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH_PATH = ROOT / "writer_generation_scope_repair_patch.py"
+
+
+def _load_patch():
+    spec = importlib.util.spec_from_file_location("writer_generation_scope_repair_patch_test", PATCH_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_platform_key_id_uses_platform_key(monkeypatch):
+    patch = _load_patch()
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")
+    monkeypatch.setenv("KRAKEN_API_KEY", "fallback-secret")
+    assert patch._platform_key_id() == hashlib.sha256(b"platform-secret").hexdigest()[:16]
+
+
+def test_user_nonce_lease_does_not_overwrite_platform_generation(monkeypatch):
+    patch = _load_patch()
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "101")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION_LAST", "101")
+
+    module = ModuleType("fake_nonce")
+
+    class Backend:
+        def _ensure_writer_lease(self, key_id):
+            os.environ["NIJA_WRITER_LEASE_GENERATION"] = "202"
+            os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = "202"
+            return 202
+
+    module._PerKeyRedisBackend = Backend
+    assert patch._patch_nonce_backend(module)
+    backend = Backend()
+    assert backend._ensure_writer_lease("user-key-id") == 202
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "101"
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] == "101"
+
+
+def test_platform_nonce_lease_publishes_platform_generation(monkeypatch):
+    patch = _load_patch()
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")
+    platform_id = hashlib.sha256(b"platform-secret").hexdigest()[:16]
+
+    module = ModuleType("fake_nonce")
+
+    class Backend:
+        def _ensure_writer_lease(self, key_id):
+            return 303
+
+    module._PerKeyRedisBackend = Backend
+    assert patch._patch_nonce_backend(module)
+    assert Backend()._ensure_writer_lease(platform_id) == 303
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "303"
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] == "303"
+
+
+def test_tracker_reads_platform_per_key_version(monkeypatch):
+    patch = _load_patch()
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")
+    platform_id = hashlib.sha256(b"platform-secret").hexdigest()[:16]
+    requested = []
+
+    class Client:
+        def get(self, key):
+            requested.append(key)
+            return "404"
+
+    tracker = ModuleType("fake_tracker")
+    tracker.get_redis_generation = lambda: (999, "")
+    tracker._connect_redis = lambda timeout_s=2: (Client(), "")
+
+    assert patch._patch_generation_tracker(tracker)
+    assert tracker.get_redis_generation() == (404, "")
+    assert requested == [f"nija:kraken:writer:lease_version:{platform_id}"]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260712e"
+_MARKER = "20260712f"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -56,6 +56,7 @@ def _set_status(value: str) -> None:
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
         "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
+        "NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -75,6 +76,7 @@ def install() -> bool:
             return True
         try:
             _install_required("prebot_writer_authority_fail_closed")
+            _install_required("writer_generation_scope_repair_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("runtime_convergence_hardening_patch")
             _install_required("runtime_convergence_v2_patch")
@@ -93,13 +95,13 @@ def install() -> bool:
             commit = _deployment_commit()
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
-                "writer_authority=installed broker_auth_recovery=installed "
-                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
-                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
-                "venue_repair=installed secondary_venue_activation=installed "
-                "secondary_venue_strict_readiness=installed account_exit_management_recovery=installed "
-                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
-                "render_readiness_bridge=installed source=main_pre_bot"
+                "writer_authority=installed writer_generation_scope=installed "
+                "broker_auth_recovery=installed runtime_convergence_hardening=installed "
+                "runtime_convergence_v2=installed runtime_auth_endpoint_repair=installed "
+                "final_runtime_convergence=installed venue_repair=installed "
+                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
+                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
+                "three_venue_stage_verifier=installed render_readiness_bridge=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)

--- a/writer_generation_scope_repair_patch.py
+++ b/writer_generation_scope_repair_patch.py
@@ -1,0 +1,152 @@
+"""Keep platform writer lineage isolated from user Kraken nonce leases.
+
+Each Kraken API key owns an independent Redis nonce lease.  The legacy backend
+published every per-key lease version into the process-wide
+NIJA_WRITER_LEASE_GENERATION variable and validated it against one global Redis
+counter.  Connecting user accounts therefore advanced the global counter and
+made the platform writer appear stale even though its own lease was healthy.
+
+This repair makes the platform key's per-key lease version authoritative for
+process writer lineage and prevents user-key leases from mutating platform
+writer-generation state.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.writer_generation_scope_repair")
+MARKER = "20260712f"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+_GENERATION_ENV_KEYS = (
+    "NIJA_WRITER_LEASE_GENERATION",
+    "NIJA_WRITER_LEASE_GENERATION_LAST",
+    "NIJA_WRITER_LEASE_GENERATION_EXPECTED",
+)
+
+
+def _platform_api_key() -> str:
+    return (
+        str(os.environ.get("KRAKEN_PLATFORM_API_KEY", "") or "").strip()
+        or str(os.environ.get("KRAKEN_API_KEY", "") or "").strip()
+    )
+
+
+def _platform_key_id() -> str:
+    raw = _platform_api_key()
+    return hashlib.sha256(raw.encode()).hexdigest()[:16] if raw else ""
+
+
+def _snapshot_generation_env() -> dict[str, str | None]:
+    return {name: os.environ.get(name) for name in _GENERATION_ENV_KEYS}
+
+
+def _restore_generation_env(snapshot: dict[str, str | None]) -> None:
+    for name, value in snapshot.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+
+def _patch_nonce_backend(module: ModuleType) -> bool:
+    backend = getattr(module, "_PerKeyRedisBackend", None)
+    if not isinstance(backend, type):
+        return False
+    original = getattr(backend, "_ensure_writer_lease", None)
+    if not callable(original) or getattr(original, "_nija_platform_generation_scoped", False):
+        return False
+
+    def _ensure_writer_lease(self: Any, key_id: str, *args: Any, **kwargs: Any) -> int:
+        platform_id = _platform_key_id()
+        is_platform = bool(platform_id and str(key_id) == platform_id)
+        before = _snapshot_generation_env()
+        version = int(original(self, key_id, *args, **kwargs))
+        if is_platform:
+            os.environ["NIJA_WRITER_LEASE_GENERATION"] = str(version)
+            os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = str(version)
+            logger.info(
+                "PLATFORM_WRITER_GENERATION_PUBLISHED marker=%s key_id=%s generation=%d",
+                MARKER, key_id, version,
+            )
+        else:
+            _restore_generation_env(before)
+            logger.debug(
+                "USER_NONCE_LEASE_GENERATION_ISOLATED marker=%s key_id=%s lease_version=%d",
+                MARKER, key_id, version,
+            )
+        return version
+
+    _ensure_writer_lease._nija_platform_generation_scoped = True  # type: ignore[attr-defined]
+    _ensure_writer_lease.__wrapped__ = original  # type: ignore[attr-defined]
+    setattr(backend, "_ensure_writer_lease", _ensure_writer_lease)
+    logger.warning("NONCE_LEASE_GENERATION_SCOPE_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _patch_generation_tracker(module: ModuleType) -> bool:
+    original = getattr(module, "get_redis_generation", None)
+    connector = getattr(module, "_connect_redis", None)
+    if not callable(original) or not callable(connector):
+        return False
+    if getattr(original, "_nija_platform_generation_scoped", False):
+        return False
+
+    def get_redis_generation() -> tuple[int, str]:
+        key_id = _platform_key_id()
+        if not key_id:
+            return 0, "platform_api_key_not_configured"
+        client, err = connector(timeout_s=2)
+        if client is None:
+            return 0, err or "redis_unavailable"
+        redis_key = f"nija:kraken:writer:lease_version:{key_id}"
+        try:
+            raw = client.get(redis_key)
+            if raw is None:
+                return 0, f"platform_lease_version_missing:{key_id}"
+            return max(0, int(str(raw).strip())), ""
+        except Exception as exc:
+            return 0, f"platform_lease_version_read_error:{exc}"
+
+    get_redis_generation._nija_platform_generation_scoped = True  # type: ignore[attr-defined]
+    get_redis_generation.__wrapped__ = original  # type: ignore[attr-defined]
+    setattr(module, "get_redis_generation", get_redis_generation)
+    logger.warning("WRITER_GENERATION_TRACKER_PLATFORM_SCOPED marker=%s", MARKER)
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return True
+        try:
+            from bot import distributed_nonce_manager as nonce_module
+            from bot import writer_generation_tracker as tracker_module
+        except ImportError:
+            import distributed_nonce_manager as nonce_module  # type: ignore[no-redef]
+            import writer_generation_tracker as tracker_module  # type: ignore[no-redef]
+
+        nonce_ok = _patch_nonce_backend(nonce_module)
+        tracker_ok = _patch_generation_tracker(tracker_module)
+        already_nonce = bool(getattr(getattr(nonce_module, "_PerKeyRedisBackend", None), "_ensure_writer_lease", None) and getattr(getattr(nonce_module._PerKeyRedisBackend, "_ensure_writer_lease"), "_nija_platform_generation_scoped", False))
+        already_tracker = bool(getattr(getattr(tracker_module, "get_redis_generation", None), "_nija_platform_generation_scoped", False))
+        _INSTALLED = (nonce_ok or already_nonce) and (tracker_ok or already_tracker)
+        if not _INSTALLED:
+            raise RuntimeError("platform writer generation scope patch did not attach")
+        os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] = "1"
+        logger.warning("WRITER_GENERATION_SCOPE_REPAIR_INSTALLED marker=%s", MARKER)
+        return True
+
+
+def installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = ["install", "installed", "_platform_key_id"]


### PR DESCRIPTION
## Summary
- Stop user Kraken nonce leases from overwriting process-wide platform writer-generation state.
- Validate writer generation against the platform API key's per-key Redis lease version instead of the global counter advanced by every account.
- Preserve independent per-user nonce fencing while keeping platform writer lineage stable.
- Install the repair before account and broker startup.
- Advance the runtime marker to `20260712f`.
- Add focused regression tests.

## Root cause
The global `nija:lease:generation` counter advances whenever any Kraken API key acquires a nonce lease. With Daivon and Tania connected, Redis advanced by two while the platform process still held its own healthy lease, producing recurring `local=357 redis=359 delta=2` mismatches. The legacy backend also published each user lease version into `NIJA_WRITER_LEASE_GENERATION`.

## Safety
This does not bypass writer authority. The platform generation is now checked against `nija:kraken:writer:lease_version:<platform_key_id>`, which is the actual platform lease. User leases retain their own owner/version fencing. Missing platform lease state fails closed.

## Expected runtime markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260712f ... writer_generation_scope=installed`
- `NONCE_LEASE_GENERATION_SCOPE_PATCHED marker=20260712f`
- `WRITER_GENERATION_TRACKER_PLATFORM_SCOPED marker=20260712f`
- `WRITER_GENERATION_SCOPE_REPAIR_INSTALLED marker=20260712f`

The recurring +2 generation mismatch and recovery loop must disappear after deployment.