### PR TITLE
Eliminate duplicate workers and normalize Kraken positions

### DIFF
--- a/bot/tests/test_final_worker_position_coinbase_repair_patch.py
+++ b/bot/tests/test_final_worker_position_coinbase_repair_patch.py
@@ -1,16 +1,10 @@
-import importlib
-import os
 import threading
 import time
 
-
-def _reload():
-    module = importlib.import_module("final_worker_position_coinbase_repair_patch")
-    return importlib.reload(module)
+import final_worker_position_coinbase_repair_patch as module
 
 
 def test_position_dict_is_normalized_from_kraken_fields():
-    module = _reload()
     position = {"vol": "2.5", "cost": "50.0"}
     result = module.normalize_position(position)
     assert result["quantity"] == 2.5
@@ -19,8 +13,6 @@ def test_position_dict_is_normalized_from_kraken_fields():
 
 
 def test_position_object_is_normalized():
-    module = _reload()
-
     class Position:
         amount = "3"
         avg_price = "7.5"
@@ -31,7 +23,6 @@ def test_position_object_is_normalized():
 
 
 def test_complete_single_line_pem_is_reframed():
-    module = _reload()
     raw = "-----BEGIN PRIVATE KEY-----QUJDRA==-----END PRIVATE KEY-----"
     repaired = module._repair_pem(raw)
     assert repaired.startswith("-----BEGIN PRIVATE KEY-----\n")
@@ -40,7 +31,6 @@ def test_complete_single_line_pem_is_reframed():
 
 
 def test_process_wide_duplicate_named_thread_is_suppressed():
-    module = _reload()
     module.install()
     release = threading.Event()
     first = threading.Thread(target=lambda: release.wait(2), name="Trader-test_kraken", daemon=True)
@@ -58,7 +48,6 @@ def test_process_wide_duplicate_named_thread_is_suppressed():
 
 
 def test_unrelated_thread_names_are_not_suppressed():
-    module = _reload()
     module.install()
     done = threading.Event()
     thread = threading.Thread(target=done.set, name="ordinary-test-thread")

--- a/bot/tests/test_final_worker_position_coinbase_repair_patch.py
+++ b/bot/tests/test_final_worker_position_coinbase_repair_patch.py
@@ -1,0 +1,67 @@
+import importlib
+import os
+import threading
+import time
+
+
+def _reload():
+    module = importlib.import_module("final_worker_position_coinbase_repair_patch")
+    return importlib.reload(module)
+
+
+def test_position_dict_is_normalized_from_kraken_fields():
+    module = _reload()
+    position = {"vol": "2.5", "cost": "50.0"}
+    result = module.normalize_position(position)
+    assert result["quantity"] == 2.5
+    assert result["size"] == 2.5
+    assert result["entry_price"] == 20.0
+
+
+def test_position_object_is_normalized():
+    module = _reload()
+
+    class Position:
+        amount = "3"
+        avg_price = "7.5"
+
+    result = module.normalize_position(Position())
+    assert result.quantity == 3.0
+    assert result.entry_price == 7.5
+
+
+def test_complete_single_line_pem_is_reframed():
+    module = _reload()
+    raw = "-----BEGIN PRIVATE KEY-----QUJDRA==-----END PRIVATE KEY-----"
+    repaired = module._repair_pem(raw)
+    assert repaired.startswith("-----BEGIN PRIVATE KEY-----\n")
+    assert repaired.endswith("\n-----END PRIVATE KEY-----\n")
+    assert "QUJDRA==" in repaired
+
+
+def test_process_wide_duplicate_named_thread_is_suppressed():
+    module = _reload()
+    module.install()
+    release = threading.Event()
+    first = threading.Thread(target=lambda: release.wait(2), name="Trader-test_kraken", daemon=True)
+    second_ran = threading.Event()
+    second = threading.Thread(target=second_ran.set, name="Trader-test_kraken", daemon=True)
+    first.start()
+    time.sleep(0.02)
+    second.start()
+    time.sleep(0.02)
+    assert first.is_alive()
+    assert not second_ran.is_set()
+    assert second.ident is None
+    release.set()
+    first.join(timeout=1)
+
+
+def test_unrelated_thread_names_are_not_suppressed():
+    module = _reload()
+    module.install()
+    done = threading.Event()
+    thread = threading.Thread(target=done.set, name="ordinary-test-thread")
+    thread.start()
+    thread.join(timeout=1)
+    assert done.is_set()

