### PR TITLE
Fix Kraken position reconciliation and equity hydration

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -47,13 +47,15 @@ def _is_adapter(obj: Any) -> bool:
         return False
     if any(callable(getattr(obj, method, None)) for method in _METHODS):
         return True
-    return _broker_key(obj) != "unknown" and any(getattr(obj, attr, None) is not None for attr in ("market_api", "account_api", "client", "session"))
+    return _broker_key(obj) != "unknown" and any(
+        getattr(obj, attr, None) is not None
+        for attr in ("market_api", "account_api", "client", "session")
+    )
 
 
 def _install_collector_override(module: Any) -> bool:
     if getattr(module, "_NIJA_BROKER_BOOL_GUARD_PATCHED_V20260705D", False):
         return True
-
     enabled = getattr(module, "_broker_enabled", lambda broker_name: True)
 
     def collect(apex: Any, explicit_broker: Any = None) -> dict[str, Any]:
@@ -82,7 +84,11 @@ def _install_collector_override(module: Any) -> bool:
             )
 
         add("explicit", explicit_broker, "explicit")
-        owners = [item for item in (apex, getattr(apex, "strategy", None), getattr(apex, "trading_strategy", None)) if item is not None]
+        owners = [
+            item
+            for item in (apex, getattr(apex, "strategy", None), getattr(apex, "trading_strategy", None))
+            if item is not None
+        ]
         for owner in owners:
             for attr in ("broker_client", "broker", "active_broker"):
                 add(attr, getattr(owner, attr, None), f"owner.{attr}")
@@ -107,39 +113,54 @@ def _install_collector_override(module: Any) -> bool:
     return True
 
 
-def _install_strategy_backrefs() -> None:
+def _install_module(primary: str, fallback: str, label: str, marker: str) -> None:
     try:
-        mod = importlib.import_module("bot.strategy_broker_backref_patch")
+        mod = importlib.import_module(primary)
     except Exception:
         try:
-            mod = importlib.import_module("strategy_broker_backref_patch")
+            mod = importlib.import_module(fallback)
         except Exception as exc:
-            logger.warning("BROKER_BOOL_GUARD_STRATEGY_BACKREF_WAIT marker=20260705d error=%s", exc)
+            logger.warning("%s_IMPORT_FAILED marker=%s error=%s", label, marker, exc)
             return
     try:
-        mod.install_import_hook()
+        installer = getattr(mod, "install_import_hook", None) or getattr(mod, "install", None)
+        if callable(installer):
+            installer()
+            logger.warning("%s_INSTALL_REQUESTED marker=%s", label, marker)
     except Exception as exc:
-        logger.warning("BROKER_BOOL_GUARD_STRATEGY_BACKREF_INSTALL_FAILED marker=20260705d error=%s", exc)
+        logger.warning("%s_INSTALL_FAILED marker=%s error=%s", label, marker, exc)
+
+
+def _install_strategy_backrefs() -> None:
+    _install_module(
+        "bot.strategy_broker_backref_patch",
+        "strategy_broker_backref_patch",
+        "BROKER_BOOL_GUARD_STRATEGY_BACKREF",
+        "20260705d",
+    )
 
 
 def _install_trade_cycle_convergence_repair() -> None:
-    try:
-        mod = importlib.import_module("bot.trade_cycle_convergence_repair_patch")
-    except Exception:
-        try:
-            mod = importlib.import_module("trade_cycle_convergence_repair_patch")
-        except Exception as exc:
-            logger.warning("TRADE_CYCLE_CONVERGENCE_IMPORT_FAILED marker=20260713a error=%s", exc)
-            return
-    try:
-        mod.install_import_hook()
-        logger.warning("TRADE_CYCLE_CONVERGENCE_INSTALL_REQUESTED marker=20260713a")
-    except Exception as exc:
-        logger.warning("TRADE_CYCLE_CONVERGENCE_INSTALL_FAILED marker=20260713a error=%s", exc)
+    _install_module(
+        "bot.trade_cycle_convergence_repair_patch",
+        "trade_cycle_convergence_repair_patch",
+        "TRADE_CYCLE_CONVERGENCE",
+        "20260713a",
+    )
+
+
+def _install_position_sync_runtime_repair() -> None:
+    _install_module(
+        "bot.position_sync_runtime_repair_patch",
+        "position_sync_runtime_repair_patch",
+        "POSITION_SYNC_RUNTIME_REPAIR",
+        "20260713-position-sync-v2",
+    )
 
 
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
+    _install_position_sync_runtime_repair()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/kraken_equity_runtime_patch.py
+++ b/bot/kraken_equity_runtime_patch.py
@@ -1,14 +1,9 @@
 """Kraken total-equity hydration patch.
 
-Kraken balances can include USD cash, held USD/open-order funds, and separate
-crypto holdings.  Earlier snapshots only counted USD available + USD held, which
-undercounted accounts where crypto holdings remain open on Kraken.
-
-This patch is conservative:
-- it does not place, cancel, or modify orders;
-- it does not change risk rules;
-- it only enriches balance snapshots/position visibility when crypto balances
-  can be priced from Kraken market data.
+This layer classifies non-cash Kraken holdings for visibility while keeping
+balance reads idempotent. It never mutates PositionTracker during a balance read,
+never recursively calls the wrapped get_account_balance method, and never adds
+crypto value twice when the broker already returned total account equity.
 """
 
 from __future__ import annotations
@@ -16,11 +11,11 @@ from __future__ import annotations
 import builtins
 import logging
 from functools import wraps
-from typing import Any, Dict, Iterable
+from typing import Any, Dict
 
 logger = logging.getLogger("nija.kraken_equity_patch")
 _PATCHED_ATTR = "__nija_kraken_equity_patch__"
