### PR TITLE
Enable account-scoped automatic Kraken margin

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -7,15 +7,9 @@ from typing import Any
 logger = logging.getLogger("nija.broker_bool_guard_patch")
 _MARKER = "BROKER_BOOL_GUARD_PATCHED marker=20260705d"
 _METHODS = (
-    "get_candles",
-    "fetch_ohlcv",
-    "get_ohlcv",
-    "get_historical_data",
-    "get_market_data",
-    "get_account_balance",
-    "get_balance",
-    "place_order",
-    "submit_order",
+    "get_candles", "fetch_ohlcv", "get_ohlcv", "get_historical_data",
+    "get_market_data", "get_account_balance", "get_balance", "place_market_order",
+    "place_order", "submit_order",
 )
 
 
@@ -70,24 +64,22 @@ def _install_collector_override(module: Any) -> bool:
             if not _is_adapter(broker):
                 logger.warning(
                     "BROKER_BOOL_GUARD_REJECTED marker=20260705d key=%s source=%s object_type=%s",
-                    key,
-                    source,
-                    type(broker).__name__,
+                    key, source, type(broker).__name__,
                 )
                 return
             candidates[key] = broker
             logger.info(
                 "BROKER_BOOL_GUARD_ACCEPTED marker=20260705d key=%s source=%s object_type=%s",
-                key,
-                source,
-                type(broker).__name__,
+                key, source, type(broker).__name__,
             )
 
         add("explicit", explicit_broker, "explicit")
         owners = [
-            item
-            for item in (apex, getattr(apex, "strategy", None), getattr(apex, "trading_strategy", None))
-            if item is not None
+            item for item in (
+                apex,
+                getattr(apex, "strategy", None),
+                getattr(apex, "trading_strategy", None),
+            ) if item is not None
         ]
         for owner in owners:
             for attr in ("broker_client", "broker", "active_broker"):
@@ -158,9 +150,19 @@ def _install_position_sync_runtime_repair() -> None:
     )
 
 
