### PR TITLE
Fix Coinbase PEM handling and expose OKX blockers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN python -m py_compile \
         /app/venue_readiness_execution_repair_patch.py \
         /app/secondary_venue_activation_patch.py \
         /app/secondary_venue_connect_semantics_repair.py \
+        /app/secondary_venue_runtime_diagnostics.py \
         /app/secondary_venue_strict_readiness_patch.py \
         /app/bot/activation_pending_commit_monitor_patch.py \
         /app/bot/writer_lock_release_guard.py \
@@ -54,11 +55,11 @@ RUN python -m py_compile \
 # writer to release its lease. The .pth hook therefore leaves the replacement
 # fail-closed on Render; source_runtime_guard_bootstrap acquires the same canonical
 # Redis lease before any bot.* import. Other providers retain early acquisition.
-RUN python -c "import pathlib, site; root = pathlib.Path(site.getsitepackages()[0]); prefix = '/app\n'; p0 = root / '000_nija_prebot_writer_authority.pth'; p0.write_text(prefix + 'import prebot_writer_authority_fail_closed as _nija_prebot_writer; _nija_prebot_writer.install(defer_if_render=True)\n', encoding='utf-8'); p1 = root / 'nija_import_hook_recursion_shield.pth'; p1.write_text(prefix + 'import import_hook_recursion_shield_patch as _nija_shield; _nija_shield.install_import_hook()\n', encoding='utf-8'); p2 = root / 'nija_disconnected_broker_execution_guard.pth'; p2.write_text(prefix + 'import disconnected_broker_execution_guard_patch as _nija_broker_guard; _nija_broker_guard.install_import_hook()\n', encoding='utf-8'); p3 = root / 'nija_secondary_venue_connect_semantics.pth'; p3.write_text(prefix + 'import secondary_venue_connect_semantics_repair as _nija_secondary_connect\n', encoding='utf-8'); assert p0.is_file() and p1.is_file() and p2.is_file() and p3.is_file()"
+RUN python -c "import pathlib, site; root = pathlib.Path(site.getsitepackages()[0]); prefix = '/app\n'; p0 = root / '000_nija_prebot_writer_authority.pth'; p0.write_text(prefix + 'import prebot_writer_authority_fail_closed as _nija_prebot_writer; _nija_prebot_writer.install(defer_if_render=True)\n', encoding='utf-8'); p1 = root / 'nija_import_hook_recursion_shield.pth'; p1.write_text(prefix + 'import import_hook_recursion_shield_patch as _nija_shield; _nija_shield.install_import_hook()\n', encoding='utf-8'); p2 = root / 'nija_disconnected_broker_execution_guard.pth'; p2.write_text(prefix + 'import disconnected_broker_execution_guard_patch as _nija_broker_guard; _nija_broker_guard.install_import_hook()\n', encoding='utf-8'); p3 = root / 'nija_secondary_venue_connect_semantics.pth'; p3.write_text(prefix + 'import secondary_venue_connect_semantics_repair as _nija_secondary_connect\n', encoding='utf-8'); p4 = root / '0001_nija_secondary_venue_runtime_diagnostics.pth'; p4.write_text(prefix + 'import secondary_venue_runtime_diagnostics as _nija_secondary_diag\n', encoding='utf-8'); assert p0.is_file() and p1.is_file() and p2.is_file() and p3.is_file() and p4.is_file()"
 
 # Reproduce provider startup from outside the repository. The hooks must be
 # importable during Python site initialization without relying on cwd=/app.
-RUN cd /tmp && python -c "import prebot_writer_authority_fail_closed, import_hook_recursion_shield_patch, disconnected_broker_execution_guard_patch, secondary_venue_connect_semantics_repair; print('NIJA_PTH_IMPORT_SMOKE_OK')"
+RUN cd /tmp && python -c "import prebot_writer_authority_fail_closed, import_hook_recursion_shield_patch, disconnected_broker_execution_guard_patch, secondary_venue_connect_semantics_repair, secondary_venue_runtime_diagnostics; print('NIJA_PTH_IMPORT_SMOKE_OK')"
 
 # Ensure Redis connectivity and production bootstrap scripts are present and executable.
 RUN test -f /app/scripts/redis_connectivity_check.sh && \

