### PR TITLE
Stabilize scan-owner repair

### DIFF
--- a/SCAN_OWNER_STABILITY_FIX.md
+++ b/SCAN_OWNER_STABILITY_FIX.md
@@ -1,0 +1,5 @@
+# Scan-owner stability fix
+
+The scan-owner convergence watchdog previously reinstalled a wrapper that had just been removed by `reentrant_scan_owner_repair.py`, creating a five-second patch/remove loop.
+
+The repair now guards the convergence module's `_patch_core` function. Canonical scan methods marked as repaired are left untouched, while newly loaded core-loop classes are repaired once and then remain stable.

--- a/STABILITY_PATCH_APPLIED.txt
+++ b/STABILITY_PATCH_APPLIED.txt
@@ -1,0 +1,1 @@
+Scan-owner convergence stabilization patch applied.

--- a/bot/tests/test_reentrant_scan_owner_repair.py
+++ b/bot/tests/test_reentrant_scan_owner_repair.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import reentrant_scan_owner_repair as repair
+
+
+def _result(scored: int = 5):
+    return SimpleNamespace(
+        symbols_scored=scored,
+        entries_taken=0,
+        entries_blocked=0,
+        exits_taken=0,
+        next_interval=15,
+        errors=[],
+    )
+
+
+def test_faulty_scan_owner_wrapper_is_removed_and_not_reinstalled():
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return _result(9)
+
+    canonical = NijaCoreLoop.run_scan_phase
+
+    def faulty(self, *args, **kwargs):
+        return SimpleNamespace(
+            symbols_scored=0,
+            entries_taken=0,
+            entries_blocked=1,
+            exits_taken=0,
+            next_interval=15,
+            errors=["reentrant_scan"],
+        )
+
+    faulty._nija_scan_owner_result_reuse_20260713b = True
+    faulty.__wrapped__ = canonical
+    NijaCoreLoop.run_scan_phase = faulty
+    module.NijaCoreLoop = NijaCoreLoop
+
+    assert repair._repair_module(module) is True
+    assert NijaCoreLoop.run_scan_phase is canonical
+    assert getattr(canonical, "_nija_scan_owner_result_reuse_20260713b", False) is True
+    assert getattr(canonical, "_nija_reentrant_scan_owner_repair_20260713c", False) is True
+    assert NijaCoreLoop().run_scan_phase().symbols_scored == 9

--- a/bot/tests/test_reentrant_scan_owner_repair_stability.py
+++ b/bot/tests/test_reentrant_scan_owner_repair_stability.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import reentrant_scan_owner_repair as repair
+import scan_owner_okx_auth_convergence_patch as convergence
+
+
+def test_repair_prevents_convergence_rewrap(monkeypatch):
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return SimpleNamespace(
+                symbols_scored=5,
+                entries_taken=0,
+                entries_blocked=0,
+                exits_taken=0,
+                next_interval=15,
+            )
+
+    module.NijaCoreLoop = NijaCoreLoop
+    assert convergence._patch_core(module) is True
+    assert getattr(NijaCoreLoop.run_scan_phase, repair._PATCH_ATTR, False)
+
+    assert repair._repair_module(module) is True
+    canonical = NijaCoreLoop.run_scan_phase
+    assert getattr(canonical, repair._REPAIR_ATTR, False)
+
+    repair._install_convergence_guard()
+    assert convergence._patch_core(module) is True
+    assert NijaCoreLoop.run_scan_phase is canonical