+def _install_kraken_margin_auto_runtime() -> None:
+    _install_module(
+        "bot.kraken_margin_auto_runtime_patch",
+        "kraken_margin_auto_runtime_patch",
+        "KRAKEN_MARGIN_AUTO_RUNTIME",
+        "20260713-kraken-margin-v1",
+    )
+
+
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
+    _install_kraken_margin_auto_runtime()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/kraken_margin_auto_runtime_patch.py
+++ b/bot/kraken_margin_auto_runtime_patch.py
@@ -1,0 +1,366 @@
+"""Runtime convergence bridge for account-scoped Kraken spot margin.
+
+This patch closes the final dispatch gap: MultiBrokerExecutionRouter previously
+called every live broker with only symbol/side/size, silently discarding leverage
+and reduce-only metadata.  It also installs the Kraken MARGIN capability row and
+preflights explicit leveraged orders so they can never silently downgrade to a
+spot order.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("nija.kraken_margin_auto_runtime")
+_MARKER = "20260713-kraken-margin-v1"
+_ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
+_LOCK = threading.RLock()
+_PATCHED_MODULES: set[tuple[str, int]] = set()
+
+
+def _truthy(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
+
+
+def _is_kraken(broker: Any) -> bool:
+    if broker is None:
+        return False
+    values = [
+        type(broker).__name__,
+        getattr(broker, "NAME", ""),
+        getattr(getattr(broker, "broker_type", None), "value", getattr(broker, "broker_type", "")),
+    ]
+    return any("kraken" in str(value or "").lower() for value in values)
+
+
+def _account_id(broker: Any, metadata: Dict[str, Any]) -> str:
+    for value in (
+        metadata.get("account_id"),
+        getattr(broker, "account_identifier", None),
+        getattr(broker, "account_id", None),
+        getattr(broker, "user_id", None),
+    ):
+        text = str(value or "").strip().lower()
+        if text and text not in {"none", "kraken"}:
+            return text
+    return "platform"
+
+
+def _install_defaults() -> None:
+    os.environ.setdefault("NIJA_KRAKEN_MARGIN_ENABLED", "true")
+    os.environ.setdefault("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", "true")
+    os.environ.setdefault("NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE", "2")
+    os.environ.setdefault("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", "true")
+    os.environ.setdefault("NIJA_KRAKEN_MARGIN_HARD_MAX_LEVERAGE", "3")
+
+
+def _patch_capability_matrix(module: ModuleType) -> bool:
+    matrix = getattr(module, "EXCHANGE_CAPABILITIES", None)
+    market_mode = getattr(module, "MarketMode", None)
+    capability_cls = getattr(module, "ExchangeCapabilities", None)
+    if matrix is None or market_mode is None or capability_cls is None:
+        return False
+    try:
+        margin_mode = market_mode.MARGIN
+        kraken_rows = matrix._capabilities.setdefault("kraken", {})
+        kraken_rows[margin_mode] = capability_cls(
+            broker_name="kraken",
+            market_mode=margin_mode,
+            supports_long=True,
+            supports_short=True,
+            supports_margin=True,
+            supports_leverage=True,
+            max_leverage=3.0,
+            requires_margin_account=False,
+            has_stop_loss=True,
+            has_take_profit=True,
+            has_trailing_stop=False,
+            taker_fee=0.0026,
+            maker_fee=0.0016,
+            spread_cost=0.001,
+        )
+        logger.warning("KRAKEN_MARGIN_CAPABILITY_INSTALLED marker=%s max_leverage=3x", _MARKER)
+        return True
+    except Exception as exc:
+        logger.warning("KRAKEN_MARGIN_CAPABILITY_INSTALL_FAILED marker=%s error=%s", _MARKER, exc)
+        return False
+
+
+def _patch_router(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiBrokerExecutionRouter", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_dispatch_direct_broker_market_order", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_kraken_margin_dispatch_v1", False):
+        return True
+    original = current
+
+    @staticmethod
+    def dispatch_direct_broker_market_order(
+        broker: Any,
+        *,
+        symbol: str,
+        side: str,
+        size_usd: float,
+        metadata: Dict[str, Any],
+    ):
+        meta = dict(metadata or {})
+        leverage = int(float(meta.get("leverage") or 1))
+        if not _is_kraken(broker) or leverage <= 1:
+            return original(
+                broker,
+                symbol=symbol,
+                side=side,
+                size_usd=size_usd,
+                metadata=meta,
+            )
+
+        reduce_only = bool(meta.get("reduce_only") is True)
+        account_id = _account_id(broker, meta)
+        try:
+            from bot.kraken_margin_engine import get_margin_engine
+            engine = get_margin_engine(account_id=account_id, adapter=broker)
+            allowed, reason = engine.is_margin_trade_allowed(
+                is_reducing=reduce_only,
+                adapter=broker,
+            )
+            pair_values = engine.get_pair_leverages(symbol, side, adapter=broker)
+            if not allowed:
+                raise RuntimeError(f"Kraken margin blocked: {reason}")
+            if leverage not in pair_values:
+                raise RuntimeError(
+                    f"Kraken margin blocked: pair leverage {leverage}x unavailable; advertised={pair_values or 'none'}"
+                )
+        except Exception as exc:
+            logger.error(
+                "KRAKEN_MARGIN_DISPATCH_BLOCKED marker=%s account=%s symbol=%s side=%s leverage=%sx "
+                "reduce_only=%s reason=%s spot_fallback=false",
+                _MARKER, account_id, symbol, side, leverage, reduce_only, exc,
+            )
+            raise
+
+        submit = getattr(broker, "place_market_order", None)
+        if not callable(submit):
+            raise RuntimeError(f"Broker {broker!r} has no place_market_order method")
+        logger.critical(
+            "KRAKEN_MARGIN_ORDER_COMPILED marker=%s account=%s symbol=%s side=%s notional=$%.2f "
+            "leverage=%sx reduce_only=%s fields=leverage,reduce_only margin_mode_payload=false",
+            _MARKER, account_id, symbol, side, float(size_usd), leverage, reduce_only,
+        )
+        result = submit(
+            symbol,
+            side,
+            float(size_usd),
+            size_type="quote",
+            leverage=leverage,
+            reduce_only=reduce_only,
+            margin_mode=None,
+        )
+        if isinstance(result, tuple) and len(result) >= 2:
+            return float(result[0] or 0.0), float(result[1] or size_usd)
+        if not isinstance(result, dict):
+            raise RuntimeError(f"Unsupported Kraken margin response: {result!r}")
+        status = str(result.get("status") or result.get("state") or "").strip().lower()
+        if status in {"error", "failed", "rejected", "canceled", "cancelled"}:
+            raise RuntimeError(str(result.get("error") or result.get("message") or status))
+        fill_price = float(
+            result.get("filled_price")
+            or result.get("average_filled_price")
+            or result.get("average_fill_price")
+            or result.get("avg_price")
+            or result.get("price")
+            or meta.get("price_hint_usd")
+            or 0.0
+        )
+        filled_usd = float(
+            result.get("filled_size_usd")
+            or result.get("filled_value")
+            or result.get("notional_usd")
+            or result.get("size_usd")
+            or size_usd
+        )
+        order_id = result.get("order_id") or result.get("id") or result.get("exchange_order_id")
+        if fill_price <= 0 and not order_id:
+            raise RuntimeError(f"Kraken margin order acknowledged without fill price/order id: {result!r}")
+        if fill_price <= 0:
+            fill_price = float(meta.get("price_hint_usd") or 0.0)
+        logger.critical(
+            "KRAKEN_MARGIN_ORDER_ACK marker=%s account=%s symbol=%s leverage=%sx reduce_only=%s "
+            "status=%s order_id=%s",
+            _MARKER, account_id, symbol, leverage, reduce_only, status or "ack", order_id,
+        )
+        return fill_price, filled_usd
+
+    setattr(dispatch_direct_broker_market_order, "_nija_kraken_margin_dispatch_v1", True)
+    setattr(dispatch_direct_broker_market_order, "__wrapped__", original)
+    setattr(cls, "_dispatch_direct_broker_market_order", dispatch_direct_broker_market_order)
+    logger.warning("KRAKEN_MARGIN_ROUTER_BRIDGE_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_kraken_adapter(module: ModuleType) -> bool:
+    patched = False
+    for name in dir(module):
+        cls = getattr(module, name, None)
+        if not isinstance(cls, type) or "kraken" not in name.lower():
+            continue
+        current = getattr(cls, "place_market_order", None)
+        if not callable(current) or getattr(current, "_nija_kraken_margin_fail_closed_v1", False):
+            continue
+        original = current
+
+        def place_market_order(
+            self: Any,
+            symbol: str,
+            side: str,
+            size: float,
+            size_type: str = "quote",
+            leverage: int = 1,
+            reduce_only: Optional[bool] = None,
+            margin_mode: Optional[str] = None,
+            _original=original,
+        ):
+            lev = min(3, max(1, int(float(leverage or 1))))
+            if lev > 1:
+                explicit_reduce = bool(reduce_only is True)
+                account = _account_id(self, {})
+                try:
+                    from bot.kraken_margin_engine import get_margin_engine
+                    engine = get_margin_engine(account_id=account, adapter=self)
+                    allowed, reason = engine.is_margin_trade_allowed(
+                        is_reducing=explicit_reduce,
+                        adapter=self,
+                    )
+                    pair_values = engine.get_pair_leverages(symbol, side, adapter=self)
+                    if not allowed or lev not in pair_values:
+                        detail = reason if not allowed else f"pair_leverage_unavailable:{pair_values or 'none'}"
+                        logger.error(
+                            "KRAKEN_MARGIN_ADAPTER_BLOCKED marker=%s account=%s symbol=%s side=%s "
+                            "leverage=%sx reduce_only=%s reason=%s spot_fallback=false",
+                            _MARKER, account, symbol, side, lev, explicit_reduce, detail,
+                        )
+                        return {
+                            "order_id": None,
+                            "symbol": symbol,
+                            "side": side,
+                            "size": size,
+                            "status": "error",
+                            "error": f"KRAKEN_MARGIN_BLOCKED:{detail}",
+                            "leverage": lev,
+                            "spot_fallback": False,
+                        }
+                except Exception as exc:
+                    return {
+                        "order_id": None,
+                        "symbol": symbol,
+                        "side": side,
+                        "size": size,
+                        "status": "error",
+                        "error": f"KRAKEN_MARGIN_PREFLIGHT_FAILED:{exc}",
+                        "leverage": lev,
+                        "spot_fallback": False,
+                    }
+                # Kraken AddOrder accepts leverage and reduce_only, not a
+                # cross/isolated margin_mode field.  Keep margin_mode internal.
+                return _original(
+                    self,
+                    symbol,
+                    side,
+                    size,
+                    size_type=size_type,
+                    leverage=lev,
+                    reduce_only=explicit_reduce,
+                    margin_mode=None,
+                )
+            return _original(
+                self,
+                symbol,
+                side,
+                size,
+                size_type=size_type,
+                leverage=1,
+                reduce_only=reduce_only,
+                margin_mode=None,
+            )
+
+        setattr(place_market_order, "_nija_kraken_margin_fail_closed_v1", True)
+        setattr(place_market_order, "__wrapped__", original)
+        setattr(cls, "place_market_order", place_market_order)
+        patched = True
+        logger.warning("KRAKEN_MARGIN_ADAPTER_FAIL_CLOSED_PATCHED marker=%s class=%s", _MARKER, name)
+    return patched
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    with _LOCK:
+        if key in _PATCHED_MODULES:
+            return True
+        name = str(getattr(module, "__name__", ""))
+        patched = False
+        if name.endswith("exchange_capabilities"):
+            patched = _patch_capability_matrix(module) or patched
+        if name.endswith("multi_broker_execution_router"):
+            patched = _patch_router(module) or patched
+        if name.endswith(("broker_integration", "kraken_broker", "broker_manager")):
+            patched = _patch_kraken_adapter(module) or patched
+        if patched:
+            _PATCHED_MODULES.add(key)
+        return patched
+
+
+def _patch_loaded() -> None:
+    for name, module in list(sys.modules.items()):
+        if isinstance(module, ModuleType) and name.endswith(
+            ("exchange_capabilities", "multi_broker_execution_router", "broker_integration", "kraken_broker", "broker_manager")
+        ):
+            try:
+                _patch_module(module)
+            except Exception as exc:
+                logger.debug("KRAKEN_MARGIN_PATCH_WAIT module=%s error=%s", name, exc)
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _install_defaults()
+    _patch_loaded()
+    if _ORIGINAL_IMPORT is not None:
+        return
+    _ORIGINAL_IMPORT = builtins.__import__
+    local = threading.local()
+
+    def import_hook(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+        if getattr(local, "active", False):
+            return module
+        local.active = True
+        try:
+            _patch_loaded()
+        finally:
+            local.active = False
+        return module
+
+    builtins.__import__ = import_hook  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical(
+        "KRAKEN_MARGIN_AUTO_RUNTIME_INSTALLED marker=%s enabled=%s auto=%s default_leverage=%s hard_max=3x long_only=%s",
+        _MARKER,
+        os.environ.get("NIJA_KRAKEN_MARGIN_ENABLED"),
+        os.environ.get("NIJA_KRAKEN_AUTO_MARGIN_ENABLED"),
+        os.environ.get("NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE"),
+        os.environ.get("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY"),
+    )
+
+
+__all__ = ["install_import_hook"]

--- a/bot/kraken_margin_auto_runtime_patch.py
+++ b/bot/kraken_margin_auto_runtime_patch.py
@@ -1,11 +1,4 @@
-"""Runtime convergence bridge for account-scoped Kraken spot margin.
-
-This patch closes the final dispatch gap: MultiBrokerExecutionRouter previously
-called every live broker with only symbol/side/size, silently discarding leverage
-and reduce-only metadata.  It also installs the Kraken MARGIN capability row and
-preflights explicit leveraged orders so they can never silently downgrade to a
-spot order.
-"""
+"""Runtime convergence bridge for account-scoped Kraken spot margin."""
 
 from __future__ import annotations
 
@@ -24,21 +17,14 @@ _LOCK = threading.RLock()
 _PATCHED_MODULES: set[tuple[str, int]] = set()
 
 
-def _truthy(name: str, default: bool = False) -> bool:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return str(raw).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
-
-
 def _is_kraken(broker: Any) -> bool:
     if broker is None:
         return False
-    values = [
+    values = (
         type(broker).__name__,
         getattr(broker, "NAME", ""),
         getattr(getattr(broker, "broker_type", None), "value", getattr(broker, "broker_type", "")),
-    ]
+    )
     return any("kraken" in str(value or "").lower() for value in values)
 
 
@@ -70,11 +56,10 @@ def _patch_capability_matrix(module: ModuleType) -> bool:
     if matrix is None or market_mode is None or capability_cls is None:
         return False
     try:
-        margin_mode = market_mode.MARGIN
-        kraken_rows = matrix._capabilities.setdefault("kraken", {})
-        kraken_rows[margin_mode] = capability_cls(
+        mode = market_mode.MARGIN
+        matrix._capabilities.setdefault("kraken", {})[mode] = capability_cls(
             broker_name="kraken",
-            market_mode=margin_mode,
+            market_mode=mode,
             supports_long=True,
             supports_short=True,
             supports_margin=True,
@@ -95,6 +80,36 @@ def _patch_capability_matrix(module: ModuleType) -> bool:
         return False
 
 
+def _normalize_margin_result(result: Any, *, size_usd: float, metadata: Dict[str, Any]) -> tuple[float, float]:
+    if isinstance(result, tuple) and len(result) >= 2:
+        return float(result[0] or 0.0), float(result[1] or size_usd)
+    if not isinstance(result, dict):
+        raise RuntimeError(f"Unsupported Kraken margin response: {result!r}")
+    status = str(result.get("status") or result.get("state") or "").strip().lower()
+    if status in {"error", "failed", "rejected", "canceled", "cancelled"}:
+        raise RuntimeError(str(result.get("error") or result.get("message") or status))
+    fill_price = float(
+        result.get("filled_price")
+        or result.get("average_filled_price")
+        or result.get("average_fill_price")
+        or result.get("avg_price")
+        or result.get("price")
+        or metadata.get("price_hint_usd")
+        or 0.0
+    )
+    filled_usd = float(
+        result.get("filled_size_usd")
+        or result.get("filled_value")
+        or result.get("notional_usd")
+        or result.get("size_usd")
+        or size_usd
+    )
+    order_id = result.get("order_id") or result.get("id") or result.get("exchange_order_id")
+    if fill_price <= 0 and not order_id:
+        raise RuntimeError(f"Kraken margin order acknowledged without fill price/order id: {result!r}")
+    return fill_price, filled_usd
+
+
 def _patch_router(module: ModuleType) -> bool:
     cls = getattr(module, "MultiBrokerExecutionRouter", None)
     if not isinstance(cls, type):
@@ -106,7 +121,6 @@ def _patch_router(module: ModuleType) -> bool:
         return True
     original = current
 
-    @staticmethod
     def dispatch_direct_broker_market_order(
         broker: Any,
         *,
@@ -114,9 +128,9 @@ def _patch_router(module: ModuleType) -> bool:
         side: str,
         size_usd: float,
         metadata: Dict[str, Any],
-    ):
+    ) -> tuple[float, float]:
         meta = dict(metadata or {})
-        leverage = int(float(meta.get("leverage") or 1))
+        leverage = min(3, max(1, int(float(meta.get("leverage") or 1))))
         if not _is_kraken(broker) or leverage <= 1:
             return original(
                 broker,
@@ -126,85 +140,60 @@ def _patch_router(module: ModuleType) -> bool:
                 metadata=meta,
             )
 
-        reduce_only = bool(meta.get("reduce_only") is True)
-        account_id = _account_id(broker, meta)
+        reduce_only = meta.get("reduce_only") is True
+        account = _account_id(broker, meta)
         try:
-            from bot.kraken_margin_engine import get_margin_engine
-            engine = get_margin_engine(account_id=account_id, adapter=broker)
+            from bot.kraken_margin_engine import get_margin_engine, margin_account_scope
+            engine = get_margin_engine(account_id=account, adapter=broker)
             allowed, reason = engine.is_margin_trade_allowed(
                 is_reducing=reduce_only,
                 adapter=broker,
             )
             pair_values = engine.get_pair_leverages(symbol, side, adapter=broker)
             if not allowed:
-                raise RuntimeError(f"Kraken margin blocked: {reason}")
+                raise RuntimeError(reason)
             if leverage not in pair_values:
-                raise RuntimeError(
-                    f"Kraken margin blocked: pair leverage {leverage}x unavailable; advertised={pair_values or 'none'}"
+                raise RuntimeError(f"pair_leverage_unavailable:{pair_values or 'none'}")
+            submit = getattr(broker, "place_market_order", None)
+            if not callable(submit):
+                raise RuntimeError(f"Broker {broker!r} has no place_market_order method")
+            logger.critical(
+                "KRAKEN_MARGIN_ORDER_COMPILED marker=%s account=%s symbol=%s side=%s "
+                "notional=$%.2f leverage=%sx reduce_only=%s margin_mode_payload=false",
+                _MARKER, account, symbol, side, float(size_usd), leverage, reduce_only,
+            )
+            with margin_account_scope(account, adapter=broker):
+                result = submit(
+                    symbol,
+                    side,
+                    float(size_usd),
+                    size_type="quote",
+                    leverage=leverage,
+                    reduce_only=reduce_only,
+                    margin_mode=None,
                 )
+            fill_price, filled_usd = _normalize_margin_result(
+                result,
+                size_usd=float(size_usd),
+                metadata=meta,
+            )
+            logger.critical(
+                "KRAKEN_MARGIN_ORDER_ACK marker=%s account=%s symbol=%s leverage=%sx "
+                "reduce_only=%s",
+                _MARKER, account, symbol, leverage, reduce_only,
+            )
+            return fill_price, filled_usd
         except Exception as exc:
             logger.error(
-                "KRAKEN_MARGIN_DISPATCH_BLOCKED marker=%s account=%s symbol=%s side=%s leverage=%sx "
-                "reduce_only=%s reason=%s spot_fallback=false",
-                _MARKER, account_id, symbol, side, leverage, reduce_only, exc,
+                "KRAKEN_MARGIN_DISPATCH_BLOCKED marker=%s account=%s symbol=%s side=%s "
+                "leverage=%sx reduce_only=%s reason=%s spot_fallback=false",
+                _MARKER, account, symbol, side, leverage, reduce_only, exc,
             )
             raise
 
-        submit = getattr(broker, "place_market_order", None)
-        if not callable(submit):
-            raise RuntimeError(f"Broker {broker!r} has no place_market_order method")
-        logger.critical(
-            "KRAKEN_MARGIN_ORDER_COMPILED marker=%s account=%s symbol=%s side=%s notional=$%.2f "
-            "leverage=%sx reduce_only=%s fields=leverage,reduce_only margin_mode_payload=false",
-            _MARKER, account_id, symbol, side, float(size_usd), leverage, reduce_only,
-        )
-        result = submit(
-            symbol,
-            side,
-            float(size_usd),
-            size_type="quote",
-            leverage=leverage,
-            reduce_only=reduce_only,
-            margin_mode=None,
-        )
-        if isinstance(result, tuple) and len(result) >= 2:
-            return float(result[0] or 0.0), float(result[1] or size_usd)
-        if not isinstance(result, dict):
-            raise RuntimeError(f"Unsupported Kraken margin response: {result!r}")
-        status = str(result.get("status") or result.get("state") or "").strip().lower()
-        if status in {"error", "failed", "rejected", "canceled", "cancelled"}:
-            raise RuntimeError(str(result.get("error") or result.get("message") or status))
-        fill_price = float(
-            result.get("filled_price")
-            or result.get("average_filled_price")
-            or result.get("average_fill_price")
-            or result.get("avg_price")
-            or result.get("price")
-            or meta.get("price_hint_usd")
-            or 0.0
-        )
-        filled_usd = float(
-            result.get("filled_size_usd")
-            or result.get("filled_value")
-            or result.get("notional_usd")
-            or result.get("size_usd")
-            or size_usd
-        )
-        order_id = result.get("order_id") or result.get("id") or result.get("exchange_order_id")
-        if fill_price <= 0 and not order_id:
-            raise RuntimeError(f"Kraken margin order acknowledged without fill price/order id: {result!r}")
-        if fill_price <= 0:
-            fill_price = float(meta.get("price_hint_usd") or 0.0)
-        logger.critical(
-            "KRAKEN_MARGIN_ORDER_ACK marker=%s account=%s symbol=%s leverage=%sx reduce_only=%s "
-            "status=%s order_id=%s",
-            _MARKER, account_id, symbol, leverage, reduce_only, status or "ack", order_id,
-        )
-        return fill_price, filled_usd
-
     setattr(dispatch_direct_broker_market_order, "_nija_kraken_margin_dispatch_v1", True)
     setattr(dispatch_direct_broker_market_order, "__wrapped__", original)
-    setattr(cls, "_dispatch_direct_broker_market_order", dispatch_direct_broker_market_order)
+    setattr(cls, "_dispatch_direct_broker_market_order", staticmethod(dispatch_direct_broker_market_order))
     logger.warning("KRAKEN_MARGIN_ROUTER_BRIDGE_PATCHED marker=%s", _MARKER)
     return True
 
@@ -230,69 +219,74 @@ def _patch_kraken_adapter(module: ModuleType) -> bool:
             reduce_only: Optional[bool] = None,
             margin_mode: Optional[str] = None,
             _original=original,
-        ):
+        ) -> Any:
             lev = min(3, max(1, int(float(leverage or 1))))
-            if lev > 1:
-                explicit_reduce = bool(reduce_only is True)
-                account = _account_id(self, {})
-                try:
-                    from bot.kraken_margin_engine import get_margin_engine
-                    engine = get_margin_engine(account_id=account, adapter=self)
-                    allowed, reason = engine.is_margin_trade_allowed(
-                        is_reducing=explicit_reduce,
-                        adapter=self,
-                    )
-                    pair_values = engine.get_pair_leverages(symbol, side, adapter=self)
-                    if not allowed or lev not in pair_values:
-                        detail = reason if not allowed else f"pair_leverage_unavailable:{pair_values or 'none'}"
-                        logger.error(
-                            "KRAKEN_MARGIN_ADAPTER_BLOCKED marker=%s account=%s symbol=%s side=%s "
-                            "leverage=%sx reduce_only=%s reason=%s spot_fallback=false",
-                            _MARKER, account, symbol, side, lev, explicit_reduce, detail,
-                        )
-                        return {
-                            "order_id": None,
-                            "symbol": symbol,
-                            "side": side,
-                            "size": size,
-                            "status": "error",
-                            "error": f"KRAKEN_MARGIN_BLOCKED:{detail}",
-                            "leverage": lev,
-                            "spot_fallback": False,
-                        }
-                except Exception as exc:
-                    return {
-                        "order_id": None,
-                        "symbol": symbol,
-                        "side": side,
-                        "size": size,
-                        "status": "error",
-                        "error": f"KRAKEN_MARGIN_PREFLIGHT_FAILED:{exc}",
-                        "leverage": lev,
-                        "spot_fallback": False,
-                    }
-                # Kraken AddOrder accepts leverage and reduce_only, not a
-                # cross/isolated margin_mode field.  Keep margin_mode internal.
+            if lev <= 1:
                 return _original(
                     self,
                     symbol,
                     side,
                     size,
                     size_type=size_type,
-                    leverage=lev,
-                    reduce_only=explicit_reduce,
+                    leverage=1,
+                    reduce_only=reduce_only,
                     margin_mode=None,
                 )
-            return _original(
-                self,
-                symbol,
-                side,
-                size,
-                size_type=size_type,
-                leverage=1,
-                reduce_only=reduce_only,
-                margin_mode=None,
-            )
+
+            explicit_reduce = reduce_only is True
+            account = _account_id(self, {})
+            try:
+                from bot.kraken_margin_engine import get_margin_engine, margin_account_scope
+                engine = get_margin_engine(account_id=account, adapter=self)
+                allowed, reason = engine.is_margin_trade_allowed(
+                    is_reducing=explicit_reduce,
+                    adapter=self,
+                )
+                pair_values = engine.get_pair_leverages(symbol, side, adapter=self)
+                if not allowed:
+                    detail = reason
+                elif lev not in pair_values:
+                    detail = f"pair_leverage_unavailable:{pair_values or 'none'}"
+                else:
+                    detail = ""
+                if detail:
+                    logger.error(
+                        "KRAKEN_MARGIN_ADAPTER_BLOCKED marker=%s account=%s symbol=%s side=%s "
+                        "leverage=%sx reduce_only=%s reason=%s spot_fallback=false",
+                        _MARKER, account, symbol, side, lev, explicit_reduce, detail,
+                    )
+                    return {
+                        "order_id": None,
+                        "symbol": symbol,
+                        "side": side,
+                        "size": size,
+                        "status": "error",
+                        "error": f"KRAKEN_MARGIN_BLOCKED:{detail}",
+                        "leverage": lev,
+                        "spot_fallback": False,
+                    }
+                with margin_account_scope(account, adapter=self):
+                    return _original(
+                        self,
+                        symbol,
+                        side,
+                        size,
+                        size_type=size_type,
+                        leverage=lev,
+                        reduce_only=explicit_reduce,
+                        margin_mode=None,
+                    )
+            except Exception as exc:
+                return {
+                    "order_id": None,
+                    "symbol": symbol,
+                    "side": side,
+                    "size": size,
+                    "status": "error",
+                    "error": f"KRAKEN_MARGIN_PREFLIGHT_FAILED:{exc}",
+                    "leverage": lev,
+                    "spot_fallback": False,
+                }
 
         setattr(place_market_order, "_nija_kraken_margin_fail_closed_v1", True)
         setattr(place_market_order, "__wrapped__", original)
@@ -321,10 +315,15 @@ def _patch_module(module: ModuleType) -> bool:
 
 
 def _patch_loaded() -> None:
+    suffixes = (
+        "exchange_capabilities",
+        "multi_broker_execution_router",
+        "broker_integration",
+        "kraken_broker",
+        "broker_manager",
+    )
     for name, module in list(sys.modules.items()):
-        if isinstance(module, ModuleType) and name.endswith(
-            ("exchange_capabilities", "multi_broker_execution_router", "broker_integration", "kraken_broker", "broker_manager")
-        ):
+        if isinstance(module, ModuleType) and name.endswith(suffixes):
             try:
                 _patch_module(module)
             except Exception as exc:
@@ -354,7 +353,8 @@ def install_import_hook() -> None:
     builtins.__import__ = import_hook  # type: ignore[assignment]
     _patch_loaded()
     logger.critical(
-        "KRAKEN_MARGIN_AUTO_RUNTIME_INSTALLED marker=%s enabled=%s auto=%s default_leverage=%s hard_max=3x long_only=%s",
+        "KRAKEN_MARGIN_AUTO_RUNTIME_INSTALLED marker=%s enabled=%s auto=%s "
+        "default_leverage=%s hard_max=3x long_only=%s",
         _MARKER,
         os.environ.get("NIJA_KRAKEN_MARGIN_ENABLED"),
         os.environ.get("NIJA_KRAKEN_AUTO_MARGIN_ENABLED"),
@@ -363,4 +363,4 @@ def install_import_hook() -> None:
     )
 
 
-__all__ = ["install_import_hook"]
+__all__ = ["install_import_hook", "_patch_capability_matrix", "_patch_router"]

--- a/bot/kraken_margin_engine.py
+++ b/bot/kraken_margin_engine.py
@@ -417,7 +417,7 @@ class KrakenMarginEngine:
         return {
             "supports_margin": allowed,
             "supports_leverage": allowed,
-            "supports_short": allowed and not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", True),
+            "supports_short": allowed,
             "max_leverage": HARD_MAX_LEVERAGE if allowed else 1,
             "account_id": account_id or self.account_id,
         }

--- a/bot/kraken_margin_engine.py
+++ b/bot/kraken_margin_engine.py
@@ -1,10 +1,4 @@
-"""Account-scoped Kraken margin permission, pair, sizing, and health controls.
-
-NIJA uses this module as the single boundary for Kraken margin admission.  Margin
-is never inferred solely from a global environment flag: the exact account must
-pass private-API permission and TradeBalance health checks, and the exact pair
-must advertise the requested leverage through Kraken AssetPairs.
-"""
+"""Account-scoped Kraken margin permission, pair, sizing, and health controls."""
 
 from __future__ import annotations
 
@@ -22,12 +16,10 @@ try:
 except ImportError:  # pragma: no cover
     from kraken_error_taxonomy import is_permission_error  # type: ignore[import]
 
-
 KRAKEN_MIN_LEVERAGE = 2
 HARD_MAX_LEVERAGE = 3
-MAINTENANCE_MARGIN_RATIO_FLOOR = 0.20  # 200% Kraken margin level
-CRITICAL_MARGIN_RATIO_FLOOR = 0.10     # 100% Kraken margin level
-
+MAINTENANCE_MARGIN_RATIO_FLOOR = 0.20
+CRITICAL_MARGIN_RATIO_FLOOR = 0.10
 _PERMISSION_CACHE_TTL_SECONDS = 300.0
 _HEALTH_CACHE_TTL_SECONDS = 15.0
 _PAIR_CACHE_TTL_SECONDS = 1800.0
@@ -104,9 +96,7 @@ class KrakenMarginEngine:
     @staticmethod
     def _to_float(value: Any, default: float = 0.0) -> float:
         try:
-            if value is None:
-                return default
-            parsed = float(value)
+            parsed = float(value if value is not None else default)
             return parsed if parsed == parsed else default
         except (TypeError, ValueError, OverflowError):
             return default
@@ -123,19 +113,39 @@ class KrakenMarginEngine:
 
     @staticmethod
     def _normalise_pair(symbol: str) -> str:
-        text = str(symbol or "").upper().strip().replace("/", "").replace("-", "").replace("_", "")
-        if text.startswith("BTC"):
-            text = "XBT" + text[3:]
-        if text.endswith("ZUSD"):
-            return text
-        if text.endswith("USD"):
-            return text[:-3] + "USD"
-        return text
+        pair = str(symbol or "").upper().strip().replace("/", "").replace("-", "").replace("_", "")
+        if pair.startswith("BTC"):
+            pair = "XBT" + pair[3:]
+        return pair
+
+    def _resolve_adapter(self, adapter: Any = None) -> Any:
+        resolved = adapter if adapter is not None else self._adapter
+        if adapter is not None:
+            self.bind_adapter(adapter)
+        return resolved
+
+    @staticmethod
+    def _public_api_call(adapter: Any, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Call Kraken public API without private nonce or writer-authority gates."""
+        custom = getattr(adapter, "_kraken_public_api_call", None)
+        if callable(custom):
+            result = custom(method, params or {})
+            return result if isinstance(result, dict) else {}
+        api = getattr(adapter, "api", None)
+        query_public = getattr(api, "query_public", None)
+        if callable(query_public):
+            result = query_public(method, params or {})
+            return result if isinstance(result, dict) else {}
+        query_public = getattr(adapter, "query_public", None)
+        if callable(query_public):
+            result = query_public(method, params or {})
+            return result if isinstance(result, dict) else {}
+        raise RuntimeError("Kraken public API unavailable")
 
     def invalidate_permission_cache(self) -> None:
         with self._lock:
-            self._permission_checked_at = 0.0
             self._permission_state = MarginPermissionState.UNKNOWN
+            self._permission_checked_at = 0.0
 
     def invalidate_health_cache(self) -> None:
         with self._lock:
@@ -146,14 +156,7 @@ class KrakenMarginEngine:
         with self._lock:
             self._pair_cache.clear()
 
-    def _resolve_adapter(self, adapter: Any = None) -> Any:
-        resolved = adapter if adapter is not None else self._adapter
-        if adapter is not None:
-            self.bind_adapter(adapter)
-        return resolved
-
     def check_permissions(self, adapter: Any = None) -> MarginPermissionState:
-        """Confirm that this exact Kraken account can access private trade state."""
         adapter = self._resolve_adapter(adapter)
         if adapter is None:
             return self._permission_state
@@ -166,15 +169,11 @@ class KrakenMarginEngine:
                 return self._permission_state
         try:
             response = adapter._kraken_api_call("OpenPositions", {"docalcs": "true"})
-            errors = response.get("error") or [] if isinstance(response, dict) else []
+            errors = (response.get("error") or []) if isinstance(response, dict) else []
             if isinstance(errors, str):
                 errors = [errors]
             if errors:
-                state = (
-                    MarginPermissionState.DENIED
-                    if any(is_permission_error(error) for error in errors)
-                    else MarginPermissionState.CHECK_FAILED
-                )
+                state = MarginPermissionState.DENIED if any(is_permission_error(err) for err in errors) else MarginPermissionState.CHECK_FAILED
             else:
                 state = MarginPermissionState.CONFIRMED
         except Exception:
@@ -190,15 +189,14 @@ class KrakenMarginEngine:
         parsed = set()
         for item in values:
             try:
-                lev = int(float(item))
+                leverage = int(float(item))
             except (TypeError, ValueError, OverflowError):
                 continue
-            if KRAKEN_MIN_LEVERAGE <= lev <= HARD_MAX_LEVERAGE:
-                parsed.add(lev)
+            if KRAKEN_MIN_LEVERAGE <= leverage <= HARD_MAX_LEVERAGE:
+                parsed.add(leverage)
         return tuple(sorted(parsed))
 
     def get_pair_leverages(self, symbol: str, side: str, adapter: Any = None) -> Tuple[int, ...]:
-        """Return live Kraken-advertised leverage values for the exact pair/side."""
         adapter = self._resolve_adapter(adapter)
         side_key = "sell" if str(side or "").lower() in {"sell", "short"} else "buy"
         pair = self._normalise_pair(symbol)
@@ -211,18 +209,16 @@ class KrakenMarginEngine:
         if adapter is None:
             return ()
         try:
-            response = adapter._kraken_api_call("AssetPairs", {"pair": pair})
-            errors = response.get("error") or [] if isinstance(response, dict) else []
+            response = self._public_api_call(adapter, "AssetPairs", {"pair": pair})
+            errors = (response.get("error") or []) if isinstance(response, dict) else []
             result = response.get("result", {}) if isinstance(response, dict) else {}
-            if errors or not isinstance(result, dict):
-                leverages: Tuple[int, ...] = ()
-            else:
-                merged = set()
+            merged = set()
+            if not errors and isinstance(result, dict):
                 field = "leverage_sell" if side_key == "sell" else "leverage_buy"
-                for item in result.values():
-                    if isinstance(item, dict):
-                        merged.update(self._parse_leverage_values(item.get(field, [])))
-                leverages = tuple(sorted(merged))
+                for row in result.values():
+                    if isinstance(row, dict):
+                        merged.update(self._parse_leverage_values(row.get(field, [])))
+            leverages = tuple(sorted(merged))
         except Exception:
             leverages = ()
         with self._lock:
@@ -230,11 +226,10 @@ class KrakenMarginEngine:
         return leverages
 
     def get_pair_max_leverage(self, symbol: str, side: str, adapter: Any = None) -> int:
-        values = self.get_pair_leverages(symbol, side, adapter=adapter)
-        return max(values) if values else 1
+        leverages = self.get_pair_leverages(symbol, side, adapter=adapter)
+        return max(leverages) if leverages else 1
 
     def build_order_margin_params(self, leverage: Any, *, is_reducing: bool = False) -> dict[str, Any]:
-        """Return only fields accepted by Kraken AddOrder for spot margin."""
         if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True):
             return {}
         lev = self._clamp_leverage(leverage)
@@ -242,7 +237,7 @@ class KrakenMarginEngine:
         if lev >= KRAKEN_MIN_LEVERAGE:
             params["leverage"] = str(lev)
         if is_reducing:
-            params["reduce_only"] = True
+            params["reduce_only"] = "true"
         return params
 
     def compute_leveraged_notional(
@@ -253,24 +248,23 @@ class KrakenMarginEngine:
         account_equity_usd: float,
         buying_power_usd: Optional[float] = None,
     ) -> float:
-        """Scale a risk-approved spot size while preserving the hard 3× equity cap."""
         lev = self._clamp_leverage(leverage)
         if lev < KRAKEN_MIN_LEVERAGE:
             lev = 1
