### PR TITLE
Stop recurring scan-wrapper churn

### DIFF
--- a/bot/tests/test_reentrant_scan_owner_wrapper_chain_stability.py
+++ b/bot/tests/test_reentrant_scan_owner_wrapper_chain_stability.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import reentrant_scan_owner_repair as repair
+
+
+def _module_with_method(method):
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        pass
+
+    NijaCoreLoop.run_scan_phase = method
+    module.NijaCoreLoop = NijaCoreLoop
+    return module
+
+
+def test_wrapper_chain_helper_detects_nested_repair_marker():
+    def canonical(self, *args, **kwargs):
+        return "ok"
+
+    setattr(canonical, repair._REPAIR_ATTR, True)
+
+    def venue_wrapper(self, *args, **kwargs):
+        return canonical(self, *args, **kwargs)
+
+    venue_wrapper.__wrapped__ = canonical
+    assert repair._wrapper_chain_has_attr(venue_wrapper, repair._REPAIR_ATTR)
+
+
+def test_repair_marker_is_promoted_to_legitimate_outer_wrapper():
+    def canonical(self, *args, **kwargs):
+        return "ok"
+
+    setattr(canonical, repair._REPAIR_ATTR, True)
+
+    def venue_wrapper(self, *args, **kwargs):
+        return canonical(self, *args, **kwargs)
+
+    venue_wrapper.__wrapped__ = canonical
+    module = _module_with_method(venue_wrapper)
+
+    assert repair._repair_module(module) is True
+    assert getattr(module.NijaCoreLoop.run_scan_phase, repair._REPAIR_ATTR, False)
+    assert module.NijaCoreLoop.run_scan_phase is venue_wrapper
+
+
+def test_convergence_guard_does_not_rewrap_repaired_chain(monkeypatch):
+    calls = {"count": 0}
+    convergence = ModuleType("scan_owner_okx_auth_convergence_patch")
+
+    def original_patch_core(module):
+        calls["count"] += 1
+        return True
+
+    convergence._patch_core = original_patch_core
+    monkeypatch.setitem(sys.modules, "scan_owner_okx_auth_convergence_patch", convergence)
+
+    def canonical(self, *args, **kwargs):
+        return "ok"
+
+    setattr(canonical, repair._REPAIR_ATTR, True)
+
+    def venue_wrapper(self, *args, **kwargs):
+        return canonical(self, *args, **kwargs)
+
+    venue_wrapper.__wrapped__ = canonical
+    module = _module_with_method(venue_wrapper)
+
+    assert repair._install_convergence_guard() is True
+    assert convergence._patch_core(module) is True
+    assert calls["count"] == 0
+    assert module.NijaCoreLoop.run_scan_phase is venue_wrapper
+    assert getattr(venue_wrapper, repair._REPAIR_ATTR, False)

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -15,12 +15,26 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.reentrant_scan_owner_repair")
-_MARKER = "20260713d"
+_MARKER = "20260713e"
 _PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
 _REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
-_GUARD_ATTR = "_nija_reentrant_scan_owner_guard_20260713d"
+_GUARD_ATTR = "_nija_reentrant_scan_owner_guard_20260713e"
 _STARTED = False
 _LOCK = threading.RLock()
+
+
+def _wrapper_chain_has_attr(func: Callable[..., Any], attr: str) -> bool:
+    """Return True when any callable in ``func.__wrapped__`` chain has ``attr``."""
+    current: Any = func
+    seen: set[int] = set()
+    for _ in range(128):
+        if not callable(current) or id(current) in seen:
+            break
+        seen.add(id(current))
+        if getattr(current, attr, False):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
 
 
 def _unwrap_faulty_owner(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -46,8 +60,22 @@ def _repair_module(module: ModuleType) -> bool:
     current = getattr(cls, "run_scan_phase", None)
     if not callable(current):
         return False
-    if getattr(current, _REPAIR_ATTR, False):
+
+    # A legitimate outer wrapper (for example venue readiness) may sit above the
+    # repaired canonical method. Promote the repair marker to that outer wrapper
+    # instead of treating it as an unprotected method. This prevents the
+    # convergence watchdog from reinstalling its owner wrapper every few seconds.
+    if _wrapper_chain_has_attr(current, _REPAIR_ATTR):
+        if not getattr(current, _REPAIR_ATTR, False):
+            setattr(current, _REPAIR_ATTR, True)
+            logger.info(
+                "REENTRANT_SCAN_OWNER_REPAIR_MARKER_PROPAGATED marker=%s module=%s wrapper=%s",
+                _MARKER,
+                getattr(module, "__name__", "unknown"),
+                getattr(current, "__qualname__", "unknown"),
+            )
         return True
+
     if not getattr(current, _PATCH_ATTR, False):
         return False
 
@@ -90,8 +118,15 @@ def _install_convergence_guard() -> bool:
     def guarded_patch_core(module: ModuleType) -> bool:
         cls = getattr(module, "NijaCoreLoop", None)
         method = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
-        if callable(method) and getattr(method, _REPAIR_ATTR, False):
+
+        # Inspect the full wrapper chain. Venue-readiness and other legitimate
+        # wrappers may be above the repaired canonical method. Checking only the
+        # outer function caused the patch/remove loop seen in live logs.
+        if callable(method) and _wrapper_chain_has_attr(method, _REPAIR_ATTR):
+            if not getattr(method, _REPAIR_ATTR, False):
+                setattr(method, _REPAIR_ATTR, True)
             return True
+
         result = original_patch_core(module)
         _repair_module(module)
         return result
@@ -134,10 +169,12 @@ def install() -> None:
 
 install()
 
+
 __all__ = [
     "install",
     "_repair_module",
     "_unwrap_faulty_owner",
+    "_wrapper_chain_has_attr",
     "_install_convergence_guard",
     "_PATCH_ATTR",
     "_REPAIR_ATTR",


### PR DESCRIPTION
## Root cause

`venue_readiness_execution_repair_patch` legitimately wraps `NijaCoreLoop.run_scan_phase` above the repaired canonical scan method. The existing reentrant-scan convergence guard checked only the outermost callable, so it could not see the repair marker below that wrapper. Every five seconds the convergence watchdog reinstalled its owner wrapper, and the repair watchdog removed it again.

## Fix

- inspect the complete `__wrapped__` chain for the repaired-canonical marker
- propagate that marker to legitimate outer wrappers
- prevent the convergence watchdog from reinstalling the defective owner wrapper
- preserve the venue-readiness wrapper and canonical independent scan path
- add regression coverage for nested wrapper chains

## Validation

- combined existing and new scan-owner tests: `5 passed`
- isolated new regression suite: `3 passed`
- Python import/compile path exercised by pytest

This restores a stable scan stack. It does not force entries or bypass signal, risk, capital, venue-readiness, or broker-order controls.