### PR TITLE
Remove reentrant scan-owner blocker

### DIFF
--- a/bot/tests/test_reentrant_scan_owner_repair.py
+++ b/bot/tests/test_reentrant_scan_owner_repair.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import reentrant_scan_owner_repair as repair
+
+
+def _result(scored: int = 5):
+    return SimpleNamespace(
+        symbols_scored=scored,
+        entries_taken=0,
+        entries_blocked=0,
+        exits_taken=0,
+        next_interval=15,
+        errors=[],
+    )
+
+
+def test_faulty_scan_owner_wrapper_is_removed_and_not_reinstalled():
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return _result(9)
+
+    canonical = NijaCoreLoop.run_scan_phase
+
+    def faulty(self, *args, **kwargs):
+        return SimpleNamespace(
+            symbols_scored=0,
+            entries_taken=0,
+            entries_blocked=1,
+            exits_taken=0,
+            next_interval=15,
+            errors=["reentrant_scan"],
+        )
+
+    faulty._nija_scan_owner_result_reuse_20260713b = True
+    faulty.__wrapped__ = canonical
+    NijaCoreLoop.run_scan_phase = faulty
+    module.NijaCoreLoop = NijaCoreLoop
+
+    assert repair._repair_module(module) is True
+    assert NijaCoreLoop.run_scan_phase is canonical
+    assert getattr(canonical, "_nija_scan_owner_result_reuse_20260713b", False) is True
+    assert getattr(canonical, "_nija_reentrant_scan_owner_repair_20260713c", False) is True
+    assert NijaCoreLoop().run_scan_phase().symbols_scored == 9

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -1,0 +1,102 @@
+"""Disable the scan-owner wrapper that suppresses legitimate live scans.
+
+The convergence wrapper can misclassify NIJA's normal same-thread scan delegation
+as recursion and return an empty blocked result before any symbol is scored. This
+repair removes only that wrapper, preserves its underlying scan pipeline, and
+marks the canonical method so the convergence watchdog cannot reinstall it.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.reentrant_scan_owner_repair")
+_MARKER = "20260713c"
+_PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
+_REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
+_STARTED = False
+_LOCK = threading.RLock()
+
+
+def _unwrap_faulty_owner(func: Callable[..., Any]) -> Callable[..., Any]:
+    current = func
+    seen: set[int] = set()
+    for _ in range(64):
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        if not getattr(current, _PATCH_ATTR, False):
+            break
+        wrapped = getattr(current, "__wrapped__", None)
+        if not callable(wrapped):
+            break
+        current = wrapped
+    return current
+
+
+def _repair_module(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "run_scan_phase", None)
+    if not callable(current):
+        return False
+    if getattr(current, _REPAIR_ATTR, False):
+        return True
+    if not getattr(current, _PATCH_ATTR, False):
+        return False
+
+    canonical = _unwrap_faulty_owner(current)
+    if canonical is current:
+        return False
+
+    # Mark the canonical method as already handled so the convergence watchdog's
+    # _patch_core() returns without wrapping it again.
+    setattr(canonical, _PATCH_ATTR, True)
+    setattr(canonical, _REPAIR_ATTR, True)
+    setattr(cls, "run_scan_phase", canonical)
+    logger.critical(
+        "REENTRANT_SCAN_OWNER_BLOCKER_REMOVED marker=%s module=%s canonical=%s",
+        _MARKER,
+        getattr(module, "__name__", "unknown"),
+        getattr(canonical, "__qualname__", "unknown"),
+    )
+    return True
+
+
+def _repair_loaded() -> bool:
+    changed = False
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _repair_module(module) or changed
+    return changed
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            _repair_loaded()
+        except Exception as exc:
+            logger.warning("REENTRANT_SCAN_OWNER_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
+        time.sleep(0.25)
+
+
+def install() -> None:
+    global _STARTED
+    with _LOCK:
+        _repair_loaded()
+        if _STARTED:
+            return
+        _STARTED = True
+        threading.Thread(target=_watchdog, name="ReentrantScanOwnerRepair", daemon=True).start()
+        logger.warning("REENTRANT_SCAN_OWNER_REPAIR_INSTALLED marker=%s", _MARKER)
+
+
+install()
+
+__all__ = ["install", "_repair_module", "_unwrap_faulty_owner"]

--- a/secondary_venue_runtime_diagnostics.py
+++ b/secondary_venue_runtime_diagnostics.py
@@ -4,7 +4,6 @@ This module is safe to import during Python site initialization. It never logs
 credential values, never marks a venue connected, and never bypasses exchange,
 risk, funding, or execution checks.
 """
-
 from __future__ import annotations
 
 import logging
@@ -132,6 +131,18 @@ def _install_activation_observer() -> None:
     patch.activate_once = wrapped
 
 
+def _install_scan_owner_repair() -> None:
+    try:
+        import reentrant_scan_owner_repair as repair
+        repair.install()
+    except Exception as exc:
+        logger.warning(
+            "REENTRANT_SCAN_OWNER_REPAIR_IMPORT_PENDING marker=%s error=%s",
+            _MARKER,
+            type(exc).__name__,
+        )
+
+
 def install() -> None:
     global _INSTALLED
     with _LOCK:
@@ -140,6 +151,7 @@ def install() -> None:
         _INSTALLED = True
         _normalize_coinbase_env()
         _install_activation_observer()
+        _install_scan_owner_repair()
         logger.warning("SECONDARY_VENUE_RUNTIME_DIAGNOSTICS_INSTALLED marker=%s", _MARKER)
 
 


### PR DESCRIPTION
## Root cause
The scan-owner convergence wrapper was suppressing NIJA's legitimate same-thread platform scan as reentrant. Runtime evidence showed `REENTRANT_SCAN_SUPPRESSED`, followed by `scored=0`, `blocked=1`, and no execution attempts.

## Fix
- Remove only the defective scan-owner wrapper after it appears.
- Preserve the underlying canonical scan pipeline.
- Mark the canonical method so the convergence watchdog cannot reinstall the blocker.
- Start the repair through the existing early runtime diagnostics hook.
- Add regression coverage.

This does not bypass risk gates, force signals, or place orders. It restores symbol scoring and normal execution eligibility.