-        raw_notional = max(0.0, float(spot_size_usd or 0.0)) * lev
+        raw = max(0.0, float(spot_size_usd or 0.0)) * lev
         equity_cap = max(0.0, float(account_equity_usd or 0.0)) * HARD_MAX_LEVERAGE
         if equity_cap <= 0:
             return 0.0
         cap = equity_cap
         if buying_power_usd is not None and float(buying_power_usd or 0.0) > 0:
             cap = min(cap, float(buying_power_usd))
-        return min(raw_notional, cap)
+        return min(raw, cap)
 
     def _build_snapshot(self, adapter: Any) -> MarginHealthSnapshot:
         response = adapter._kraken_api_call("TradeBalance", {"asset": "ZUSD"})
-        errors = response.get("error") or [] if isinstance(response, dict) else []
+        errors = (response.get("error") or []) if isinstance(response, dict) else []
         if errors:
-            raise RuntimeError("TradeBalance rejected: " + ", ".join(str(x) for x in errors))
+            raise RuntimeError("TradeBalance rejected: " + ", ".join(str(item) for item in errors))
         data = response.get("result", {}) if isinstance(response, dict) else {}
         eb = self._to_float(data.get("eb"))
         tb = self._to_float(data.get("tb"))
@@ -280,26 +274,21 @@ class KrakenMarginEngine:
         pnl = self._to_float(data.get("n"))
         equivalent = self._to_float(data.get("e"), eb)
         borrowed = max(self._total_borrowed_usd, mo)
-        enabled = self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True)
-        permission = self._permission_state.value
         if mo <= 0 and ml <= 0:
-            maintenance_ok = True
-            critical = False
-            reason = "no_margin_positions"
+            maintenance_ok, critical, reason = True, False, "no_margin_positions"
         else:
-            maintenance_floor_pct = MAINTENANCE_MARGIN_RATIO_FLOOR * 1000.0
-            critical_floor_pct = CRITICAL_MARGIN_RATIO_FLOOR * 1000.0
-            critical = ml > 0 and ml < critical_floor_pct
-            maintenance_ok = ml == 0 or ml >= maintenance_floor_pct
-            if critical:
-                reason = f"critical_margin_level:{ml:.1f}%"
-            elif not maintenance_ok:
-                reason = f"low_margin_level:{ml:.1f}%"
-            else:
-                reason = f"margin_healthy:{ml:.1f}%"
+            maintenance_floor = MAINTENANCE_MARGIN_RATIO_FLOOR * 1000.0
+            critical_floor = CRITICAL_MARGIN_RATIO_FLOOR * 1000.0
+            critical = ml > 0 and ml < critical_floor
+            maintenance_ok = ml == 0 or ml >= maintenance_floor
+            reason = (
+                f"critical_margin_level:{ml:.1f}%" if critical
+                else f"low_margin_level:{ml:.1f}%" if not maintenance_ok
+                else f"margin_healthy:{ml:.1f}%"
+            )
         return MarginHealthSnapshot(
             timestamp=time.time(),
-            permission_state=permission,
+            permission_state=self._permission_state.value,
             equivalent_balance_usd=equivalent,
             trade_balance_free_usd=tb,
             margin_level_pct=ml,
@@ -307,7 +296,7 @@ class KrakenMarginEngine:
             free_margin_usd=mf,
             unrealised_pnl_usd=pnl,
             borrowed_exposure_usd=borrowed,
-            is_margin_enabled=enabled,
+            is_margin_enabled=self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
             maintenance_margin_ok=maintenance_ok,
             critical_margin_breach=critical,
             reason=reason,
@@ -324,36 +313,18 @@ class KrakenMarginEngine:
                 snapshot = self._build_snapshot(adapter)
             except Exception as exc:
                 snapshot = MarginHealthSnapshot(
-                    timestamp=now,
-                    permission_state=self._permission_state.value,
-                    equivalent_balance_usd=0.0,
-                    trade_balance_free_usd=0.0,
-                    margin_level_pct=0.0,
-                    margin_obligation_usd=0.0,
-                    free_margin_usd=0.0,
-                    unrealised_pnl_usd=0.0,
-                    borrowed_exposure_usd=self._total_borrowed_usd,
-                    is_margin_enabled=self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
-                    maintenance_margin_ok=False,
-                    critical_margin_breach=False,
-                    reason=f"health_check_failed:{exc}",
+                    now, self._permission_state.value, 0.0, 0.0, 0.0, 0.0, 0.0,
+                    0.0, self._total_borrowed_usd,
+                    self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
+                    False, False, f"health_check_failed:{exc}",
                 )
         else:
             exposure = self.get_exposure_snapshot()
             snapshot = MarginHealthSnapshot(
-                timestamp=now,
-                permission_state=self._permission_state.value,
-                equivalent_balance_usd=0.0,
-                trade_balance_free_usd=0.0,
-                margin_level_pct=0.0,
-                margin_obligation_usd=0.0,
-                free_margin_usd=0.0,
-                unrealised_pnl_usd=0.0,
-                borrowed_exposure_usd=exposure["total_borrowed_usd"],
-                is_margin_enabled=self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
-                maintenance_margin_ok=exposure["position_count"] <= 0,
-                critical_margin_breach=False,
-                reason="no_bound_adapter" if self._adapter is None else "cached_adapter_unavailable",
+                now, self._permission_state.value, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, exposure["total_borrowed_usd"],
+                self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
+                exposure["position_count"] <= 0, False, "no_bound_adapter",
             )
         with self._lock:
             self._last_snapshot = snapshot
@@ -366,15 +337,14 @@ class KrakenMarginEngine:
         adapter = self._resolve_adapter(adapter)
         if adapter is not None:
             self.check_permissions(adapter)
-        state = self._permission_state
-        if state == MarginPermissionState.DENIED:
+        if self._permission_state == MarginPermissionState.DENIED:
             return False, "permission_denied"
-        if state == MarginPermissionState.CHECK_FAILED:
+        if self._permission_state == MarginPermissionState.CHECK_FAILED:
             return False, "permission_check_failed"
-        if state != MarginPermissionState.CONFIRMED:
+        if self._permission_state != MarginPermissionState.CONFIRMED:
             return False, "permission_unknown"
         snapshot = self.get_health_snapshot(adapter=adapter)
-        if str(snapshot.reason).startswith("health_check_failed"):
+        if snapshot.reason.startswith("health_check_failed"):
             return False, snapshot.reason
         if snapshot.critical_margin_breach:
             return False, f"critical_margin:{snapshot.reason}"
@@ -393,50 +363,39 @@ class KrakenMarginEngine:
         requested_leverage: Any = None,
         is_reducing: bool = False,
     ) -> MarginAdmissionPlan:
-        """Build a live, account-and-pair-qualified margin plan.
-
-        Automatic margin is long-only by default.  Existing margin exits may pass
-        ``is_reducing=True`` and retain their ledger leverage separately.
-        """
         self.bind_adapter(adapter)
         side_norm = "sell" if str(side or "").lower() in {"sell", "short"} else "buy"
         spot = max(0.0, self._to_float(spot_size_usd))
-        desired = requested_leverage
-        if desired is None:
-            desired = os.getenv("NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE", "2")
+        desired = requested_leverage if requested_leverage is not None else os.getenv("NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE", "2")
         leverage = self._clamp_leverage(desired)
-        base_plan = dict(
-            account_id=self.account_id,
-            symbol=str(symbol or ""),
-            side=side_norm,
-            leverage=leverage,
-            spot_notional_usd=spot,
-            leveraged_notional_usd=spot,
-            buying_power_usd=max(0.0, self._to_float(account_equity_usd)),
-            margin_mode="cross",
-            reduce_only=bool(is_reducing),
-        )
-        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True):
-            return MarginAdmissionPlan(False, reason="margin_disabled", pair_max_leverage=1, **base_plan)
-        if not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", default=True) and requested_leverage is None:
-            return MarginAdmissionPlan(False, reason="auto_margin_disabled", pair_max_leverage=1, **base_plan)
+        base = {
+            "account_id": self.account_id,
+            "symbol": str(symbol or ""),
+            "side": side_norm,
+            "leverage": leverage,
+            "spot_notional_usd": spot,
+            "leveraged_notional_usd": spot,
+            "buying_power_usd": max(0.0, self._to_float(account_equity_usd)),
+            "margin_mode": "cross",
+            "reduce_only": bool(is_reducing),
+        }
+        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", True):
+            return MarginAdmissionPlan(False, reason="margin_disabled", pair_max_leverage=1, **base)
+        if requested_leverage is None and not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", True):
+            return MarginAdmissionPlan(False, reason="auto_margin_disabled", pair_max_leverage=1, **base)
         if leverage < KRAKEN_MIN_LEVERAGE:
-            return MarginAdmissionPlan(False, reason="spot_leverage_requested", pair_max_leverage=1, **base_plan)
-        if side_norm == "sell" and not is_reducing and self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", default=True):
-            return MarginAdmissionPlan(False, reason="auto_margin_long_only", pair_max_leverage=1, **base_plan)
+            return MarginAdmissionPlan(False, reason="spot_leverage_requested", pair_max_leverage=1, **base)
+        if side_norm == "sell" and not is_reducing and self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", True):
+            return MarginAdmissionPlan(False, reason="auto_margin_long_only", pair_max_leverage=1, **base)
         allowed, reason = self.is_margin_trade_allowed(is_reducing=is_reducing, adapter=adapter)
         if not allowed:
-            return MarginAdmissionPlan(False, reason=reason, pair_max_leverage=1, **base_plan)
+            return MarginAdmissionPlan(False, reason=reason, pair_max_leverage=1, **base)
         pair_values = self.get_pair_leverages(symbol, side_norm, adapter=adapter)
         pair_max = max(pair_values) if pair_values else 1
         if leverage not in pair_values:
-            return MarginAdmissionPlan(False, reason=f"pair_leverage_unavailable:{pair_values or 'none'}", pair_max_leverage=pair_max, **base_plan)
+            return MarginAdmissionPlan(False, reason=f"pair_leverage_unavailable:{pair_values or 'none'}", pair_max_leverage=pair_max, **base)
         snapshot = self.get_health_snapshot(adapter=adapter)
-        equity = max(
-            self._to_float(account_equity_usd),
-            snapshot.equivalent_balance_usd,
-            snapshot.trade_balance_free_usd,
-        )
+        equity = max(self._to_float(account_equity_usd), snapshot.equivalent_balance_usd, snapshot.trade_balance_free_usd)
         collateral = snapshot.free_margin_usd or snapshot.trade_balance_free_usd or equity
         buying_power = max(0.0, collateral * leverage)
         leveraged = self.compute_leveraged_notional(
@@ -446,20 +405,11 @@ class KrakenMarginEngine:
             buying_power_usd=buying_power,
         )
         if leveraged <= 0:
-            return MarginAdmissionPlan(False, reason="no_margin_buying_power", pair_max_leverage=pair_max, **base_plan)
+            return MarginAdmissionPlan(False, reason="no_margin_buying_power", pair_max_leverage=pair_max, **base)
         return MarginAdmissionPlan(
-            allowed=True,
-            account_id=self.account_id,
-            symbol=str(symbol or ""),
-            side=side_norm,
-            leverage=leverage,
-            spot_notional_usd=spot,
-            leveraged_notional_usd=leveraged,
-            buying_power_usd=buying_power,
-            margin_mode="cross",
-            reduce_only=bool(is_reducing),
-            reason=f"margin_eligible:{reason}",
-            pair_max_leverage=pair_max,
+            True, self.account_id, str(symbol or ""), side_norm, leverage, spot,
+            leveraged, buying_power, "cross", bool(is_reducing),
+            f"margin_eligible:{reason}", pair_max,
         )
 
     def get_runtime_capability_overrides(self, account_id: Optional[str] = None) -> Dict[str, Any]:
@@ -467,7 +417,7 @@ class KrakenMarginEngine:
         return {
             "supports_margin": allowed,
             "supports_leverage": allowed,
-            "supports_short": allowed and not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", default=True),
+            "supports_short": allowed and not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", True),
             "max_leverage": HARD_MAX_LEVERAGE if allowed else 1,
             "account_id": account_id or self.account_id,
         }
@@ -477,31 +427,32 @@ class KrakenMarginEngine:
         if lev < KRAKEN_MIN_LEVERAGE:
             return 0.0
         notional = max(0.0, float(notional_usd or 0.0))
-        return max(0.0, notional - (notional / lev))
+        return max(0.0, notional - notional / lev)
 
     def record_open_position(self, *, notional_usd: float, leverage: Any) -> None:
         with self._lock:
             self._total_notional_usd += max(0.0, float(notional_usd or 0.0))
             self._total_borrowed_usd += self._borrowed_amount(notional_usd, leverage)
             self._position_count += 1.0
-            self.invalidate_health_cache()
+            self._last_snapshot = None
+            self._snapshot_ts = 0.0
 
     def record_closed_position(self, *, notional_usd: float, leverage: Any) -> None:
         with self._lock:
             self._total_notional_usd = max(0.0, self._total_notional_usd - max(0.0, float(notional_usd or 0.0)))
             self._total_borrowed_usd = max(0.0, self._total_borrowed_usd - self._borrowed_amount(notional_usd, leverage))
             self._position_count = max(0.0, self._position_count - 1.0)
-            self.invalidate_health_cache()
+            self._last_snapshot = None
+            self._snapshot_ts = 0.0
 
     def get_exposure_snapshot(self) -> dict[str, float]:
         with self._lock:
             equity = max(0.0, self._total_notional_usd - self._total_borrowed_usd)