-_CASH_ASSETS = {"USD", "ZUSD", "USDT", "USDC", "ZEUR", "EUR"}
+_CASH_ASSETS = {"USD", "ZUSD", "USDT", "USDC", "ZEUR", "EUR", "USDG", "USAT"}
 _ASSET_ALIASES = {
     "XXBT": "BTC",
     "XBT": "BTC",
@@ -28,13 +23,39 @@ _ASSET_ALIASES = {
     "ZUSD": "USD",
     "ZEUR": "EUR",
 }
+_NON_ASSET_BALANCE_KEYS = {
+    "ERROR",
+    "RESULT",
+    "EB",
+    "TB",
+    "M",
+    "UV",
+    "N",
+    "C",
+    "V",
+    "E",
+    "MF",
+    "MFO",
+    "TOTAL_FUNDS",
+    "TOTAL_BALANCE",
+    "TOTAL_EQUITY",
+    "EQUITY",
+    "TRADING_BALANCE",
+    "USD_HELD",
+    "USDT_HELD",
+    "USDC_HELD",
+    "TOTAL_HELD",
+    "NON_USD_USD",
+    "CRYPTO_USD",
+}
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:
     try:
-        return float(value or 0.0)
-    except (TypeError, ValueError):
+        parsed = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
         return default
+    return parsed if parsed == parsed else default
 
 
 def _asset_name(asset: str) -> str:
@@ -47,34 +68,48 @@ def _is_cash(asset: str) -> bool:
 
 
 def _extract_raw_balances(payload: Any) -> Dict[str, float]:
-    """Extract Kraken raw asset quantities from common response shapes."""
+    """Extract positive non-cash asset quantities from Kraken balance payloads."""
     if not isinstance(payload, dict):
         return {}
-    candidates = []
+    candidates: list[dict] = []
     for key in ("crypto", "assets", "balances", "raw_balances", "result"):
         value = payload.get(key)
         if isinstance(value, dict):
             candidates.append(value)
-    # Some code stores raw balances directly at the top level.
     candidates.append(payload)
+
     out: Dict[str, float] = {}
     for data in candidates:
         for asset, value in data.items():
             name = _asset_name(str(asset))
-            if not name or name in {"USD_HELD", "USDT_HELD", "TOTAL_HELD", "TOTAL_FUNDS", "TRADING_BALANCE"}:
+            if not name or name in _NON_ASSET_BALANCE_KEYS or _is_cash(name):
+                continue
+            if isinstance(value, (dict, list, tuple, set)):
                 continue
             qty = _safe_float(value)
-            if qty > 0 and not _is_cash(name):
+            if qty > 0:
                 out[name] = max(out.get(name, 0.0), qty)
     return out
 
 
-def _call_balance_payload(instance: Any) -> dict:
-    for attr in ("_last_raw_balances", "last_raw_balances", "_raw_balances", "raw_balances", "_balance_payload", "balance_payload"):
+def _call_balance_payload(instance: Any, *, allow_live_probe: bool = True) -> dict:
+    """Return cached balance metadata, optionally probing non-recursive helpers."""
+    for attr in (
+        "_last_raw_balances",
+        "last_raw_balances",
+        "_raw_balances",
+        "raw_balances",
+        "_balance_payload",
+        "balance_payload",
+    ):
         cached = getattr(instance, attr, None)
         if isinstance(cached, dict):
             return cached
-    for method_name in ("get_balance_snapshot", "get_portfolio_breakdown", "get_balances", "get_account_balance"):
+
+    methods = ["get_balance_snapshot", "get_portfolio_breakdown", "get_balances"]
+    if allow_live_probe:
+        methods.append("get_account_balance")
+    for method_name in methods:
         method = getattr(instance, method_name, None)
         if not callable(method):
             continue
@@ -96,7 +131,14 @@ def _call_balance_payload(instance: Any) -> dict:
 
 def _price_asset(instance: Any, asset: str) -> float:
     base = _asset_name(asset)
-    pairs = [f"{base}-USD", f"{base}/USD", f"{base}USD", f"{base}-USDT", f"{base}/USDT", f"{base}USDT"]
+    pairs = [
+        f"{base}-USD",
+        f"{base}/USD",
+        f"{base}USD",
+        f"{base}-USDT",
+        f"{base}/USDT",
+        f"{base}USDT",
+    ]
     for method_name in ("get_current_price", "get_price", "fetch_price", "get_ticker_price"):
         method = getattr(instance, method_name, None)
         if not callable(method):
@@ -108,22 +150,22 @@ def _price_asset(instance: Any, asset: str) -> float:
                     return price
             except Exception:
                 continue
-    ticker_methods = ("get_ticker", "fetch_ticker", "ticker")
-    for method_name in ticker_methods:
+    for method_name in ("get_ticker", "fetch_ticker", "ticker"):
         method = getattr(instance, method_name, None)
         if not callable(method):
             continue
         for pair in pairs:
             try:
                 ticker = method(pair)
-                if isinstance(ticker, dict):
-                    for key in ("last", "price", "c", "close"):
-                        value = ticker.get(key)
-                        if isinstance(value, (list, tuple)) and value:
-                            value = value[0]
-                        price = _safe_float(value)
-                        if price > 0:
-                            return price
+                if not isinstance(ticker, dict):
+                    continue
+                for key in ("last", "price", "c", "close"):
+                    value = ticker.get(key)
+                    if isinstance(value, (list, tuple)) and value:
+                        value = value[0]
+                    price = _safe_float(value)
+                    if price > 0:
+                        return price
             except Exception:
                 continue
     return 0.0
@@ -134,43 +176,88 @@ def _build_positions(instance: Any, raw_assets: Dict[str, float]) -> list[Dict[s
     for asset, qty in raw_assets.items():
         price = _price_asset(instance, asset)
         size_usd = qty * price if price > 0 else 0.0
-        positions.append({
-            "symbol": f"{asset}-USD",
-            "asset": asset,
-            "currency": asset,
-            "quantity": qty,
-            "side": "long",
-            "current_price": price,
-            "size_usd": size_usd,
-            "source": "kraken.crypto_balance",
-            "status": "active_position",
-        })
+        positions.append(
+            {
+                "symbol": f"{asset}-USD",
+                "asset": asset,
+                "currency": asset,
+                "quantity": qty,
+                "side": "long",
+                "current_price": price,
+                "size_usd": size_usd,
+                "source": "kraken.crypto_balance",
+                "status": "active_position",
+            }
+        )
     return positions
 
 
-def _sync_tracker(instance: Any, positions: list[Dict[str, Any]]) -> None:
-    if not positions:
-        return
-    for tracker_attr in ("position_tracker", "_position_tracker", "tracker"):
-        tracker = getattr(instance, tracker_attr, None)
-        if tracker is None:
-            continue
-        for pos in positions:
-            for method_name in ("add_position", "record_position", "sync_position", "update_position"):
-                method = getattr(tracker, method_name, None)
-                if not callable(method):
-                    continue
-                try:
-                    method(pos)
-                    break
-                except TypeError:
-                    try:
-                        method(pos.get("symbol"), pos.get("quantity"), pos.get("current_price", 0.0))
-                        break
-                    except Exception:
-                        continue
-                except Exception:
-                    continue
+def _cash_from_payload(payload: dict) -> float:
+    candidates: list[dict] = []
+    for key in ("result", "balances", "raw_balances", "assets"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            candidates.append(value)
+    candidates.append(payload)
+    cash = 0.0
+    for data in candidates:
+        subtotal = 0.0
+        for asset, value in data.items():
+            if _is_cash(str(asset)) and not isinstance(value, (dict, list, tuple, set)):
+                subtotal += max(0.0, _safe_float(value))
+        cash = max(cash, subtotal)
+    return cash
+
+
+def _direct_total_from_payload(payload: dict) -> float:
+    totals = []
+    for key in (
+        "total_funds",
+        "total_balance",
+        "total_equity",
+        "equity",
+        "portfolio_value",
+        "account_equity",
+        "eb",
+        "e",
+    ):
+        if key in payload:
+            totals.append(_safe_float(payload.get(key)))
+    result = payload.get("result")
+    if isinstance(result, dict):
+        for key in ("total_funds", "total_balance", "total_equity", "equity", "eb", "e"):
+            if key in result:
+                totals.append(_safe_float(result.get(key)))
+    return max([0.0] + totals)
+
+
+def _payload_total_equity(payload: dict, positions: list[Dict[str, Any]]) -> float:
+    if not isinstance(payload, dict):
+        payload = {}
+    direct = _direct_total_from_payload(payload)
+    cash = _cash_from_payload(payload)
+    held = max(
+        _safe_float(payload.get("usd_held")),
+        _safe_float(payload.get("total_held")),
+        0.0,
+    )
+    crypto_usd = sum(_safe_float(position.get("size_usd")) for position in positions)
+    declared_crypto = max(
+        _safe_float(payload.get("crypto_usd")),
+        _safe_float(payload.get("non_usd_usd")),
+        0.0,
+    )
+    computed = cash + held + max(crypto_usd, declared_crypto)
+    return max(direct, computed)
+
+
+def _cache_position_snapshot(instance: Any, positions: list[Dict[str, Any]]) -> None:
+    """Cache visibility only; PositionTracker reconciliation happens elsewhere."""
+    try:
+        setattr(instance, "_last_kraken_position_snapshot", tuple(dict(item) for item in positions))
+        setattr(instance, "_last_kraken_position_snapshot_count", len(positions))
+    except Exception:
+        pass
 
 
 def _patch_kraken_class(cls: type) -> bool:
@@ -180,28 +267,28 @@ def _patch_kraken_class(cls: type) -> bool:
     original_get_positions = getattr(cls, "get_positions", None)
 
     def get_positions(self: Any):
-        existing = []
+        existing: list[Dict[str, Any]] = []
         if callable(original_get_positions):
             try:
                 result = original_get_positions(self)
                 if isinstance(result, list):
-                    existing.extend(result)
+                    existing.extend(item for item in result if isinstance(item, dict))
             except Exception as exc:
                 logger.warning("KRAKEN_EQUITY_POSITION_CLASSIFICATION original get_positions failed: %s", exc)
-        payload = _call_balance_payload(self)
+        payload = _call_balance_payload(self, allow_live_probe=False)
         raw_assets = _extract_raw_balances(payload)
         positions = _build_positions(self, raw_assets)
-        seen = {str(p.get("symbol", "")).upper() for p in existing if isinstance(p, dict)}
-        for pos in positions:
-            if str(pos.get("symbol", "")).upper() not in seen:
-                existing.append(pos)
+        seen = {str(item.get("symbol", "")).upper() for item in existing}
+        for position in positions:
+            if str(position.get("symbol", "")).upper() not in seen:
+                existing.append(position)
+        _cache_position_snapshot(self, positions)
         if positions:
-            _sync_tracker(self, positions)
             logger.warning(
-                "KRAKEN_CRYPTO_POSITIONS_CLASSIFIED count=%d total_crypto_usd=%.2f symbols=%s",
+                "KRAKEN_CRYPTO_POSITIONS_CLASSIFIED count=%d total_crypto_usd=%.2f symbols=%s tracker_mutation=false",
                 len(positions),
-                sum(_safe_float(p.get("size_usd")) for p in positions),
-                ",".join(str(p.get("symbol")) for p in positions),
+                sum(_safe_float(item.get("size_usd")) for item in positions),
+                ",".join(str(item.get("symbol")) for item in positions),
             )
         return existing
 
@@ -212,28 +299,34 @@ def _patch_kraken_class(cls: type) -> bool:
         @wraps(original_get_account_balance)
         def get_account_balance(self: Any, *args: Any, **kwargs: Any):
             base_total = _safe_float(original_get_account_balance(self, *args, **kwargs))
-            payload = _call_balance_payload(self)
+            # Do not call get_account_balance again from payload discovery.
+            payload = _call_balance_payload(self, allow_live_probe=False)
             raw_assets = _extract_raw_balances(payload)
             positions = _build_positions(self, raw_assets)
-            crypto_usd = sum(_safe_float(p.get("size_usd")) for p in positions)
-            enriched_total = base_total + crypto_usd
-            if crypto_usd > 0:
-                setattr(self, "_last_known_balance", enriched_total)
+            authoritative_total = _payload_total_equity(payload, positions)
+            final_total = max(base_total, authoritative_total)
+            _cache_position_snapshot(self, positions)
+            if final_total > 0:
+                setattr(self, "_last_known_balance", final_total)
                 try:
-                    payload["crypto_usd"] = crypto_usd
-                    payload["total_funds"] = max(_safe_float(payload.get("total_funds")), enriched_total)
-                    setattr(self, "_last_raw_balances", payload)
+                    enriched_payload = dict(payload)
+                    enriched_payload["crypto_usd"] = sum(
+                        _safe_float(item.get("size_usd")) for item in positions
+                    )
+                    enriched_payload["total_funds"] = final_total
+                    setattr(self, "_last_raw_balances", enriched_payload)
                 except Exception:
                     pass
-                _sync_tracker(self, positions)
-                logger.warning(
-                    "KRAKEN_EQUITY_ENRICHED base_total=%.2f crypto_usd=%.2f enriched_total=%.2f symbols=%s",
-                    base_total,
-                    crypto_usd,
-                    enriched_total,
-                    ",".join(str(p.get("symbol")) for p in positions),
-                )
-            return enriched_total if enriched_total > base_total else base_total
+            logger.warning(
+                "KRAKEN_EQUITY_CANONICAL base_total=%.2f payload_total=%.2f final_total=%.2f "
+                "crypto_usd=%.2f double_count_prevented=true tracker_mutation=false",
+                base_total,
+                authoritative_total,
+                final_total,
+                sum(_safe_float(item.get("size_usd")) for item in positions),
+            )
+            return final_total
+
         setattr(cls, "get_account_balance", get_account_balance)
 
     original_connect = getattr(cls, "connect", None)
@@ -241,25 +334,22 @@ def _patch_kraken_class(cls: type) -> bool:
         @wraps(original_connect)
         def connect(self: Any, *args: Any, **kwargs: Any):
             result = original_connect(self, *args, **kwargs)
-            try:
-                positions = get_positions(self)
-                crypto_usd = sum(_safe_float(p.get("size_usd")) for p in positions if isinstance(p, dict) and p.get("source") == "kraken.crypto_balance")
-                if crypto_usd > 0:
-                    base = _safe_float(getattr(self, "_last_known_balance", 0.0))
-                    setattr(self, "_last_known_balance", max(base, base + crypto_usd if base else crypto_usd))
+            if result:
+                try:
+                    positions = get_positions(self)
                     logger.warning(
-                        "KRAKEN_STARTUP_EQUITY_SYNC positions=%d crypto_usd=%.2f symbols=%s",
+                        "KRAKEN_STARTUP_POSITION_VISIBILITY positions=%d symbols=%s tracker_mutation=false",
                         len(positions),
-                        crypto_usd,
-                        ",".join(str(p.get("symbol")) for p in positions if isinstance(p, dict)),
+                        ",".join(str(item.get("symbol")) for item in positions if isinstance(item, dict)),
                     )
-            except Exception as exc:
-                logger.warning("KRAKEN_STARTUP_EQUITY_SYNC_ERROR error=%s", exc)
+                except Exception as exc:
+                    logger.warning("KRAKEN_STARTUP_POSITION_VISIBILITY_ERROR error=%s", exc)
             return result
+
         setattr(cls, "connect", connect)
 
     setattr(cls, _PATCHED_ATTR, True)
-    logger.warning("KRAKEN_EQUITY_HYDRATION_PATCHED class=%s", cls.__name__)
+    logger.warning("KRAKEN_EQUITY_HYDRATION_PATCHED class=%s canonical_total=true", cls.__name__)
     return True
 
 
@@ -278,28 +368,38 @@ def install_import_hook() -> None:
     import sys
 
     for name, module in list(sys.modules.items()):
-        if name.endswith(("broker_manager", "kraken_broker", "execution_engine")):
+        if name.endswith(("broker_manager", "kraken_broker", "broker_integration", "execution_engine")):
             try:
-                if _patch_module(module):
-                    return
+                _patch_module(module)
             except Exception:
                 continue
 
     if getattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED", False):
         return
-
     original_import = builtins.__import__
+    hook_local = __import__("threading").local()
 
     def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
         module = original_import(name, globals, locals, fromlist, level)
-        if name.endswith(("broker_manager", "kraken_broker", "execution_engine")):
+        if getattr(hook_local, "active", False):
+            return module
+        if name.endswith(("broker_manager", "kraken_broker", "broker_integration", "execution_engine")):
+            hook_local.active = True
             try:
-                if _patch_module(module):
-                    builtins.__import__ = original_import
-                    setattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED", False)
+                _patch_module(module)
             except Exception as exc:
                 logger.warning("Kraken equity runtime patch failed: %s", exc)
+            finally:
+                hook_local.active = False
         return module
 
     builtins.__import__ = guarded_import
     setattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED", True)
+
+
+__all__ = [
+    "install_import_hook",
+    "_extract_raw_balances",
+    "_payload_total_equity",
+    "_patch_kraken_class",
+]

--- a/bot/position_sync_runtime_repair_patch.py
+++ b/bot/position_sync_runtime_repair_patch.py
@@ -1,0 +1,175 @@
+"""Recurring position reconciliation for brokers that connect after startup.
+
+The original usercustomize hook permanently marked startup sync complete after the
+first capital refresh. Platform Kraken was often connected at that point while
+user brokers were still binding, so Daivon/Tania never received startup position
+reconciliation. This final wrapper is deliberately idempotent and rate-limited.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("nija.position_sync_runtime_repair")
+_MARKER = "20260713-position-sync-v2"
+_PATCH_ATTR = "_nija_position_sync_runtime_repair_v2"
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_PATCHED: set[tuple[str, int]] = set()
+_LOCK = threading.RLock()
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if parsed == parsed else default
+
+
+def _connected_brokers(manager: Any) -> dict[str, Any]:
+    brokers: dict[str, Any] = {}
+    for broker_type, broker in (getattr(manager, "platform_brokers", {}) or {}).items():
+        if broker is not None and getattr(broker, "connected", False):
+            key = str(getattr(broker_type, "value", broker_type)).lower()
+            brokers[f"platform:{key}"] = broker
+    for user_id, mapping in (getattr(manager, "user_brokers", {}) or {}).items():
+        for broker_type, broker in (mapping or {}).items():
+            if broker is not None and getattr(broker, "connected", False):
+                key = str(getattr(broker_type, "value", broker_type)).lower()
+                brokers[f"user:{user_id}:{key}"] = broker
+    return brokers
+
+
+def _should_reconcile(manager: Any, now: float) -> bool:
+    try:
+        interval = max(5.0, float(os.environ.get("NIJA_POSITION_SYNC_REFRESH_INTERVAL_S", "30") or "30"))
+    except Exception:
+        interval = 30.0
+    last = _safe_float(getattr(manager, "_nija_position_sync_last_attempt_at", 0.0))
+    return now - last >= interval
+
+
+def _run_reconcile(manager: Any, trigger: str) -> None:
+    now = time.time()
+    if not _should_reconcile(manager, now):
+        return
+    setattr(manager, "_nija_position_sync_last_attempt_at", now)
+
+    try:
+        from bot.startup_position_sync import sync_exchange_positions_on_startup
+    except ImportError:
+        from startup_position_sync import sync_exchange_positions_on_startup  # type: ignore[import]
+
+    connected_before = _connected_brokers(manager)
+    reconciled = sync_exchange_positions_on_startup(
+        SimpleNamespace(multi_account_manager=manager)
+    )
+    connected_after = _connected_brokers(manager)
+    synced = {
+        name: bool(getattr(broker, "_startup_position_sync_adopted", False))
+        for name, broker in connected_after.items()
+    }
+    setattr(manager, "_startup_position_sync_done", bool(synced) and all(synced.values()))
+    setattr(manager, "_nija_position_sync_last_connected", tuple(sorted(connected_after)))
+    logger.critical(
+        "POSITION_SYNC_RUNTIME_RECONCILE marker=%s trigger=%s connected_before=%s "
+        "connected_after=%s synced=%s reconciled=%d all_synced=%s",
+        _MARKER,
+        trigger,
+        sorted(connected_before),
+        sorted(connected_after),
+        synced,
+        reconciled,
+        bool(synced) and all(synced.values()),
+    )
+
+
+def _patch_mabm(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    def refresh_capital_authority(self: Any, *args: Any, **kwargs: Any):
+        result = original(self, *args, **kwargs)
+        try:
+            ready = isinstance(result, dict) and _safe_float(result.get("ready")) > 0.0
+            capital = _safe_float(result.get("total_capital")) if isinstance(result, dict) else 0.0
+            if ready and capital > 0.0:
+                _run_reconcile(
+                    self,
+                    str(kwargs.get("trigger", "refresh_capital_authority")),
+                )
+        except Exception as exc:
+            logger.exception("POSITION_SYNC_RUNTIME_RECONCILE_FAILED marker=%s error=%s", _MARKER, exc)
+        return result
+
+    setattr(refresh_capital_authority, _PATCH_ATTR, True)
+    setattr(refresh_capital_authority, "__wrapped__", original)
+    setattr(cls, "refresh_capital_authority", refresh_capital_authority)
+    logger.warning("POSITION_SYNC_RUNTIME_REPAIR_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    with _LOCK:
+        if key in _PATCHED:
+            return True
+        patched = _patch_mabm(module)
+        if patched:
+            _PATCHED.add(key)
+        return patched
+
+
+def _patch_loaded() -> None:
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch_module(module)
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    os.environ.setdefault("NIJA_POSITION_SYNC_REFRESH_INTERVAL_S", "30")
+    _patch_loaded()
+    if _ORIGINAL_IMPORT is not None:
+        return
+
+    _ORIGINAL_IMPORT = builtins.__import__
+    local = threading.local()
+
+    def import_hook(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+        if getattr(local, "active", False):
+            return module
+        local.active = True
+        try:
+            _patch_loaded()
+        finally:
+            local.active = False
+        return module
+
+    builtins.__import__ = import_hook  # type: ignore[assignment]
+    _patch_loaded()
+    logger.warning("POSITION_SYNC_RUNTIME_REPAIR_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = [
+    "install_import_hook",
+    "_patch_mabm",
+    "_run_reconcile",
+]

--- a/bot/position_tracker.py
+++ b/bot/position_tracker.py
@@ -1,22 +1,20 @@
 """
 NIJA Position Tracker
-Persistent storage of position entry prices and profit/loss tracking
 
-This module solves the problem that Coinbase API doesn't return entry prices,
-making it impossible to calculate profit/loss for exit decisions.
+Persistent, thread-safe storage for position entry prices and P&L tracking.
 """
 
+from __future__ import annotations
+
 import json
-import os
 import logging
-from typing import Dict, Optional, List
+import os
 from datetime import datetime
 from threading import Lock
+from typing import Dict, List, Optional
 
 logger = logging.getLogger("nija")
 
-# Entry price store — optional; imported lazily so PositionTracker can still
-# function if the module is unavailable for any reason.
 try:
     from bot.entry_price_store import get_entry_price_store
     ENTRY_PRICE_STORE_AVAILABLE = True
@@ -25,299 +23,345 @@ except Exception:
 
 
 class PositionTracker:
-    """
-    Tracks entry prices and manages position P&L for profit-based exits.
-
-    Persists data to JSON file to survive bot restarts.
-    """
+    """Track position cost basis and quantities across process restarts."""
 
     def __init__(self, storage_file: str = "positions.json"):
-        """
-        Initialize position tracker.
-
-        Args:
-            storage_file: Path to JSON file for persistence
-        """
         self.storage_file = os.path.abspath(storage_file)
         self.positions: Dict[str, Dict] = {}
         self.lock = Lock()
-
-        # Load existing positions
         self._load_positions()
-
-        # Entry Price Store — rich metadata persistence (price/timestamp/source/quantity)
         self._eps = get_entry_price_store() if ENTRY_PRICE_STORE_AVAILABLE else None
+        logger.info("PositionTracker initialized: %d tracked positions", len(self.positions))
 
-        logger.info(f"PositionTracker initialized: {len(self.positions)} tracked positions")
+    @staticmethod
+    def _safe_float(value, default: float = 0.0) -> float:
+        try:
+            parsed = float(value or 0.0)
+        except (TypeError, ValueError, OverflowError):
+            return default
+        return parsed if parsed == parsed else default
 
-    def _load_positions(self):
-        """Load positions from JSON file"""
+    def _load_positions(self) -> None:
         try:
             if os.path.exists(self.storage_file):
-                with open(self.storage_file, 'r') as f:
-                    data = json.load(f)
-                    self.positions = data.get('positions', {})
-                logger.info(f"Loaded {len(self.positions)} positions from {self.storage_file}")
+                with open(self.storage_file, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                self.positions = data.get("positions", {}) if isinstance(data, dict) else {}
+                logger.info("Loaded %d positions from %s", len(self.positions), self.storage_file)
             else:
                 logger.info("No existing positions file found - starting fresh")
-        except Exception as e:
-            logger.error(f"Error loading positions: {e}")
+        except Exception as exc:
+            logger.error("Error loading positions: %s", exc)
             self.positions = {}
 
-    def _save_positions(self):
-        """Save positions to JSON file (assumes lock is already held)"""
+    def _save_positions(self) -> None:
         try:
-            data = {
-                'positions': self.positions,
-                'last_updated': datetime.now().isoformat()
+            parent = os.path.dirname(self.storage_file)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            payload = {
+                "positions": self.positions,
+                "last_updated": datetime.now().isoformat(),
             }
-            # Write to temp file first, then rename for atomicity
-            temp_file = self.storage_file + '.tmp'
-            with open(temp_file, 'w') as f:
-                json.dump(data, f, indent=2)
+            temp_file = self.storage_file + ".tmp"
+            with open(temp_file, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
             os.replace(temp_file, self.storage_file)
-        except Exception as e:
-            logger.error(f"Error saving positions: {e}")
+        except Exception as exc:
+            logger.error("Error saving positions: %s", exc)
 
-    def track_entry(self, symbol: str, entry_price: float, quantity: float,
-                   size_usd: float, strategy: str = "APEX_v7.1", 
-                   position_source: str = "nija_strategy") -> bool:
-        """
-        Record a new position entry.
-
-        Args:
-            symbol: Trading symbol (e.g., 'BTC-USD')
-            entry_price: Entry price
-            quantity: Quantity of asset purchased
-            size_usd: Position size in USD
-            strategy: Strategy name for tracking
-            position_source: Source of position ('nija_strategy', 'broker_existing', 'manual')
-
-        Returns:
-            True if tracked successfully
-        """
+    def _persist_entry_price(self, symbol: str, price: float, quantity: float, source: str) -> None:
+        if not ENTRY_PRICE_STORE_AVAILABLE or price <= 0:
+            return
         try:
+            get_entry_price_store().save(
+                symbol,
+                price,
+                source=source,
+                quantity=quantity,
+            )
+        except Exception as exc:
+            logger.debug("[PositionTracker] entry_price_store save failed for %s: %s", symbol, exc)
+
+    def track_entry(
+        self,
+        symbol: str,
+        entry_price: float,
+        quantity: float,
+        size_usd: float,
+        strategy: str = "APEX_v7.1",
+        position_source: str = "nija_strategy",
+    ) -> bool:
+        """Record an actual additive trade fill."""
+        try:
+            symbol = str(symbol or "").strip()
+            entry_price = self._safe_float(entry_price)
+            quantity = self._safe_float(quantity)
+            size_usd = self._safe_float(size_usd)
+            if not symbol or quantity <= 0:
+                return False
+
             with self.lock:
-                # If position already exists, calculate average entry price
                 if symbol in self.positions:
                     existing = self.positions[symbol]
-                    old_qty = existing['quantity']
-                    old_price = existing['entry_price']
-                    old_size = existing['size_usd']
-
-                    # Calculate new weighted average entry price correctly
-                    # Formula: (old_qty * old_price + new_qty * new_price) / total_qty
+                    old_qty = self._safe_float(existing.get("quantity"))
+                    old_price = self._safe_float(existing.get("entry_price"))
+                    old_size = self._safe_float(existing.get("size_usd"))
                     total_qty = old_qty + quantity
                     total_cost = (old_qty * old_price) + (quantity * entry_price)
                     avg_price = total_cost / total_qty if total_qty > 0 else entry_price
                     total_size = old_size + size_usd
-
                     self.positions[symbol] = {
-                        'entry_price': avg_price,
-                        'quantity': total_qty,
-                        'size_usd': total_size,
-                        'first_entry_time': existing['first_entry_time'],
-                        'last_entry_time': datetime.now().isoformat(),
-                        'strategy': strategy,
-                        'num_adds': existing.get('num_adds', 0) + 1,
-                        'previous_profit_pct': existing.get('previous_profit_pct', 0.0),  # Preserve previous profit tracking
-                        'position_source': existing.get('position_source', position_source)  # Keep original source
+                        "entry_price": avg_price,
+                        "quantity": total_qty,
+                        "size_usd": total_size,
+                        "first_entry_time": existing.get("first_entry_time", datetime.now().isoformat()),
+                        "last_entry_time": datetime.now().isoformat(),
+                        "strategy": strategy,
+                        "num_adds": int(existing.get("num_adds", 0) or 0) + 1,
+                        "previous_profit_pct": self._safe_float(existing.get("previous_profit_pct")),
+                        "position_source": existing.get("position_source", position_source),
                     }
-                    logger.info(f"Updated position {symbol}: avg_entry=${avg_price:.2f}, qty={total_qty:.8f}")
+                    logger.info("Updated position %s: avg_entry=$%.2f, qty=%.8f", symbol, avg_price, total_qty)
                 else:
-                    # New position
                     self.positions[symbol] = {
-                        'entry_price': entry_price,
-                        'quantity': quantity,
-                        'size_usd': size_usd,
-                        'first_entry_time': datetime.now().isoformat(),
-                        'last_entry_time': datetime.now().isoformat(),
-                        'strategy': strategy,
-                        'num_adds': 0,
-                        'previous_profit_pct': 0.0,  # Initialize previous profit tracking
-                        'position_source': position_source  # Track position source
+                        "entry_price": entry_price,
+                        "quantity": quantity,
+                        "size_usd": size_usd,
+                        "first_entry_time": datetime.now().isoformat(),
+                        "last_entry_time": datetime.now().isoformat(),
+                        "strategy": strategy,
+                        "num_adds": 0,
+                        "previous_profit_pct": 0.0,
+                        "position_source": position_source,
                     }
-                    logger.info(f"Tracking new position {symbol}: entry=${entry_price:.2f}, qty={quantity:.8f}, source={position_source}")
+                    logger.info(
+                        "Tracking new position %s: entry=$%.2f, qty=%.8f, source=%s",
+                        symbol,
+                        entry_price,
+                        quantity,
+                        position_source,
+                    )
 
                 self._save_positions()
-                # Persist entry price to the dedicated store so it survives
-                # broker-API failures.  Use the final effective entry price
-                # (avg_price for adds, entry_price for new positions).
-                _effective_price = self.positions[symbol]['entry_price']
-                if ENTRY_PRICE_STORE_AVAILABLE:
-                    try:
-                        entry_price_store = get_entry_price_store()
-                        entry_price_store.save(symbol, _effective_price)
-                    except Exception as _eps_err:
-                        logger.debug(f"[PositionTracker] entry_price_store save failed for {symbol}: {_eps_err}")
-                return True
-        except Exception as e:
-            logger.error(f"Error tracking entry for {symbol}: {e}")
+                effective = self._safe_float(self.positions[symbol].get("entry_price"))
+                final_qty = self._safe_float(self.positions[symbol].get("quantity"))
+
+            self._persist_entry_price(symbol, effective, final_qty, "execution")
+            return True
+        except Exception as exc:
+            logger.error("Error tracking entry for %s: %s", symbol, exc)
+            return False
+
+    def sync_position_snapshot(
+        self,
+        symbol: str,
+        quantity: float,
+        entry_price: float = 0.0,
+        current_price: float = 0.0,
+        size_usd: float = 0.0,
+        strategy: str = "BROKER_SYNC",
+        position_source: str = "broker_existing",
+        entry_price_source: str = "override",
+    ) -> bool:
+        """Reconcile an exact broker snapshot without treating it as a new fill.
+
+        Broker balance/position hydration is idempotent. It must replace the live
+        quantity rather than add it to the tracker each time a balance is read.
+        This method also repairs the common zero-price dilution failure where the
+        stored quantity was duplicated while the original cost basis stayed flat.
+        """
+        try:
+            symbol = str(symbol or "").strip()
+            quantity = self._safe_float(quantity)
+            supplied_entry = self._safe_float(entry_price)
+            current_price = self._safe_float(current_price)
+            broker_value = self._safe_float(size_usd)
+            if not symbol or quantity <= 0:
+                return False
+
+            with self.lock:
+                existing = self.positions.get(symbol)
+                old_qty = self._safe_float((existing or {}).get("quantity"))
+                old_entry = self._safe_float((existing or {}).get("entry_price"))
+                old_cost = self._safe_float((existing or {}).get("size_usd"))
+
+                repaired_from_cost = False
+                if supplied_entry > 0:
+                    effective_entry = supplied_entry
+                elif existing and old_cost > 0 and quantity > 0:
+                    # Reconstruct the undiluted entry price after duplicate snapshot
+                    # additions: original cost basis / actual broker quantity.
+                    effective_entry = old_cost / quantity
+                    repaired_from_cost = True
+                elif old_entry > 0:
+                    effective_entry = old_entry
+                elif current_price > 0:
+                    effective_entry = current_price
+                elif broker_value > 0:
+                    effective_entry = broker_value / quantity
+                else:
+                    effective_entry = 0.0
+
+                cost_basis_usd = quantity * effective_entry if effective_entry > 0 else broker_value
+                now = datetime.now().isoformat()
+                original_source = (existing or {}).get("position_source")
+                original_strategy = (existing or {}).get("strategy")
+                source = original_source or position_source
+                chosen_strategy = original_strategy or strategy
+
+                self.positions[symbol] = {
+                    "entry_price": effective_entry,
+                    "quantity": quantity,
+                    "size_usd": cost_basis_usd,
+                    "first_entry_time": (existing or {}).get("first_entry_time", now),
+                    "last_entry_time": now,
+                    "strategy": chosen_strategy,
+                    "num_adds": int((existing or {}).get("num_adds", 0) or 0),
+                    "previous_profit_pct": self._safe_float((existing or {}).get("previous_profit_pct")),
+                    "position_source": source,
+                    "last_broker_snapshot_value_usd": broker_value,
+                    "last_broker_snapshot_price": current_price,
+                }
+                self._save_positions()
+
+            changed = (
+                existing is None
+                or abs(old_qty - quantity) > max(1e-10, quantity * 1e-8)
+                or abs(old_entry - effective_entry) > max(1e-8, abs(effective_entry) * 1e-8)
+            )
+            logger.warning(
+                "POSITION_SNAPSHOT_SYNCED symbol=%s old_qty=%.8f new_qty=%.8f "
+                "old_entry=$%.8f new_entry=$%.8f cost_basis=$%.2f broker_value=$%.2f "
+                "changed=%s repaired_from_cost=%s",
+                symbol,
+                old_qty,
+                quantity,
+                old_entry,
+                effective_entry,
+                cost_basis_usd,
+                broker_value,
+                changed,
+                repaired_from_cost,
+            )
+            self._persist_entry_price(
+                symbol,
+                effective_entry,
+                quantity,
+                entry_price_source if supplied_entry > 0 else "override",
+            )
+            return True
+        except Exception as exc:
+            logger.error("Error synchronizing broker snapshot for %s: %s", symbol, exc)
             return False
 
     def track_exit(self, symbol: str, exit_quantity: float = None) -> bool:
-        """
-        Record a position exit (partial or full).
-
-        Args:
-            symbol: Trading symbol
-            exit_quantity: Quantity sold (None = full exit)
-
-        Returns:
-            True if tracked successfully
-        """
         try:
             with self.lock:
                 if symbol not in self.positions:
-                    logger.warning(f"Attempted to exit untracked position: {symbol}")
+                    logger.warning("Attempted to exit untracked position: %s", symbol)
                     return False
 
                 if exit_quantity is None:
-                    # Full exit - remove position
                     del self.positions[symbol]
-                    logger.info(f"Removed position {symbol} (full exit)")
-                    _full_exit = True
+                    logger.info("Removed position %s (full exit)", symbol)
+                    full_exit = True
                 else:
-                    _full_exit = False
-                    # Partial exit - reduce quantity
+                    full_exit = False
                     position = self.positions[symbol]
-                    remaining_qty = position['quantity'] - exit_quantity
-
+                    quantity = self._safe_float(position.get("quantity"))
+                    remaining_qty = quantity - self._safe_float(exit_quantity)
                     if remaining_qty <= 0:
-                        # Exit consumed entire position
                         del self.positions[symbol]
-                        logger.info(f"Removed position {symbol} (partial exit cleared position)")
-                        _full_exit = True
+                        logger.info("Removed position %s (partial exit cleared position)", symbol)
+                        full_exit = True
                     else:
-                        # Update remaining quantity and proportional size
-                        # Preserve proportional cost basis
-                        remaining_size = position['size_usd'] * (remaining_qty / position['quantity'])
-                        position['quantity'] = remaining_qty
-                        position['size_usd'] = remaining_size
-                        logger.info(f"Reduced position {symbol}: remaining_qty={remaining_qty:.8f}, remaining_size=${remaining_size:.2f}")
-
+                        remaining_size = self._safe_float(position.get("size_usd")) * (remaining_qty / quantity)
+                        position["quantity"] = remaining_qty
+                        position["size_usd"] = remaining_size
+                        logger.info(
+                            "Reduced position %s: remaining_qty=%.8f, remaining_size=$%.2f",
+                            symbol,
+                            remaining_qty,
+                            remaining_size,
+                        )
                 self._save_positions()
-                # Remove from entry price store when position is fully closed
-                if _full_exit and ENTRY_PRICE_STORE_AVAILABLE:
-                    try:
-                        entry_price_store = get_entry_price_store()
-                        entry_price_store.clear(symbol)
-                    except Exception as _eps_err:
-                        logger.debug(f"[PositionTracker] entry_price_store clear failed for {symbol}: {_eps_err}")
-                return True
-        except Exception as e:
-            logger.error(f"Error tracking exit for {symbol}: {e}")
+
+            if full_exit and ENTRY_PRICE_STORE_AVAILABLE:
+                try:
+                    get_entry_price_store().clear(symbol)
+                except Exception as exc:
+                    logger.debug("[PositionTracker] entry_price_store clear failed for %s: %s", symbol, exc)
+            return True
+        except Exception as exc:
+            logger.error("Error tracking exit for %s: %s", symbol, exc)
             return False
 
     def get_position(self, symbol: str) -> Optional[Dict]:
-        """
-        Get tracked position data.
-
-        Args:
-            symbol: Trading symbol
-
-        Returns:
-            Position dict with entry_price, quantity, size_usd, etc. or None
-        """
         with self.lock:
             return self.positions.get(symbol)
 
     def calculate_pnl(self, symbol: str, current_price: float) -> Optional[Dict]:
-        """
-        Calculate profit/loss for a position.
-
-        Args:
-            symbol: Trading symbol
-            current_price: Current market price
-
-        Returns:
-            Dict with pnl_dollars, pnl_percent, current_value, previous_profit_pct, or None if not tracked
-        """
         position = self.get_position(symbol)
         if not position:
             return None
-
-        entry_price = position['entry_price']
-        quantity = position['quantity']
-        entry_value = position['size_usd']
-
-        current_value = quantity * current_price
+        entry_price = self._safe_float(position.get("entry_price"))
+        quantity = self._safe_float(position.get("quantity"))
+        entry_value = self._safe_float(position.get("size_usd"))
+        current_value = quantity * self._safe_float(current_price)
         pnl_dollars = current_value - entry_value
-        # NORMALIZED FORMAT (Option A - Fractional): -0.01 = -1%, not -1.0 = -1%
-        pnl_pct = (pnl_dollars / entry_value) if entry_value > 0 else 0
-
-        # CRITICAL: Validate PnL is in fractional format
-        # Large values (>1 or <-1) could indicate bugs or extreme market moves (>100%)
-        # This is a monitoring warning - no corrective action needed, just alerting
+        pnl_pct = pnl_dollars / entry_value if entry_value > 0 else 0.0
         if abs(pnl_pct) >= 1.0:
-            logger.warning(f"⚠️ Large PnL detected for {symbol}: {pnl_pct*100:.2f}% - this is unusual but valid for extreme moves")
-
-        # Track previous profit for immediate exit on profit decrease
-        # NIJA takes profit as soon as profit starts to decrease
+            logger.warning("⚠️ Large PnL detected for %s: %.2f%%", symbol, pnl_pct * 100.0)
         with self.lock:
-            previous_profit = position.get('previous_profit_pct', 0.0)
-            # Update previous profit for next check
-            position['previous_profit_pct'] = pnl_pct
-            # Save updated previous profit
+            previous_profit = self._safe_float(position.get("previous_profit_pct"))
+            position["previous_profit_pct"] = pnl_pct
             self._save_positions()
-
         return {
-            'symbol': symbol,
-            'entry_price': entry_price,
-            'current_price': current_price,
-            'quantity': quantity,
-            'entry_value': entry_value,
-            'current_value': current_value,
-            'pnl_dollars': pnl_dollars,
-            'pnl_percent': pnl_pct,  # FRACTIONAL: -0.01 = -1%, -0.12 = -12%
-            'previous_profit_pct': previous_profit  # Profit from previous check
+            "symbol": symbol,
+            "entry_price": entry_price,
+            "current_price": current_price,
+            "quantity": quantity,
+            "entry_value": entry_value,
+            "current_value": current_value,
+            "pnl_dollars": pnl_dollars,
+            "pnl_percent": pnl_pct,
+            "previous_profit_pct": previous_profit,
         }
 
     def get_all_positions(self) -> List[str]:
-        """Get list of all tracked symbols"""
         with self.lock:
             return list(self.positions.keys())
 
     def sync_with_broker(self, broker_positions: List[Dict]) -> int:
-        """
-        Sync tracker with actual broker positions.
-        Remove any tracked positions that no longer exist at broker.
-
-        Args:
-            broker_positions: List of position dicts from broker
-
-        Returns:
-            Number of positions removed
-        """
         try:
             with self.lock:
-                broker_symbols = {pos.get('symbol') for pos in broker_positions if pos.get('symbol')}
+                broker_symbols = {
+                    str(pos.get("symbol") or "").strip()
+                    for pos in (broker_positions or [])
+                    if isinstance(pos, dict) and pos.get("symbol")
+                }
                 tracked_symbols = set(self.positions.keys())
-
-                # Find positions we're tracking but broker doesn't have
                 orphaned = tracked_symbols - broker_symbols
-
-                if orphaned:
-                    logger.info(f"Removing {len(orphaned)} orphaned tracked positions: {orphaned}")
-                    for symbol in orphaned:
-                        del self.positions[symbol]
-                    self._save_positions()
-                    return len(orphaned)
-
-                return 0
-        except Exception as e:
-            logger.error(f"Error syncing with broker: {e}")
+                if not orphaned:
+                    return 0
+                logger.info("Removing %d orphaned tracked positions: %s", len(orphaned), orphaned)
+                for symbol in orphaned:
+                    del self.positions[symbol]
+                self._save_positions()
+                return len(orphaned)
+        except Exception as exc:
+            logger.error("Error syncing with broker: %s", exc)
             return 0
 
     def clear_all(self) -> bool:
-        """Clear all tracked positions (emergency use only)"""
         try:
             with self.lock:
                 count = len(self.positions)
                 self.positions = {}
                 self._save_positions()
-                logger.warning(f"Cleared all {count} tracked positions")
-                return True
-        except Exception as e:
-            logger.error(f"Error clearing positions: {e}")
+            logger.warning("Cleared all %d tracked positions", count)
+            return True
+        except Exception as exc:
+            logger.error("Error clearing positions: %s", exc)
             return False

--- a/bot/startup_position_sync.py
+++ b/bot/startup_position_sync.py
@@ -7,7 +7,6 @@ must never be treated as additive fills.
 from __future__ import annotations
 
 import logging
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("nija")
@@ -36,11 +35,35 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
     return parsed if parsed == parsed else default
 
 
+def _legacy_duplicate_snapshot_detected(
+    existing: Optional[Dict],
+    broker_quantity: float,
+) -> bool:
+    """Detect cost-basis dilution caused by additive broker snapshot ingestion."""
+    if not existing or broker_quantity <= 0:
+        return False
+    existing_qty = _safe_float(existing.get("quantity"))
+    existing_cost = _safe_float(existing.get("size_usd"))
+    num_adds = int(_safe_float(existing.get("num_adds")))
+    strategy = str(existing.get("strategy", "") or "").strip().upper()
+    position_source = str(existing.get("position_source", "") or "").strip().lower()
+    quantity_error = abs(existing_qty - broker_quantity) / max(broker_quantity, 1e-12)
+    startup_owned = strategy == "STARTUP_SYNC" or position_source == "broker_existing"
+    return (
+        existing_qty > 0
+        and existing_cost > 0
+        and num_adds > 0
+        and startup_owned
+        and quantity_error > 0.05
+    )
+
+
 def _resolve_entry_price(
     broker: Any,
     symbol: str,
     eps: Optional[Any],
     broker_quantity: float,
+    existing: Optional[Dict] = None,
 ) -> Tuple[float, str]:
     """Resolve a trustworthy cost-basis price without using current market price."""
     if hasattr(broker, "get_real_entry_price"):
@@ -51,6 +74,26 @@ def _resolve_entry_price(
         except Exception as exc:
             logger.debug("startup_position_sync: get_real_entry_price(%s) failed: %s", symbol, exc)
 
+    # Old startup sync treated every broker snapshot as a new fill. The diluted
+    # average was then persisted with the default "execution" source and no
+    # quantity, so source alone cannot prove the record is trustworthy. When the
+    # tracker carries the duplicate-sync signature, force exact snapshot repair
+    # to reconstruct entry from stored cost basis / actual broker quantity.
+    if _legacy_duplicate_snapshot_detected(existing, broker_quantity):
+        existing_qty = _safe_float((existing or {}).get("quantity"))
+        existing_cost = _safe_float((existing or {}).get("size_usd"))
+        reconstructed = existing_cost / broker_quantity if broker_quantity > 0 else 0.0
+        logger.warning(
+            "EXCHANGE_POSITION_SYNC legacy_diluted_entry_ignored symbol=%s "
+            "tracked_qty=%.8f broker_qty=%.8f stored_cost=$%.8f reconstructed_entry=$%.8f",
+            symbol,
+            existing_qty,
+            broker_quantity,
+            existing_cost,
+            reconstructed,
+        )
+        return 0.0, "reconstructed_cost_basis"
+
     if eps is not None:
         try:
             record = eps.get(symbol) if callable(getattr(eps, "get", None)) else None
@@ -58,10 +101,6 @@ def _resolve_entry_price(
             source = str(getattr(record, "source", "override") or "override")
             stored_qty = _safe_float(getattr(record, "quantity", 0.0))
             if stored > 0:
-                # Execution/API prices remain useful even if the held quantity
-                # changed. Override prices with a mismatched quantity may be the
-                # product of the old duplicate-snapshot bug, so let the tracker
-                # reconstruct cost basis instead of trusting them blindly.
                 if source in {"execution", "api"}:
                     return stored, source
                 if stored_qty <= 0 or broker_quantity <= 0:
@@ -130,7 +169,6 @@ def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -
             "EXCHANGE_POSITION_SYNC broker=%s reconciled=0 skipped_invalid=0 errors=0 reason=no_open_positions",
             broker_name,
         )
-        # A broker may connect before balances hydrate. Keep it retryable.
         setattr(broker, "_startup_position_sync_adopted", False)
         return 0
 
@@ -166,6 +204,7 @@ def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -
                 symbol,
                 eps,
                 quantity,
+                existing,
             )
             changed = _position_changed(existing, quantity, entry_price)
 
@@ -184,8 +223,6 @@ def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -
                     )
                 )
             elif existing is None:
-                # Legacy fallback only for a new position. Never call additive
-                # track_entry for an existing broker snapshot.
                 fallback_entry = entry_price or current_price
                 cost_basis = quantity * fallback_entry if fallback_entry > 0 else broker_value
                 ok = bool(
@@ -339,4 +376,5 @@ __all__ = [
     "sync_exchange_positions_on_startup",
     "_adopt_broker_positions",
     "_collect_connected_brokers",
+    "_legacy_duplicate_snapshot_detected",
 ]

--- a/bot/startup_position_sync.py
+++ b/bot/startup_position_sync.py
@@ -1,22 +1,19 @@
-"""
-NIJA Startup Position Sync
-==========================
+"""Synchronize exchange positions into account-scoped position trackers.
 
-Synchronises exchange positions with the internal PositionTracker on bot
-startup. Called AFTER brokers are connected so holdings that existed before a
-restart are visible to exit logic, P&L calculation, and duplicate-entry guards.
+Broker snapshots are authoritative for quantity. They are reconciled exactly and
+must never be treated as additive fills.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("nija")
 
 
 def _get_entry_price_store() -> Optional[Any]:
-    """Return the EntryPriceStore singleton, or None."""
     try:
         from bot.entry_price_store import get_entry_price_store
         return get_entry_price_store()
@@ -31,27 +28,57 @@ def _get_entry_price_store() -> Optional[Any]:
         return None
 
 
-def _resolve_entry_price(broker: Any, symbol: str, current_price: float, eps: Optional[Any]) -> float:
-    """Resolve the best available entry price for *symbol*."""
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if parsed == parsed else default
+
+
+def _resolve_entry_price(
+    broker: Any,
+    symbol: str,
+    eps: Optional[Any],
+    broker_quantity: float,
+) -> Tuple[float, str]:
+    """Resolve a trustworthy cost-basis price without using current market price."""
     if hasattr(broker, "get_real_entry_price"):
         try:
-            price = broker.get_real_entry_price(symbol)
-            if price and float(price) > 0:
-                return float(price)
+            price = _safe_float(broker.get_real_entry_price(symbol))
+            if price > 0:
+                return price, "api"
         except Exception as exc:
             logger.debug("startup_position_sync: get_real_entry_price(%s) failed: %s", symbol, exc)
 
     if eps is not None:
         try:
-            stored = eps.get_price(symbol)
-            if stored and float(stored) > 0:
-                return float(stored)
+            record = eps.get(symbol) if callable(getattr(eps, "get", None)) else None
+            stored = _safe_float(getattr(record, "price", None))
+            source = str(getattr(record, "source", "override") or "override")
+            stored_qty = _safe_float(getattr(record, "quantity", 0.0))
+            if stored > 0:
+                # Execution/API prices remain useful even if the held quantity
+                # changed. Override prices with a mismatched quantity may be the
+                # product of the old duplicate-snapshot bug, so let the tracker
+                # reconstruct cost basis instead of trusting them blindly.
+                if source in {"execution", "api"}:
+                    return stored, source
+                if stored_qty <= 0 or broker_quantity <= 0:
+                    return stored, source
+                relative_qty_error = abs(stored_qty - broker_quantity) / max(broker_quantity, 1e-12)
+                if relative_qty_error <= 0.05:
+                    return stored, source
+                logger.warning(
+                    "EXCHANGE_POSITION_SYNC stale_override_ignored symbol=%s stored_qty=%.8f broker_qty=%.8f",
+                    symbol,
+                    stored_qty,
+                    broker_quantity,
+                )
         except Exception as exc:
-            logger.debug("startup_position_sync: EntryPriceStore.get_price(%s) failed: %s", symbol, exc)
+            logger.debug("startup_position_sync: EntryPriceStore lookup failed for %s: %s", symbol, exc)
 
-    if current_price and float(current_price) > 0:
-        return float(current_price)
-    return 0.0
+    return 0.0, "override"
 
 
 def _tracker_count(tracker: Any) -> int:
@@ -64,8 +91,18 @@ def _tracker_count(tracker: Any) -> int:
         return 0
 
 
+def _position_changed(existing: Optional[Dict], quantity: float, entry_price: float) -> bool:
+    if existing is None:
+        return True
+    old_qty = _safe_float(existing.get("quantity"))
+    old_entry = _safe_float(existing.get("entry_price"))
+    qty_changed = abs(old_qty - quantity) > max(1e-10, quantity * 1e-8)
+    entry_changed = entry_price > 0 and abs(old_entry - entry_price) > max(1e-8, entry_price * 1e-8)
+    return qty_changed or entry_changed
+
+
 def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -> int:
-    """Fetch and adopt open positions from *broker* into its PositionTracker."""
+    """Fetch and exactly reconcile open positions for one broker."""
     tracker = getattr(broker, "position_tracker", None)
     if tracker is None:
         logger.warning("EXCHANGE_POSITION_SYNC broker=%s has no position_tracker — skipping", broker_name)
@@ -73,44 +110,45 @@ def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -
 
     before_count = _tracker_count(tracker)
     try:
-        positions: List[Dict] = broker.get_positions()
+        raw_positions = broker.get_positions()
+        positions: List[Dict] = list(raw_positions or []) if isinstance(raw_positions, list) else []
     except Exception as exc:
         logger.warning("EXCHANGE_POSITION_SYNC broker=%s fetch_failed error=%s", broker_name, exc)
         return 0
 
-    fetched_count = len(positions or [])
     logger.info(
-        "EXCHANGE_POSITION_SYNC broker=%s fetched=%d tracked_before=%d connected=%s already_adopted=%s",
+        "EXCHANGE_POSITION_SYNC broker=%s fetched=%d tracked_before=%d connected=%s previously_synced=%s",
         broker_name,
-        fetched_count,
+        len(positions),
         before_count,
         getattr(broker, "connected", None),
         getattr(broker, "_startup_position_sync_adopted", False),
     )
 
     if not positions:
-        logger.info("EXCHANGE_POSITION_SYNC broker=%s adopted=0 skipped_existing=0 skipped_invalid=0 reason=no_open_positions", broker_name)
-        # Do not mark the broker adopted when no positions are returned. Some
-        # brokers connect before portfolio/position hydration is complete, so a
-        # later retry may still discover exchange holdings.
+        logger.info(
+            "EXCHANGE_POSITION_SYNC broker=%s reconciled=0 skipped_invalid=0 errors=0 reason=no_open_positions",
+            broker_name,
+        )
+        # A broker may connect before balances hydrate. Keep it retryable.
+        setattr(broker, "_startup_position_sync_adopted", False)
         return 0
 
-    if getattr(broker, "_startup_position_sync_adopted", False):
-        logger.debug("EXCHANGE_POSITION_SYNC broker=%s skipped — already adopted on this instance", broker_name)
-        return 0
-
-    adopted = 0
-    skipped_existing = 0
+    reconciled = 0
+    unchanged = 0
     skipped_invalid = 0
-    skipped_errors = 0
+    errors = 0
+    successful_symbols: list[str] = []
 
     for pos in positions:
         try:
+            if not isinstance(pos, dict):
+                skipped_invalid += 1
+                continue
             symbol = str(pos.get("symbol", "") or "").strip()
-            quantity = float(pos.get("quantity", 0) or 0)
-            current_price = float(pos.get("current_price", 0) or 0)
-            size_usd = float(pos.get("size_usd", 0) or 0)
-
+            quantity = _safe_float(pos.get("quantity", pos.get("size", 0.0)))
+            current_price = _safe_float(pos.get("current_price", pos.get("price", 0.0)))
+            broker_value = _safe_float(pos.get("size_usd", pos.get("market_value", 0.0)))
             if not symbol or quantity <= 0:
                 skipped_invalid += 1
                 logger.info(
@@ -122,74 +160,99 @@ def _adopt_broker_positions(broker: Any, broker_name: str, eps: Optional[Any]) -
                 )
                 continue
 
-            existing = tracker.get_position(symbol)
-            if existing is not None:
-                skipped_existing += 1
-                logger.info(
-                    "EXCHANGE_POSITION_SYNC broker=%s skip_existing symbol=%s qty=%.8f entry=$%.4f",
+            existing = tracker.get_position(symbol) if callable(getattr(tracker, "get_position", None)) else None
+            entry_price, entry_source = _resolve_entry_price(
+                broker,
+                symbol,
+                eps,
+                quantity,
+            )
+            changed = _position_changed(existing, quantity, entry_price)
+
+            exact_sync = getattr(tracker, "sync_position_snapshot", None)
+            if callable(exact_sync):
+                ok = bool(
+                    exact_sync(
+                        symbol=symbol,
+                        quantity=quantity,
+                        entry_price=entry_price,
+                        current_price=current_price,
+                        size_usd=broker_value,
+                        strategy="STARTUP_SYNC",
+                        position_source="broker_existing",
+                        entry_price_source=entry_source,
+                    )
+                )
+            elif existing is None:
+                # Legacy fallback only for a new position. Never call additive
+                # track_entry for an existing broker snapshot.
+                fallback_entry = entry_price or current_price
+                cost_basis = quantity * fallback_entry if fallback_entry > 0 else broker_value
+                ok = bool(
+                    tracker.track_entry(
+                        symbol=symbol,
+                        entry_price=fallback_entry,
+                        quantity=quantity,
+                        size_usd=cost_basis,
+                        strategy="STARTUP_SYNC",
+                        position_source="broker_existing",
+                    )
+                )
+            else:
+                logger.error(
+                    "EXCHANGE_POSITION_SYNC broker=%s exact_sync_unavailable symbol=%s existing_position_not_modified",
                     broker_name,
                     symbol,
-                    float(existing.get("quantity", 0) or 0),
-                    float(existing.get("entry_price", 0) or 0),
                 )
+                ok = False
+
+            if not ok:
+                errors += 1
                 continue
 
-            entry_price = _resolve_entry_price(broker, symbol, current_price, eps)
-            if entry_price <= 0:
-                logger.warning(
-                    "EXCHANGE_POSITION_SYNC broker=%s symbol=%s entry_price_unavailable current_price=%.8f adopting_for_repair",
-                    broker_name,
-                    symbol,
-                    current_price,
-                )
-
-            if size_usd <= 0 and entry_price > 0:
-                size_usd = quantity * entry_price
-
-            tracker.track_entry(
-                symbol=symbol,
-                entry_price=entry_price,
-                quantity=quantity,
-                size_usd=size_usd,
-                strategy="STARTUP_SYNC",
-                position_source="broker_existing",
-            )
-
-            if eps is not None and entry_price > 0:
-                try:
-                    eps.save(symbol, entry_price, source="override", quantity=quantity)
-                except Exception as eps_err:
-                    logger.debug("startup_position_sync: EntryPriceStore.save(%s) failed: %s", symbol, eps_err)
-
+            successful_symbols.append(symbol)
+            if changed:
+                reconciled += 1
+            else:
+                unchanged += 1
+            final_position = tracker.get_position(symbol) if callable(getattr(tracker, "get_position", None)) else None
             logger.info(
-                "EXCHANGE_POSITION_SYNC broker=%s adopted_symbol=%s qty=%.8f entry=$%.4f size=$%.2f",
+                "EXCHANGE_POSITION_SYNC broker=%s synced_symbol=%s qty=%.8f entry=$%.8f current=$%.8f broker_value=$%.2f changed=%s",
                 broker_name,
                 symbol,
                 quantity,
-                entry_price,
-                size_usd,
+                _safe_float((final_position or {}).get("entry_price", entry_price)),
+                current_price,
+                broker_value,
+                changed,
             )
-            adopted += 1
-        except Exception as pos_exc:
-            skipped_errors += 1
-            logger.warning("EXCHANGE_POSITION_SYNC broker=%s position_adoption_error raw=%r error=%s", broker_name, pos, pos_exc)
+        except Exception as exc:
+            errors += 1
+            logger.warning(
+                "EXCHANGE_POSITION_SYNC broker=%s position_reconcile_error raw=%r error=%s",
+                broker_name,
+                pos,
+                exc,
+            )
 
     after_count = _tracker_count(tracker)
-    if adopted > 0 or skipped_existing > 0:
-        broker._startup_position_sync_adopted = True
+    fully_synced = bool(successful_symbols) and errors == 0
+    setattr(broker, "_startup_position_sync_adopted", fully_synced)
+    setattr(broker, "_startup_position_sync_symbols", tuple(sorted(successful_symbols)))
     logger.info(
-        "EXCHANGE_POSITION_SYNC broker=%s fetched=%d adopted=%d skipped_existing=%d skipped_invalid=%d skipped_errors=%d tracked_before=%d tracked_after=%d marked_adopted=%s",
+        "EXCHANGE_POSITION_SYNC broker=%s fetched=%d reconciled=%d unchanged=%d skipped_invalid=%d errors=%d "
+        "tracked_before=%d tracked_after=%d marked_synced=%s",
         broker_name,
-        fetched_count,
-        adopted,
-        skipped_existing,
+        len(positions),
+        reconciled,
+        unchanged,
         skipped_invalid,
-        skipped_errors,
+        errors,
         before_count,
         after_count,
-        getattr(broker, "_startup_position_sync_adopted", False),
+        fully_synced,
     )
-    return adopted
+    return reconciled
 
 
 def _broker_name(broker_type: Any, *, prefix: str = "") -> str:
@@ -198,63 +261,55 @@ def _broker_name(broker_type: Any, *, prefix: str = "") -> str:
 
 
 def _collect_connected_brokers(strategy: Any) -> Dict[str, Any]:
-    """Collect connected platform and user brokers from MABM and BrokerManager."""
     brokers: Dict[str, Any] = {}
     mam = getattr(strategy, "multi_account_manager", None)
 
     if mam is not None:
         try:
-            raw_platform = getattr(mam, "platform_brokers", {}) or {}
-            for broker_type, broker in raw_platform.items():
+            for broker_type, broker in (getattr(mam, "platform_brokers", {}) or {}).items():
                 if broker is not None and getattr(broker, "connected", False):
                     brokers[_broker_name(broker_type, prefix="platform:")] = broker
         except Exception as exc:
-            logger.warning("EXCHANGE_POSITION_SYNC could not read platform_brokers from multi_account_manager: %s", exc)
+            logger.warning("EXCHANGE_POSITION_SYNC could not read platform_brokers: %s", exc)
 
         try:
-            raw_users = getattr(mam, "user_brokers", {}) or {}
-            for user_id, user_broker_dict in raw_users.items():
+            for user_id, user_broker_dict in (getattr(mam, "user_brokers", {}) or {}).items():
                 for broker_type, broker in (user_broker_dict or {}).items():
                     if broker is not None and getattr(broker, "connected", False):
                         brokers[_broker_name(broker_type, prefix=f"user:{user_id}:")] = broker
         except Exception as exc:
-            logger.warning("EXCHANGE_POSITION_SYNC could not read user_brokers from multi_account_manager: %s", exc)
+            logger.warning("EXCHANGE_POSITION_SYNC could not read user_brokers: %s", exc)
 
     bm = getattr(strategy, "broker_manager", None)
     if bm is not None:
         try:
-            raw_brokers = getattr(bm, "brokers", {}) or {}
-            for broker_type, broker in raw_brokers.items():
+            for broker_type, broker in (getattr(bm, "brokers", {}) or {}).items():
                 if broker is not None and getattr(broker, "connected", False):
-                    name = _broker_name(broker_type, prefix="broker_manager:")
-                    brokers.setdefault(name, broker)
+                    brokers.setdefault(_broker_name(broker_type, prefix="broker_manager:"), broker)
         except Exception as exc:
-            logger.warning("EXCHANGE_POSITION_SYNC could not read brokers from broker_manager: %s", exc)
+            logger.warning("EXCHANGE_POSITION_SYNC could not read broker_manager brokers: %s", exc)
 
     return brokers
 
 
 def sync_exchange_positions_on_startup(strategy: Any) -> int:
-    """Sync open exchange positions into each connected broker's PositionTracker."""
+    """Reconcile every currently connected platform and user broker."""
     logger.info("EXCHANGE_POSITION_SYNC starting startup position synchronisation")
-
     eps = _get_entry_price_store()
     connected_brokers = _collect_connected_brokers(strategy)
-
     logger.info(
         "EXCHANGE_POSITION_SYNC connected_broker_count=%d brokers=%s",
         len(connected_brokers),
         sorted(connected_brokers.keys()),
     )
-
     if not connected_brokers:
         logger.warning("EXCHANGE_POSITION_SYNC no connected brokers found — retry will remain eligible")
         return 0
 
-    total_adopted = 0
+    total_reconciled = 0
     for broker_name, broker in connected_brokers.items():
         try:
-            total_adopted += _adopt_broker_positions(broker, broker_name, eps)
+            total_reconciled += _adopt_broker_positions(broker, broker_name, eps)
         except Exception as exc:
             logger.warning("EXCHANGE_POSITION_SYNC broker=%s unexpected error: %s", broker_name, exc)
 
@@ -266,11 +321,22 @@ def sync_exchange_positions_on_startup(strategy: Any) -> int:
             tracker_seen.add(id(tracker))
             total_tracked += _tracker_count(tracker)
 
+    synced_brokers = sum(
+        1 for broker in connected_brokers.values() if getattr(broker, "_startup_position_sync_adopted", False)
+    )
     logger.info(
-        "EXCHANGE_POSITION_SYNC complete connected_brokers=%d adopted_total=%d total_tracked=%d",
+        "EXCHANGE_POSITION_SYNC complete connected_brokers=%d synced_brokers=%d reconciled_total=%d total_tracked=%d",
         len(connected_brokers),
-        total_adopted,
+        synced_brokers,
+        total_reconciled,
         total_tracked,
     )
     logger.info("PositionTracker initialized: %d tracked positions", total_tracked)
-    return total_adopted
+    return total_reconciled
+
+
+__all__ = [
+    "sync_exchange_positions_on_startup",
+    "_adopt_broker_positions",
+    "_collect_connected_brokers",
+]

--- a/bot/tests/test_position_sync_runtime_repair.py
+++ b/bot/tests/test_position_sync_runtime_repair.py
@@ -180,6 +180,9 @@ class RecurringPositionSyncTests(unittest.TestCase):
 
         fake_startup_module = types.ModuleType("bot.startup_position_sync")
         fake_startup_module.sync_exchange_positions_on_startup = fake_sync
+        fake_bot_package = types.ModuleType("bot")
+        fake_bot_package.__path__ = []
+        fake_bot_package.startup_position_sync = fake_startup_module
 
         class Manager:
             def __init__(self):
@@ -198,7 +201,10 @@ class RecurringPositionSyncTests(unittest.TestCase):
 
         with patch.dict(
             sys.modules,
-            {"bot.startup_position_sync": fake_startup_module},
+            {
+                "bot": fake_bot_package,
+                "bot.startup_position_sync": fake_startup_module,
+            },
             clear=False,
         ), patch.dict(
             os.environ,

--- a/bot/tests/test_position_sync_runtime_repair.py
+++ b/bot/tests/test_position_sync_runtime_repair.py
@@ -107,6 +107,67 @@ class PositionSnapshotSyncTests(unittest.TestCase):
         self.assertAlmostEqual(repaired["quantity"], quantity, places=8)
         self.assertAlmostEqual(repaired["entry_price"], entry, places=8)
 
+    def test_startup_sync_ignores_legacy_execution_label_with_no_quantity(self) -> None:
+        tracker = position_tracker_module.PositionTracker(self.storage)
+        quantity = 5.13699973
+        entry = 8.20
+        cost = quantity * entry
+        tracker.track_entry(
+            "SOL-USD",
+            entry,
+            quantity,
+            cost,
+            strategy="STARTUP_SYNC",
+            position_source="broker_existing",
+        )
+        tracker.track_entry(
+            "SOL-USD",
+            0.0,
+            quantity,
+            0.0,
+            strategy="STARTUP_SYNC",
+            position_source="broker_existing",
+        )
+        tracker.track_entry(
+            "SOL-USD",
+            0.0,
+            quantity,
+            0.0,
+            strategy="STARTUP_SYNC",
+            position_source="broker_existing",
+        )
+
+        class LegacyEPS:
+            def get(self, symbol):
+                return SimpleNamespace(price=entry / 3.0, quantity=0.0, source="execution")
+
+        class Broker:
+            connected = True
+            position_tracker = tracker
+
+            def get_real_entry_price(self, symbol):
+                return None
+
+            def get_positions(self):
+                return [
+                    {
+                        "symbol": "SOL-USD",
+                        "quantity": quantity,
+                        "current_price": 150.0,
+                        "size_usd": quantity * 150.0,
+                    }
+                ]
+
+        reconciled = startup_sync_module._adopt_broker_positions(
+            Broker(),
+            "platform:kraken",
+            LegacyEPS(),
+        )
+        self.assertEqual(reconciled, 1)
+        repaired = tracker.get_position("SOL-USD")
+        self.assertAlmostEqual(repaired["quantity"], quantity, places=8)
+        self.assertAlmostEqual(repaired["entry_price"], entry, places=8)
+
 
 class KrakenEquityCanonicalizationTests(unittest.TestCase):
     def test_trade_balance_metadata_is_not_classified_as_crypto(self) -> None:

--- a/bot/tests/test_position_sync_runtime_repair.py
+++ b/bot/tests/test_position_sync_runtime_repair.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+position_tracker_module = load_module("position_tracker_under_test", "position_tracker.py")
+startup_sync_module = load_module("startup_position_sync_under_test", "startup_position_sync.py")
+kraken_patch_module = load_module("kraken_equity_patch_under_test", "kraken_equity_runtime_patch.py")
+runtime_sync_module = load_module("position_sync_runtime_patch_under_test", "position_sync_runtime_repair_patch.py")
+
+
+class PositionSnapshotSyncTests(unittest.TestCase):
+    def setUp(self) -> None:
+        position_tracker_module.ENTRY_PRICE_STORE_AVAILABLE = False
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.storage = str(Path(self.tempdir.name) / "positions.json")
+
+    def test_exact_snapshot_repairs_duplicate_zero_price_dilution(self) -> None:
+        tracker = position_tracker_module.PositionTracker(self.storage)
+        quantity = 5.13699973
+        entry = 8.20
+        cost = quantity * entry
+
+        self.assertTrue(tracker.track_entry("SOL-USD", entry, quantity, cost))
+        self.assertTrue(tracker.track_entry("SOL-USD", 0.0, quantity, 0.0))
+        self.assertTrue(tracker.track_entry("SOL-USD", 0.0, quantity, 0.0))
+        corrupted = tracker.get_position("SOL-USD")
+        self.assertAlmostEqual(corrupted["quantity"], quantity * 3, places=8)
+        self.assertLess(corrupted["entry_price"], entry)
+
+        self.assertTrue(
+            tracker.sync_position_snapshot(
+                symbol="SOL-USD",
+                quantity=quantity,
+                entry_price=0.0,
+                current_price=150.0,
+                size_usd=quantity * 150.0,
+            )
+        )
+        repaired = tracker.get_position("SOL-USD")
+        self.assertAlmostEqual(repaired["quantity"], quantity, places=8)
+        self.assertAlmostEqual(repaired["entry_price"], entry, places=8)
+        self.assertAlmostEqual(repaired["size_usd"], cost, places=8)
+        self.assertAlmostEqual(
+            repaired["last_broker_snapshot_value_usd"],
+            quantity * 150.0,
+            places=8,
+        )
+
+    def test_startup_sync_ignores_stale_override_quantity(self) -> None:
+        tracker = position_tracker_module.PositionTracker(self.storage)
+        quantity = 5.13699973
+        entry = 8.20
+        cost = quantity * entry
+        tracker.track_entry("SOL-USD", entry, quantity, cost)
+        tracker.track_entry("SOL-USD", 0.0, quantity, 0.0)
+        tracker.track_entry("SOL-USD", 0.0, quantity, 0.0)
+
+        class StaleEPS:
+            def get(self, symbol):
+                return SimpleNamespace(price=2.22, quantity=quantity * 3, source="override")
+
+        class Broker:
+            connected = True
+            position_tracker = tracker
+
+            def get_real_entry_price(self, symbol):
+                return None
+
+            def get_positions(self):
+                return [
+                    {
+                        "symbol": "SOL-USD",
+                        "quantity": quantity,
+                        "current_price": 150.0,
+                        "size_usd": quantity * 150.0,
+                    }
+                ]
+
+        reconciled = startup_sync_module._adopt_broker_positions(
+            Broker(),
+            "platform:kraken",
+            StaleEPS(),
+        )
+        self.assertEqual(reconciled, 1)
+        repaired = tracker.get_position("SOL-USD")
+        self.assertAlmostEqual(repaired["quantity"], quantity, places=8)
+        self.assertAlmostEqual(repaired["entry_price"], entry, places=8)
+
+
+class KrakenEquityCanonicalizationTests(unittest.TestCase):
+    def test_trade_balance_metadata_is_not_classified_as_crypto(self) -> None:
+        payload = {
+            "result": {
+                "eb": "221.6666",
+                "tb": "218.1133",
+                "m": "0.0000",
+                "SOL": "1.0",
+                "ZUSD": "116.09",
+            }
+        }
+        assets = kraken_patch_module._extract_raw_balances(payload)
+        self.assertEqual(assets, {"SOL": 1.0})
+
+    def test_total_equity_uses_max_not_addition(self) -> None:
+        payload = {
+            "ZUSD": "116.09",
+            "usd_held": 3.55,
+            "total_funds": 225.20,
+        }
+        positions = [{"symbol": "SOL-USD", "size_usd": 105.56}]
+        total = kraken_patch_module._payload_total_equity(payload, positions)
+        self.assertAlmostEqual(total, 225.20, places=2)
+
+    def test_wrapped_balance_does_not_recurse_or_mutate_tracker(self) -> None:
+        class ExplodingTracker:
+            def track_entry(self, *args, **kwargs):
+                raise AssertionError("balance hydration must not mutate tracker")
+
+        class KrakenBroker:
+            def __init__(self):
+                self.calls = 0
+                self.connected = True
+                self.position_tracker = ExplodingTracker()
+                self._last_raw_balances = {
+                    "result": {"ZUSD": "116.09", "SOL": "1.0"},
+                    "total_funds": 225.20,
+                }
+
+            def get_account_balance(self):
+                self.calls += 1
+                return 225.20
+
+            def get_positions(self):
+                return []
+
+            def get_current_price(self, symbol):
+                return 105.56
+
+        kraken_patch_module._patch_kraken_class(KrakenBroker)
+        broker = KrakenBroker()
+        self.assertAlmostEqual(broker.get_account_balance(), 225.20, places=2)
+        self.assertEqual(broker.calls, 1)
+        positions = broker.get_positions()
+        self.assertEqual(len(positions), 1)
+        self.assertEqual(positions[0]["symbol"], "SOL-USD")
+
+
+class RecurringPositionSyncTests(unittest.TestCase):
+    def test_late_user_broker_is_reconciled_after_first_platform_sync(self) -> None:
+        calls = []
+
+        def fake_sync(strategy):
+            manager = strategy.multi_account_manager
+            names = sorted(runtime_sync_module._connected_brokers(manager))
+            calls.append(names)
+            for broker in runtime_sync_module._connected_brokers(manager).values():
+                broker._startup_position_sync_adopted = True
+            return len(names)
+
+        fake_startup_module = types.ModuleType("bot.startup_position_sync")
+        fake_startup_module.sync_exchange_positions_on_startup = fake_sync
+
+        class Manager:
+            def __init__(self):
+                self.platform_brokers = {
+                    "kraken": SimpleNamespace(connected=True),
+                }
+                self.user_brokers = {}
+
+            def refresh_capital_authority(self, *args, **kwargs):
+                return {"ready": 1.0, "total_capital": 225.20}
+
+        module = types.ModuleType("bot.multi_account_broker_manager")
+        module.MultiAccountBrokerManager = Manager
+        runtime_sync_module._patch_mabm(module)
+        manager = Manager()
+
+        with patch.dict(
+            sys.modules,
+            {"bot.startup_position_sync": fake_startup_module},
+            clear=False,
+        ), patch.dict(
+            os.environ,
+            {"NIJA_POSITION_SYNC_REFRESH_INTERVAL_S": "30"},
+            clear=False,
+        ):
+            manager.refresh_capital_authority(trigger="platform_ready")
+            self.assertEqual(calls[-1], ["platform:kraken"])
+
+            manager.user_brokers = {
+                "daivon_frazier": {
+                    "kraken": SimpleNamespace(connected=True),
+                }
+            }
+            manager._nija_position_sync_last_attempt_at = 0.0
+            manager.refresh_capital_authority(trigger="user_connected")
+
+        self.assertEqual(
+            calls[-1],
+            ["platform:kraken", "user:daivon_frazier:kraken"],
+        )
+        self.assertTrue(manager._startup_position_sync_done)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Confirmed defects fixed

- Broker position snapshots were passed through additive `track_entry`, multiplying SOL/ETH quantities and diluting average entry prices on repeated balance/position hydration.
- Kraken equity enrichment added crypto value to an account total that already included crypto, inflating capital.
- Kraken balance payload discovery could call the wrapped `get_account_balance` recursively.
- Kraken TradeBalance metadata keys such as `eb`, `tb`, and `m` could be misclassified as assets.
- Startup position sync marked itself complete after platform Kraken synchronized, before late-connected Daivon/Tania brokers were available.
- Legacy diluted prices could be persisted with an `execution` label and no quantity, allowing the corrupted price to override later repair.

## Repairs

- Added exact, idempotent `sync_position_snapshot` reconciliation. Broker quantity replaces the tracked quantity; it is never treated as another fill.
- Preserved additive `track_entry` only for genuine execution fills.
- Added recovery for the observed zero-price dilution pattern by reconstructing cost basis from stored cost divided by actual broker quantity.
- Added a narrow legacy-corruption detector requiring repeated startup-sync additions, broker-owned position state, and a material quantity mismatch before ignoring an old execution-labeled record.
- Separated market value from cost basis in tracked positions.
- Reworked Kraken equity hydration to use the maximum authoritative total instead of adding crypto twice.
- Removed PositionTracker mutation from Kraken balance reads and connection probes.
- Blocked recursive account-balance probing and filtered TradeBalance metadata.
- Added recurring, rate-limited reconciliation so newly connected platform and user brokers are synchronized after startup.
- Installed the repair through the existing broker startup hook.

## Safety

- No risk, signal, profitability, position-cap, exchange-minimum, or writer-authority controls are bypassed.
- Coinbase/OKX authentication failures remain isolated; invalid or missing external credentials are not fabricated in code.
- Kraken remains independently execution-eligible while secondary venues are unavailable.

## Regression coverage added

- duplicate SOL quantity and diluted entry-price recovery;
- stale override entry-price rejection;
- legacy execution-labeled record with missing quantity;
- exact startup reconciliation;
- Kraken equity double-count prevention;
- recursive balance-read prevention;
- no tracker mutation during balance hydration;
- late user-broker reconciliation after platform startup.

## Expected deployment markers

- `POSITION_SNAPSHOT_SYNCED`
- `EXCHANGE_POSITION_SYNC legacy_diluted_entry_ignored`
- `KRAKEN_EQUITY_CANONICAL ... double_count_prevented=true tracker_mutation=false`
- `POSITION_SYNC_RUNTIME_REPAIR_INSTALLED`
- `POSITION_SYNC_RUNTIME_RECONCILE`

## CI infrastructure status

GitHub creates the workflow jobs but terminates them before checkout or test execution. The current preflight job exposes no steps and no log URL (`steps=None`, `logs_url=None`), so the reported Actions failures do not contain an actionable repository-code error.