--- a/bot/tests/test_secondary_venue_runtime_diagnostics.py
+++ b/bot/tests/test_secondary_venue_runtime_diagnostics.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib
+import os
+
+
+def test_normalize_coinbase_private_key_restores_escaped_newlines(monkeypatch):
+    monkeypatch.delenv("COINBASE_API_SECRET", raising=False)
+    module = importlib.import_module("secondary_venue_runtime_diagnostics")
+    raw = '"-----BEGIN EC PRIVATE KEY-----\\nABC\\n-----END EC PRIVATE KEY-----"'
+    normalized = module.normalize_coinbase_private_key(raw)
+    assert normalized == "-----BEGIN EC PRIVATE KEY-----\nABC\n-----END EC PRIVATE KEY-----\n"
+
+
+def test_missing_coinbase_secret_is_fail_closed(monkeypatch):
+    for name in (
+        "COINBASE_API_SECRET",
+        "COINBASE_PLATFORM_API_SECRET",
+        "COINBASE_ADVANCED_API_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    module = importlib.reload(importlib.import_module("secondary_venue_runtime_diagnostics"))
+    module._normalize_coinbase_env()
+    assert os.environ["NIJA_COINBASE_PEM_STATE"] == "missing"
+
+
+def test_invalid_coinbase_secret_is_not_marked_valid(monkeypatch):
+    monkeypatch.setenv("COINBASE_API_SECRET", "not-a-pem")
+    module = importlib.reload(importlib.import_module("secondary_venue_runtime_diagnostics"))
+    module._normalize_coinbase_env()
+    assert os.environ["NIJA_COINBASE_PEM_STATE"] == "invalid"

--- a/secondary_venue_runtime_diagnostics.py
+++ b/secondary_venue_runtime_diagnostics.py
@@ -1,0 +1,148 @@
+"""Normalize secondary-venue credentials and expose fail-closed diagnostics.
+
+This module is safe to import during Python site initialization. It never logs
+credential values, never marks a venue connected, and never bypasses exchange,
+risk, funding, or execution checks.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+logger = logging.getLogger("nija.secondary_venue_runtime_diagnostics")
+_MARKER = "20260713b"
+_INSTALLED = False
+_LOCK = threading.RLock()
+_LAST_LOG: dict[str, float] = {}
+
+
+def _strip_outer_quotes(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1].strip()
+    return value
+
+
+def normalize_coinbase_private_key(value: str) -> str:
+    """Return a PEM string suitable for Coinbase's Python SDK.
+
+    Render and other dashboards commonly store multiline values with literal
+    ``\\n`` sequences. Coinbase requires those newlines to be restored.
+    """
+    value = _strip_outer_quotes(str(value or ""))
+    value = value.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n").replace("\r", "\n")
+    value = value.strip()
+    return value + ("\n" if value else "")
+
+
+def _validate_coinbase_key(secret: str) -> tuple[bool, str]:
+    if not secret:
+        return False, "missing"
+    if "-----BEGIN" not in secret or "PRIVATE KEY-----" not in secret:
+        return False, "missing_pem_header"
+    try:
+        from cryptography.hazmat.primitives import serialization
+
+        key = serialization.load_pem_private_key(secret.encode("utf-8"), password=None)
+        curve = getattr(getattr(key, "curve", None), "name", "unknown")
+        if curve not in {"secp256r1", "prime256v1"}:
+            return False, f"unsupported_curve:{curve}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}:{str(exc)[:120]}"
+    return True, "valid_es256"
+
+
+def _normalize_coinbase_env() -> None:
+    aliases = ("COINBASE_API_SECRET", "COINBASE_PLATFORM_API_SECRET", "COINBASE_ADVANCED_API_SECRET")
+    source = next((name for name in aliases if os.environ.get(name, "").strip()), "")
+    if not source:
+        os.environ["NIJA_COINBASE_PEM_STATE"] = "missing"
+        logger.error("COINBASE_PEM_INVALID marker=%s reason=missing_secret", _MARKER)
+        return
+
+    normalized = normalize_coinbase_private_key(os.environ[source])
+    for name in aliases:
+        if name == source or not os.environ.get(name, "").strip():
+            os.environ[name] = normalized
+
+    valid, reason = _validate_coinbase_key(normalized)
+    os.environ["NIJA_COINBASE_PEM_STATE"] = "valid" if valid else "invalid"
+    if valid:
+        logger.warning(
+            "COINBASE_PEM_NORMALIZED marker=%s source=%s newline_count=%d format=ES256",
+            _MARKER,
+            source,
+            normalized.count("\n"),
+        )
+    else:
+        logger.error(
+            "COINBASE_PEM_INVALID marker=%s source=%s reason=%s action=replace_with_cdp_ecdsa_private_key",
+            _MARKER,
+            source,
+            reason,
+        )
+
+
+def _log_state(venue: str, *, force: bool = False) -> None:
+    now = time.monotonic()
+    if not force and now - _LAST_LOG.get(venue, 0.0) < 30.0:
+        return
+    _LAST_LOG[venue] = now
+    upper = venue.upper()
+    logger.warning(
+        "SECONDARY_VENUE_RUNTIME_STATE marker=%s venue=%s activation=%s connected=%s ready=%s spendable=%s base_url=%s pem=%s",
+        _MARKER,
+        venue,
+        os.environ.get(f"NIJA_{upper}_ACTIVATION_STATE", "unknown"),
+        os.environ.get(f"NIJA_{upper}_CONNECTED", "0"),
+        os.environ.get(f"NIJA_{upper}_TRADING_READY", "0"),
+        os.environ.get(f"NIJA_{upper}_SPENDABLE_QUOTE", "unknown"),
+        os.environ.get("OKX_BASE_URL", "default") if venue == "okx" else "api.coinbase.com",
+        os.environ.get("NIJA_COINBASE_PEM_STATE", "n/a") if venue == "coinbase" else "n/a",
+    )
+
+
+def _install_activation_observer() -> None:
+    try:
+        import secondary_venue_activation_patch as patch
+    except Exception as exc:
+        logger.warning("SECONDARY_VENUE_DIAGNOSTIC_IMPORT_PENDING marker=%s error=%s", _MARKER, type(exc).__name__)
+        return
+
+    original = getattr(patch, "activate_once", None)
+    if not callable(original) or getattr(original, "_nija_runtime_diag_v20260713b", False):
+        return
+
+    def wrapped(venue: Any, *args: Any, **kwargs: Any) -> str:
+        name = str(getattr(venue, "name", "unknown"))
+        try:
+            result = original(venue, *args, **kwargs)
+        except Exception:
+            _log_state(name, force=True)
+            raise
+        _log_state(name, force=True)
+        return result
+
+    wrapped._nija_runtime_diag_v20260713b = True  # type: ignore[attr-defined]
+    wrapped.__wrapped__ = original  # type: ignore[attr-defined]
+    patch.activate_once = wrapped
+
+
+def install() -> None:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return
+        _INSTALLED = True
+        _normalize_coinbase_env()
+        _install_activation_observer()
+        logger.warning("SECONDARY_VENUE_RUNTIME_DIAGNOSTICS_INSTALLED marker=%s", _MARKER)
+
+
+install()
+
+__all__ = ["install", "normalize_coinbase_private_key"]


### PR DESCRIPTION
## Root causes addressed
- Render commonly stores Coinbase multiline private keys with literal `\n` sequences or wrapping quotes. Coinbase requires preserved PEM newlines and an ECDSA/ES256 private key.
- Existing secondary-venue logs did not expose enough state to distinguish missing credentials, malformed PEM, failed connection, insufficient funds, or market discovery.

## Changes
- Normalize Coinbase private-key secrets before Coinbase SDK imports.
- Validate the PEM cryptographically without logging secret material.
- Fail closed for missing, malformed, non-EC, or unsupported-curve keys.
- Emit explicit Coinbase/OKX activation, connection, readiness, spendable, and endpoint diagnostics.
- Install the repair through an early `.pth` startup hook.
- Add Docker compilation/smoke validation and regression tests.

This does not fabricate credentials, bypass authentication, mark venues connected, or weaken risk/funding checks.