### PR TITLE
Permanently stop scan-owner wrapper reinstallation

### DIFF
--- a/bot/tests/test_reentrant_scan_owner_repair_stability.py
+++ b/bot/tests/test_reentrant_scan_owner_repair_stability.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import reentrant_scan_owner_repair as repair
+import scan_owner_okx_auth_convergence_patch as convergence
+
+
+def test_repair_prevents_convergence_rewrap():
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def run_scan_phase(self, *args, **kwargs):
+            return SimpleNamespace(
+                symbols_scored=5,
+                entries_taken=0,
+                entries_blocked=0,
+                exits_taken=0,
+                next_interval=15,
+            )
+
+    module.NijaCoreLoop = NijaCoreLoop
+    assert convergence._patch_core(module) is True
+    assert getattr(NijaCoreLoop.run_scan_phase, repair._PATCH_ATTR, False)
+
+    assert repair._repair_module(module) is True
+    canonical = NijaCoreLoop.run_scan_phase
+    assert getattr(canonical, repair._REPAIR_ATTR, False)
+
+    assert repair._install_convergence_guard() is True
+    assert convergence._patch_core(module) is True
+    assert NijaCoreLoop.run_scan_phase is canonical

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -3,7 +3,7 @@
 The convergence wrapper can misclassify NIJA's normal same-thread scan delegation
 as recursion and return an empty blocked result before any symbol is scored. This
 repair removes only that wrapper, preserves its underlying scan pipeline, and
-marks the canonical method so the convergence watchdog cannot reinstall it.
+permanently guards the convergence patch from reinstalling it.
 """
 from __future__ import annotations
 
@@ -15,9 +15,10 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.reentrant_scan_owner_repair")
-_MARKER = "20260713c"
+_MARKER = "20260713d"
 _PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
 _REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
+_GUARD_ATTR = "_nija_reentrant_scan_owner_guard_20260713d"
 _STARTED = False
 _LOCK = threading.RLock()
 
@@ -54,8 +55,6 @@ def _repair_module(module: ModuleType) -> bool:
     if canonical is current:
         return False
 
-    # Mark the canonical method as already handled so the convergence watchdog's
-    # _patch_core() returns without wrapping it again.
     setattr(canonical, _PATCH_ATTR, True)
     setattr(canonical, _REPAIR_ATTR, True)
     setattr(cls, "run_scan_phase", canonical)
@@ -68,8 +67,44 @@ def _repair_module(module: ModuleType) -> bool:
     return True
 
 
+def _install_convergence_guard() -> bool:
+    """Make the convergence watchdog respect repaired canonical scan methods."""
+    try:
+        import scan_owner_okx_auth_convergence_patch as convergence
+    except Exception as exc:
+        logger.debug(
+            "REENTRANT_SCAN_OWNER_GUARD_IMPORT_PENDING marker=%s error=%s",
+            _MARKER,
+            type(exc).__name__,
+        )
+        return False
+
+    current_patch_core = getattr(convergence, "_patch_core", None)
+    if not callable(current_patch_core):
+        return False
+    if getattr(current_patch_core, _GUARD_ATTR, False):
+        return True
+
+    original_patch_core = current_patch_core
+
+    def guarded_patch_core(module: ModuleType) -> bool:
+        cls = getattr(module, "NijaCoreLoop", None)
+        method = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+        if callable(method) and getattr(method, _REPAIR_ATTR, False):
+            return True
+        result = original_patch_core(module)
+        _repair_module(module)
+        return result
+
+    setattr(guarded_patch_core, _GUARD_ATTR, True)
+    setattr(guarded_patch_core, "__wrapped__", original_patch_core)
+    convergence._patch_core = guarded_patch_core
+    logger.critical("REENTRANT_SCAN_OWNER_CONVERGENCE_GUARDED marker=%s", _MARKER)
+    return True
+
+
 def _repair_loaded() -> bool:
-    changed = False
+    changed = _install_convergence_guard()
     for name in ("bot.nija_core_loop", "nija_core_loop"):
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
@@ -83,7 +118,7 @@ def _watchdog() -> None:
             _repair_loaded()
         except Exception as exc:
             logger.warning("REENTRANT_SCAN_OWNER_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
-        time.sleep(0.25)
+        time.sleep(0.5)
 
 
 def install() -> None:
@@ -99,4 +134,11 @@ def install() -> None:
 
 install()
 
-__all__ = ["install", "_repair_module", "_unwrap_faulty_owner"]
+__all__ = [
+    "install",
+    "_repair_module",
+    "_unwrap_faulty_owner",
+    "_install_convergence_guard",
+    "_PATCH_ATTR",
+    "_REPAIR_ATTR",
+]


### PR DESCRIPTION
## Root cause
The scan-owner convergence watchdog reinstalled its wrapper every five seconds after `reentrant_scan_owner_repair` removed it, creating a patch/remove loop and risking repeated scan suppression.

## Fix
- Guard the convergence module's `_patch_core` function.
- Leave repaired canonical scan methods untouched.
- Repair newly loaded core-loop classes once, then keep them stable.
- Add regression coverage proving the convergence watchdog cannot rewrap the canonical scan method.

This does not bypass strategy, risk, capital, or order-admission controls.