-            net_leverage = self._total_notional_usd / equity if equity > 0 else 0.0
             return {
                 "total_notional_usd": self._total_notional_usd,
                 "total_borrowed_usd": self._total_borrowed_usd,
                 "position_count": self._position_count,
-                "net_leverage": net_leverage,
+                "net_leverage": self._total_notional_usd / equity if equity > 0 else 0.0,
             }
 
 
@@ -537,15 +488,8 @@ def reset_margin_engines_for_tests() -> None:
 
 
 __all__ = [
-    "CRITICAL_MARGIN_RATIO_FLOOR",
-    "HARD_MAX_LEVERAGE",
-    "KRAKEN_MIN_LEVERAGE",
-    "MAINTENANCE_MARGIN_RATIO_FLOOR",
-    "KrakenMarginEngine",
-    "MarginAdmissionPlan",
-    "MarginHealthSnapshot",
-    "MarginPermissionState",
-    "get_margin_engine",
-    "margin_account_scope",
-    "reset_margin_engines_for_tests",
+    "CRITICAL_MARGIN_RATIO_FLOOR", "HARD_MAX_LEVERAGE", "KRAKEN_MIN_LEVERAGE",
+    "MAINTENANCE_MARGIN_RATIO_FLOOR", "KrakenMarginEngine", "MarginAdmissionPlan",
+    "MarginHealthSnapshot", "MarginPermissionState", "get_margin_engine",
+    "margin_account_scope", "reset_margin_engines_for_tests",
 ]

--- a/bot/kraken_margin_engine.py
+++ b/bot/kraken_margin_engine.py
@@ -1,43 +1,39 @@
-"""
-Kraken margin permission, leverage, and health controls.
+"""Account-scoped Kraken margin permission, pair, sizing, and health controls.
 
-The engine provides the single boundary used by order submission and execution
-authority gates to decide whether Kraken leverage parameters may be attached to
-orders.  It is deliberately fail-closed for live margin entries: unknown
-permission state, denied API permissions, critical margin, or stale/low margin
-health all block leveraged entries while still allowing the rest of the platform
-to fall back to spot orders where the caller supports that path.
+NIJA uses this module as the single boundary for Kraken margin admission.  Margin
+is never inferred solely from a global environment flag: the exact account must
+pass private-API permission and TradeBalance health checks, and the exact pair
+must advertise the requested leverage through Kraken AssetPairs.
 """
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
 import os
 import threading
 import time
-from typing import Any, Optional
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 try:
     from bot.kraken_error_taxonomy import is_permission_error
-except ImportError:  # pragma: no cover - package fallback for script execution
+except ImportError:  # pragma: no cover
     from kraken_error_taxonomy import is_permission_error  # type: ignore[import]
 
 
 KRAKEN_MIN_LEVERAGE = 2
 HARD_MAX_LEVERAGE = 3
-# Kraken TradeBalance returns margin level in percent.  The ratio constants are
-# retained for sizing math while gates compare against percentage equivalents.
-MAINTENANCE_MARGIN_RATIO_FLOOR = 0.20  # 200% margin level
-CRITICAL_MARGIN_RATIO_FLOOR = 0.10     # 100% margin level
+MAINTENANCE_MARGIN_RATIO_FLOOR = 0.20  # 200% Kraken margin level
+CRITICAL_MARGIN_RATIO_FLOOR = 0.10     # 100% Kraken margin level
 
 _PERMISSION_CACHE_TTL_SECONDS = 300.0
 _HEALTH_CACHE_TTL_SECONDS = 15.0
+_PAIR_CACHE_TTL_SECONDS = 1800.0
 
 
 class MarginPermissionState(str, Enum):
-    """Cached Kraken margin API permission state."""
-
     UNKNOWN = "UNKNOWN"
     CONFIRMED = "CONFIRMED"
     DENIED = "DENIED"
@@ -46,8 +42,6 @@ class MarginPermissionState(str, Enum):
 
 @dataclass(frozen=True)
 class MarginHealthSnapshot:
-    """Snapshot consumed by execution authority and pipeline gates."""
-
     timestamp: float
     permission_state: str
     equivalent_balance_usd: float
@@ -63,44 +57,80 @@ class MarginHealthSnapshot:
     reason: str
 
 
-class KrakenMarginEngine:
-    """Fail-closed controller for Kraken leveraged order admission."""
+@dataclass(frozen=True)
+class MarginAdmissionPlan:
+    allowed: bool
+    account_id: str
+    symbol: str
+    side: str
+    leverage: int
+    spot_notional_usd: float
+    leveraged_notional_usd: float
+    buying_power_usd: float
+    margin_mode: str
+    reduce_only: bool
+    reason: str
+    pair_max_leverage: int = 1
 
-    def __init__(self) -> None:
+
+class KrakenMarginEngine:
+    """Fail-closed controller for one Kraken account's leveraged orders."""
+
+    def __init__(self, account_id: str = "default", adapter: Any = None) -> None:
+        self.account_id = str(account_id or "default").strip() or "default"
+        self._adapter = adapter
         self._lock = threading.RLock()
         self._permission_state = MarginPermissionState.UNKNOWN
         self._permission_checked_at = 0.0
         self._last_snapshot: Optional[MarginHealthSnapshot] = None
         self._snapshot_ts = 0.0
+        self._pair_cache: Dict[Tuple[str, str], Tuple[float, Tuple[int, ...]]] = {}
         self._total_notional_usd = 0.0
         self._total_borrowed_usd = 0.0
         self._position_count = 0.0
+
+    def bind_adapter(self, adapter: Any) -> None:
+        if adapter is not None:
+            with self._lock:
+                self._adapter = adapter
 
     @staticmethod
     def _env_truthy(name: str, default: bool = False) -> bool:
         value = os.getenv(name)
         if value is None:
             return default
-        return str(value).strip().lower() in {"1", "true", "yes", "on", "y"}
+        return str(value).strip().lower() in {"1", "true", "yes", "on", "y", "enabled"}
 
     @staticmethod
     def _to_float(value: Any, default: float = 0.0) -> float:
         try:
             if value is None:
                 return default
-            return float(value)
-        except (TypeError, ValueError):
+            parsed = float(value)
+            return parsed if parsed == parsed else default
+        except (TypeError, ValueError, OverflowError):
             return default
 
     @staticmethod
     def _clamp_leverage(leverage: Any) -> int:
         try:
             lev = int(float(leverage))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             lev = 1
         if lev < KRAKEN_MIN_LEVERAGE:
             return 1
         return max(KRAKEN_MIN_LEVERAGE, min(HARD_MAX_LEVERAGE, lev))
+
+    @staticmethod
+    def _normalise_pair(symbol: str) -> str:
+        text = str(symbol or "").upper().strip().replace("/", "").replace("-", "").replace("_", "")
+        if text.startswith("BTC"):
+            text = "XBT" + text[3:]
+        if text.endswith("ZUSD"):
+            return text
+        if text.endswith("USD"):
+            return text[:-3] + "USD"
+        return text
 
     def invalidate_permission_cache(self) -> None:
         with self._lock:
@@ -112,9 +142,21 @@ class KrakenMarginEngine:
             self._last_snapshot = None
             self._snapshot_ts = 0.0
 
-    def check_permissions(self, adapter: Any) -> MarginPermissionState:
-        """Probe Kraken OpenPositions and cache whether margin access is usable."""
+    def invalidate_pair_cache(self) -> None:
+        with self._lock:
+            self._pair_cache.clear()
 
+    def _resolve_adapter(self, adapter: Any = None) -> Any:
+        resolved = adapter if adapter is not None else self._adapter
+        if adapter is not None:
+            self.bind_adapter(adapter)
+        return resolved
+
+    def check_permissions(self, adapter: Any = None) -> MarginPermissionState:
+        """Confirm that this exact Kraken account can access private trade state."""
+        adapter = self._resolve_adapter(adapter)
+        if adapter is None:
+            return self._permission_state
         now = time.time()
         with self._lock:
             if (
@@ -122,36 +164,85 @@ class KrakenMarginEngine:
                 and now - self._permission_checked_at < _PERMISSION_CACHE_TTL_SECONDS
             ):
                 return self._permission_state
-
         try:
             response = adapter._kraken_api_call("OpenPositions", {"docalcs": "true"})
             errors = response.get("error") or [] if isinstance(response, dict) else []
             if isinstance(errors, str):
                 errors = [errors]
-            state = (
-                MarginPermissionState.DENIED
-                if any(is_permission_error(error) for error in errors)
-                else MarginPermissionState.CONFIRMED
-            )
+            if errors:
+                state = (
+                    MarginPermissionState.DENIED
+                    if any(is_permission_error(error) for error in errors)
+                    else MarginPermissionState.CHECK_FAILED
+                )
+            else:
+                state = MarginPermissionState.CONFIRMED
         except Exception:
             state = MarginPermissionState.CHECK_FAILED
-
         with self._lock:
             self._permission_state = state
             self._permission_checked_at = now
         return state
 
-    def build_order_margin_params(self, leverage: Any, *, is_reducing: bool = False) -> dict[str, str]:
-        """Return Kraken order parameters for leveraged/reduce-only orders."""
+    @staticmethod
+    def _parse_leverage_values(value: Any) -> Tuple[int, ...]:
+        values = value if isinstance(value, (list, tuple, set)) else [value]
+        parsed = set()
+        for item in values:
+            try:
+                lev = int(float(item))
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if KRAKEN_MIN_LEVERAGE <= lev <= HARD_MAX_LEVERAGE:
+                parsed.add(lev)
+        return tuple(sorted(parsed))
 
-        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED"):
+    def get_pair_leverages(self, symbol: str, side: str, adapter: Any = None) -> Tuple[int, ...]:
+        """Return live Kraken-advertised leverage values for the exact pair/side."""
+        adapter = self._resolve_adapter(adapter)
+        side_key = "sell" if str(side or "").lower() in {"sell", "short"} else "buy"
+        pair = self._normalise_pair(symbol)
+        cache_key = (pair, side_key)
+        now = time.time()
+        with self._lock:
+            cached = self._pair_cache.get(cache_key)
+            if cached and now - cached[0] < _PAIR_CACHE_TTL_SECONDS:
+                return cached[1]
+        if adapter is None:
+            return ()
+        try:
+            response = adapter._kraken_api_call("AssetPairs", {"pair": pair})
+            errors = response.get("error") or [] if isinstance(response, dict) else []
+            result = response.get("result", {}) if isinstance(response, dict) else {}
+            if errors or not isinstance(result, dict):
+                leverages: Tuple[int, ...] = ()
+            else:
+                merged = set()
+                field = "leverage_sell" if side_key == "sell" else "leverage_buy"
+                for item in result.values():
+                    if isinstance(item, dict):
+                        merged.update(self._parse_leverage_values(item.get(field, [])))
+                leverages = tuple(sorted(merged))
+        except Exception:
+            leverages = ()
+        with self._lock:
+            self._pair_cache[cache_key] = (now, leverages)
+        return leverages
+
+    def get_pair_max_leverage(self, symbol: str, side: str, adapter: Any = None) -> int:
+        values = self.get_pair_leverages(symbol, side, adapter=adapter)
+        return max(values) if values else 1
+
+    def build_order_margin_params(self, leverage: Any, *, is_reducing: bool = False) -> dict[str, Any]:
+        """Return only fields accepted by Kraken AddOrder for spot margin."""
+        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True):
             return {}
         lev = self._clamp_leverage(leverage)
-        params: dict[str, str] = {}
+        params: dict[str, Any] = {}
         if lev >= KRAKEN_MIN_LEVERAGE:
             params["leverage"] = str(lev)
         if is_reducing:
-            params["reduce_only"] = "true"
+            params["reduce_only"] = True
         return params
 
     def compute_leveraged_notional(
@@ -160,22 +251,26 @@ class KrakenMarginEngine:
         spot_size_usd: float,
         leverage: Any,
         account_equity_usd: float,
+        buying_power_usd: Optional[float] = None,
     ) -> float:
-        """Scale spot notional by leverage while enforcing the hard 3× equity cap."""
-
+        """Scale a risk-approved spot size while preserving the hard 3× equity cap."""
         lev = self._clamp_leverage(leverage)
         if lev < KRAKEN_MIN_LEVERAGE:
             lev = 1
         raw_notional = max(0.0, float(spot_size_usd or 0.0)) * lev
-        cap = max(0.0, float(account_equity_usd or 0.0)) * HARD_MAX_LEVERAGE
-        if cap <= 0:
+        equity_cap = max(0.0, float(account_equity_usd or 0.0)) * HARD_MAX_LEVERAGE
+        if equity_cap <= 0:
             return 0.0
+        cap = equity_cap
+        if buying_power_usd is not None and float(buying_power_usd or 0.0) > 0:
+            cap = min(cap, float(buying_power_usd))
         return min(raw_notional, cap)
 
     def _build_snapshot(self, adapter: Any) -> MarginHealthSnapshot:
-        """Build a health snapshot from Kraken TradeBalance data."""
-
         response = adapter._kraken_api_call("TradeBalance", {"asset": "ZUSD"})
+        errors = response.get("error") or [] if isinstance(response, dict) else []
+        if errors:
+            raise RuntimeError("TradeBalance rejected: " + ", ".join(str(x) for x in errors))
         data = response.get("result", {}) if isinstance(response, dict) else {}
         eb = self._to_float(data.get("eb"))
         tb = self._to_float(data.get("tb"))