--- a/final_worker_position_coinbase_repair_patch.py
+++ b/final_worker_position_coinbase_repair_patch.py
@@ -1,0 +1,217 @@
+"""Final process-wide runtime repair for NIJA.
+
+Prevents duplicate NIJA worker threads across multiple manager instances, normalizes
+Kraken position fields at the broker boundary, and repairs/validates Coinbase PEM
+material before SDK construction. Exchange authentication remains authoritative.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import sys
+import threading
+import time
+import weakref
+from typing import Any
+
+logger = logging.getLogger("nija.final_worker_position_coinbase_repair")
+_MARKER = "20260712g"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_ORIGINAL_THREAD_START = threading.Thread.start
+_ACTIVE_THREADS: dict[str, weakref.ReferenceType[threading.Thread]] = {}
+_GUARDED_PREFIXES = (
+    "Trader-",
+    "AccountExitRecoverySupervisor",
+    "csm-watchdog-",
+)
+
+
+def _guarded_name(name: str) -> bool:
+    return any(name == prefix or name.startswith(prefix) for prefix in _GUARDED_PREFIXES)
+
+
+def _thread_start(self: threading.Thread, *args: Any, **kwargs: Any):
+    name = str(getattr(self, "name", "") or "")
+    if not _guarded_name(name):
+        return _ORIGINAL_THREAD_START(self, *args, **kwargs)
+    with _LOCK:
+        ref = _ACTIVE_THREADS.get(name)
+        active = ref() if ref is not None else None
+        if active is not None and active is not self and active.is_alive():
+            logger.critical(
+                "PROCESS_WIDE_DUPLICATE_THREAD_SUPPRESSED marker=%s name=%s existing_ident=%s",
+                _MARKER,
+                name,
+                getattr(active, "ident", None),
+            )
+            return None
+        _ACTIVE_THREADS[name] = weakref.ref(self)
+    try:
+        return _ORIGINAL_THREAD_START(self, *args, **kwargs)
+    except Exception:
+        with _LOCK:
+            ref = _ACTIVE_THREADS.get(name)
+            if ref is not None and ref() is self:
+                _ACTIVE_THREADS.pop(name, None)
+        raise
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _first_value(position: Any, names: tuple[str, ...]) -> float:
+    if isinstance(position, dict):
+        for name in names:
+            if name in position and position[name] not in (None, ""):
+                value = _float(position[name])
+                if value != 0.0:
+                    return value
+        return 0.0
+    for name in names:
+        if hasattr(position, name):
+            value = _float(getattr(position, name, 0.0))
+            if value != 0.0:
+                return value
+    return 0.0
+
+
+def _set_value(position: Any, name: str, value: float) -> None:
+    if isinstance(position, dict):
+        position.setdefault(name, value)
+        return
+    try:
+        current = getattr(position, name, None)
+        if current in (None, "", 0, 0.0):
+            setattr(position, name, value)
+    except Exception:
+        return
+
+
+def normalize_position(position: Any) -> Any:
+    quantity = _first_value(position, (
+        "quantity", "qty", "size", "position_size", "volume", "vol", "amount", "balance", "units",
+    ))
+    entry_price = _first_value(position, (
+        "entry_price", "average_entry_price", "avg_entry_price", "avg_price", "average_price", "cost_basis_price", "price",
+    ))
+    if entry_price <= 0.0:
+        cost = _first_value(position, ("cost", "cost_basis", "total_cost", "notional"))
+        if cost > 0.0 and abs(quantity) > 0.0:
+            entry_price = cost / abs(quantity)
+    _set_value(position, "quantity", quantity)
+    _set_value(position, "size", quantity)
+    _set_value(position, "entry_price", entry_price)
+    _set_value(position, "average_entry_price", entry_price)
+    return position
+
+
+def _wrap_positions_method(cls: type, method_name: str) -> None:
+    original = getattr(cls, method_name, None)
+    if not callable(original) or getattr(original, "_nija_position_normalized", False):
+        return
+
+    def wrapped(self: Any, *args: Any, **kwargs: Any):
+        result = original(self, *args, **kwargs)
+        if isinstance(result, list):
+            return [normalize_position(item) for item in result]
+        if isinstance(result, tuple):
+            return tuple(normalize_position(item) for item in result)
+        if isinstance(result, dict):
+            for key, value in list(result.items()):
+                if isinstance(value, (dict, object)) and not isinstance(value, (str, bytes, int, float, bool, type(None))):
+                    result[key] = normalize_position(value)
+            return result
+        return result
+
+    wrapped._nija_position_normalized = True
+    setattr(cls, method_name, wrapped)
+    logger.warning("KRAKEN_POSITION_NORMALIZER_PATCHED marker=%s class=%s method=%s", _MARKER, cls.__name__, method_name)
+
+
+def _repair_pem(raw: str) -> str:
+    value = str(raw or "").strip().strip('"').strip("'")
+    value = value.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n").replace("\r", "\n")
+    if "BEGIN" not in value:
+        try:
+            decoded = base64.b64decode(value, validate=True).decode("utf-8").strip()
+            if "BEGIN" in decoded and "PRIVATE KEY" in decoded:
+                value = decoded
+        except Exception:
+            pass
+    match = re.search(r"-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----(.*?)-----END \1-----", value, re.S)
+    if match:
+        label = match.group(1)
+        body = re.sub(r"\s+", "", match.group(2))
+        if body:
+            lines = [body[i:i + 64] for i in range(0, len(body), 64)]
+            value = f"-----BEGIN {label}-----\n" + "\n".join(lines) + f"\n-----END {label}-----\n"
+    return value
+
+
+def _validate_coinbase_pem() -> bool:
+    names = ("COINBASE_API_SECRET", "COINBASE_API_PRIVATE_KEY", "COINBASE_PRIVATE_KEY")
+    source = next((name for name in names if str(os.environ.get(name, "") or "").strip()), "")
+    if not source:
+        return False
+    repaired = _repair_pem(os.environ[source])
+    for name in names:
+        if name == source or name in os.environ:
+            os.environ[name] = repaired
+    try:
+        from cryptography.hazmat.primitives.serialization import load_pem_private_key
+        load_pem_private_key(repaired.encode("utf-8"), password=None)
+        os.environ["NIJA_COINBASE_PEM_VALID"] = "1"
+        logger.warning("COINBASE_PEM_VALIDATED marker=%s source=%s lines=%d", _MARKER, source, len(repaired.splitlines()))
+        return True
+    except Exception as exc:
+        os.environ["NIJA_COINBASE_PEM_VALID"] = "0"
+        os.environ["NIJA_COINBASE_AUTH_ISOLATED"] = "1"
+        logger.error("COINBASE_PEM_INVALID_ISOLATED marker=%s source=%s lines=%d error=%s", _MARKER, source, len(repaired.splitlines()), type(exc).__name__)
+        return False
+
+
+def _patch_loaded_brokers() -> None:
+    for module_name in ("bot.broker_manager", "bot.broker_integration", "bot.multi_account_broker_manager"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        for class_name in ("KrakenBroker", "KrakenBrokerAdapter"):
+            cls = getattr(module, class_name, None)
+            if isinstance(cls, type):
+                for method_name in ("get_positions", "fetch_positions", "get_open_positions"):
+                    _wrap_positions_method(cls, method_name)
+
+
+def _watchdog() -> None:
+    deadline = time.monotonic() + 180.0
+    while time.monotonic() < deadline:
+        _patch_loaded_brokers()
+        time.sleep(0.25)
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return True
+        threading.Thread.start = _thread_start
+        _validate_coinbase_pem()
+        _patch_loaded_brokers()
+        threading.Thread(target=_watchdog, name="final-worker-position-watchdog", daemon=True).start()
+        os.environ["NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED"] = "1"
+        _INSTALLED = True
+        logger.warning(
+            "FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED marker=%s process_thread_guard=true kraken_position_normalizer=true coinbase_preflight=true",
+            _MARKER,
+        )
+        return True
+
+
+__all__ = ["install", "normalize_position"]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260712f"
+_MARKER = "20260712g"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -57,6 +57,7 @@ def _set_status(value: str) -> None:
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
         "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
         "NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED",
+        "NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -77,6 +78,7 @@ def install() -> bool:
         try:
             _install_required("prebot_writer_authority_fail_closed")
             _install_required("writer_generation_scope_repair_patch")
+            _install_required("final_worker_position_coinbase_repair_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("runtime_convergence_hardening_patch")
             _install_required("runtime_convergence_v2_patch")
@@ -96,12 +98,13 @@ def install() -> bool:
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
                 "writer_authority=installed writer_generation_scope=installed "
-                "broker_auth_recovery=installed runtime_convergence_hardening=installed "
-                "runtime_convergence_v2=installed runtime_auth_endpoint_repair=installed "
-                "final_runtime_convergence=installed venue_repair=installed "
-                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed source=main_pre_bot"
+                "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
+                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
+                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
+                "venue_repair=installed secondary_venue_activation=installed "
+                "secondary_venue_strict_readiness=installed account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)


### PR DESCRIPTION
## Summary
- Enforce one live NIJA worker per process-wide thread identity for platform traders, user traders, exit supervisors, and connection-stability watchdogs.
- Normalize Kraken position quantity and entry-price fields at the broker boundary, including cost/quantity entry-price derivation.
- Repair complete single-line or escaped-newline Coinbase PEM values before SDK construction.
- Cryptographically validate Coinbase PEM material and isolate Coinbase clearly when the deployed key is invalid or incomplete.
- Install the repair before broker and worker startup.
- Advance the runtime marker to `20260712g`.

## Root causes
Instance-local worker registries could not detect a second `IndependentBrokerTrader` or recovery manager, so identical `Trader-*` and `AccountExitRecoverySupervisor` threads launched twice. Kraken position payloads used fields such as `vol`, `amount`, `size`, `avg_price`, or `cost`, while some downstream paths expected `quantity` and `entry_price`. Coinbase could reach the SDK with escaped, quoted, base64-encoded, or complete single-line PEM material before strict validation.

## Safety
This does not force trades, change position caps, fabricate quantities, create Coinbase credentials, or mark a broker connected without a successful authenticated private probe. Invalid Coinbase key material remains isolated. Writer authority, nonce fencing, risk controls, and exit protections remain authoritative.

## Expected runtime markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260712g ... final_worker_position_coinbase_repair=installed`
- `FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED marker=20260712g`
- `PROCESS_WIDE_DUPLICATE_THREAD_SUPPRESSED marker=20260712g name=...` when duplicate startup is attempted
- `KRAKEN_POSITION_NORMALIZER_PATCHED marker=20260712g`
- Coinbase: either `COINBASE_PEM_VALIDATED marker=20260712g` or `COINBASE_PEM_INVALID_ISOLATED marker=20260712g`

## Validation
Focused tests cover Kraken dictionary/object normalization, complete single-line PEM reframing, duplicate-thread suppression, and unaffected ordinary threads.