--- a/bot/tests/test_reentrant_scan_owner_repair_stability_v2.py
+++ b/bot/tests/test_reentrant_scan_owner_repair_stability_v2.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import reentrant_scan_owner_repair as repair
+import scan_owner_okx_auth_convergence_patch as convergence
+
+
+def test_repaired_scan_is_not_rewrapped():
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return SimpleNamespace(
+                symbols_scored=5,
+                entries_taken=0,
+                entries_blocked=0,
+                exits_taken=0,
+                next_interval=15,
+            )
+
+    module.NijaCoreLoop = NijaCoreLoop
+    assert convergence._patch_core(module) is True
+    assert repair._repair_module(module) is True
+    canonical = NijaCoreLoop.run_scan_phase
+
+    assert repair._install_convergence_guard() is True
+    assert convergence._patch_core(module) is True
+    assert NijaCoreLoop.run_scan_phase is canonical

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -1,0 +1,102 @@
+"""Disable the scan-owner wrapper that suppresses legitimate live scans.
+
+The convergence wrapper can misclassify NIJA's normal same-thread scan delegation
+as recursion and return an empty blocked result before any symbol is scored. This
+repair removes only that wrapper, preserves its underlying scan pipeline, and
+marks the canonical method so the convergence watchdog cannot reinstall it.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.reentrant_scan_owner_repair")
+_MARKER = "20260713c"
+_PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
+_REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
+_STARTED = False
+_LOCK = threading.RLock()
+
+
+def _unwrap_faulty_owner(func: Callable[..., Any]) -> Callable[..., Any]:
+    current = func
+    seen: set[int] = set()
+    for _ in range(64):
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        if not getattr(current, _PATCH_ATTR, False):
+            break
+        wrapped = getattr(current, "__wrapped__", None)
+        if not callable(wrapped):
+            break
+        current = wrapped
+    return current
+
+
+def _repair_module(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "run_scan_phase", None)
+    if not callable(current):
+        return False
+    if getattr(current, _REPAIR_ATTR, False):
+        return True
+    if not getattr(current, _PATCH_ATTR, False):
+        return False
+
+    canonical = _unwrap_faulty_owner(current)
+    if canonical is current:
+        return False
+
+    # Mark the canonical method as already handled so the convergence watchdog's
+    # _patch_core() returns without wrapping it again.
+    setattr(canonical, _PATCH_ATTR, True)
+    setattr(canonical, _REPAIR_ATTR, True)
+    setattr(cls, "run_scan_phase", canonical)
+    logger.critical(
+        "REENTRANT_SCAN_OWNER_BLOCKER_REMOVED marker=%s module=%s canonical=%s",
+        _MARKER,
+        getattr(module, "__name__", "unknown"),
+        getattr(canonical, "__qualname__", "unknown"),
+    )
+    return True
+
+
+def _repair_loaded() -> bool:
+    changed = False
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _repair_module(module) or changed
+    return changed
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            _repair_loaded()
+        except Exception as exc:
+            logger.warning("REENTRANT_SCAN_OWNER_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
+        time.sleep(0.25)
+
+
+def install() -> None:
+    global _STARTED
+    with _LOCK:
+        _repair_loaded()
+        if _STARTED:
+            return
+        _STARTED = True
+        threading.Thread(target=_watchdog, name="ReentrantScanOwnerRepair", daemon=True).start()
+        logger.warning("REENTRANT_SCAN_OWNER_REPAIR_INSTALLED marker=%s", _MARKER)
+
+
+install()
+
+__all__ = ["install", "_repair_module", "_unwrap_faulty_owner"]

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -3,7 +3,7 @@
 The convergence wrapper can misclassify NIJA's normal same-thread scan delegation
 as recursion and return an empty blocked result before any symbol is scored. This
 repair removes only that wrapper, preserves its underlying scan pipeline, and
-marks the canonical method so the convergence watchdog cannot reinstall it.
+permanently guards the convergence patch from reinstalling it.
 """
 from __future__ import annotations
 
@@ -15,9 +15,10 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.reentrant_scan_owner_repair")
-_MARKER = "20260713c"
+_MARKER = "20260713d"
 _PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
 _REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
+_GUARD_ATTR = "_nija_reentrant_scan_owner_guard_20260713d"
 _STARTED = False
 _LOCK = threading.RLock()
 
@@ -54,8 +55,6 @@ def _repair_module(module: ModuleType) -> bool:
     if canonical is current:
         return False
 
-    # Mark the canonical method as already handled so the convergence watchdog's
-    # _patch_core() returns without wrapping it again.
     setattr(canonical, _PATCH_ATTR, True)
     setattr(canonical, _REPAIR_ATTR, True)
     setattr(cls, "run_scan_phase", canonical)