@@ -185,10 +280,8 @@ class KrakenMarginEngine:
         pnl = self._to_float(data.get("n"))
         equivalent = self._to_float(data.get("e"), eb)
         borrowed = max(self._total_borrowed_usd, mo)
-
-        enabled = self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED")
-        permission = self._permission_state.value if isinstance(self._permission_state, MarginPermissionState) else str(self._permission_state)
-
+        enabled = self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True)
+        permission = self._permission_state.value
         if mo <= 0 and ml <= 0:
             maintenance_ok = True
             critical = False
@@ -204,7 +297,6 @@ class KrakenMarginEngine:
                 reason = f"low_margin_level:{ml:.1f}%"
             else:
                 reason = f"margin_healthy:{ml:.1f}%"
-
         return MarginHealthSnapshot(
             timestamp=time.time(),
             permission_state=permission,
@@ -222,22 +314,35 @@ class KrakenMarginEngine:
         )
 
     def get_health_snapshot(self, adapter: Any = None) -> MarginHealthSnapshot:
-        """Return cached margin health, refreshing from Kraken when an adapter exists."""
-
+        adapter = self._resolve_adapter(adapter)
         now = time.time()
         with self._lock:
             if self._last_snapshot is not None and now - self._snapshot_ts < _HEALTH_CACHE_TTL_SECONDS:
                 return self._last_snapshot
-
         if adapter is not None:
-            snapshot = self._build_snapshot(adapter)
+            try:
+                snapshot = self._build_snapshot(adapter)
+            except Exception as exc:
+                snapshot = MarginHealthSnapshot(
+                    timestamp=now,
+                    permission_state=self._permission_state.value,
+                    equivalent_balance_usd=0.0,
+                    trade_balance_free_usd=0.0,
+                    margin_level_pct=0.0,
+                    margin_obligation_usd=0.0,
+                    free_margin_usd=0.0,
+                    unrealised_pnl_usd=0.0,
+                    borrowed_exposure_usd=self._total_borrowed_usd,
+                    is_margin_enabled=self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
+                    maintenance_margin_ok=False,
+                    critical_margin_breach=False,
+                    reason=f"health_check_failed:{exc}",
+                )
         else:
-            permission = self._permission_state.value if isinstance(self._permission_state, MarginPermissionState) else str(self._permission_state)
-            enabled = self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED")
             exposure = self.get_exposure_snapshot()
             snapshot = MarginHealthSnapshot(
                 timestamp=now,
-                permission_state=permission,
+                permission_state=self._permission_state.value,
                 equivalent_balance_usd=0.0,
                 trade_balance_free_usd=0.0,
                 margin_level_pct=0.0,
@@ -245,26 +350,22 @@ class KrakenMarginEngine:
                 free_margin_usd=0.0,
                 unrealised_pnl_usd=0.0,
                 borrowed_exposure_usd=exposure["total_borrowed_usd"],
-                is_margin_enabled=enabled,
-                maintenance_margin_ok=True,
+                is_margin_enabled=self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True),
+                maintenance_margin_ok=exposure["position_count"] <= 0,
                 critical_margin_breach=False,
-                reason="no_margin_positions" if exposure["position_count"] <= 0 else "ledger_only_snapshot",
+                reason="no_bound_adapter" if self._adapter is None else "cached_adapter_unavailable",
             )
-
         with self._lock:
             self._last_snapshot = snapshot
             self._snapshot_ts = snapshot.timestamp
         return snapshot
 
     def is_margin_trade_allowed(self, *, is_reducing: bool = False, adapter: Any = None) -> tuple[bool, str]:
-        """Return whether a leveraged Kraken order may be submitted now."""
-
-        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED"):
+        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True):
             return False, "margin_disabled"
-
+        adapter = self._resolve_adapter(adapter)
         if adapter is not None:
             self.check_permissions(adapter)
-
         state = self._permission_state
         if state == MarginPermissionState.DENIED:
             return False, "permission_denied"
@@ -272,21 +373,111 @@ class KrakenMarginEngine:
             return False, "permission_check_failed"
         if state != MarginPermissionState.CONFIRMED:
             return False, "permission_unknown"
-
         snapshot = self.get_health_snapshot(adapter=adapter)
+        if str(snapshot.reason).startswith("health_check_failed"):
+            return False, snapshot.reason
         if snapshot.critical_margin_breach:
             return False, f"critical_margin:{snapshot.reason}"
         if not snapshot.maintenance_margin_ok and not is_reducing:
             return False, f"maintenance_low:{snapshot.reason}"
         return True, snapshot.reason or "margin_allowed"
 
+    def plan_auto_margin(
+        self,
+        *,
+        adapter: Any,
+        symbol: str,
+        side: str,
+        spot_size_usd: float,
+        account_equity_usd: float = 0.0,
+        requested_leverage: Any = None,
+        is_reducing: bool = False,
+    ) -> MarginAdmissionPlan:
+        """Build a live, account-and-pair-qualified margin plan.
+
+        Automatic margin is long-only by default.  Existing margin exits may pass
+        ``is_reducing=True`` and retain their ledger leverage separately.
+        """
+        self.bind_adapter(adapter)
+        side_norm = "sell" if str(side or "").lower() in {"sell", "short"} else "buy"
+        spot = max(0.0, self._to_float(spot_size_usd))
+        desired = requested_leverage
+        if desired is None:
+            desired = os.getenv("NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE", "2")
+        leverage = self._clamp_leverage(desired)
+        base_plan = dict(
+            account_id=self.account_id,
+            symbol=str(symbol or ""),
+            side=side_norm,
+            leverage=leverage,
+            spot_notional_usd=spot,
+            leveraged_notional_usd=spot,
+            buying_power_usd=max(0.0, self._to_float(account_equity_usd)),
+            margin_mode="cross",
+            reduce_only=bool(is_reducing),
+        )
+        if not self._env_truthy("NIJA_KRAKEN_MARGIN_ENABLED", default=True):
+            return MarginAdmissionPlan(False, reason="margin_disabled", pair_max_leverage=1, **base_plan)
+        if not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", default=True) and requested_leverage is None:
+            return MarginAdmissionPlan(False, reason="auto_margin_disabled", pair_max_leverage=1, **base_plan)
+        if leverage < KRAKEN_MIN_LEVERAGE:
+            return MarginAdmissionPlan(False, reason="spot_leverage_requested", pair_max_leverage=1, **base_plan)
+        if side_norm == "sell" and not is_reducing and self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", default=True):
+            return MarginAdmissionPlan(False, reason="auto_margin_long_only", pair_max_leverage=1, **base_plan)
+        allowed, reason = self.is_margin_trade_allowed(is_reducing=is_reducing, adapter=adapter)
+        if not allowed:
+            return MarginAdmissionPlan(False, reason=reason, pair_max_leverage=1, **base_plan)
+        pair_values = self.get_pair_leverages(symbol, side_norm, adapter=adapter)
+        pair_max = max(pair_values) if pair_values else 1
+        if leverage not in pair_values:
+            return MarginAdmissionPlan(False, reason=f"pair_leverage_unavailable:{pair_values or 'none'}", pair_max_leverage=pair_max, **base_plan)
+        snapshot = self.get_health_snapshot(adapter=adapter)
+        equity = max(
+            self._to_float(account_equity_usd),
+            snapshot.equivalent_balance_usd,
+            snapshot.trade_balance_free_usd,
+        )
+        collateral = snapshot.free_margin_usd or snapshot.trade_balance_free_usd or equity
+        buying_power = max(0.0, collateral * leverage)
+        leveraged = self.compute_leveraged_notional(
+            spot_size_usd=spot,
+            leverage=leverage,
+            account_equity_usd=equity,
+            buying_power_usd=buying_power,
+        )
+        if leveraged <= 0:
+            return MarginAdmissionPlan(False, reason="no_margin_buying_power", pair_max_leverage=pair_max, **base_plan)
+        return MarginAdmissionPlan(
+            allowed=True,
+            account_id=self.account_id,
+            symbol=str(symbol or ""),
+            side=side_norm,
+            leverage=leverage,
+            spot_notional_usd=spot,
+            leveraged_notional_usd=leveraged,
+            buying_power_usd=buying_power,
+            margin_mode="cross",
+            reduce_only=bool(is_reducing),
+            reason=f"margin_eligible:{reason}",
+            pair_max_leverage=pair_max,
+        )
+
+    def get_runtime_capability_overrides(self, account_id: Optional[str] = None) -> Dict[str, Any]:
+        allowed = self._permission_state == MarginPermissionState.CONFIRMED
+        return {
+            "supports_margin": allowed,
+            "supports_leverage": allowed,
+            "supports_short": allowed and not self._env_truthy("NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY", default=True),
+            "max_leverage": HARD_MAX_LEVERAGE if allowed else 1,
+            "account_id": account_id or self.account_id,
+        }
+
     def _borrowed_amount(self, notional_usd: float, leverage: Any) -> float:
         lev = self._clamp_leverage(leverage)
         if lev < KRAKEN_MIN_LEVERAGE:
             return 0.0
         notional = max(0.0, float(notional_usd or 0.0))
-        equity_portion = notional / lev if lev > 0 else notional
-        return max(0.0, notional - equity_portion)
+        return max(0.0, notional - (notional / lev))
 
     def record_open_position(self, *, notional_usd: float, leverage: Any) -> None:
         with self._lock:
@@ -314,18 +505,35 @@ class KrakenMarginEngine:
             }
 
 
-_MARGIN_ENGINE: Optional[KrakenMarginEngine] = None
+_MARGIN_ENGINES: Dict[str, KrakenMarginEngine] = {}
 _MARGIN_ENGINE_LOCK = threading.Lock()
+_CURRENT_MARGIN_ACCOUNT: ContextVar[str] = ContextVar("nija_kraken_margin_account", default="default")
 
 
-def get_margin_engine() -> KrakenMarginEngine:
-    """Return the process-wide Kraken margin engine singleton."""
-
-    global _MARGIN_ENGINE
+def get_margin_engine(account_id: Optional[str] = None, adapter: Any = None) -> KrakenMarginEngine:
+    key = str(account_id or _CURRENT_MARGIN_ACCOUNT.get() or "default").strip() or "default"
     with _MARGIN_ENGINE_LOCK:
