### PR TITLE
Scope authority heartbeat to platform generation

### DIFF
--- a/authority_heartbeat_generation_scope_patch.py
+++ b/authority_heartbeat_generation_scope_patch.py
@@ -1,0 +1,216 @@
+"""Keep authority heartbeat generation aligned with the platform Kraken lease.
+
+The legacy heartbeat writer read the global ``nija:lease:generation`` counter.
+Every user Kraken nonce lease increments that counter, so Daivon and Tania could
+make the platform heartbeat appear stale even while the platform lease remained
+healthy.  This repair reads the platform key's own lease version through the
+already-scoped writer generation tracker and never copies the global counter
+into platform writer lineage.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.authority_heartbeat_generation_scope")
+MARKER = "20260713a"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_WATCHDOG_STARTED = False
+
+
+def _platform_generation() -> tuple[int, str]:
+    try:
+        try:
+            from bot.writer_generation_tracker import get_redis_generation
+        except ImportError:
+            from writer_generation_tracker import get_redis_generation  # type: ignore[import]
+        generation, error = get_redis_generation()
+        return max(0, int(generation or 0)), str(error or "")
+    except Exception as exc:
+        return 0, f"platform_generation_lookup_failed:{exc}"
+
+
+def _redis_url() -> str:
+    try:
+        try:
+            from bot.redis_env import get_redis_url
+        except ImportError:
+            from redis_env import get_redis_url  # type: ignore[import]
+        return str(get_redis_url() or "").strip()
+    except Exception:
+        return ""
+
+
+def _patch_module(module: ModuleType) -> bool:
+    cls = getattr(module, "AuthorityHeartbeatMonitor", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_write_heartbeat_to_redis", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_platform_generation_scoped_20260713a", False):
+        return True
+
+    def _write_heartbeat_to_redis(self: Any) -> None:
+        redis_url = _redis_url()
+        if not redis_url:
+            logger.debug("AUTHORITY_HEARTBEAT_PLATFORM_SCOPE_SKIP marker=%s reason=redis_not_configured", MARKER)
+            return
+
+        generation, generation_error = _platform_generation()
+        if generation_error or generation <= 0:
+            # Fail closed: do not publish a heartbeat with an unverified or global
+            # generation.  The authority check remains responsible for lockdown.
+            logger.error(
+                "AUTHORITY_HEARTBEAT_PLATFORM_GENERATION_UNAVAILABLE marker=%s error=%s",
+                MARKER,
+                generation_error or "invalid_platform_generation",
+            )
+            return
+
+        local_before = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+        if local_before != str(generation):
+            logger.warning(
+                "AUTHORITY_HEARTBEAT_PLATFORM_GENERATION_REPAIRED marker=%s local=%s platform=%s",
+                MARKER,
+                local_before or "unset",
+                generation,
+            )
+        os.environ["NIJA_WRITER_LEASE_GENERATION"] = str(generation)
+        os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = str(generation)
+
+        try:
+            import redis as redis_lib
+
+            client = redis_lib.from_url(redis_url, socket_connect_timeout=3)
+            self._redis_client = client
+            heartbeat_data = {
+                "timestamp": time.time(),
+                "generation": str(generation),
+                "generation_scope": "platform_kraken_key",
+                "instance_id": os.environ.get("NIJA_WRITER_INSTANCE_ID", "unknown"),
+            }
+            client.set("nija:writer_heartbeat_active", json.dumps(heartbeat_data), ex=30)
+
+            lock_scope = os.environ.get("NIJA_WRITER_SCOPE", "platform")
+            lock_key = (
+                os.environ.get("NIJA_WRITER_LOCK_KEY", "").strip()
+                or f"nija:writer_lock:{lock_scope}"
+            )
+            lock_ttl_s = max(
+                60,
+                int(os.environ.get("NIJA_WRITER_LOCK_TTL_S", "30") or 30) * 3,
+            )
+            expected_token = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
+            if expected_token:
+                current_lock = client.get(lock_key)
+                if current_lock is not None:
+                    if isinstance(current_lock, bytes):
+                        current_lock = current_lock.decode("utf-8", errors="replace")
+                    current_prefix = str(current_lock or "").split(":", 1)[0]
+                    if current_prefix == expected_token:
+                        client.expire(lock_key, lock_ttl_s)
+                    else:
+                        logger.critical(
+                            "AUTHORITY_HEARTBEAT_LOCK_OWNER_MISMATCH marker=%s lock_key=%s expected=%s actual=%s",
+                            MARKER,
+                            lock_key,
+                            expected_token[:8],
+                            current_prefix[:8],
+                        )
+                else:
+                    owner_id = os.environ.get("NIJA_WRITER_OWNER_ID", "heartbeat_recovered")
+                    lock_value = f"{expected_token}:{owner_id}"
+                    reacquired = client.set(lock_key, lock_value, ex=lock_ttl_s, nx=True)
+                    if reacquired:
+                        logger.warning(
+                            "AUTHORITY_HEARTBEAT_LOCK_REACQUIRED marker=%s lock_key=%s token_prefix=%s",
+                            MARKER,
+                            lock_key,
+                            expected_token[:8],
+                        )
+                    else:
+                        logger.critical(
+                            "AUTHORITY_HEARTBEAT_LOCK_REACQUIRE_FAILED marker=%s lock_key=%s token_prefix=%s",
+                            MARKER,
+                            lock_key,
+                            expected_token[:8],
+                        )
+
+            logger.info(
+                "AUTHORITY_HEARTBEAT_PLATFORM_GENERATION_PUBLISHED marker=%s generation=%s",
+                MARKER,
+                generation,
+            )
+        except Exception as exc:
+            logger.error(
+                "AUTHORITY_HEARTBEAT_PLATFORM_WRITE_FAILED marker=%s error=%s",
+                MARKER,
+                exc,
+                exc_info=True,
+            )
+
+    _write_heartbeat_to_redis._nija_platform_generation_scoped_20260713a = True  # type: ignore[attr-defined]
+    _write_heartbeat_to_redis.__wrapped__ = current  # type: ignore[attr-defined]
+    setattr(cls, "_write_heartbeat_to_redis", _write_heartbeat_to_redis)
+    logger.warning("AUTHORITY_HEARTBEAT_GENERATION_SCOPE_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _try_loaded() -> bool:
+    patched = False
+    for name in ("bot.authority_heartbeat", "authority_heartbeat"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_module(module) or patched
+    return patched
+
+
+def _watchdog() -> None:
+    deadline = time.monotonic() + max(
+        60.0,
+        float(os.environ.get("NIJA_AUTHORITY_HEARTBEAT_SCOPE_WATCHDOG_S", "600") or 600),
+    )
+    while time.monotonic() < deadline:
+        try:
+            if _try_loaded():
+                # Continue briefly because some runtimes import the same module
+                # under both package and top-level names.
+                pass
+        except Exception as exc:
+            logger.debug("AUTHORITY_HEARTBEAT_SCOPE_RETRY marker=%s error=%s", MARKER, exc)
+        time.sleep(0.25)
+
+
+def install() -> bool:
+    global _INSTALLED, _WATCHDOG_STARTED
+    with _LOCK:
+        _INSTALLED = _try_loaded() or _INSTALLED
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="AuthorityHeartbeatGenerationScopeWatchdog",
+                daemon=True,
+            ).start()
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] = "1"
+        logger.warning(
+            "AUTHORITY_HEARTBEAT_GENERATION_SCOPE_REPAIR_INSTALLED marker=%s patched=%s",
+            MARKER,
+            _INSTALLED,
+        )
+        return True
+
+
+def installed() -> bool:
+    return _INSTALLED or _WATCHDOG_STARTED
+
+
+__all__ = ["install", "installed", "_patch_module", "_platform_generation"]

--- a/bot/tests/test_authority_heartbeat_generation_scope_patch.py
+++ b/bot/tests/test_authority_heartbeat_generation_scope_patch.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import ModuleType
+
+import authority_heartbeat_generation_scope_patch as patch
+
+
+class FakeRedisClient:
+    def __init__(self) -> None:
+        self.values = {"nija:writer_lock:platform": b"token123:owner"}
+        self.set_calls: list[tuple[str, object, int | None, bool | None]] = []
+        self.get_calls: list[str] = []
+        self.expire_calls: list[tuple[str, int]] = []
+
+    def get(self, key: str):
+        self.get_calls.append(key)
+        return self.values.get(key)
+
+    def set(self, key: str, value, ex=None, nx=None):
+        self.set_calls.append((key, value, ex, nx))
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def expire(self, key: str, ttl: int):
+        self.expire_calls.append((key, ttl))
+        return True
+
+
+class FakeRedisModule(ModuleType):
+    def __init__(self, client: FakeRedisClient) -> None:
+        super().__init__("redis")
+        self._client = client
+
+    def from_url(self, *_args, **_kwargs):
+        return self._client
+
+
+def _fake_authority_module() -> tuple[ModuleType, type]:
+    module = ModuleType("bot.authority_heartbeat")
+
+    class AuthorityHeartbeatMonitor:
+        def _write_heartbeat_to_redis(self):
+            raise AssertionError("legacy global-generation writer must not run")
+
+    module.AuthorityHeartbeatMonitor = AuthorityHeartbeatMonitor
+    return module, AuthorityHeartbeatMonitor
+
+
+def test_heartbeat_writer_uses_platform_generation_not_global_counter(monkeypatch):
+    module, cls = _fake_authority_module()
+    client = FakeRedisClient()
+    monkeypatch.setitem(sys.modules, "redis", FakeRedisModule(client))
+    monkeypatch.setattr(patch, "_platform_generation", lambda: (439, ""))
+    monkeypatch.setattr(patch, "_redis_url", lambda: "redis://example")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "441")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token123")
+    monkeypatch.setenv("NIJA_WRITER_OWNER_ID", "owner")
+
+    assert patch._patch_module(module) is True
+    monitor = cls()
+    monitor._write_heartbeat_to_redis()
+
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "439"
+    assert "nija:lease:generation" not in client.get_calls
+    heartbeat_call = next(call for call in client.set_calls if call[0] == "nija:writer_heartbeat_active")
+    payload = json.loads(heartbeat_call[1])
+    assert payload["generation"] == "439"
+    assert payload["generation_scope"] == "platform_kraken_key"
+    assert client.expire_calls == [("nija:writer_lock:platform", 90)]
+
+
+def test_heartbeat_writer_fails_closed_when_platform_generation_missing(monkeypatch):
+    module, cls = _fake_authority_module()
+    client = FakeRedisClient()
+    monkeypatch.setitem(sys.modules, "redis", FakeRedisModule(client))
+    monkeypatch.setattr(patch, "_platform_generation", lambda: (0, "platform_lease_version_missing"))
+    monkeypatch.setattr(patch, "_redis_url", lambda: "redis://example")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "439")
+
+    assert patch._patch_module(module) is True
+    cls()._write_heartbeat_to_redis()
+
+    assert client.set_calls == []
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "439"
+
+
+def test_patch_is_idempotent():
+    module, cls = _fake_authority_module()
+    assert patch._patch_module(module) is True
+    first = cls._write_heartbeat_to_redis
+    assert patch._patch_module(module) is True
+    assert cls._write_heartbeat_to_redis is first

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -20,6 +20,10 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
         "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
+        "NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED",
+        "NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED",
+        "NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED",
+        "NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
@@ -30,16 +34,20 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_writer_and_convergence_before_broker_activation(monkeypatch):
+def test_source_bootstrap_installs_authority_repairs_before_broker_activation(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
         ("prebot_writer_authority_fail_closed", "writer", "install"),
+        ("writer_generation_scope_repair_patch", "generation_scope", "install"),
+        ("authority_heartbeat_generation_scope_patch", "heartbeat_scope", "install"),
+        ("final_worker_position_coinbase_repair_patch", "worker_position", "install"),
         ("broker_auth_recovery_patch", "auth", "install"),
         ("runtime_convergence_hardening_patch", "convergence", "install"),
         ("runtime_convergence_v2_patch", "convergence_v2", "install"),
         ("runtime_auth_recursion_endpoint_repair_patch", "auth_endpoint", "install"),
         ("final_runtime_convergence_patch", "final_convergence", "install"),
+        ("scan_wrapper_convergence_repair_patch", "scan_wrapper", "install"),
         ("venue_readiness_execution_repair_patch", "venue", "install"),
         ("secondary_venue_activation_patch", "activator", "install"),
         ("secondary_venue_strict_readiness_patch", "strict", "install"),
@@ -68,16 +76,15 @@ def test_source_bootstrap_installs_writer_and_convergence_before_broker_activati
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == [
-        "writer", "auth", "convergence", "convergence_v2", "auth_endpoint",
-        "final_convergence", "venue", "activator", "strict", "exit_recovery",
+        "writer", "generation_scope", "heartbeat_scope", "worker_position", "auth",
+        "convergence", "convergence_v2", "auth_endpoint", "final_convergence",
+        "scan_wrapper", "venue", "activator", "strict", "exit_recovery",
         "exit_bootstrap", "stage", "bridge",
     ]
-    assert source_bootstrap.installed_marker() == "20260712d"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_BROKER_AUTH_RECOVERY_INSTALLED"] == "1"
+    assert source_bootstrap.installed_marker() == "20260713a"
+    assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
 
@@ -96,10 +103,8 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
         source_bootstrap.install()
 
     assert exc_info.value.code == 78
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260712h"
+_MARKER = "20260713a"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -58,6 +58,7 @@ def _set_status(value: str) -> None:
         "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
         "NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED",
         "NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED",
+        "NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED",
         "NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
@@ -79,6 +80,7 @@ def install() -> bool:
         try:
             _install_required("prebot_writer_authority_fail_closed")
             _install_required("writer_generation_scope_repair_patch")
+            _install_required("authority_heartbeat_generation_scope_patch")
             _install_required("final_worker_position_coinbase_repair_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("runtime_convergence_hardening_patch")
@@ -101,6 +103,7 @@ def install() -> bool:
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
                 "writer_authority=installed writer_generation_scope=installed "
+                "authority_heartbeat_generation_scope=installed "
                 "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
                 "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
                 "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "


### PR DESCRIPTION
## Summary
- Replace the legacy authority heartbeat Redis writer with a platform-key-scoped implementation.
- Read the platform Kraken lease version through the scoped writer generation tracker.
- Never copy the global `nija:lease:generation` counter into platform writer lineage.
- Publish Redis heartbeat payloads with `generation_scope=platform_kraken_key`.
- Preserve fencing-token ownership checks, lock TTL refresh, fail-closed authority behavior, and user nonce isolation.
- Add regression tests for the exact `local=439 redis=441` false mismatch.
- Advance the startup marker to `20260713a`.

## Root cause
`AuthorityHeartbeatMonitor._write_heartbeat_to_redis()` still read the global lease-generation counter. Daivon and Tania's independent Kraken nonce leases incremented that global counter by two, causing the platform heartbeat to overwrite its valid platform generation and report a false mismatch.

## Expected runtime markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260713a`
- `AUTHORITY_HEARTBEAT_GENERATION_SCOPE_REPAIR_INSTALLED marker=20260713a`
- `AUTHORITY_HEARTBEAT_GENERATION_SCOPE_PATCHED marker=20260713a`
- `AUTHORITY_HEARTBEAT_PLATFORM_GENERATION_PUBLISHED marker=20260713a generation=<platform generation>`

The old `AuthorityHeartbeat: generation mismatch detected — resyncing local=<platform> redis=<global>` message should disappear.