@@ -68,8 +67,40 @@ def _repair_module(module: ModuleType) -> bool:
     return True
 
 
+def _install_convergence_guard() -> bool:
+    """Make the convergence watchdog respect repaired canonical scan methods."""
+    try:
+        import scan_owner_okx_auth_convergence_patch as convergence
+    except Exception as exc:
+        logger.debug("REENTRANT_SCAN_OWNER_GUARD_IMPORT_PENDING marker=%s error=%s", _MARKER, type(exc).__name__)
+        return False
+
+    current_patch_core = getattr(convergence, "_patch_core", None)
+    if not callable(current_patch_core):
+        return False
+    if getattr(current_patch_core, _GUARD_ATTR, False):
+        return True
+
+    original_patch_core = current_patch_core
+
+    def guarded_patch_core(module: ModuleType) -> bool:
+        cls = getattr(module, "NijaCoreLoop", None)
+        method = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+        if callable(method) and getattr(method, _REPAIR_ATTR, False):
+            return True
+        result = original_patch_core(module)
+        _repair_module(module)
+        return result
+
+    setattr(guarded_patch_core, _GUARD_ATTR, True)
+    setattr(guarded_patch_core, "__wrapped__", original_patch_core)
+    convergence._patch_core = guarded_patch_core
+    logger.critical("REENTRANT_SCAN_OWNER_CONVERGENCE_GUARDED marker=%s", _MARKER)
+    return True
+
+
 def _repair_loaded() -> bool:
-    changed = False
+    changed = _install_convergence_guard()
     for name in ("bot.nija_core_loop", "nija_core_loop"):
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
@@ -83,7 +114,7 @@ def _watchdog() -> None:
             _repair_loaded()
         except Exception as exc:
             logger.warning("REENTRANT_SCAN_OWNER_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
-        time.sleep(0.25)
+        time.sleep(0.5)
 
 
 def install() -> None:
@@ -99,4 +130,11 @@ def install() -> None:
 
 install()
 
-__all__ = ["install", "_repair_module", "_unwrap_faulty_owner"]
+__all__ = [
+    "install",
+    "_repair_module",
+    "_unwrap_faulty_owner",
+    "_install_convergence_guard",
+    "_PATCH_ATTR",
+    "_REPAIR_ATTR",
+]

--- a/secondary_venue_runtime_diagnostics.py
+++ b/secondary_venue_runtime_diagnostics.py
@@ -4,7 +4,6 @@ This module is safe to import during Python site initialization. It never logs
 credential values, never marks a venue connected, and never bypasses exchange,
 risk, funding, or execution checks.
 """
-
 from __future__ import annotations
 
 import logging
@@ -132,6 +131,18 @@ def _install_activation_observer() -> None:
     patch.activate_once = wrapped
 
 
+def _install_scan_owner_repair() -> None:
+    try:
+        import reentrant_scan_owner_repair as repair
+        repair.install()
+    except Exception as exc:
+        logger.warning(
+            "REENTRANT_SCAN_OWNER_REPAIR_IMPORT_PENDING marker=%s error=%s",
+            _MARKER,
+            type(exc).__name__,
+        )
+
+
 def install() -> None:
     global _INSTALLED
     with _LOCK:
@@ -140,6 +151,7 @@ def install() -> None:
         _INSTALLED = True
         _normalize_coinbase_env()
         _install_activation_observer()
+        _install_scan_owner_repair()
         logger.warning("SECONDARY_VENUE_RUNTIME_DIAGNOSTICS_INSTALLED marker=%s", _MARKER)
 
 


### PR DESCRIPTION
## Root cause
The convergence watchdog kept reinstalling the scan-owner wrapper every few seconds, while `reentrant_scan_owner_repair.py` removed it again. Logs showed repeated `SCAN_OWNER_RESULT_REUSE_PATCHED` followed by `REENTRANT_SCAN_OWNER_BLOCKER_REMOVED`.

## Fix
- Guard the convergence module's `_patch_core` function.
- Leave canonical repaired scan methods untouched.
- Repair newly loaded core-loop classes once, then keep them stable.
- Add regression coverage.

This preserves all risk, signal, capital, and order-admission checks.