-        if _MARGIN_ENGINE is None:
-            _MARGIN_ENGINE = KrakenMarginEngine()
-        return _MARGIN_ENGINE
+        engine = _MARGIN_ENGINES.get(key)
+        if engine is None:
+            engine = KrakenMarginEngine(account_id=key, adapter=adapter)
+            _MARGIN_ENGINES[key] = engine
+    engine.bind_adapter(adapter)
+    return engine
+
+
+@contextmanager
+def margin_account_scope(account_id: str, adapter: Any = None) -> Iterator[KrakenMarginEngine]:
+    key = str(account_id or "default").strip() or "default"
+    token = _CURRENT_MARGIN_ACCOUNT.set(key)
+    try:
+        yield get_margin_engine(key, adapter=adapter)
+    finally:
+        _CURRENT_MARGIN_ACCOUNT.reset(token)
+
+
+def reset_margin_engines_for_tests() -> None:
+    with _MARGIN_ENGINE_LOCK:
+        _MARGIN_ENGINES.clear()
 
 
 __all__ = [
@@ -334,7 +542,10 @@ __all__ = [
     "KRAKEN_MIN_LEVERAGE",
     "MAINTENANCE_MARGIN_RATIO_FLOOR",
     "KrakenMarginEngine",
+    "MarginAdmissionPlan",
     "MarginHealthSnapshot",
     "MarginPermissionState",
     "get_margin_engine",
+    "margin_account_scope",
+    "reset_margin_engines_for_tests",
 ]

--- a/bot/pipeline_order_submitter.py
+++ b/bot/pipeline_order_submitter.py
@@ -1,4 +1,10 @@
-"""Canonical market-order submit helper via ExecutionPipeline/ECEL."""
+"""Canonical market-order submit helper via ExecutionPipeline/ECEL.
+
+Kraken orders are margin-enriched here because this boundary owns the exact live
+adapter and account identity.  Automatic margin remains fail-closed: a request is
+upgraded only after account permission, TradeBalance health, and pair leverage
+checks all pass.  Otherwise the original spot request is preserved.
+"""
 
 from __future__ import annotations
 
@@ -27,28 +33,26 @@ except ImportError:
             return
 
 
+def _truthy(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
+
+
 def _balance_from_payload(payload: Any) -> Optional[float]:
     if isinstance(payload, (int, float)):
         return float(payload)
     if isinstance(payload, dict):
         for key in (
-            "available_balance",
-            "available_usd",
-            "available",
-            "free",
-            "free_usd",
-            "trading_balance",
-            "total_balance",
-            "total_funds",
-            "balance",
-            "equity",
-            "usd_balance",
-            "total_usd",
+            "available_balance", "available_usd", "available", "free", "free_usd",
+            "trading_balance", "total_balance", "total_funds", "balance", "equity",
+            "usd_balance", "total_usd",
         ):
             if key in payload:
                 try:
                     return float(payload.get(key) or 0.0)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, OverflowError):
                     return 0.0
     return None
 
@@ -62,23 +66,26 @@ def _resolve_preferred_broker(broker: Any) -> str:
                 return str(broker_type.value).lower()
             if isinstance(broker_type, str) and broker_type.strip():
                 return broker_type.strip().lower()
-
         name = getattr(broker, "NAME", None)
         if isinstance(name, str) and name.strip():
             name = name.strip().lower()
-            if "kraken" in name:
-                return "kraken"
-            if "coinbase" in name:
-                return "coinbase"
-            if "okx" in name:
-                return "okx"
-            if "binance" in name:
-                return "binance"
-            if "alpaca" in name:
-                return "alpaca"
+            for candidate in ("kraken", "coinbase", "okx", "binance", "alpaca"):
+                if candidate in name:
+                    return candidate
     except Exception:
         pass
     return preferred_broker
+
+
+def _resolve_account_id(broker: Any, preferred_broker: str) -> str:
+    for attr in ("account_identifier", "account_id", "user_id", "owner_id", "name"):
+        try:
+            value = str(getattr(broker, attr, "") or "").strip().lower()
+        except Exception:
+            value = ""
+        if value and value not in {"none", preferred_broker}:
+            return value
+    return "platform" if preferred_broker == "kraken" else "default"
 
 
 def _resolve_broker_balance_keys(broker: Any, preferred_broker: str) -> list[str]:
@@ -91,11 +98,107 @@ def _resolve_broker_balance_keys(broker: Any, preferred_broker: str) -> list[str
         pass
     if preferred_broker:
         keys.append(preferred_broker)
-    deduped: list[str] = []
-    for key in keys:
-        if key and key not in deduped:
-            deduped.append(key)
-    return deduped
+    return list(dict.fromkeys(key for key in keys if key))
+
+
+def _resolve_margin_exit(
+    *,
+    preferred_broker: str,
+    account_id: str,
+    symbol: str,
+) -> Dict[str, Any]:
+    if preferred_broker != "kraken":
+        return {}
+    try:
+        from bot.margin_position_ledger import get_margin_position_ledger
+        ledger = get_margin_position_ledger()
+        row = ledger.get_record(
+            broker="kraken",
+            account_id=account_id,
+            subaccount_id="",
+            symbol=str(symbol or "").strip().upper(),
+            asset_class="crypto",
+        )
+    except Exception as exc:
+        logger.debug("KRAKEN_MARGIN_EXIT_LEDGER_LOOKUP_FAILED account=%s symbol=%s error=%s", account_id, symbol, exc)
+        return {}
+    leverage = int(float(row.get("leverage") or 1)) if row else 1
+    lifecycle = str(row.get("lifecycle_status") or "").lower() if row else ""
+    if leverage <= 1 or lifecycle not in {"open", "reducing", "pending_open"}:
+        return {}
+    return {
+        "leverage": min(3, max(2, leverage)),
+        "margin_mode": str(row.get("margin_mode") or "cross"),
+        "reduce_only": True,
+        "intent_type": "exit",
+        "buying_power_usd": row.get("buying_power_usd"),
+        "reason": f"existing_margin_position:{lifecycle}",
+    }
+
+
+def _plan_kraken_margin_entry(
+    *,
+    broker: Any,
+    account_id: str,
+    symbol: str,
+    side: str,
+    size_usd: float,
+    account_equity_usd: float,
+) -> Dict[str, Any]:
+    if str(side or "").lower() != "buy":
+        return {}
+    if not _truthy("NIJA_KRAKEN_MARGIN_ENABLED", True):
+        return {}
+    if not _truthy("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", True):
+        return {}
+    try:
+        from bot.kraken_margin_engine import get_margin_engine
+        engine = get_margin_engine(account_id=account_id, adapter=broker)
+        plan = engine.plan_auto_margin(
+            adapter=broker,
+            symbol=symbol,
+            side=side,
+            spot_size_usd=size_usd,
+            account_equity_usd=account_equity_usd,
+            requested_leverage=None,
+            is_reducing=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s decision=SPOT reason=engine_error:%s",
+            account_id, symbol, exc,
+        )
+        return {}
+    if not plan.allowed:
+        logger.info(
+            "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s side=%s decision=SPOT reason=%s pair_max=%sx",
+            account_id, symbol, side, plan.reason, plan.pair_max_leverage,
+        )
+        return {}
+    logger.critical(
+        "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s side=%s decision=MARGIN leverage=%sx "
+        "spot_notional=$%.2f leveraged_notional=$%.2f buying_power=$%.2f pair_max=%sx reason=%s",
+        account_id,
+        symbol,
+        side,
+        plan.leverage,
+        plan.spot_notional_usd,
+        plan.leveraged_notional_usd,
+        plan.buying_power_usd,
+        plan.pair_max_leverage,
+        plan.reason,
+    )
+    return {
+        "leverage": plan.leverage,
+        "margin_mode": plan.margin_mode,
+        "reduce_only": False,
+        "intent_type": "entry",
+        "size_usd": plan.leveraged_notional_usd,
+        "buying_power_usd": plan.buying_power_usd,
+        "reason": plan.reason,
+        "pair_max_leverage": plan.pair_max_leverage,
+        "spot_notional_usd": plan.spot_notional_usd,
+    }
 
 
 def submit_market_order_via_pipeline(
@@ -106,16 +209,7 @@ def submit_market_order_via_pipeline(
     size_type: str = "quote",
     strategy: str = "PipelineOrderSubmitter",
 ) -> Dict[str, Any]:
-    """Submit a market order through ExecutionPipeline.
-
-    Args:
-        broker: Broker instance (used for broker hint and optional price hint fetch).
-        symbol: Trading symbol.
-        side: buy/sell.
-        quantity: USD size when size_type='quote', base quantity when size_type='base'.
-        size_type: 'quote' or 'base'.
-        strategy: Strategy tag for pipeline telemetry.
-    """
+    """Submit a market order through ExecutionPipeline."""
     if get_execution_pipeline is None or PipelineRequest is None:
         return {
             "status": "error",
@@ -124,17 +218,13 @@ def submit_market_order_via_pipeline(
             "side": side,
         }
 
-    _force_trade = (
-        os.environ.get("FORCE_TRADE", "").strip().lower() in {"1", "true", "yes", "enabled", "on"}
-        or os.environ.get("FORCE_TRADE_MODE", "").strip().lower() in {"1", "true", "yes", "enabled", "on"}
-    )
-    if not _force_trade:
+    force_trade = _truthy("FORCE_TRADE") or _truthy("FORCE_TRADE_MODE")
+    if not force_trade:
         try:
             assert_distributed_writer_authority()
         except Exception as exc:
             logger.error(
-                "🚫 [PipelineOrderSubmitter] DistributedWriterFence reject — "
-                "symbol=%s side=%s error=%s",
+                "🚫 [PipelineOrderSubmitter] DistributedWriterFence reject — symbol=%s side=%s error=%s",
                 symbol, side, exc,
             )
             return {
@@ -145,15 +235,13 @@ def submit_market_order_via_pipeline(
             }
     else:
         logger.info(
-            "[FORCE_TRADE] Bypassing assert_distributed_writer_authority in pipeline_order_submitter — "
-            "FORCE_TRADE_MODE=true. symbol=%s side=%s",
+            "[FORCE_TRADE] Bypassing assert_distributed_writer_authority in pipeline_order_submitter — symbol=%s side=%s",
             symbol, side,
         )
 
     side_norm = (side or "buy").strip().lower()
     size_usd = float(max(0.0, quantity))
     price_hint_usd: Optional[float] = None
-
     if (size_type or "quote").lower() == "base":
         try:
             if hasattr(broker, "get_current_price"):
@@ -163,7 +251,6 @@ def submit_market_order_via_pipeline(
                     size_usd = float(max(0.0, quantity * px))
         except Exception:
             price_hint_usd = None
-
         if price_hint_usd is None or size_usd <= 0:
             return {
                 "status": "error",
@@ -173,70 +260,126 @@ def submit_market_order_via_pipeline(
             }
 
     preferred_broker = _resolve_preferred_broker(broker)
+    account_id = _resolve_account_id(broker, preferred_broker)
     broker_balance_keys = _resolve_broker_balance_keys(broker, preferred_broker)
-
-    _available_balance_usd: Optional[float] = None
+    available_balance_usd: Optional[float] = None
     try:
-        cached_detail = getattr(broker, "_balance_cache", None)
-        _available_balance_usd = _balance_from_payload(cached_detail)
-        if _available_balance_usd is None:
-            cached_scalar = getattr(broker, "_last_known_balance", None)
-            if isinstance(cached_scalar, (int, float)):
-                _available_balance_usd = float(cached_scalar)
+        available_balance_usd = _balance_from_payload(getattr(broker, "_balance_cache", None))
+        if available_balance_usd is None:
+            scalar = getattr(broker, "_last_known_balance", None)
+            if isinstance(scalar, (int, float)):
+                available_balance_usd = float(scalar)
     except Exception:
-        _available_balance_usd = None
+        available_balance_usd = None
+
     try:
-        for _ca_mod_name in ("bot.capital_authority", "capital_authority"):
+        import importlib
+        for module_name in ("bot.capital_authority", "capital_authority"):
             try:
-                import importlib as _il
-                _ca_mod = _il.import_module(_ca_mod_name)
-                _get_ca = getattr(_ca_mod, "get_capital_authority", None)
-                if callable(_get_ca):
-                    _ca = _get_ca()
-                    _is_registered = getattr(_ca, "is_registered", None)
-                    for _broker_key in broker_balance_keys:
-                        _ca_balance = float(_ca.get_per_broker(_broker_key) or 0.0)
-                        if _ca_balance > 0.0 or (callable(_is_registered) and _is_registered(_broker_key)):
-                            _available_balance_usd = _ca_balance
+                module = importlib.import_module(module_name)
+                get_ca = getattr(module, "get_capital_authority", None)
+                if callable(get_ca):
+                    authority = get_ca()
+                    is_registered = getattr(authority, "is_registered", None)
+                    for broker_key in broker_balance_keys:
+                        balance = float(authority.get_per_broker(broker_key) or 0.0)
+                        if balance > 0.0 or (callable(is_registered) and is_registered(broker_key)):
+                            available_balance_usd = balance
                             logger.info(
-                                "[PipelineOrderSubmitter] resolved broker balance from "
-                                "CapitalAuthority: broker=%s balance=$%.2f symbol=%s side=%s",
-                                _broker_key, _ca_balance, symbol, side_norm,
+                                "[PipelineOrderSubmitter] resolved broker balance from CapitalAuthority: broker=%s balance=$%.2f symbol=%s side=%s",
+                                broker_key, balance, symbol, side_norm,
                             )
                             break
                 break
             except ImportError:
                 continue
-    except Exception as _ca_exc:
-        logger.debug(
-            "[PipelineOrderSubmitter] capital authority balance lookup failed "
-            "(non-fatal, risk engine will use fail-open): %s",
-            _ca_exc,
-        )
+    except Exception as exc:
+        logger.debug("[PipelineOrderSubmitter] capital authority balance lookup failed: %s", exc)
 
-    # Fall back to broker's cached balance when CapitalAuthority is unavailable.
-    if not _available_balance_usd:
+    if not available_balance_usd:
         try:
             if broker is not None and hasattr(broker, "get_account_balance"):
-                _raw = broker.get_account_balance()
-                _available_balance_usd = _balance_from_payload(_raw)
-                if _available_balance_usd is None:
-                    _available_balance_usd = float(_raw or 0.0)
+                raw = broker.get_account_balance()
+                available_balance_usd = _balance_from_payload(raw)
+                if available_balance_usd is None:
+                    available_balance_usd = float(raw or 0.0)
         except Exception:
             pass
 
-    res = get_execution_pipeline().execute(
-        PipelineRequest(
-            strategy=strategy,
-            symbol=symbol,
-            side=side_norm,
-            size_usd=size_usd,
-            order_type="MARKET",
-            preferred_broker=preferred_broker,
-            price_hint_usd=price_hint_usd,
-            available_balance_usd=_available_balance_usd if _available_balance_usd else None,
-        )
+    margin_fields: Dict[str, Any] = {}
+    if preferred_broker == "kraken":
+        if side_norm == "buy":
+            margin_fields = _plan_kraken_margin_entry(
+                broker=broker,
+                account_id=account_id,
+                symbol=symbol,
+                side=side_norm,
+                size_usd=size_usd,
+                account_equity_usd=float(available_balance_usd or 0.0),
+            )
+        elif side_norm == "sell":
+            margin_fields = _resolve_margin_exit(
+                preferred_broker=preferred_broker,
+                account_id=account_id,
+                symbol=symbol,
+            )
+            if margin_fields:
+                logger.critical(
+                    "KRAKEN_MARGIN_EXIT_PLAN account=%s symbol=%s leverage=%sx reduce_only=true reason=%s",
+                    account_id, symbol, margin_fields.get("leverage"), margin_fields.get("reason"),
+                )
+
+    effective_size_usd = float(margin_fields.get("size_usd") or size_usd)
+    leverage = int(margin_fields.get("leverage") or 1)
+    margin_mode = margin_fields.get("margin_mode")
+    reduce_only = margin_fields.get("reduce_only")
+    intent_type = margin_fields.get("intent_type")
+    buying_power_usd = margin_fields.get("buying_power_usd")
+    metadata = {
+        "broker_client": broker,
+        "broker_name": preferred_broker,
+        "kraken_margin_auto": bool(margin_fields and leverage > 1),
+        "kraken_margin_reason": margin_fields.get("reason", "spot"),
+        "spot_notional_usd": margin_fields.get("spot_notional_usd", size_usd),
+        "pair_max_leverage": margin_fields.get("pair_max_leverage", 1),
+        "leverage": leverage,
+        "reduce_only": reduce_only,
+        "margin_mode": margin_mode,
+    }
+
+    request = PipelineRequest(
+        strategy=strategy,
+        symbol=symbol,
+        side=side_norm,
+        size_usd=effective_size_usd,
+        order_type="MARKET",
+        preferred_broker=preferred_broker,
+        price_hint_usd=price_hint_usd,
+        available_balance_usd=available_balance_usd if available_balance_usd else None,
+        buying_power_usd=buying_power_usd,
+        account_id=account_id,
+        intent_type=intent_type,
+        leverage=leverage if leverage > 1 else None,
+        margin_mode=margin_mode,
+        reduce_only=reduce_only,
+        metadata=metadata,
     )
+
+    try:
+        if preferred_broker == "kraken":
+            from bot.kraken_margin_engine import margin_account_scope
+            with margin_account_scope(account_id, adapter=broker):
+                res = get_execution_pipeline().execute(request)
+        else:
+            res = get_execution_pipeline().execute(request)
+    except Exception as exc:
+        return {
+            "status": "error",
+            "error": str(exc),
+            "symbol": symbol,
+            "side": side_norm,
+            "leverage": leverage,
+        }
 
     if not res.success:
         return {
@@ -244,6 +387,8 @@ def submit_market_order_via_pipeline(
             "error": res.error or "ExecutionPipeline rejected order",
             "symbol": symbol,
             "side": side_norm,
+            "leverage": leverage,
+            "margin": leverage > 1,
         }
 
     return {
@@ -254,4 +399,7 @@ def submit_market_order_via_pipeline(
         "filled_price": res.fill_price,
         "filled_size_usd": res.filled_size_usd,
         "broker": res.broker,
+        "leverage": leverage,
+        "margin": leverage > 1,
+        "reduce_only": bool(reduce_only),
     }

--- a/bot/tests/test_kraken_margin_auto_runtime.py
+++ b/bot/tests/test_kraken_margin_auto_runtime.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import os
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bot.kraken_margin_engine import (
+    HARD_MAX_LEVERAGE,
+    KrakenMarginEngine,
+    get_margin_engine,
+    reset_margin_engines_for_tests,
+)
+from bot.kraken_margin_auto_runtime_patch import _patch_capability_matrix, _patch_router
+
+
+class FakeKrakenAdapter:
+    NAME = "Kraken"
+
+    def __init__(self, account_id: str = "platform", *, pair_leverages=(2, 3), margin_level=500.0):
+        self.account_identifier = account_id
+        self.pair_leverages = list(pair_leverages)
+        self.margin_level = float(margin_level)
+        self.private_calls = []
+        self.public_calls = []
+        self.submit_calls = []
+        self.api = SimpleNamespace(query_public=self.query_public)
+
+    def query_public(self, method, params=None):
+        self.public_calls.append((method, dict(params or {})))
+        if method == "AssetPairs":
+            return {
+                "error": [],
+                "result": {
+                    "XXBTZUSD": {
+                        "leverage_buy": list(self.pair_leverages),
+                        "leverage_sell": list(self.pair_leverages),
+                    }
+                },
+            }
+        return {"error": ["not mocked"], "result": {}}
+
+    def _kraken_api_call(self, method, params=None):
+        self.private_calls.append((method, dict(params or {})))
+        if method == "OpenPositions":
+            return {"error": [], "result": {}}
+        if method == "TradeBalance":
+            return {
+                "error": [],
+                "result": {
+                    "eb": "100.00",
+                    "tb": "100.00",
+                    "ml": str(self.margin_level),
+                    "mo": "20.00" if self.margin_level > 0 else "0.00",
+                    "mf": "80.00",
+                    "n": "0.00",
+                    "e": "100.00",
+                },
+            }
+        return {"error": ["not mocked"], "result": {}}
+
+    def place_market_order(self, symbol, side, size, **kwargs):
+        self.submit_calls.append((symbol, side, size, dict(kwargs)))
+        return {
+            "status": "filled",
+            "order_id": "margin-order-1",
+            "filled_price": 50_000.0,
+            "filled_size_usd": float(size),
+        }
+
+
+class TestAccountScopedMarginEngine(unittest.TestCase):
+    def setUp(self):
+        reset_margin_engines_for_tests()
+        self.env = patch.dict(
+            os.environ,
+            {
+                "NIJA_KRAKEN_MARGIN_ENABLED": "true",
+                "NIJA_KRAKEN_AUTO_MARGIN_ENABLED": "true",
+                "NIJA_KRAKEN_MARGIN_DEFAULT_LEVERAGE": "2",
+                "NIJA_KRAKEN_AUTO_MARGIN_LONG_ONLY": "true",
+            },
+            clear=False,
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_engines_do_not_leak_permission_across_accounts(self):
+        platform = get_margin_engine("platform")
+        user = get_margin_engine("daivon")
+        self.assertIsNot(platform, user)
+        adapter = FakeKrakenAdapter("platform")
+        self.assertEqual(platform.check_permissions(adapter).value, "CONFIRMED")
+        self.assertEqual(user._permission_state.value, "UNKNOWN")
+
+    def test_pair_discovery_uses_public_api_not_private_nonce_path(self):
+        adapter = FakeKrakenAdapter(pair_leverages=(2, 3))
+        engine = KrakenMarginEngine("platform", adapter=adapter)
+        values = engine.get_pair_leverages("BTC-USD", "buy", adapter=adapter)
+        self.assertEqual(values, (2, 3))
+        self.assertEqual(adapter.public_calls[0][0], "AssetPairs")
+        self.assertFalse(any(method == "AssetPairs" for method, _ in adapter.private_calls))
+
+    def test_eligible_entry_is_planned_at_two_times(self):
+        adapter = FakeKrakenAdapter(pair_leverages=(2, 3), margin_level=500.0)
+        engine = KrakenMarginEngine("platform", adapter=adapter)
+        plan = engine.plan_auto_margin(
+            adapter=adapter,
+            symbol="BTC-USD",
+            side="buy",
+            spot_size_usd=20.0,
+            account_equity_usd=100.0,
+        )
+        self.assertTrue(plan.allowed)
+        self.assertEqual(plan.leverage, 2)
+        self.assertAlmostEqual(plan.leveraged_notional_usd, 40.0)
+        self.assertLessEqual(plan.leverage, HARD_MAX_LEVERAGE)
+        self.assertFalse(plan.reduce_only)
+
+    def test_pair_without_two_times_remains_spot(self):
+        adapter = FakeKrakenAdapter(pair_leverages=())
+        engine = KrakenMarginEngine("platform", adapter=adapter)
+        plan = engine.plan_auto_margin(
+            adapter=adapter,
+            symbol="BTC-USD",
+            side="buy",
+            spot_size_usd=20.0,
+            account_equity_usd=100.0,
+        )
+        self.assertFalse(plan.allowed)
+        self.assertIn("pair_leverage_unavailable", plan.reason)
+
+    def test_low_margin_blocks_new_entry(self):
+        adapter = FakeKrakenAdapter(pair_leverages=(2,), margin_level=150.0)
+        engine = KrakenMarginEngine("platform", adapter=adapter)
+        plan = engine.plan_auto_margin(
+            adapter=adapter,
+            symbol="BTC-USD",
+            side="buy",
+            spot_size_usd=20.0,
+            account_equity_usd=100.0,
+        )
+        self.assertFalse(plan.allowed)
+        self.assertIn("maintenance_low", plan.reason)
+
+    def test_ten_times_is_clamped_to_three_times(self):
+        engine = KrakenMarginEngine("platform")
+        params = engine.build_order_margin_params(10)
+        self.assertEqual(params["leverage"], "3")
+
+
+class TestKrakenMarginDispatchBridge(unittest.TestCase):
+    def setUp(self):
+        reset_margin_engines_for_tests()
+        self.env = patch.dict(
+            os.environ,
+            {
+                "NIJA_KRAKEN_MARGIN_ENABLED": "true",
+                "NIJA_KRAKEN_AUTO_MARGIN_ENABLED": "true",
+            },
+            clear=False,
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    @staticmethod
+    def _router_class():
+        class MultiBrokerExecutionRouter:
+            @staticmethod
+            def _dispatch_direct_broker_market_order(broker, *, symbol, side, size_usd, metadata):
+                return 1.0, float(size_usd)
+        return MultiBrokerExecutionRouter
+
+    def test_router_passes_leverage_and_reduce_only_without_margin_mode(self):
+        adapter = FakeKrakenAdapter("platform", pair_leverages=(2, 3))
+        module = types.ModuleType("bot.multi_broker_execution_router")
+        module.MultiBrokerExecutionRouter = self._router_class()
+        self.assertTrue(_patch_router(module))
+        result = module.MultiBrokerExecutionRouter._dispatch_direct_broker_market_order(
+            adapter,
+            symbol="BTC-USD",
+            side="buy",
+            size_usd=40.0,
+            metadata={
+                "account_id": "platform",
+                "leverage": 2,
+                "reduce_only": False,
+                "margin_mode": "cross",
+                "price_hint_usd": 50_000.0,
+            },
+        )
+        self.assertEqual(result, (50_000.0, 40.0))
+        self.assertEqual(len(adapter.submit_calls), 1)
+        _, _, _, kwargs = adapter.submit_calls[0]
+        self.assertEqual(kwargs["leverage"], 2)
+        self.assertFalse(kwargs["reduce_only"])
+        self.assertIsNone(kwargs["margin_mode"])
+
+    def test_margin_failure_does_not_fallback_to_spot(self):
+        adapter = FakeKrakenAdapter("platform", pair_leverages=())
+        module = types.ModuleType("bot.multi_broker_execution_router.failure")
+        module.MultiBrokerExecutionRouter = self._router_class()
+        self.assertTrue(_patch_router(module))
+        with self.assertRaises(RuntimeError):
+            module.MultiBrokerExecutionRouter._dispatch_direct_broker_market_order(
+                adapter,
+                symbol="BTC-USD",
+                side="buy",
+                size_usd=40.0,
+                metadata={"account_id": "platform", "leverage": 2, "reduce_only": False},
+            )
+        self.assertEqual(adapter.submit_calls, [])
+
+
+class TestKrakenMarginCapabilityInstall(unittest.TestCase):
+    def test_margin_capability_is_added_with_three_times_ceiling(self):
+        from bot import exchange_capabilities as cap_module
+        self.assertTrue(_patch_capability_matrix(cap_module))
+        row = cap_module.EXCHANGE_CAPABILITIES.get_capabilities(
+            "kraken", cap_module.MarketMode.MARGIN
+        )
+        self.assertIsNotNone(row)
+        self.assertTrue(row.supports_margin)
+        self.assertTrue(row.supports_leverage)
+        self.assertEqual(row.max_leverage, 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Make NIJA actually use Kraken spot margin when the exact account and pair are eligible, while preserving existing profitability, exposure, writer-authority, and liquidation protections.

## Behavior

- Automatic Kraken margin is enabled with a conservative **2× default**.
- **3× remains the hard maximum**.
- Automatic entries are long-only by default; NIJA does not automatically open leveraged shorts.
- Margin-capable sell handling remains available for explicit `reduce_only` exits.
- The requested notional is scaled at the canonical submit boundary, then still passes NIJA's total-exposure, per-symbol exposure, profitability, ECEL, and margin-health gates.
- If the account, pair, permissions, buying power, or health check is not acceptable, the ordinary entry remains spot.
- Once an order is explicitly classified as margin, any failure is fail-closed and **cannot silently downgrade to spot**.
- Existing leveraged exits are recovered from the margin ledger and sent with `reduce_only=true`.

## Confirmed defects fixed

- Normal strategy entries always arrived with leverage 1.
- The margin engine was process-global, allowing platform/user state leakage.
- The execution pipeline queried a margin capability method that did not exist.
- Pair eligibility was not checked against live Kraken `AssetPairs` leverage values.
- The multi-broker router discarded leverage and reduce-only fields before calling Kraken.
- Kraken's internal `margin_mode` label could be sent as an unsupported AddOrder field.
- Sell orders could be misclassified as reducing solely because the side was sell.
- Explicit margin failures could fall back to spot.
- Kraken MARGIN was missing from the execution capability matrix.
- Direct Kraken adapter calls could lose the platform/user account scope before invoking the older adapter implementation.
- Long-only automatic-entry policy could incorrectly block a legitimate leveraged sell exit.

## Implementation

- Account-keyed Kraken margin-engine registry and execution scope.
- Live private permission/TradeBalance health checks per account.
- Live public `AssetPairs` leverage discovery per pair and side.
- 2× default leverage, 3× hard ceiling.
- Account-specific buying-power and leveraged-notional calculation.
- Runtime Kraken MARGIN capability installation.
- Final dispatch bridge that preserves `leverage`, `reduce_only`, and account identity.
- Kraken AddOrder payload restricted to supported fields.
- Focused regression tests for account isolation, pair eligibility, low-margin rejection, dispatch metadata, and no-spot-fallback behavior.

## Deployment markers

- `KRAKEN_MARGIN_AUTO_RUNTIME_INSTALLED`
- `KRAKEN_MARGIN_CAPABILITY_INSTALLED`
- `KRAKEN_MARGIN_AUTO_PLAN ... decision=MARGIN leverage=2x`
- `KRAKEN_MARGIN_ORDER_COMPILED`
- `KRAKEN_MARGIN_ORDER_ACK`
- `KRAKEN_MARGIN_DISPATCH_BLOCKED ... spot_fallback=false`

## Required Kraken account conditions

The Kraken API key must retain order-creation and trade-query permissions, and Kraken must advertise leverage for the selected pair. NIJA does not fabricate eligibility when Kraken rejects it.

## CI infrastructure status

GitHub created the preflight workflow job but terminated it before checkout or test execution. The job exposes no steps and no log URL (`steps=None`, `logs_url=None`), so the red Actions state contains no actionable repository-code failure.