### PR TITLE
Keep every Kraken account connected and exit-capable

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -177,12 +177,22 @@ def _install_kraken_exit_safety_convergence() -> None:
     )
 
 
+def _install_kraken_exit_final_guards() -> None:
+    _install_module(
+        "bot.kraken_exit_final_guards_patch",
+        "kraken_exit_final_guards_patch",
+        "KRAKEN_EXIT_FINAL_GUARDS",
+        "20260713-kraken-exit-final-guards-v1",
+    )
+
+
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
     _install_kraken_margin_auto_runtime()
     _install_kraken_all_account_exit_runtime()
     _install_kraken_exit_safety_convergence()
+    _install_kraken_exit_final_guards()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -195,6 +195,15 @@ def _install_kraken_exit_execution_safety() -> None:
     )
 
 
+def _install_kraken_exit_margin_cost() -> None:
+    _install_module(
+        "bot.kraken_exit_margin_cost_patch",
+        "kraken_exit_margin_cost_patch",
+        "KRAKEN_EXIT_MARGIN_COST",
+        "20260713-kraken-exit-margin-cost-v1",
+    )
+
+
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
@@ -203,6 +212,7 @@ def install_import_hook() -> None:
     _install_kraken_exit_safety_convergence()
     _install_kraken_exit_final_guards()
     _install_kraken_exit_execution_safety()
+    _install_kraken_exit_margin_cost()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -159,10 +159,30 @@ def _install_kraken_margin_auto_runtime() -> None:
     )
 
 
+def _install_kraken_all_account_exit_runtime() -> None:
+    _install_module(
+        "bot.kraken_all_account_exit_runtime_patch",
+        "kraken_all_account_exit_runtime_patch",
+        "KRAKEN_ALL_ACCOUNT_EXIT_RUNTIME",
+        "20260713-kraken-all-account-exit-v1",
+    )
+
+
+def _install_kraken_exit_safety_convergence() -> None:
+    _install_module(
+        "bot.kraken_exit_safety_convergence_patch",
+        "kraken_exit_safety_convergence_patch",
+        "KRAKEN_EXIT_SAFETY_CONVERGENCE",
+        "20260713-kraken-exit-safety-v1",
+    )
+
+
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
     _install_kraken_margin_auto_runtime()
+    _install_kraken_all_account_exit_runtime()
+    _install_kraken_exit_safety_convergence()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -186,6 +186,15 @@ def _install_kraken_exit_final_guards() -> None:
     )
 
 
+def _install_kraken_exit_execution_safety() -> None:
+    _install_module(
+        "bot.kraken_exit_execution_safety_patch",
+        "kraken_exit_execution_safety_patch",
+        "KRAKEN_EXIT_EXECUTION_SAFETY",
+        "20260713-kraken-exit-execution-safety-v1",
+    )
+
+
 def install_import_hook() -> None:
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
@@ -193,6 +202,7 @@ def install_import_hook() -> None:
     _install_kraken_all_account_exit_runtime()
     _install_kraken_exit_safety_convergence()
     _install_kraken_exit_final_guards()
+    _install_kraken_exit_execution_safety()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")

--- a/bot/kraken_all_account_exit_runtime_patch.py
+++ b/bot/kraken_all_account_exit_runtime_patch.py
@@ -1,0 +1,762 @@
+"""Account-local Kraken connection and profit/break-even exit convergence.
+
+This runtime layer fixes three structural problems:
+
+1. A live trading thread was treated as proof that its broker was still privately
+   authenticated.  The exit supervisor could therefore hand off while the exact
+   platform/user Kraken adapter was disconnected or stale.
+2. The legacy automatic exit worker was process-global and bound to whichever
+   execution engine/broker happened to start first.  Multi-account user positions
+   could be monitored through the wrong adapter or not monitored at all.
+3. Entry-only gates (cash buying power, throttling, allocation and short-capability
+   checks) could block a legitimate sell-to-close/reduce-only exit.
+
+The patch keeps writer authority, Kraken private authentication, ECEL validation,
+exchange minimums and broker acknowledgements fail-closed.  Profit is not
+promised: normal exits prefer net profit, then fee-adjusted break-even, while
+configured stop-loss and critical margin reduction may still realise a loss.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from functools import wraps
+from types import ModuleType
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+
+logger = logging.getLogger("nija.kraken_all_account_exit")
+_MARKER = "20260713-kraken-all-account-exit-v1"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_IMPORT_LOCK = threading.RLock()
+_ORIGINAL_IMPORT = None
+_PATCHED: set[tuple[str, int]] = set()
+_PRIVATE_HEALTH: Dict[int, Tuple[float, bool, str]] = {}
+_PAIR_CACHE: Dict[Tuple[int, str], Tuple[float, Optional[str]]] = {}
+_EXIT_STATE: Dict[Tuple[str, str], Dict[str, Any]] = {}
+_ACTIVE_EXITS: set[Tuple[str, str]] = set()
+_EXIT_LOCK = threading.RLock()
+_PIPELINE_LOCK = threading.RLock()
+_EXIT_SCOPE: ContextVar[bool] = ContextVar("nija_account_exit_scope", default=False)
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+        return default if parsed != parsed else parsed
+    except Exception:
+        return default
+
+
+def _identity(broker: Any, fallback: str = "") -> str:
+    for value in (
+        fallback,
+        getattr(broker, "account_identifier", None),
+        getattr(broker, "account_id", None),
+        getattr(broker, "user_id", None),
+    ):
+        text = str(value or "").strip().lower()
+        if text and text not in {"none", "kraken"}:
+            return text
+    return "platform:kraken"
+
+
+def _is_kraken(broker: Any) -> bool:
+    if broker is None:
+        return False
+    values = (
+        type(broker).__name__,
+        getattr(broker, "NAME", ""),
+        getattr(getattr(broker, "broker_type", None), "value", getattr(broker, "broker_type", "")),
+    )
+    return any("kraken" in str(value or "").lower() for value in values)
+
+
+def _connected(broker: Any) -> bool:
+    try:
+        value = getattr(broker, "connected", False)
+        return bool(value() if callable(value) else value)
+    except Exception:
+        return False
+
+
+def _private_probe_ttl() -> float:
+    return max(5.0, _f(os.environ.get("NIJA_KRAKEN_PRIVATE_PROBE_TTL_S"), 20.0))
+
+
+def _private_ready(broker: Any, identity: str = "", *, force: bool = False) -> Tuple[bool, str]:
+    """Verify private Kraken account access for the exact adapter."""
+    if broker is None:
+        return False, "broker_missing"
+    if not _is_kraken(broker):
+        return _connected(broker), "non_kraken_connected" if _connected(broker) else "disconnected"
+    if not _connected(broker):
+        return False, "connected_flag_false"
+
+    key = id(broker)
+    now = time.time()
+    cached = _PRIVATE_HEALTH.get(key)
+    if not force and cached and now - cached[0] < _private_probe_ttl():
+        return cached[1], cached[2]
+
+    account = _identity(broker, identity)
+    try:
+        private_call = getattr(broker, "_kraken_api_call", None)
+        if callable(private_call):
+            payload = private_call("TradeBalance", {"asset": "ZUSD"})
+            errors = payload.get("error") or [] if isinstance(payload, dict) else ["invalid_payload"]
+            result = payload.get("result") if isinstance(payload, dict) else None
+            if isinstance(errors, str):
+                errors = [errors]
+            if errors:
+                reason = "private_api_error:" + ",".join(str(item) for item in errors)
+                _PRIVATE_HEALTH[key] = (now, False, reason)
+                logger.warning(
+                    "KRAKEN_ACCOUNT_PRIVATE_PROBE_FAILED marker=%s account=%s reason=%s",
+                    _MARKER, account, reason,
+                )
+                return False, reason
+            if not isinstance(result, Mapping):
+                reason = "trade_balance_result_missing"
+                _PRIVATE_HEALTH[key] = (now, False, reason)
+                return False, reason
+            _PRIVATE_HEALTH[key] = (now, True, "trade_balance_ok")
+            logger.info(
+                "KRAKEN_ACCOUNT_PRIVATE_READY marker=%s account=%s equity=%s free_margin=%s",
+                _MARKER, account, result.get("e", result.get("eb")), result.get("mf", result.get("tb")),
+            )
+            return True, "trade_balance_ok"
+
+        getter = getattr(broker, "get_account_balance", None)
+        if callable(getter):
+            value = getter()
+            if _f(value if not isinstance(value, Mapping) else value.get("total_funds", value.get("balance")), -1.0) >= 0:
+                _PRIVATE_HEALTH[key] = (now, True, "balance_ok")
+                return True, "balance_ok"
+    except Exception as exc:
+        reason = f"private_probe_exception:{exc}"
+        _PRIVATE_HEALTH[key] = (now, False, reason)
+        logger.warning(
+            "KRAKEN_ACCOUNT_PRIVATE_PROBE_FAILED marker=%s account=%s reason=%s",
+            _MARKER, account, reason,
+        )
+        return False, reason
+
+    _PRIVATE_HEALTH[key] = (now, False, "private_probe_unavailable")
+    return False, "private_probe_unavailable"
+
+
+def _force_reconnect(broker: Any, identity: str) -> bool:
+    if broker is None:
+        return False
+    account = _identity(broker, identity)
+    ready, _ = _private_ready(broker, account)
+    if ready:
+        return True
+    try:
+        for attr in ("connected", "_connected"):
+            if hasattr(broker, attr):
+                try:
+                    setattr(broker, attr, False)
+                except Exception:
+                    pass
+        connector = getattr(broker, "connect", None)
+        if not callable(connector):
+            return False
+        result = connector()
+        _PRIVATE_HEALTH.pop(id(broker), None)
+        ready, reason = _private_ready(broker, account, force=True)
+        logger.warning(
+            "KRAKEN_ACCOUNT_RECONNECT_RESULT marker=%s account=%s connect_result=%s private_ready=%s reason=%s",
+            _MARKER, account, result, ready, reason,
+        )
+        return ready
+    except Exception as exc:
+        logger.warning(
+            "KRAKEN_ACCOUNT_RECONNECT_FAILED marker=%s account=%s error=%s",
+            _MARKER, account, exc,
+        )
+        return False
+
+
+def _normalise_symbol(value: Any) -> str:
+    return str(value or "").strip().upper().replace("/", "-").replace("_", "-")
+
+
+def _base_asset(symbol: str) -> str:
+    text = _normalise_symbol(symbol)
+    if "-" in text:
+        base = text.split("-", 1)[0]
+    elif text.endswith("USDT"):
+        base = text[:-4]
+    elif text.endswith("USDC"):
+        base = text[:-4]
+    elif text.endswith("USD") or text.endswith("EUR"):
+        base = text[:-3]
+    else:
+        base = text
+    aliases = {"XXBT": "XBT", "BTC": "XBT", "XETH": "ETH"}
+    return aliases.get(base, base)
+
+
+def _public_call(broker: Any, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    custom = getattr(broker, "_kraken_public_api_call", None)
+    if callable(custom):
+        result = custom(method, params or {})
+        return result if isinstance(result, dict) else {}
+    api = getattr(broker, "api", None)
+    query_public = getattr(api, "query_public", None)
+    if callable(query_public):
+        result = query_public(method, params or {})
+        return result if isinstance(result, dict) else {}
+    query_public = getattr(broker, "query_public", None)
+    if callable(query_public):
+        result = query_public(method, params or {})
+        return result if isinstance(result, dict) else {}
+    return {}
+
+
+def _resolve_pair(broker: Any, symbol: str) -> Optional[str]:
+    canonical = _normalise_symbol(symbol)
+    key = (id(broker), canonical)
+    now = time.time()
+    cached = _PAIR_CACHE.get(key)
+    if cached and now - cached[0] < 1800.0:
+        return cached[1]
+
+    base = _base_asset(canonical)
+    if not base:
+        _PAIR_CACHE[key] = (now, None)
+        return None
+
+    candidates = []
+    if "-" in canonical:
+        candidates.append(canonical.replace("-", ""))
+    candidates.extend(f"{base}{quote}" for quote in ("USD", "USDT", "USDC", "EUR"))
+    candidates = list(dict.fromkeys(candidates))
+
+    for candidate in candidates:
+        try:
+            payload = _public_call(broker, "AssetPairs", {"pair": candidate})
+            errors = payload.get("error") or [] if isinstance(payload, dict) else ["invalid"]
+            result = payload.get("result", {}) if isinstance(payload, dict) else {}
+            if not errors and isinstance(result, Mapping) and result:
+                row = next(iter(result.values()))
+                altname = str(row.get("altname") or candidate) if isinstance(row, Mapping) else candidate
+                _PAIR_CACHE[key] = (now, altname)
+                logger.info(
+                    "KRAKEN_EXIT_PAIR_RESOLVED marker=%s symbol=%s pair=%s",
+                    _MARKER, canonical, altname,
+                )
+                return altname
+        except Exception:
+            continue
+
+    _PAIR_CACHE[key] = (now, None)
+    logger.warning(
+        "KRAKEN_EXIT_PAIR_UNRESOLVED marker=%s symbol=%s candidates=%s",
+        _MARKER, canonical, candidates,
+    )
+    return None
+
+
+def _ticker_price(broker: Any, pair: str) -> float:
+    for method_name in ("get_current_price", "get_price", "fetch_price"):
+        method = getattr(broker, method_name, None)
+        if callable(method):
+            try:
+                value = _f(method(pair))
+                if value > 0:
+                    return value
+            except Exception:
+                pass
+    try:
+        payload = _public_call(broker, "Ticker", {"pair": pair})
+        result = payload.get("result", {}) if isinstance(payload, dict) else {}
+        if isinstance(result, Mapping) and result:
+            row = next(iter(result.values()))
+            if isinstance(row, Mapping):
+                close = row.get("c")
+                if isinstance(close, (list, tuple)) and close:
+                    return _f(close[0])
+                for key in ("last", "price", "close"):
+                    value = _f(row.get(key))
+                    if value > 0:
+                        return value
+    except Exception:
+        pass
+    return 0.0
+
+
+def _position_rows(broker: Any) -> Iterable[MutableMapping[str, Any]]:
+    tracker = getattr(broker, "position_tracker", None)
+    yielded: set[str] = set()
+    if tracker is not None:
+        try:
+            for symbol in tracker.get_all_positions() or []:
+                row = tracker.get_position(symbol)
+                if isinstance(row, MutableMapping):
+                    payload = dict(row)
+                    payload.setdefault("symbol", symbol)
+                    yielded.add(_normalise_symbol(symbol))
+                    yield payload
+        except Exception:
+            pass
+    getter = getattr(broker, "get_positions", None)
+    if callable(getter):
+        try:
+            rows = getter() or []
+            if isinstance(rows, Mapping):
+                rows = list(rows.values())
+            for row in rows if isinstance(rows, (list, tuple, set)) else []:
+                if not isinstance(row, Mapping):
+                    continue
+                symbol = _normalise_symbol(row.get("symbol"))
+                if not symbol or symbol in yielded:
+                    continue
+                yield dict(row)
+        except Exception:
+            pass
+
+
+def _entry_price(position: Mapping[str, Any]) -> float:
+    for key in (
+        "entry_price", "avg_entry_price", "average_price", "cost_basis_price",
+        "average_filled_price", "avg_fill_price", "avg_price", "purchase_price",
+    ):
+        value = _f(position.get(key))
+        if value > 0:
+            return value
+    quantity = abs(_f(position.get("quantity", position.get("qty", position.get("size")))))
+    total_cost = _f(position.get("size_usd", position.get("cost_basis_usd", position.get("total_cost"))))
+    return total_cost / quantity if quantity > 0 and total_cost > 0 else 0.0
+
+
+def _quantity(position: Mapping[str, Any]) -> float:
+    for key in ("quantity", "qty", "amount", "size", "units"):
+        value = abs(_f(position.get(key)))
+        if value > 0:
+            return value
+    return 0.0
+
+
+def _held_minutes(position: Mapping[str, Any]) -> float:
+    raw = position.get("first_entry_time") or position.get("entry_time") or position.get("opened_at")
+    if raw is None:
+        return 0.0
+    try:
+        if isinstance(raw, datetime):
+            dt = raw
+        else:
+            dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return max(0.0, (datetime.now(timezone.utc) - dt).total_seconds() / 60.0)
+    except Exception:
+        return 0.0
+
+
+def _margin_extra_buffer(account: str, symbol: str) -> float:
+    try:
+        from bot.margin_position_ledger import get_margin_position_ledger
+        row = get_margin_position_ledger().get_record(
+            broker="kraken", account_id=account, subaccount_id="",
+            symbol=_normalise_symbol(symbol), asset_class="crypto",
+        )
+        if row and int(_f(row.get("leverage"), 1.0)) > 1:
+            return max(0.0, _f(os.environ.get("NIJA_KRAKEN_MARGIN_EXIT_EXTRA_BUFFER_PCT"), 0.002))
+    except Exception:
+        pass
+    return 0.0
+
+
+def _exit_thresholds(account: str, symbol: str, entry: float) -> Tuple[float, float]:
+    round_trip = max(0.001, _f(os.environ.get("NIJA_KRAKEN_EXIT_ROUND_TRIP_COST_PCT"), 0.008))
+    round_trip += _margin_extra_buffer(account, symbol)
+    net_target = max(0.001, _f(os.environ.get("NIJA_KRAKEN_EXIT_NET_PROFIT_TARGET_PCT"), 0.004))
+    return entry * (1.0 + round_trip), entry * (1.0 + round_trip + net_target)
+
+
+def _exit_reason(position: Mapping[str, Any], price: float, account: str, symbol: str) -> Tuple[Optional[str], float, float]:
+    entry = _entry_price(position)
+    if entry <= 0 or price <= 0:
+        return None, 0.0, 0.0
+    side = str(position.get("side") or "long").strip().lower()
+    short = side in {"short", "sell"}
+    breakeven, target = _exit_thresholds(account, symbol, entry)
+    if short:
+        round_trip = max(0.001, (breakeven / entry) - 1.0)
+        net_target = max(0.001, (target / entry) - (breakeven / entry))
+        breakeven = entry * (1.0 - round_trip)
+        target = entry * (1.0 - round_trip - net_target)
+
+    stop = _f(position.get("stop_loss"))
+    if stop > 0 and ((not short and price <= stop) or (short and price >= stop)):
+        return "emergency_stop_loss", breakeven, target
+
+    for key in ("take_profit_1", "take_profit_2", "take_profit_3", "take_profit"):
+        tp = _f(position.get(key))
+        if tp > 0 and ((not short and price >= tp) or (short and price <= tp)):
+            return key, breakeven, target
+
+    state_key = (account, symbol)
+    state = _EXIT_STATE.setdefault(state_key, {"high": price, "low": price, "armed": False})
+    state["high"] = max(_f(state.get("high"), price), price)
+    state["low"] = min(_f(state.get("low"), price), price)
+    profit_hit = price >= target if not short else price <= target
+    if profit_hit:
+        state["armed"] = True
+        return "net_profit_target", breakeven, target
+
+    held = _held_minutes(position)
+    break_even_hold = max(5.0, _f(os.environ.get("NIJA_KRAKEN_BREAK_EVEN_MAX_HOLD_MINUTES"), 60.0))
+    at_breakeven = price >= breakeven if not short else price <= breakeven
+    if _truthy("NIJA_KRAKEN_BREAK_EVEN_EXIT_ENABLED", "true") and held >= break_even_hold and at_breakeven:
+        return "fee_adjusted_break_even", breakeven, target
+
+    trail = max(0.001, _f(os.environ.get("NIJA_KRAKEN_PROFIT_LOCK_TRAIL_PCT"), 0.0035))
+    if state.get("armed") and at_breakeven:
+        retraced = price <= state["high"] * (1.0 - trail) if not short else price >= state["low"] * (1.0 + trail)
+        if retraced:
+            return "profit_lock_break_even", breakeven, target
+    return None, breakeven, target
+
+
+def _submit_exit(broker: Any, account: str, pair: str, quantity: float, reason: str) -> Mapping[str, Any]:
+    try:
+        from bot.pipeline_order_submitter import submit_market_order_via_pipeline
+        with _EXIT_LOCK:
+            result = submit_market_order_via_pipeline(
+                broker=broker,
+                symbol=pair,
+                side="sell",
+                quantity=quantity,
+                size_type="base",
+                strategy=f"KrakenAccountExit:{reason}",
+            )
+        return result if isinstance(result, Mapping) else {"status": "error", "error": str(result)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+
+def _scan_account_exits(trader: Any, identity: str, broker: Any) -> int:
+    if not _truthy("NIJA_KRAKEN_ALL_ACCOUNT_EXIT_ENABLED", "true") or not _is_kraken(broker):
+        return 0
+    account = _identity(broker, identity)
+    ready, reason = _private_ready(broker, account)
+    if not ready:
+        logger.warning(
+            "KRAKEN_ACCOUNT_EXIT_SCAN_BLOCKED marker=%s account=%s reason=%s",
+            _MARKER, account, reason,
+        )
+        return 0
+
+    closed = 0
+    for position in list(_position_rows(broker)):
+        symbol = _normalise_symbol(position.get("symbol"))
+        quantity = _quantity(position)
+        entry = _entry_price(position)
+        if not symbol or quantity <= 0:
+            continue
+        pair = _resolve_pair(broker, symbol)
+        if not pair:
+            continue
+        price = _ticker_price(broker, pair)
+        if price <= 0:
+            logger.warning(
+                "KRAKEN_ACCOUNT_EXIT_PRICE_MISSING marker=%s account=%s symbol=%s pair=%s",
+                _MARKER, account, symbol, pair,
+            )
+            continue
+        reason, breakeven, target = _exit_reason(position, price, account, symbol)
+        logger.info(
+            "KRAKEN_ACCOUNT_EXIT_EVALUATED marker=%s account=%s symbol=%s pair=%s qty=%.8f "
+            "entry=$%.8f market=$%.8f breakeven=$%.8f profit_target=$%.8f decision=%s",
+            _MARKER, account, symbol, pair, quantity, entry, price, breakeven, target, reason or "hold",
+        )
+        if not reason:
+            continue
+
+        active_key = (account, symbol)
+        with _EXIT_LOCK:
+            if active_key in _ACTIVE_EXITS:
+                continue
+            _ACTIVE_EXITS.add(active_key)
+        try:
+            logger.critical(
+                "KRAKEN_ACCOUNT_EXIT_TRIGGER marker=%s account=%s symbol=%s pair=%s reason=%s "
+                "market=$%.8f breakeven=$%.8f profit_target=$%.8f",
+                _MARKER, account, symbol, pair, reason, price, breakeven, target,
+            )
+            result = _submit_exit(broker, account, pair, quantity, reason)
+            status = str(result.get("status") or "").lower()
+            success = status in {"filled", "closed", "done", "complete", "completed", "success", "accepted"} or bool(result.get("order_id"))
+            if not success:
+                logger.error(
+                    "KRAKEN_ACCOUNT_EXIT_ORDER_FAILED marker=%s account=%s symbol=%s reason=%s error=%s",
+                    _MARKER, account, symbol, reason, result.get("error", result),
+                )
+                continue
+            tracker = getattr(broker, "position_tracker", None)
+            if tracker is not None and callable(getattr(tracker, "track_exit", None)):
+                try:
+                    tracker.track_exit(symbol)
+                except Exception:
+                    pass
+            _EXIT_STATE.pop(active_key, None)
+            closed += 1
+            logger.critical(
+                "KRAKEN_ACCOUNT_EXIT_ORDER_ACK marker=%s account=%s symbol=%s reason=%s "
+                "order_id=%s filled_price=%s",
+                _MARKER, account, symbol, reason, result.get("order_id"), result.get("filled_price"),
+            )
+        finally:
+            with _EXIT_LOCK:
+                _ACTIVE_EXITS.discard(active_key)
+    return closed
+
+
+def _patch_recovery_module(module: ModuleType) -> bool:
+    changed = False
+    original_connect = getattr(module, "_connect", None)
+    if callable(original_connect) and not getattr(original_connect, "_nija_private_ready_v1", False):
+        @wraps(original_connect)
+        def connect(broker: Any, identity: str) -> bool:
+            if _private_ready(broker, identity)[0]:
+                return True
+            result = original_connect(broker, identity)
+            return bool(result and _private_ready(broker, identity, force=True)[0]) or _force_reconnect(broker, identity)
+        connect._nija_private_ready_v1 = True  # type: ignore[attr-defined]
+        module._connect = connect
+        changed = True
+
+    original_alive = getattr(module, "_normal_thread_alive", None)
+    if callable(original_alive) and not getattr(original_alive, "_nija_private_ready_v1", False):
+        @wraps(original_alive)
+        def normal_thread_alive(trader: Any, scope: str, user_id: Optional[str], broker_type: Any, broker: Any) -> bool:
+            alive = bool(original_alive(trader, scope, user_id, broker_type, broker))
+            if not alive:
+                return False
+            name = str(getattr(broker_type, "value", broker_type) or "kraken").lower()
+            identity = f"platform:{name}" if scope == "platform" else f"user:{user_id}:{name}"
+            ready, reason = _private_ready(broker, identity)
+            if not ready:
+                logger.warning(
+                    "KRAKEN_THREAD_HANDOFF_REJECTED marker=%s account=%s reason=%s thread_alive=true",
+                    _MARKER, identity, reason,
+                )
+                return False
+            return True
+        normal_thread_alive._nija_private_ready_v1 = True  # type: ignore[attr-defined]
+        module._normal_thread_alive = normal_thread_alive
+        changed = True
+
+    original_manage = getattr(module, "_adopt_and_manage", None)
+    if callable(original_manage) and not getattr(original_manage, "_nija_account_exit_scan_v1", False):
+        @wraps(original_manage)
+        def adopt_and_manage(trader: Any, identity: str, broker: Any):
+            result = original_manage(trader, identity, broker)
+            try:
+                _scan_account_exits(trader, identity, broker)
+            except Exception:
+                logger.exception(
+                    "KRAKEN_ACCOUNT_EXIT_SCAN_FAILED marker=%s account=%s",
+                    _MARKER, identity,
+                )
+            return result
+        adopt_and_manage._nija_account_exit_scan_v1 = True  # type: ignore[attr-defined]
+        module._adopt_and_manage = adopt_and_manage
+        changed = True
+
+    original_retry = getattr(module, "_retry_all_accounts", None)
+    if callable(original_retry) and not getattr(original_retry, "_nija_account_matrix_v1", False):
+        @wraps(original_retry)
+        def retry_all_accounts(trader: Any):
+            result = original_retry(trader)
+            rows = []
+            iterator = getattr(module, "_iter_accounts", None)
+            if callable(iterator):
+                for identity, scope, user_id, broker_type, broker in list(iterator(trader)):
+                    if not _is_kraken(broker):
+                        continue
+                    ready, reason = _private_ready(broker, identity)
+                    rows.append(f"{identity}={'ready' if ready else 'down'}:{reason}")
+            logger.critical(
+                "KRAKEN_ALL_ACCOUNT_CONNECTION_MATRIX marker=%s accounts=%s",
+                _MARKER, rows,
+            )
+            return result
+        retry_all_accounts._nija_account_matrix_v1 = True  # type: ignore[attr-defined]
+        module._retry_all_accounts = retry_all_accounts
+        changed = True
+    return changed
+
+
+def _is_exit_request(request: Any) -> bool:
+    intent = str(getattr(request, "intent_type", "") or "").strip().lower()
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    return intent in {"exit", "reduce"} or effect in {"close", "reduce"} or metadata.get("closing_position") is True
+
+
+def _patch_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+    changed = False
+
+    original_caps = getattr(cls, "_gate_broker_capabilities", None)
+    if callable(original_caps) and not getattr(original_caps, "_nija_exit_capability_v1", False):
+        @wraps(original_caps)
+        def gate_broker_capabilities(self: Any, request: Any, t_start: float):
+            if _is_exit_request(request):
+                logger.info(
+                    "ACCOUNT_EXIT_CAPABILITY_CLOSE_ALLOWED marker=%s account=%s symbol=%s side=%s",
+                    _MARKER, getattr(request, "account_id", "default"), getattr(request, "symbol", ""), getattr(request, "side", ""),
+                )
+                return None
+            return original_caps(self, request, t_start)
+        gate_broker_capabilities._nija_exit_capability_v1 = True  # type: ignore[attr-defined]
+        cls._gate_broker_capabilities = gate_broker_capabilities
+        changed = True
+
+    original_execute = getattr(cls, "execute", None)
+    if callable(original_execute) and not getattr(original_execute, "_nija_exit_entry_gate_split_v1", False):
+        @wraps(original_execute)
+        def execute(self: Any, request: Any):
+            with _PIPELINE_LOCK:
+                if not _is_exit_request(request):
+                    return original_execute(self, request)
+                token = _EXIT_SCOPE.set(True)
+                names = (
+                    "_pre_trade_risk_engine", "_allocation_clamp", "_execution_observer",
+                    "_throttler", "_downstream_guard",
+                )
+                saved = {name: getattr(self, name, None) for name in names}
+                try:
+                    for name in names:
+                        setattr(self, name, None)
+                    logger.critical(
+                        "ACCOUNT_EXIT_ENTRY_ONLY_GATES_BYPASSED marker=%s account=%s symbol=%s "
+                        "writer_and_broker_gates_preserved=true",
+                        _MARKER, getattr(request, "account_id", "default"), getattr(request, "symbol", ""),
+                    )
+                    return original_execute(self, request)
+                finally:
+                    for name, value in saved.items():
+                        setattr(self, name, value)
+                    _EXIT_SCOPE.reset(token)
+        execute._nija_exit_entry_gate_split_v1 = True  # type: ignore[attr-defined]
+        cls.execute = execute
+        changed = True
+    return changed
+
+
+def _patch_auto_exit_module(module: ModuleType) -> bool:
+    starter = getattr(module, "_start_monitor", None)
+    if not callable(starter) or getattr(starter, "_nija_account_local_disabled_v1", False):
+        return False
+
+    def start_monitor(engine: Any) -> None:
+        logger.warning(
+            "GLOBAL_SINGLETON_AUTO_EXIT_DISABLED marker=%s reason=account_local_kraken_supervisor_active",
+            _MARKER,
+        )
+        return None
+
+    start_monitor._nija_account_local_disabled_v1 = True  # type: ignore[attr-defined]
+    start_monitor.__wrapped__ = starter  # type: ignore[attr-defined]
+    module._start_monitor = start_monitor
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    name = str(getattr(module, "__name__", ""))
+    changed = False
+    if name.endswith("account_exit_management_recovery_patch"):
+        changed = _patch_recovery_module(module) or changed
+    if name.endswith("execution_pipeline"):
+        changed = _patch_execution_pipeline(module) or changed
+    if name.endswith("auto_exit_sl_tp_runtime_patch"):
+        changed = _patch_auto_exit_module(module) or changed
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def _set_defaults() -> None:
+    defaults = {
+        "NIJA_KRAKEN_ALL_ACCOUNT_EXIT_ENABLED": "true",
+        "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_ENABLED": "true",
+        "NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S": "10",
+        "NIJA_KRAKEN_PRIVATE_PROBE_TTL_S": "20",
+        "NIJA_KRAKEN_EXIT_ROUND_TRIP_COST_PCT": "0.008",
+        "NIJA_KRAKEN_MARGIN_EXIT_EXTRA_BUFFER_PCT": "0.002",
+        "NIJA_KRAKEN_EXIT_NET_PROFIT_TARGET_PCT": "0.004",
+        "NIJA_KRAKEN_BREAK_EVEN_EXIT_ENABLED": "true",
+        "NIJA_KRAKEN_BREAK_EVEN_MAX_HOLD_MINUTES": "60",
+        "NIJA_KRAKEN_PROFIT_LOCK_TRAIL_PCT": "0.0035",
+    }
+    for key, value in defaults.items():
+        os.environ.setdefault(key, value)
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _set_defaults()
+    _patch_loaded()
+    with _IMPORT_LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical(
+        "KRAKEN_ALL_ACCOUNT_EXIT_RUNTIME_INSTALLED marker=%s interval_s=%s "
+        "profit_target_net=%s break_even_hold_min=%s",
+        _MARKER,
+        os.environ.get("NIJA_ACCOUNT_EXIT_MANAGEMENT_INTERVAL_S"),
+        os.environ.get("NIJA_KRAKEN_EXIT_NET_PROFIT_TARGET_PCT"),
+        os.environ.get("NIJA_KRAKEN_BREAK_EVEN_MAX_HOLD_MINUTES"),
+    )
+
+
+__all__ = [
+    "install_import_hook", "_private_ready", "_resolve_pair", "_exit_reason",
+    "_scan_account_exits", "_patch_execution_pipeline", "_patch_recovery_module",
+]

--- a/bot/kraken_exit_execution_safety_patch.py
+++ b/bot/kraken_exit_execution_safety_patch.py
@@ -1,0 +1,129 @@
+"""Preserve downstream execution safety while bypassing entry-only exit gates."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.kraken_exit_execution_safety")
+_MARKER = "20260713-kraken-exit-execution-safety-v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+_EXIT_EXECUTION_LOCK = threading.RLock()
+
+
+def _is_exit_request(request: Any) -> bool:
+    intent = str(getattr(request, "intent_type", "") or "").strip().lower()
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    return intent in {"exit", "reduce"} or effect in {"close", "reduce"} or metadata.get("closing_position") is True
+
+
+def _patch_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "execute", None)
+    if not callable(current) or getattr(current, "_nija_exit_safe_gate_split_v2", False):
+        return False
+
+    # The earlier all-account patch wraps the canonical execute method and stores
+    # it through functools.wraps. Replace that broad wrapper rather than stacking
+    # another layer that would still disable the downstream guard internally.
+    original = getattr(current, "__wrapped__", None)
+    if not (
+        getattr(current, "_nija_exit_entry_gate_split_v1", False)
+        and callable(original)
+    ):
+        original = current
+
+    @wraps(original)
+    def execute(self: Any, request: Any):
+        if not _is_exit_request(request):
+            return original(self, request)
+        with _EXIT_EXECUTION_LOCK:
+            bypass_names = (
+                "_pre_trade_risk_engine",
+                "_allocation_clamp",
+                "_throttler",
+            )
+            saved = {name: getattr(self, name, None) for name in bypass_names}
+            observer = getattr(self, "_execution_observer", None)
+            downstream = getattr(self, "_downstream_guard", None)
+            try:
+                for name in bypass_names:
+                    setattr(self, name, None)
+                logger.critical(
+                    "ACCOUNT_EXIT_ENTRY_GATES_BYPASSED_SAFELY marker=%s account=%s symbol=%s "
+                    "execution_observer_preserved=%s downstream_guard_preserved=%s",
+                    _MARKER,
+                    getattr(request, "account_id", "default"),
+                    getattr(request, "symbol", ""),
+                    observer is not None,
+                    downstream is not None,
+                )
+                return original(self, request)
+            finally:
+                for name, value in saved.items():
+                    setattr(self, name, value)
+
+    execute._nija_exit_safe_gate_split_v2 = True  # type: ignore[attr-defined]
+    execute._nija_exit_entry_gate_split_v1 = True  # type: ignore[attr-defined]
+    cls.execute = execute
+    logger.warning("ACCOUNT_EXIT_DOWNSTREAM_SAFETY_PRESERVED marker=%s", _MARKER)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    changed = False
+    if str(getattr(module, "__name__", "")).endswith("execution_pipeline"):
+        changed = _patch_execution_pipeline(module)
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("KRAKEN_EXIT_EXECUTION_SAFETY_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = ["install_import_hook", "_patch_execution_pipeline"]

--- a/bot/kraken_exit_final_guards_patch.py
+++ b/bot/kraken_exit_final_guards_patch.py
@@ -91,6 +91,22 @@ def _patch_exit_decision(module: ModuleType) -> bool:
     return True
 
 
+def _hard_deny(self: Any, request: Any, t_start: float, reason: str):
+    deny = getattr(self, "_deny", None)
+    if callable(deny):
+        return deny(request, t_start, reason)
+    result_cls = getattr(sys.modules.get(type(self).__module__), "PipelineResult", None)
+    if isinstance(result_cls, type):
+        return result_cls(
+            success=False,
+            symbol=getattr(request, "symbol", ""),
+            side=getattr(request, "side", ""),
+            size_usd=float(getattr(request, "size_usd", 0.0) or 0.0),
+            error=reason,
+        )
+    return reason
+
+
 def _patch_execution_gate(module: ModuleType) -> bool:
     cls = getattr(module, "ExecutionPipeline", None)
     if not isinstance(cls, type):
@@ -113,13 +129,17 @@ def _patch_execution_gate(module: ModuleType) -> bool:
                     getattr(request, "side", ""),
                 )
                 return None
+            error = f"Account exit denied: distributed writer authority unavailable: {reason}"
             logger.error(
-                "ACCOUNT_EXIT_STATE_GATE_NOT_BYPASSED marker=%s account=%s symbol=%s reason=%s",
+                "ACCOUNT_EXIT_WRITER_AUTHORITY_DENIED marker=%s account=%s symbol=%s reason=%s",
                 _MARKER,
                 getattr(request, "account_id", "default"),
                 getattr(request, "symbol", ""),
                 reason,
             )
+            # Do not delegate to the legacy gate here: FORCE_TRADE can bypass that
+            # gate. A close without writer fencing risks duplicate orders.
+            return _hard_deny(self, request, t_start, error)
         return current(self, request, t_start)
 
     enforce_execution_gate._nija_risk_reducing_exit_gate_v1 = True  # type: ignore[attr-defined]

--- a/bot/kraken_exit_final_guards_patch.py
+++ b/bot/kraken_exit_final_guards_patch.py
@@ -1,0 +1,186 @@
+"""Final writer-authorized and cost-basis guards for Kraken account exits."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+logger = logging.getLogger("nija.kraken_exit_final_guards")
+_MARKER = "20260713-kraken-exit-final-guards-v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _is_exit_request(request: Any) -> bool:
+    intent = str(getattr(request, "intent_type", "") or "").strip().lower()
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    return intent in {"exit", "reduce"} or effect in {"close", "reduce"} or metadata.get("closing_position") is True
+
+
+def _live_mode() -> bool:
+    return not (
+        _truthy("DRY_RUN_MODE")
+        or _truthy("PAPER_MODE")
+        or _truthy("APP_STORE_MODE")
+        or _truthy("NIJA_APP_STORE_MODE")
+    )
+
+
+def _writer_authorized() -> tuple[bool, str]:
+    try:
+        try:
+            from bot.execution_authority_context import assert_distributed_writer_authority
+        except ImportError:
+            from execution_authority_context import assert_distributed_writer_authority  # type: ignore[import]
+        assert_distributed_writer_authority()
+        return True, "distributed_writer_authority_ok"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _unverified_cost_basis(position: Any) -> bool:
+    if not isinstance(position, Mapping):
+        return True
+    if position.get("cost_basis_verified") is False or position.get("auto_exit_blocked") is True:
+        return True
+    text = " ".join(
+        str(position.get(key) or "").lower()
+        for key in ("entry_price_source", "exit_profile", "notes", "auto_exit_block_reason")
+    )
+    return any(
+        token in text
+        for token in (
+            "unverified_cost_basis",
+            "estimated_from_adoption_mark",
+            "reconciliation_required",
+        )
+    )
+
+
+def _patch_exit_decision(module: ModuleType) -> bool:
+    current = getattr(module, "_exit_reason", None)
+    if not callable(current) or getattr(current, "_nija_verified_cost_basis_v1", False):
+        return False
+
+    @wraps(current)
+    def exit_reason(position: Any, price: float, account: str, symbol: str):
+        if _unverified_cost_basis(position):
+            logger.critical(
+                "KRAKEN_EXIT_SKIPPED_UNVERIFIED_COST_BASIS marker=%s account=%s symbol=%s",
+                _MARKER, account, symbol,
+            )
+            return None, 0.0, 0.0
+        return current(position, price, account, symbol)
+
+    exit_reason._nija_verified_cost_basis_v1 = True  # type: ignore[attr-defined]
+    module._exit_reason = exit_reason
+    logger.warning("KRAKEN_VERIFIED_COST_BASIS_EXIT_GUARD_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_execution_gate(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_enforce_execution_gate", None)
+    if not callable(current) or getattr(current, "_nija_risk_reducing_exit_gate_v1", False):
+        return False
+
+    @wraps(current)
+    def enforce_execution_gate(self: Any, request: Any, t_start: float):
+        if _is_exit_request(request) and _live_mode():
+            authorized, reason = _writer_authorized()
+            if authorized:
+                logger.critical(
+                    "ACCOUNT_EXIT_STATE_GATE_BYPASSED marker=%s account=%s symbol=%s side=%s "
+                    "writer_authority_verified=true broker_and_ecel_gates_preserved=true",
+                    _MARKER,
+                    getattr(request, "account_id", "default"),
+                    getattr(request, "symbol", ""),
+                    getattr(request, "side", ""),
+                )
+                return None
+            logger.error(
+                "ACCOUNT_EXIT_STATE_GATE_NOT_BYPASSED marker=%s account=%s symbol=%s reason=%s",
+                _MARKER,
+                getattr(request, "account_id", "default"),
+                getattr(request, "symbol", ""),
+                reason,
+            )
+        return current(self, request, t_start)
+
+    enforce_execution_gate._nija_risk_reducing_exit_gate_v1 = True  # type: ignore[attr-defined]
+    cls._enforce_execution_gate = enforce_execution_gate
+    logger.warning("ACCOUNT_EXIT_WRITER_AUTHORIZED_STATE_GATE_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    name = str(getattr(module, "__name__", ""))
+    changed = False
+    if name.endswith("kraken_all_account_exit_runtime_patch"):
+        changed = _patch_exit_decision(module) or changed
+    if name.endswith("execution_pipeline"):
+        changed = _patch_execution_gate(module) or changed
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("KRAKEN_EXIT_FINAL_GUARDS_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = [
+    "install_import_hook",
+    "_is_exit_request",
+    "_unverified_cost_basis",
+    "_patch_exit_decision",
+    "_patch_execution_gate",
+]

--- a/bot/kraken_exit_margin_cost_patch.py
+++ b/bot/kraken_exit_margin_cost_patch.py
@@ -1,0 +1,102 @@
+"""Normalize account identities for Kraken margin exit cost buffers."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.kraken_exit_margin_cost")
+_MARKER = "20260713-kraken-exit-margin-cost-v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+
+
+def _canonical_account_id(identity: Any) -> str:
+    text = str(identity or "").strip().lower().replace("/", ":")
+    parts = [part for part in text.split(":") if part]
+    if parts:
+        if parts[0] == "platform":
+            return "platform"
+        if parts[0] == "user" and len(parts) >= 2:
+            return parts[1]
+    if text.startswith("user_"):
+        text = text[5:]
+    if text.endswith("_kraken"):
+        text = text[:-7]
+    return text or "platform"
+
+
+def _patch_exit_runtime(module: ModuleType) -> bool:
+    current = getattr(module, "_margin_extra_buffer", None)
+    if not callable(current) or getattr(current, "_nija_canonical_margin_cost_v1", False):
+        return False
+
+    @wraps(current)
+    def margin_extra_buffer(account: str, symbol: str) -> float:
+        canonical = _canonical_account_id(account)
+        value = float(current(canonical, symbol) or 0.0)
+        logger.debug(
+            "KRAKEN_MARGIN_EXIT_COST_BUFFER marker=%s supervisor=%s account_id=%s symbol=%s buffer=%.6f",
+            _MARKER, account, canonical, symbol, value,
+        )
+        return value
+
+    margin_extra_buffer._nija_canonical_margin_cost_v1 = True  # type: ignore[attr-defined]
+    module._margin_extra_buffer = margin_extra_buffer
+    logger.warning("KRAKEN_MARGIN_EXIT_COST_ACCOUNT_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    changed = False
+    if str(getattr(module, "__name__", "")).endswith("kraken_all_account_exit_runtime_patch"):
+        changed = _patch_exit_runtime(module)
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("KRAKEN_EXIT_MARGIN_COST_PATCH_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = ["install_import_hook", "_canonical_account_id", "_patch_exit_runtime"]

--- a/bot/kraken_exit_safety_convergence_patch.py
+++ b/bot/kraken_exit_safety_convergence_patch.py
@@ -1,6 +1,6 @@
 """Final convergence for account-local Kraken exits.
 
-Loaded after ``kraken_all_account_exit_runtime_patch``.  It supplies explicit
+Loaded after ``kraken_all_account_exit_runtime_patch``. It supplies explicit
 pipeline exit context, preserves legacy non-Kraken exit monitoring, and allows a
 private-authenticated reduce-only margin close during low/critical margin health.
 It never bypasses Kraken permission or private API failures.
@@ -14,7 +14,7 @@ import sys
 import threading
 from functools import wraps
 from types import ModuleType
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 logger = logging.getLogger("nija.kraken_exit_safety_convergence")
 _MARKER = "20260713-kraken-exit-safety-v1"
@@ -34,6 +34,33 @@ def _is_kraken(broker: Any) -> bool:
     return any("kraken" in str(value or "").lower() for value in values)
 
 
+def _canonical_account_id(identity: Any, broker: Any = None) -> str:
+    text = str(identity or "").strip().lower().replace("/", ":")
+    parts = [part for part in text.split(":") if part]
+    if parts:
+        if parts[0] == "platform":
+            return "platform"
+        if parts[0] == "user" and len(parts) >= 2:
+            return parts[1]
+    if text.startswith("user_"):
+        text = text[5:]
+    if text.endswith("_kraken"):
+        text = text[:-7]
+    if text and text not in {"kraken", "none", "default"}:
+        return text
+    for attr in ("account_identifier", "account_id", "user_id", "owner_id"):
+        value = str(getattr(broker, attr, "") or "").strip().lower()
+        if value.startswith("user:"):
+            return value.split(":", 1)[1]
+        if value.startswith("user_"):
+            value = value[5:]
+        if value.endswith("_kraken"):
+            value = value[:-7]
+        if value and value not in {"kraken", "none", "default"}:
+            return "platform" if value.startswith("platform") else value
+    return "platform"
+
+
 def _patch_all_account_exit(module: ModuleType) -> bool:
     current = getattr(module, "_submit_exit", None)
     if not callable(current) or getattr(current, "_nija_explicit_exit_context_v1", False):
@@ -46,6 +73,7 @@ def _patch_all_account_exit(module: ModuleType) -> bool:
         quantity: float,
         reason: str,
     ) -> Mapping[str, Any]:
+        account_id = _canonical_account_id(account, broker)
         try:
             from bot.pipeline_order_submitter import submit_market_order_via_pipeline
             result = submit_market_order_via_pipeline(
@@ -56,14 +84,19 @@ def _patch_all_account_exit(module: ModuleType) -> bool:
                 size_type="base",
                 strategy=f"KrakenAccountExit:{reason}",
                 intent_type="exit",
-                account_id_override=account,
+                account_id_override=account_id,
                 reduce_only_override=None,
                 position_effect="close",
                 metadata_override={
                     "closing_position": True,
                     "exit_reason": reason,
                     "account_exit_supervisor": True,
+                    "supervisor_identity": account,
                 },
+            )
+            logger.critical(
+                "KRAKEN_EXIT_ACCOUNT_CONTEXT marker=%s supervisor=%s account_id=%s pair=%s reason=%s",
+                _MARKER, account, account_id, pair, reason,
             )
             return result if isinstance(result, Mapping) else {
                 "status": "error", "error": str(result),
@@ -103,9 +136,6 @@ def _patch_margin_engine(module: ModuleType) -> bool:
                 or reason_text.startswith("maintenance_low:")
             )
         ):
-            # Permission/health API checks already passed inside the original
-            # method.  The only failing condition is the risk ratio itself, so a
-            # reduce-only close improves rather than expands exposure.
             logger.critical(
                 "KRAKEN_MARGIN_RISK_REDUCING_EXIT_ALLOWED marker=%s account=%s reason=%s",
                 _MARKER, getattr(self, "account_id", "default"), reason_text,
@@ -127,10 +157,7 @@ def _patch_legacy_auto_exit(module: ModuleType) -> bool:
         if callable(original):
             module._start_monitor = original
             changed = True
-            logger.warning(
-                "NON_KRAKEN_GLOBAL_AUTO_EXIT_RESTORED marker=%s",
-                _MARKER,
-            )
+            logger.warning("NON_KRAKEN_GLOBAL_AUTO_EXIT_RESTORED marker=%s", _MARKER)
 
     current_scan = getattr(module, "_scan_once", None)
     if callable(current_scan) and not getattr(current_scan, "_nija_kraken_account_local_owner_v1", False):
@@ -147,15 +174,12 @@ def _patch_legacy_auto_exit(module: ModuleType) -> bool:
 
         scan_once._nija_kraken_account_local_owner_v1 = True  # type: ignore[attr-defined]
         module._scan_once = scan_once
-        engine_cls = None
         for candidate in ("bot.execution_engine", "execution_engine"):
             loaded = sys.modules.get(candidate)
             cls = getattr(loaded, "ExecutionEngine", None) if isinstance(loaded, ModuleType) else None
             if isinstance(cls, type):
-                engine_cls = cls
+                cls.scan_stop_loss_take_profit_once = scan_once
                 break
-        if engine_cls is not None:
-            engine_cls.scan_stop_loss_take_profit_once = scan_once
         changed = True
         logger.warning("KRAKEN_GLOBAL_AUTO_EXIT_SCAN_REDIRECTED marker=%s", _MARKER)
     return changed
@@ -214,6 +238,7 @@ def install_import_hook() -> None:
 
 __all__ = [
     "install_import_hook",
+    "_canonical_account_id",
     "_patch_all_account_exit",
     "_patch_margin_engine",
     "_patch_legacy_auto_exit",

--- a/bot/kraken_exit_safety_convergence_patch.py
+++ b/bot/kraken_exit_safety_convergence_patch.py
@@ -1,9 +1,10 @@
 """Final convergence for account-local Kraken exits.
 
 Loaded after ``kraken_all_account_exit_runtime_patch``. It supplies explicit
-pipeline exit context, preserves legacy non-Kraken exit monitoring, and allows a
-private-authenticated reduce-only margin close during low/critical margin health.
-It never bypasses Kraken permission or private API failures.
+pipeline exit context, keeps recovery cycles position-management-only, preserves
+legacy non-Kraken exit monitoring, and allows a private-authenticated reduce-only
+margin close during low/critical margin health. It never bypasses Kraken
+permission or private API failures.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import builtins
 import logging
 import sys
 import threading
+from contextvars import ContextVar
 from functools import wraps
 from types import ModuleType
 from typing import Any, Mapping
@@ -21,6 +23,7 @@ _MARKER = "20260713-kraken-exit-safety-v1"
 _ORIGINAL_IMPORT = None
 _LOCK = threading.RLock()
 _PATCHED: set[tuple[str, int]] = set()
+_EXIT_MANAGEMENT_SCOPE: ContextVar[bool] = ContextVar("nija_exit_management_scope", default=False)
 
 
 def _is_kraken(broker: Any) -> bool:
@@ -111,6 +114,50 @@ def _patch_all_account_exit(module: ModuleType) -> bool:
     return True
 
 
+def _patch_recovery_scope(module: ModuleType) -> bool:
+    current = getattr(module, "_adopt_and_manage", None)
+    if not callable(current) or getattr(current, "_nija_exit_management_scope_v1", False):
+        return False
+
+    @wraps(current)
+    def adopt_and_manage(trader: Any, identity: str, broker: Any):
+        token = _EXIT_MANAGEMENT_SCOPE.set(True)
+        try:
+            logger.info(
+                "EXIT_ONLY_MANAGEMENT_SCOPE_ENTER marker=%s account=%s",
+                _MARKER, identity,
+            )
+            return current(trader, identity, broker)
+        finally:
+            _EXIT_MANAGEMENT_SCOPE.reset(token)
+
+    adopt_and_manage._nija_exit_management_scope_v1 = True  # type: ignore[attr-defined]
+    module._adopt_and_manage = adopt_and_manage
+    logger.warning("ACCOUNT_EXIT_MANAGEMENT_SCOPE_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_trade_cycle_truth(module: ModuleType) -> bool:
+    current = getattr(module, "_truthy", None)
+    if not callable(current) or getattr(current, "_nija_exit_scope_truth_v1", False):
+        return False
+
+    @wraps(current)
+    def truthy(name: str, default: bool = False) -> bool:
+        if _EXIT_MANAGEMENT_SCOPE.get() and name == "NIJA_INDEPENDENT_USER_TRADING":
+            logger.info(
+                "EXIT_ONLY_USER_MODE_PRESERVED marker=%s auto_promotion_blocked=true",
+                _MARKER,
+            )
+            return False
+        return bool(current(name, default))
+
+    truthy._nija_exit_scope_truth_v1 = True  # type: ignore[attr-defined]
+    module._truthy = truthy
+    logger.warning("TRADE_CYCLE_EXIT_SCOPE_PROMOTION_GUARD_PATCHED marker=%s", _MARKER)
+    return True
+
+
 def _patch_margin_engine(module: ModuleType) -> bool:
     cls = getattr(module, "KrakenMarginEngine", None)
     if not isinstance(cls, type):
@@ -193,6 +240,10 @@ def _patch_module(module: ModuleType) -> bool:
     changed = False
     if name.endswith("kraken_all_account_exit_runtime_patch"):
         changed = _patch_all_account_exit(module) or changed
+    if name.endswith("account_exit_management_recovery_patch"):
+        changed = _patch_recovery_scope(module) or changed
+    if name.endswith("trade_cycle_convergence_repair_patch"):
+        changed = _patch_trade_cycle_truth(module) or changed
     if name.endswith("kraken_margin_engine"):
         changed = _patch_margin_engine(module) or changed
     if name.endswith("auto_exit_sl_tp_runtime_patch"):
@@ -240,6 +291,8 @@ __all__ = [
     "install_import_hook",
     "_canonical_account_id",
     "_patch_all_account_exit",
+    "_patch_recovery_scope",
+    "_patch_trade_cycle_truth",
     "_patch_margin_engine",
     "_patch_legacy_auto_exit",
 ]

--- a/bot/kraken_exit_safety_convergence_patch.py
+++ b/bot/kraken_exit_safety_convergence_patch.py
@@ -1,0 +1,220 @@
+"""Final convergence for account-local Kraken exits.
+
+Loaded after ``kraken_all_account_exit_runtime_patch``.  It supplies explicit
+pipeline exit context, preserves legacy non-Kraken exit monitoring, and allows a
+private-authenticated reduce-only margin close during low/critical margin health.
+It never bypasses Kraken permission or private API failures.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger("nija.kraken_exit_safety_convergence")
+_MARKER = "20260713-kraken-exit-safety-v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+
+
+def _is_kraken(broker: Any) -> bool:
+    if broker is None:
+        return False
+    values = (
+        type(broker).__name__,
+        getattr(broker, "NAME", ""),
+        getattr(getattr(broker, "broker_type", None), "value", getattr(broker, "broker_type", "")),
+    )
+    return any("kraken" in str(value or "").lower() for value in values)
+
+
+def _patch_all_account_exit(module: ModuleType) -> bool:
+    current = getattr(module, "_submit_exit", None)
+    if not callable(current) or getattr(current, "_nija_explicit_exit_context_v1", False):
+        return False
+
+    def submit_exit(
+        broker: Any,
+        account: str,
+        pair: str,
+        quantity: float,
+        reason: str,
+    ) -> Mapping[str, Any]:
+        try:
+            from bot.pipeline_order_submitter import submit_market_order_via_pipeline
+            result = submit_market_order_via_pipeline(
+                broker=broker,
+                symbol=pair,
+                side="sell",
+                quantity=quantity,
+                size_type="base",
+                strategy=f"KrakenAccountExit:{reason}",
+                intent_type="exit",
+                account_id_override=account,
+                reduce_only_override=None,
+                position_effect="close",
+                metadata_override={
+                    "closing_position": True,
+                    "exit_reason": reason,
+                    "account_exit_supervisor": True,
+                },
+            )
+            return result if isinstance(result, Mapping) else {
+                "status": "error", "error": str(result),
+            }
+        except Exception as exc:
+            return {"status": "error", "error": str(exc)}
+
+    submit_exit._nija_explicit_exit_context_v1 = True  # type: ignore[attr-defined]
+    submit_exit.__wrapped__ = current  # type: ignore[attr-defined]
+    module._submit_exit = submit_exit
+    logger.warning("KRAKEN_EXPLICIT_EXIT_CONTEXT_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_margin_engine(module: ModuleType) -> bool:
+    cls = getattr(module, "KrakenMarginEngine", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "is_margin_trade_allowed", None)
+    if not callable(current) or getattr(current, "_nija_reduce_only_health_escape_v1", False):
+        return False
+
+    @wraps(current)
+    def is_margin_trade_allowed(
+        self: Any,
+        *,
+        is_reducing: bool = False,
+        adapter: Any = None,
+    ) -> tuple[bool, str]:
+        allowed, reason = current(self, is_reducing=is_reducing, adapter=adapter)
+        reason_text = str(reason or "")
+        if (
+            is_reducing
+            and not allowed
+            and (
+                reason_text.startswith("critical_margin:")
+                or reason_text.startswith("maintenance_low:")
+            )
+        ):
+            # Permission/health API checks already passed inside the original
+            # method.  The only failing condition is the risk ratio itself, so a
+            # reduce-only close improves rather than expands exposure.
+            logger.critical(
+                "KRAKEN_MARGIN_RISK_REDUCING_EXIT_ALLOWED marker=%s account=%s reason=%s",
+                _MARKER, getattr(self, "account_id", "default"), reason_text,
+            )
+            return True, f"risk_reducing_exit:{reason_text}"
+        return allowed, reason
+
+    is_margin_trade_allowed._nija_reduce_only_health_escape_v1 = True  # type: ignore[attr-defined]
+    cls.is_margin_trade_allowed = is_margin_trade_allowed
+    logger.warning("KRAKEN_MARGIN_REDUCE_ONLY_HEALTH_ESCAPE_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_legacy_auto_exit(module: ModuleType) -> bool:
+    changed = False
+    starter = getattr(module, "_start_monitor", None)
+    if callable(starter) and getattr(starter, "_nija_account_local_disabled_v1", False):
+        original = getattr(starter, "__wrapped__", None)
+        if callable(original):
+            module._start_monitor = original
+            changed = True
+            logger.warning(
+                "NON_KRAKEN_GLOBAL_AUTO_EXIT_RESTORED marker=%s",
+                _MARKER,
+            )
+
+    current_scan = getattr(module, "_scan_once", None)
+    if callable(current_scan) and not getattr(current_scan, "_nija_kraken_account_local_owner_v1", False):
+        @wraps(current_scan)
+        def scan_once(engine: Any) -> int:
+            broker = getattr(engine, "broker_client", None)
+            if _is_kraken(broker):
+                logger.debug(
+                    "GLOBAL_KRAKEN_AUTO_EXIT_SCAN_SKIPPED marker=%s reason=account_local_supervisor_owns_scan",
+                    _MARKER,
+                )
+                return 0
+            return int(current_scan(engine) or 0)
+
+        scan_once._nija_kraken_account_local_owner_v1 = True  # type: ignore[attr-defined]
+        module._scan_once = scan_once
+        engine_cls = None
+        for candidate in ("bot.execution_engine", "execution_engine"):
+            loaded = sys.modules.get(candidate)
+            cls = getattr(loaded, "ExecutionEngine", None) if isinstance(loaded, ModuleType) else None
+            if isinstance(cls, type):
+                engine_cls = cls
+                break
+        if engine_cls is not None:
+            engine_cls.scan_stop_loss_take_profit_once = scan_once
+        changed = True
+        logger.warning("KRAKEN_GLOBAL_AUTO_EXIT_SCAN_REDIRECTED marker=%s", _MARKER)
+    return changed
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    name = str(getattr(module, "__name__", ""))
+    changed = False
+    if name.endswith("kraken_all_account_exit_runtime_patch"):
+        changed = _patch_all_account_exit(module) or changed
+    if name.endswith("kraken_margin_engine"):
+        changed = _patch_margin_engine(module) or changed
+    if name.endswith("auto_exit_sl_tp_runtime_patch"):
+        changed = _patch_legacy_auto_exit(module) or changed
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("KRAKEN_EXIT_SAFETY_CONVERGENCE_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = [
+    "install_import_hook",
+    "_patch_all_account_exit",
+    "_patch_margin_engine",
+    "_patch_legacy_auto_exit",
+]

--- a/bot/pipeline_order_submitter.py
+++ b/bot/pipeline_order_submitter.py
@@ -1,9 +1,9 @@
-"""Canonical market-order submit helper via ExecutionPipeline/ECEL.
+"""Canonical market-order submission through ExecutionPipeline/ECEL.
 
-Kraken orders are margin-enriched here because this boundary owns the exact live
-adapter and account identity.  Automatic margin remains fail-closed: a request is
-upgraded only after account permission, TradeBalance health, and pair leverage
-checks all pass.  Otherwise the original spot request is preserved.
+The submitter preserves the exact broker adapter and account identity.  Kraken
+entries may be upgraded to qualified margin orders; exits can explicitly declare
+``intent_type=exit`` and ``position_effect=close`` so they are never interpreted
+as new short entries or sized from platform capital.
 """
 
 from __future__ import annotations
@@ -15,13 +15,13 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger("nija.pipeline_order_submitter")
 
 try:
-    from bot.execution_pipeline import get_execution_pipeline, PipelineRequest
+    from bot.execution_pipeline import PipelineRequest, get_execution_pipeline
 except ImportError:
     try:
-        from execution_pipeline import get_execution_pipeline, PipelineRequest
+        from execution_pipeline import PipelineRequest, get_execution_pipeline
     except ImportError:
-        get_execution_pipeline = None  # type: ignore
-        PipelineRequest = None  # type: ignore
+        PipelineRequest = None  # type: ignore[assignment]
+        get_execution_pipeline = None  # type: ignore[assignment]
 
 try:
     from bot.execution_authority_context import assert_distributed_writer_authority
@@ -30,14 +30,22 @@ except ImportError:
         from execution_authority_context import assert_distributed_writer_authority
     except ImportError:
         def assert_distributed_writer_authority() -> None:
-            return
+            return None
 
 
 def _truthy(name: str, default: bool = False) -> bool:
-    raw = os.environ.get(name)
-    if raw is None:
+    value = os.environ.get(name)
+    if value is None:
         return default
-    return str(raw).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
+    return str(value).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+        return default if parsed != parsed else parsed
+    except Exception:
+        return default
 
 
 def _balance_from_payload(payload: Any) -> Optional[float]:
@@ -50,69 +58,103 @@ def _balance_from_payload(payload: Any) -> Optional[float]:
             "usd_balance", "total_usd",
         ):
             if key in payload:
-                try:
-                    return float(payload.get(key) or 0.0)
-                except (TypeError, ValueError, OverflowError):
-                    return 0.0
+                return _float(payload.get(key))
     return None
 
 
 def _resolve_preferred_broker(broker: Any) -> str:
-    preferred_broker = "coinbase"
-    try:
-        broker_type = getattr(broker, "broker_type", None)
-        if broker_type is not None:
-            if hasattr(broker_type, "value"):
-                return str(broker_type.value).lower()
-            if isinstance(broker_type, str) and broker_type.strip():
-                return broker_type.strip().lower()
-        name = getattr(broker, "NAME", None)
-        if isinstance(name, str) and name.strip():
-            name = name.strip().lower()
-            for candidate in ("kraken", "coinbase", "okx", "binance", "alpaca"):
-                if candidate in name:
-                    return candidate
-    except Exception:
-        pass
-    return preferred_broker
+    broker_type = getattr(broker, "broker_type", None)
+    raw = getattr(broker_type, "value", broker_type)
+    text = str(raw or "").strip().lower()
+    if text:
+        return text
+    values = (getattr(broker, "NAME", ""), type(broker).__name__)
+    for value in values:
+        lowered = str(value or "").lower()
+        for candidate in ("kraken", "coinbase", "okx", "binance", "alpaca"):
+            if candidate in lowered:
+                return candidate
+    return "coinbase"
 
 
 def _resolve_account_id(broker: Any, preferred_broker: str) -> str:
     for attr in ("account_identifier", "account_id", "user_id", "owner_id", "name"):
-        try:
-            value = str(getattr(broker, attr, "") or "").strip().lower()
-        except Exception:
-            value = ""
+        value = str(getattr(broker, attr, "") or "").strip().lower()
         if value and value not in {"none", preferred_broker}:
             return value
     return "platform" if preferred_broker == "kraken" else "default"
 
 
-def _resolve_broker_balance_keys(broker: Any, preferred_broker: str) -> list[str]:
+def _resolve_balance_keys(broker: Any, preferred_broker: str, account_id: str) -> list[str]:
     keys: list[str] = []
-    try:
-        account_identifier = str(getattr(broker, "account_identifier", "") or "").strip().lower()
-        if account_identifier and account_identifier not in {"none", "platform", preferred_broker}:
-            keys.append(f"{preferred_broker}:{account_identifier}")
-    except Exception:
-        pass
-    if preferred_broker:
-        keys.append(preferred_broker)
+    account = str(account_id or "").strip().lower()
+    if account and account not in {"default", "platform", preferred_broker}:
+        keys.extend((f"{preferred_broker}:{account}", f"{preferred_broker}:user:{account}"))
+    identity = str(getattr(broker, "account_identifier", "") or "").strip().lower()
+    if identity and identity not in {"default", "platform", preferred_broker}:
+        keys.append(f"{preferred_broker}:{identity}")
+    keys.append(preferred_broker)
     return list(dict.fromkeys(key for key in keys if key))
 
 
-def _resolve_margin_exit(
-    *,
+def _resolve_available_balance(
+    broker: Any,
     preferred_broker: str,
     account_id: str,
-    symbol: str,
-) -> Dict[str, Any]:
+) -> Optional[float]:
+    cached = _balance_from_payload(getattr(broker, "_balance_cache", None))
+    if cached is None:
+        scalar = getattr(broker, "_last_known_balance", None)
+        if isinstance(scalar, (int, float)):
+            cached = float(scalar)
+
+    # Prefer account-specific authority records.  The plain Kraken key remains a
+    # fallback for the platform account only; it must never size a user order.
+    try:
+        import importlib
+        for module_name in ("bot.capital_authority", "capital_authority"):
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+            get_authority = getattr(module, "get_capital_authority", None)
+            if not callable(get_authority):
+                break
+            authority = get_authority()
+            is_registered = getattr(authority, "is_registered", None)
+            for key in _resolve_balance_keys(broker, preferred_broker, account_id):
+                if account_id not in {"platform", "default"} and key == preferred_broker:
+                    continue
+                amount = _float(authority.get_per_broker(key))
+                if amount > 0 or (callable(is_registered) and is_registered(key)):
+                    logger.info(
+                        "PIPELINE_ACCOUNT_BALANCE_RESOLVED broker_key=%s account=%s balance=$%.2f",
+                        key, account_id, amount,
+                    )
+                    return amount
+            break
+    except Exception as exc:
+        logger.debug("account authority balance lookup failed: %s", exc)
+
+    if cached is not None:
+        return cached
+    try:
+        getter = getattr(broker, "get_account_balance", None)
+        if callable(getter):
+            payload = getter()
+            parsed = _balance_from_payload(payload)
+            return parsed if parsed is not None else _float(payload)
+    except Exception:
+        pass
+    return None
+
+
+def _resolve_margin_exit(preferred_broker: str, account_id: str, symbol: str) -> Dict[str, Any]:
     if preferred_broker != "kraken":
         return {}
     try:
         from bot.margin_position_ledger import get_margin_position_ledger
-        ledger = get_margin_position_ledger()
-        row = ledger.get_record(
+        row = get_margin_position_ledger().get_record(
             broker="kraken",
             account_id=account_id,
             subaccount_id="",
@@ -120,10 +162,13 @@ def _resolve_margin_exit(
             asset_class="crypto",
         )
     except Exception as exc:
-        logger.debug("KRAKEN_MARGIN_EXIT_LEDGER_LOOKUP_FAILED account=%s symbol=%s error=%s", account_id, symbol, exc)
+        logger.debug(
+            "KRAKEN_MARGIN_EXIT_LEDGER_LOOKUP_FAILED account=%s symbol=%s error=%s",
+            account_id, symbol, exc,
+        )
         return {}
-    leverage = int(float(row.get("leverage") or 1)) if row else 1
-    lifecycle = str(row.get("lifecycle_status") or "").lower() if row else ""
+    leverage = int(_float((row or {}).get("leverage"), 1.0))
+    lifecycle = str((row or {}).get("lifecycle_status") or "").lower()
     if leverage <= 1 or lifecycle not in {"open", "reducing", "pending_open"}:
         return {}
     return {
@@ -136,8 +181,7 @@ def _resolve_margin_exit(
     }
 
 
-def _plan_kraken_margin_entry(
-    *,
+def _plan_margin_entry(
     broker: Any,
     account_id: str,
     symbol: str,
@@ -145,16 +189,13 @@ def _plan_kraken_margin_entry(
     size_usd: float,
     account_equity_usd: float,
 ) -> Dict[str, Any]:
-    if str(side or "").lower() != "buy":
-        return {}
-    if not _truthy("NIJA_KRAKEN_MARGIN_ENABLED", True):
+    if side != "buy" or not _truthy("NIJA_KRAKEN_MARGIN_ENABLED", True):
         return {}
     if not _truthy("NIJA_KRAKEN_AUTO_MARGIN_ENABLED", True):
         return {}
     try:
         from bot.kraken_margin_engine import get_margin_engine
-        engine = get_margin_engine(account_id=account_id, adapter=broker)
-        plan = engine.plan_auto_margin(
+        plan = get_margin_engine(account_id=account_id, adapter=broker).plan_auto_margin(
             adapter=broker,
             symbol=symbol,
             side=side,
@@ -171,22 +212,15 @@ def _plan_kraken_margin_entry(
         return {}
     if not plan.allowed:
         logger.info(
-            "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s side=%s decision=SPOT reason=%s pair_max=%sx",
-            account_id, symbol, side, plan.reason, plan.pair_max_leverage,
+            "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s decision=SPOT reason=%s pair_max=%sx",
+            account_id, symbol, plan.reason, plan.pair_max_leverage,
         )
         return {}
     logger.critical(
-        "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s side=%s decision=MARGIN leverage=%sx "
-        "spot_notional=$%.2f leveraged_notional=$%.2f buying_power=$%.2f pair_max=%sx reason=%s",
-        account_id,
-        symbol,
-        side,
-        plan.leverage,
-        plan.spot_notional_usd,
-        plan.leveraged_notional_usd,
-        plan.buying_power_usd,
-        plan.pair_max_leverage,
-        plan.reason,
+        "KRAKEN_MARGIN_AUTO_PLAN account=%s symbol=%s decision=MARGIN leverage=%sx "
+        "spot_notional=$%.2f leveraged_notional=$%.2f buying_power=$%.2f",
+        account_id, symbol, plan.leverage, plan.spot_notional_usd,
+        plan.leveraged_notional_usd, plan.buying_power_usd,
     )
     return {
         "leverage": plan.leverage,
@@ -208,136 +242,78 @@ def submit_market_order_via_pipeline(
     quantity: float,
     size_type: str = "quote",
     strategy: str = "PipelineOrderSubmitter",
+    *,
+    intent_type: Optional[str] = None,
+    account_id_override: Optional[str] = None,
+    reduce_only_override: Optional[bool] = None,
+    position_effect: Optional[str] = None,
+    metadata_override: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Submit a market order through ExecutionPipeline."""
+    """Submit a market order while preserving explicit account/exit context."""
     if get_execution_pipeline is None or PipelineRequest is None:
-        return {
-            "status": "error",
-            "error": "ExecutionPipeline unavailable and direct broker bypass blocked",
-            "symbol": symbol,
-            "side": side,
-        }
+        return {"status": "error", "error": "ExecutionPipeline unavailable", "symbol": symbol, "side": side}
 
-    force_trade = _truthy("FORCE_TRADE") or _truthy("FORCE_TRADE_MODE")
-    if not force_trade:
+    if not (_truthy("FORCE_TRADE") or _truthy("FORCE_TRADE_MODE")):
         try:
             assert_distributed_writer_authority()
         except Exception as exc:
-            logger.error(
-                "🚫 [PipelineOrderSubmitter] DistributedWriterFence reject — symbol=%s side=%s error=%s",
-                symbol, side, exc,
-            )
             return {
                 "status": "error",
                 "error": f"DistributedWriterFence reject: {exc}",
                 "symbol": symbol,
                 "side": side,
             }
-    else:
-        logger.info(
-            "[FORCE_TRADE] Bypassing assert_distributed_writer_authority in pipeline_order_submitter — symbol=%s side=%s",
-            symbol, side,
-        )
 
-    side_norm = (side or "buy").strip().lower()
-    size_usd = float(max(0.0, quantity))
+    side_norm = str(side or "buy").strip().lower()
+    preferred_broker = _resolve_preferred_broker(broker)
+    account_id = str(account_id_override or _resolve_account_id(broker, preferred_broker)).strip().lower()
+    explicit_intent = str(intent_type or "").strip().lower()
+    is_exit = explicit_intent in {"exit", "reduce"} or str(position_effect or "").lower() in {"close", "reduce"}
+
+    size_usd = max(0.0, _float(quantity))
     price_hint_usd: Optional[float] = None
-    if (size_type or "quote").lower() == "base":
+    if str(size_type or "quote").lower() == "base":
         try:
-            if hasattr(broker, "get_current_price"):
-                px = float(broker.get_current_price(symbol) or 0.0)
-                if px > 0:
-                    price_hint_usd = px
-                    size_usd = float(max(0.0, quantity * px))
+            price_hint_usd = _float(getattr(broker, "get_current_price")(symbol))
         except Exception:
-            price_hint_usd = None
-        if price_hint_usd is None or size_usd <= 0:
+            price_hint_usd = 0.0
+        if price_hint_usd <= 0:
             return {
                 "status": "error",
                 "error": "Cannot compile base-size order without valid price hint",
                 "symbol": symbol,
                 "side": side_norm,
+                "account_id": account_id,
             }
+        size_usd = max(0.0, _float(quantity) * price_hint_usd)
 
-    preferred_broker = _resolve_preferred_broker(broker)
-    account_id = _resolve_account_id(broker, preferred_broker)
-    broker_balance_keys = _resolve_broker_balance_keys(broker, preferred_broker)
-    available_balance_usd: Optional[float] = None
-    try:
-        available_balance_usd = _balance_from_payload(getattr(broker, "_balance_cache", None))
-        if available_balance_usd is None:
-            scalar = getattr(broker, "_last_known_balance", None)
-            if isinstance(scalar, (int, float)):
-                available_balance_usd = float(scalar)
-    except Exception:
-        available_balance_usd = None
-
-    try:
-        import importlib
-        for module_name in ("bot.capital_authority", "capital_authority"):
-            try:
-                module = importlib.import_module(module_name)
-                get_ca = getattr(module, "get_capital_authority", None)
-                if callable(get_ca):
-                    authority = get_ca()
-                    is_registered = getattr(authority, "is_registered", None)
-                    for broker_key in broker_balance_keys:
-                        balance = float(authority.get_per_broker(broker_key) or 0.0)
-                        if balance > 0.0 or (callable(is_registered) and is_registered(broker_key)):
-                            available_balance_usd = balance
-                            logger.info(
-                                "[PipelineOrderSubmitter] resolved broker balance from CapitalAuthority: broker=%s balance=$%.2f symbol=%s side=%s",
-                                broker_key, balance, symbol, side_norm,
-                            )
-                            break
-                break
-            except ImportError:
-                continue
-    except Exception as exc:
-        logger.debug("[PipelineOrderSubmitter] capital authority balance lookup failed: %s", exc)
-
-    if not available_balance_usd:
-        try:
-            if broker is not None and hasattr(broker, "get_account_balance"):
-                raw = broker.get_account_balance()
-                available_balance_usd = _balance_from_payload(raw)
-                if available_balance_usd is None:
-                    available_balance_usd = float(raw or 0.0)
-        except Exception:
-            pass
-
+    available_balance = _resolve_available_balance(broker, preferred_broker, account_id)
     margin_fields: Dict[str, Any] = {}
     if preferred_broker == "kraken":
-        if side_norm == "buy":
-            margin_fields = _plan_kraken_margin_entry(
-                broker=broker,
-                account_id=account_id,
-                symbol=symbol,
-                side=side_norm,
-                size_usd=size_usd,
-                account_equity_usd=float(available_balance_usd or 0.0),
+        if side_norm == "buy" and not is_exit:
+            margin_fields = _plan_margin_entry(
+                broker, account_id, symbol, side_norm, size_usd, _float(available_balance),
             )
         elif side_norm == "sell":
-            margin_fields = _resolve_margin_exit(
-                preferred_broker=preferred_broker,
-                account_id=account_id,
-                symbol=symbol,
-            )
-            if margin_fields:
-                logger.critical(
-                    "KRAKEN_MARGIN_EXIT_PLAN account=%s symbol=%s leverage=%sx reduce_only=true reason=%s",
-                    account_id, symbol, margin_fields.get("leverage"), margin_fields.get("reason"),
-                )
+            margin_fields = _resolve_margin_exit(preferred_broker, account_id, symbol)
 
-    effective_size_usd = float(margin_fields.get("size_usd") or size_usd)
-    leverage = int(margin_fields.get("leverage") or 1)
+    effective_size = _float(margin_fields.get("size_usd"), size_usd)
+    leverage = int(_float(margin_fields.get("leverage"), 1.0))
     margin_mode = margin_fields.get("margin_mode")
+    resolved_intent = explicit_intent or str(margin_fields.get("intent_type") or "entry")
     reduce_only = margin_fields.get("reduce_only")
-    intent_type = margin_fields.get("intent_type")
-    buying_power_usd = margin_fields.get("buying_power_usd")
+    if reduce_only_override is not None:
+        reduce_only = bool(reduce_only_override)
+    if resolved_intent in {"exit", "reduce"} and leverage > 1:
+        reduce_only = True
+    if reduce_only is None:
+        reduce_only = False
+
     metadata = {
         "broker_client": broker,
         "broker_name": preferred_broker,
+        "account_id": account_id,
+        "closing_position": resolved_intent in {"exit", "reduce"},
         "kraken_margin_auto": bool(margin_fields and leverage > 1),
         "kraken_margin_reason": margin_fields.get("reason", "spot"),
         "spot_notional_usd": margin_fields.get("spot_notional_usd", size_usd),
@@ -346,60 +322,71 @@ def submit_market_order_via_pipeline(
         "reduce_only": reduce_only,
         "margin_mode": margin_mode,
     }
+    metadata.update(dict(metadata_override or {}))
 
     request = PipelineRequest(
         strategy=strategy,
         symbol=symbol,
         side=side_norm,
-        size_usd=effective_size_usd,
-        order_type="MARKET",
+        size_usd=effective_size,
+        order_type="market",
         preferred_broker=preferred_broker,
         price_hint_usd=price_hint_usd,
-        available_balance_usd=available_balance_usd if available_balance_usd else None,
-        buying_power_usd=buying_power_usd,
+        available_balance_usd=available_balance,
+        buying_power_usd=margin_fields.get("buying_power_usd"),
         account_id=account_id,
-        intent_type=intent_type,
+        intent_type=resolved_intent,
+        position_effect=position_effect or ("close" if resolved_intent in {"exit", "reduce"} else None),
         leverage=leverage if leverage > 1 else None,
         margin_mode=margin_mode,
-        reduce_only=reduce_only,
+        reduce_only=bool(reduce_only),
         metadata=metadata,
     )
 
+    logger.critical(
+        "PIPELINE_ORDER_CONTEXT account=%s broker=%s symbol=%s side=%s intent=%s "
+        "position_effect=%s leverage=%sx reduce_only=%s notional=$%.2f",
+        account_id, preferred_broker, symbol, side_norm, resolved_intent,
+        request.position_effect, leverage, bool(reduce_only), effective_size,
+    )
     try:
         if preferred_broker == "kraken":
             from bot.kraken_margin_engine import margin_account_scope
             with margin_account_scope(account_id, adapter=broker):
-                res = get_execution_pipeline().execute(request)
+                result = get_execution_pipeline().execute(request)
         else:
-            res = get_execution_pipeline().execute(request)
+            result = get_execution_pipeline().execute(request)
     except Exception as exc:
         return {
-            "status": "error",
-            "error": str(exc),
-            "symbol": symbol,
-            "side": side_norm,
-            "leverage": leverage,
+            "status": "error", "error": str(exc), "symbol": symbol,
+            "side": side_norm, "account_id": account_id, "leverage": leverage,
         }
 
-    if not res.success:
+    if not result.success:
         return {
             "status": "error",
-            "error": res.error or "ExecutionPipeline rejected order",
+            "error": result.error or "ExecutionPipeline rejected order",
             "symbol": symbol,
             "side": side_norm,
+            "account_id": account_id,
             "leverage": leverage,
             "margin": leverage > 1,
+            "intent_type": resolved_intent,
         }
-
     return {
         "status": "filled",
         "order_id": "pipeline",
         "symbol": symbol,
         "side": side_norm,
-        "filled_price": res.fill_price,
-        "filled_size_usd": res.filled_size_usd,
-        "broker": res.broker,
+        "account_id": account_id,
+        "filled_price": result.fill_price,
+        "filled_size_usd": result.filled_size_usd,
+        "broker": result.broker,
         "leverage": leverage,
         "margin": leverage > 1,
         "reduce_only": bool(reduce_only),
+        "intent_type": resolved_intent,
     }
+
+
+__all__ = ["submit_market_order_via_pipeline"]

--- a/bot/tests/test_kraken_all_account_exit_runtime.py
+++ b/bot/tests/test_kraken_all_account_exit_runtime.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+exit_runtime = load_module(
+    "kraken_all_account_exit_runtime_under_test",
+    "kraken_all_account_exit_runtime_patch.py",
+)
+safety = load_module(
+    "kraken_exit_safety_convergence_under_test",
+    "kraken_exit_safety_convergence_patch.py",
+)
+
+
+class KrakenBroker:
+    NAME = "Kraken"
+
+    def __init__(self, account="platform", private_ok=True):
+        self.account_identifier = account
+        self.connected = True
+        self.private_ok = private_ok
+        self.private_calls = []
+        self.public_calls = []
+
+    def _kraken_api_call(self, method, params=None):
+        self.private_calls.append((method, dict(params or {})))
+        if method == "TradeBalance":
+            if not self.private_ok:
+                return {"error": ["EAPI:Invalid key"], "result": {}}
+            return {
+                "error": [],
+                "result": {
+                    "eb": "100.0",
+                    "e": "100.0",
+                    "tb": "90.0",
+                    "mf": "90.0",
+                    "m": "0.0",
+                },
+            }
+        return {"error": [], "result": {}}
+
+    def query_public(self, method, params=None):
+        self.public_calls.append((method, dict(params or {})))
+        pair = str((params or {}).get("pair") or "")
+        if method == "AssetPairs" and pair == "AIREUR":
+            return {"error": [], "result": {"AIREUR": {"altname": "AIREUR"}}}
+        if method == "AssetPairs":
+            return {"error": ["EQuery:Unknown asset pair"], "result": {}}
+        if method == "Ticker" and pair == "AIREUR":
+            return {"error": [], "result": {"AIREUR": {"c": ["0.011", "1"]}}}
+        return {"error": ["not mocked"], "result": {}}
+
+
+class TestPrivateConnectionHealth:
+    def setup_method(self):
+        exit_runtime._PRIVATE_HEALTH.clear()
+
+    def test_private_probe_is_per_adapter(self):
+        platform = KrakenBroker("platform", private_ok=True)
+        tania = KrakenBroker("USER:tania_gilbert", private_ok=False)
+
+        assert exit_runtime._private_ready(platform, "platform:kraken", force=True)[0] is True
+        ready, reason = exit_runtime._private_ready(tania, "user:tania_gilbert:kraken", force=True)
+        assert ready is False
+        assert "Invalid key" in reason
+        assert len(platform.private_calls) == 1
+        assert len(tania.private_calls) == 1
+
+    def test_alive_thread_requires_private_readiness(self):
+        module = types.ModuleType("account_exit_management_recovery_patch")
+        module._connect = lambda broker, identity: broker.connected
+        module._normal_thread_alive = lambda *args: True
+        module._adopt_and_manage = lambda trader, identity, broker: (0, 0)
+        module._retry_all_accounts = lambda trader: None
+        assert exit_runtime._patch_recovery_module(module)
+
+        broker = KrakenBroker("USER:tania_gilbert", private_ok=False)
+        alive = module._normal_thread_alive(
+            SimpleNamespace(), "user", "tania_gilbert",
+            SimpleNamespace(value="kraken"), broker,
+        )
+        assert alive is False
+
+
+class TestPairAndExitDecisions:
+    def setup_method(self):
+        exit_runtime._PAIR_CACHE.clear()
+        exit_runtime._EXIT_STATE.clear()
+
+    def test_air_resolves_to_an_available_kraken_quote_pair(self):
+        broker = KrakenBroker("USER:tania_gilbert")
+        assert exit_runtime._resolve_pair(broker, "AIR-USD") == "AIREUR"
+        attempted = [params["pair"] for method, params in broker.public_calls if method == "AssetPairs"]
+        assert "AIRUSD" in attempted
+        assert "AIRUSDT" in attempted
+        assert "AIREUR" in attempted
+
+    def test_net_profit_target_is_preferred(self):
+        position = {
+            "symbol": "SOL-USD",
+            "side": "long",
+            "entry_price": 100.0,
+            "quantity": 1.0,
+            "first_entry_time": datetime.now(timezone.utc).isoformat(),
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_KRAKEN_EXIT_ROUND_TRIP_COST_PCT": "0.008",
+                "NIJA_KRAKEN_EXIT_NET_PROFIT_TARGET_PCT": "0.004",
+            },
+            clear=False,
+        ):
+            reason, breakeven, target = exit_runtime._exit_reason(
+                position, 101.25, "platform:kraken", "SOL-USD"
+            )
+        assert reason == "net_profit_target"
+        assert round(breakeven, 2) == 100.80
+        assert round(target, 2) == 101.20
+
+    def test_fee_adjusted_break_even_after_max_hold(self):
+        position = {
+            "symbol": "SOL-USD",
+            "side": "long",
+            "entry_price": 100.0,
+            "quantity": 1.0,
+            "first_entry_time": (
+                datetime.now(timezone.utc) - timedelta(minutes=61)
+            ).isoformat(),
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_KRAKEN_EXIT_ROUND_TRIP_COST_PCT": "0.008",
+                "NIJA_KRAKEN_EXIT_NET_PROFIT_TARGET_PCT": "0.004",
+                "NIJA_KRAKEN_BREAK_EVEN_MAX_HOLD_MINUTES": "60",
+                "NIJA_KRAKEN_BREAK_EVEN_EXIT_ENABLED": "true",
+            },
+            clear=False,
+        ):
+            reason, _, _ = exit_runtime._exit_reason(
+                position, 100.90, "platform:kraken", "SOL-USD"
+            )
+        assert reason == "fee_adjusted_break_even"
+
+    def test_stop_loss_remains_available_when_market_never_recovers(self):
+        position = {
+            "symbol": "SOL-USD",
+            "side": "long",
+            "entry_price": 100.0,
+            "quantity": 1.0,
+            "stop_loss": 95.0,
+        }
+        reason, _, _ = exit_runtime._exit_reason(
+            position, 94.0, "platform:kraken", "SOL-USD"
+        )
+        assert reason == "emergency_stop_loss"
+
+
+class TestExplicitExitContext:
+    def test_supervisor_identity_is_normalized_for_pipeline_and_ledger(self):
+        captured = {}
+
+        def submit_market_order_via_pipeline(**kwargs):
+            captured.update(kwargs)
+            return {"status": "filled", "order_id": "1"}
+
+        fake_submitter = types.ModuleType("bot.pipeline_order_submitter")
+        fake_submitter.submit_market_order_via_pipeline = submit_market_order_via_pipeline
+        fake_bot = types.ModuleType("bot")
+        fake_bot.__path__ = []
+        fake_bot.pipeline_order_submitter = fake_submitter
+
+        module = types.ModuleType("bot.kraken_all_account_exit_runtime_patch")
+        module._submit_exit = lambda *args, **kwargs: {"status": "error"}
+        assert safety._patch_all_account_exit(module)
+
+        with patch.dict(
+            sys.modules,
+            {"bot": fake_bot, "bot.pipeline_order_submitter": fake_submitter},
+            clear=False,
+        ):
+            result = module._submit_exit(
+                KrakenBroker("USER:tania_gilbert"),
+                "user:tania_gilbert:kraken",
+                "AIREUR",
+                100.0,
+                "fee_adjusted_break_even",
+            )
+
+        assert result["status"] == "filled"
+        assert captured["account_id_override"] == "tania_gilbert"
+        assert captured["intent_type"] == "exit"
+        assert captured["position_effect"] == "close"
+        assert captured["metadata_override"]["closing_position"] is True
+
+    def test_platform_and_user_identity_normalization(self):
+        assert safety._canonical_account_id("platform:kraken") == "platform"
+        assert safety._canonical_account_id("user:daivon_frazier:kraken") == "daivon_frazier"
+        assert safety._canonical_account_id("USER:tania_gilbert") == "tania_gilbert"
+
+
+class TestExitOnlyCycleScope:
+    def test_recovery_user_mode_cannot_be_auto_promoted_to_entries(self):
+        truth_module = types.ModuleType("bot.trade_cycle_convergence_repair_patch")
+        truth_module._truthy = lambda name, default=False: True
+        recovery = types.ModuleType("account_exit_management_recovery_patch")
+        recovery._adopt_and_manage = lambda trader, identity, broker: truth_module._truthy(
+            "NIJA_INDEPENDENT_USER_TRADING", True
+        )
+
+        assert safety._patch_trade_cycle_truth(truth_module)
+        assert safety._patch_recovery_scope(recovery)
+        assert truth_module._truthy("NIJA_INDEPENDENT_USER_TRADING", True) is True
+        assert recovery._adopt_and_manage(None, "user:daivon:kraken", None) is False
+        assert truth_module._truthy("NIJA_INDEPENDENT_USER_TRADING", True) is True
+
+
+class TestMarginRiskReduction:
+    def test_critical_margin_allows_reduce_only_but_not_new_entry(self):
+        class KrakenMarginEngine:
+            account_id = "tania_gilbert"
+
+            def is_margin_trade_allowed(self, *, is_reducing=False, adapter=None):
+                return False, "critical_margin:critical_margin_level:85.0%"
+
+        module = types.ModuleType("bot.kraken_margin_engine")
+        module.KrakenMarginEngine = KrakenMarginEngine
+        assert safety._patch_margin_engine(module)
+        engine = KrakenMarginEngine()
+
+        assert engine.is_margin_trade_allowed(is_reducing=False)[0] is False
+        allowed, reason = engine.is_margin_trade_allowed(is_reducing=True)
+        assert allowed is True
+        assert reason.startswith("risk_reducing_exit:")
+
+    def test_permission_failure_is_not_bypassed(self):
+        class KrakenMarginEngine:
+            account_id = "daivon_frazier"
+
+            def is_margin_trade_allowed(self, *, is_reducing=False, adapter=None):
+                return False, "permission_denied"
+
+        module = types.ModuleType("bot.kraken_margin_engine.permission")
+        module.KrakenMarginEngine = KrakenMarginEngine
+        assert safety._patch_margin_engine(module)
+        assert KrakenMarginEngine().is_margin_trade_allowed(is_reducing=True) == (
+            False, "permission_denied"
+        )
+
+
+class TestPipelineExitGateSplit:
+    def test_exit_bypasses_entry_only_gates_and_restores_them(self):
+        sentinel = object()
+
+        class ExecutionPipeline:
+            def __init__(self):
+                self._pre_trade_risk_engine = sentinel
+                self._allocation_clamp = sentinel
+                self._execution_observer = sentinel
+                self._throttler = sentinel
+                self._downstream_guard = sentinel
+
+            def _gate_broker_capabilities(self, request, t_start):
+                return "blocked_as_short"
+
+            def execute(self, request):
+                return tuple(
+                    getattr(self, name)
+                    for name in (
+                        "_pre_trade_risk_engine", "_allocation_clamp",
+                        "_execution_observer", "_throttler", "_downstream_guard",
+                    )
+                )
+
+        module = types.ModuleType("bot.execution_pipeline")
+        module.ExecutionPipeline = ExecutionPipeline
+        assert exit_runtime._patch_execution_pipeline(module)
+        pipeline = ExecutionPipeline()
+        exit_request = SimpleNamespace(
+            intent_type="exit", position_effect="close", metadata={},
+            account_id="tania_gilbert", symbol="AIR-EUR", side="sell",
+        )
+        entry_request = SimpleNamespace(
+            intent_type="entry", position_effect=None, metadata={},
+            account_id="tania_gilbert", symbol="AIR-EUR", side="sell",
+        )
+
+        assert pipeline._gate_broker_capabilities(exit_request, 0.0) is None
+        assert pipeline._gate_broker_capabilities(entry_request, 0.0) == "blocked_as_short"
+        assert pipeline.execute(exit_request) == (None, None, None, None, None)
+        assert pipeline.execute(entry_request) == (sentinel, sentinel, sentinel, sentinel, sentinel)
+        assert pipeline._pre_trade_risk_engine is sentinel
+        assert pipeline._throttler is sentinel
+
+
+class TestLegacyMonitorIsolation:
+    def test_only_kraken_global_scan_is_redirected(self):
+        original_start = lambda engine: "started"
+
+        def disabled_start(engine):
+            return None
+
+        disabled_start._nija_account_local_disabled_v1 = True
+        disabled_start.__wrapped__ = original_start
+
+        module = types.ModuleType("bot.auto_exit_sl_tp_runtime_patch")
+        module._start_monitor = disabled_start
+        module._scan_once = lambda engine: 7
+        assert safety._patch_legacy_auto_exit(module)
+
+        assert module._start_monitor(None) == "started"
+        assert module._scan_once(SimpleNamespace(broker_client=KrakenBroker())) == 0
+        assert module._scan_once(
+            SimpleNamespace(broker_client=SimpleNamespace(NAME="Coinbase"))
+        ) == 7

--- a/bot/tests/test_kraken_exit_execution_safety.py
+++ b/bot/tests/test_kraken_exit_execution_safety.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import types
+from functools import wraps
+from pathlib import Path
+from types import SimpleNamespace
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+safety = load_module(
+    "kraken_exit_execution_safety_under_test",
+    "kraken_exit_execution_safety_patch.py",
+)
+
+
+def test_broad_exit_wrapper_is_replaced_and_downstream_guard_stays_active():
+    sentinel = object()
+
+    class ExecutionPipeline:
+        def __init__(self):
+            self._pre_trade_risk_engine = sentinel
+            self._allocation_clamp = sentinel
+            self._execution_observer = sentinel
+            self._throttler = sentinel
+            self._downstream_guard = sentinel
+
+        def execute(self, request):
+            return (
+                self._pre_trade_risk_engine,
+                self._allocation_clamp,
+                self._execution_observer,
+                self._throttler,
+                self._downstream_guard,
+            )
+
+    original = ExecutionPipeline.execute
+
+    @wraps(original)
+    def broad_wrapper(self, request):
+        names = (
+            "_pre_trade_risk_engine", "_allocation_clamp", "_execution_observer",
+            "_throttler", "_downstream_guard",
+        )
+        saved = {name: getattr(self, name) for name in names}
+        try:
+            for name in names:
+                setattr(self, name, None)
+            return original(self, request)
+        finally:
+            for name, value in saved.items():
+                setattr(self, name, value)
+
+    broad_wrapper._nija_exit_entry_gate_split_v1 = True
+    ExecutionPipeline.execute = broad_wrapper
+
+    module = types.ModuleType("bot.execution_pipeline")
+    module.ExecutionPipeline = ExecutionPipeline
+    assert safety._patch_execution_pipeline(module)
+
+    pipeline = ExecutionPipeline()
+    exit_request = SimpleNamespace(
+        intent_type="exit",
+        position_effect="close",
+        metadata={"closing_position": True},
+        account_id="tania_gilbert",
+        symbol="AIR-EUR",
+    )
+    entry_request = SimpleNamespace(
+        intent_type="entry",
+        position_effect=None,
+        metadata={},
+        account_id="tania_gilbert",
+        symbol="AIR-EUR",
+    )
+
+    assert pipeline.execute(exit_request) == (
+        None,
+        None,
+        sentinel,
+        None,
+        sentinel,
+    )
+    assert pipeline.execute(entry_request) == (
+        sentinel,
+        sentinel,
+        sentinel,
+        sentinel,
+        sentinel,
+    )
+    assert pipeline._execution_observer is sentinel
+    assert pipeline._downstream_guard is sentinel

--- a/bot/tests/test_kraken_exit_final_guards.py
+++ b/bot/tests/test_kraken_exit_final_guards.py
@@ -68,6 +68,9 @@ class TestWriterAuthorizedStateGate:
             def _enforce_execution_gate(self, request, t_start):
                 return "state_gate_blocked"
 
+            def _deny(self, request, t_start, reason):
+                return f"hard_deny:{reason}"
+
         module = types.ModuleType("bot.execution_pipeline")
         module.ExecutionPipeline = ExecutionPipeline
         return module
@@ -81,6 +84,7 @@ class TestWriterAuthorizedStateGate:
             account_id="tania_gilbert",
             symbol="AIR-EUR",
             side="sell",
+            size_usd=1.1,
         )
 
     def test_live_exit_bypasses_entry_state_only_after_writer_verification(self):
@@ -106,7 +110,7 @@ class TestWriterAuthorizedStateGate:
             assert pipeline._enforce_execution_gate(self._request("exit"), 0.0) is None
             assert pipeline._enforce_execution_gate(self._request("entry"), 0.0) == "state_gate_blocked"
 
-    def test_missing_writer_authority_keeps_state_gate_blocked(self):
+    def test_missing_writer_authority_is_hard_denied(self):
         module = self._pipeline_module()
         assert guards._patch_execution_gate(module)
 
@@ -126,11 +130,18 @@ class TestWriterAuthorizedStateGate:
             clear=False,
         ), patch.dict(
             os.environ,
-            {"DRY_RUN_MODE": "false", "PAPER_MODE": "false", "APP_STORE_MODE": "false"},
+            {
+                "DRY_RUN_MODE": "false",
+                "PAPER_MODE": "false",
+                "APP_STORE_MODE": "false",
+                "FORCE_TRADE": "true",
+            },
             clear=False,
         ):
             pipeline = module.ExecutionPipeline()
-            assert pipeline._enforce_execution_gate(self._request("exit"), 0.0) == "state_gate_blocked"
+            result = pipeline._enforce_execution_gate(self._request("exit"), 0.0)
+        assert result.startswith("hard_deny:Account exit denied")
+        assert "writer lease unavailable" in result
 
     def test_dry_run_exit_is_not_promoted_to_live(self):
         module = self._pipeline_module()

--- a/bot/tests/test_kraken_exit_final_guards.py
+++ b/bot/tests/test_kraken_exit_final_guards.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guards = load_module(
+    "kraken_exit_final_guards_under_test",
+    "kraken_exit_final_guards_patch.py",
+)
+
+
+class TestVerifiedCostBasis:
+    def test_explicitly_unverified_position_cannot_trigger_profit_exit(self):
+        module = types.ModuleType("bot.kraken_all_account_exit_runtime_patch")
+        module._exit_reason = lambda position, price, account, symbol: (
+            "net_profit_target", 100.8, 101.2
+        )
+        assert guards._patch_exit_decision(module)
+
+        result = module._exit_reason(
+            {
+                "entry_price": 100.0,
+                "cost_basis_verified": False,
+                "auto_exit_blocked": True,
+                "auto_exit_block_reason": "unverified_cost_basis",
+            },
+            102.0,
+            "user:tania_gilbert:kraken",
+            "AIR-EUR",
+        )
+        assert result == (None, 0.0, 0.0)
+
+    def test_verified_position_reaches_normal_exit_policy(self):
+        module = types.ModuleType("bot.kraken_all_account_exit_runtime_patch.verified")
+        module._exit_reason = lambda position, price, account, symbol: (
+            "fee_adjusted_break_even", 100.8, 101.2
+        )
+        assert guards._patch_exit_decision(module)
+        assert module._exit_reason(
+            {"entry_price": 100.0, "cost_basis_verified": True},
+            100.9,
+            "platform:kraken",
+            "SOL-USD",
+        )[0] == "fee_adjusted_break_even"
+
+
+class TestWriterAuthorizedStateGate:
+    @staticmethod
+    def _pipeline_module():
+        class ExecutionPipeline:
+            def _enforce_execution_gate(self, request, t_start):
+                return "state_gate_blocked"
+
+        module = types.ModuleType("bot.execution_pipeline")
+        module.ExecutionPipeline = ExecutionPipeline
+        return module
+
+    @staticmethod
+    def _request(intent="exit"):
+        return SimpleNamespace(
+            intent_type=intent,
+            position_effect="close" if intent == "exit" else None,
+            metadata={"closing_position": intent == "exit"},
+            account_id="tania_gilbert",
+            symbol="AIR-EUR",
+            side="sell",
+        )
+
+    def test_live_exit_bypasses_entry_state_only_after_writer_verification(self):
+        module = self._pipeline_module()
+        assert guards._patch_execution_gate(module)
+
+        authority = types.ModuleType("bot.execution_authority_context")
+        authority.assert_distributed_writer_authority = lambda: None
+        fake_bot = types.ModuleType("bot")
+        fake_bot.__path__ = []
+        fake_bot.execution_authority_context = authority
+
+        with patch.dict(
+            sys.modules,
+            {"bot": fake_bot, "bot.execution_authority_context": authority},
+            clear=False,
+        ), patch.dict(
+            os.environ,
+            {"DRY_RUN_MODE": "false", "PAPER_MODE": "false", "APP_STORE_MODE": "false"},
+            clear=False,
+        ):
+            pipeline = module.ExecutionPipeline()
+            assert pipeline._enforce_execution_gate(self._request("exit"), 0.0) is None
+            assert pipeline._enforce_execution_gate(self._request("entry"), 0.0) == "state_gate_blocked"
+
+    def test_missing_writer_authority_keeps_state_gate_blocked(self):
+        module = self._pipeline_module()
+        assert guards._patch_execution_gate(module)
+
+        authority = types.ModuleType("bot.execution_authority_context")
+
+        def reject():
+            raise RuntimeError("writer lease unavailable")
+
+        authority.assert_distributed_writer_authority = reject
+        fake_bot = types.ModuleType("bot")
+        fake_bot.__path__ = []
+        fake_bot.execution_authority_context = authority
+
+        with patch.dict(
+            sys.modules,
+            {"bot": fake_bot, "bot.execution_authority_context": authority},
+            clear=False,
+        ), patch.dict(
+            os.environ,
+            {"DRY_RUN_MODE": "false", "PAPER_MODE": "false", "APP_STORE_MODE": "false"},
+            clear=False,
+        ):
+            pipeline = module.ExecutionPipeline()
+            assert pipeline._enforce_execution_gate(self._request("exit"), 0.0) == "state_gate_blocked"
+
+    def test_dry_run_exit_is_not_promoted_to_live(self):
+        module = self._pipeline_module()
+        assert guards._patch_execution_gate(module)
+        with patch.dict(os.environ, {"DRY_RUN_MODE": "true"}, clear=False):
+            pipeline = module.ExecutionPipeline()
+            assert pipeline._enforce_execution_gate(self._request("exit"), 0.0) == "state_gate_blocked"

--- a/bot/tests/test_kraken_exit_margin_cost.py
+++ b/bot/tests/test_kraken_exit_margin_cost.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+patch = load_module(
+    "kraken_exit_margin_cost_under_test",
+    "kraken_exit_margin_cost_patch.py",
+)
+
+
+def test_user_supervisor_identity_uses_user_margin_ledger_key():
+    captured = {}
+    module = types.ModuleType("bot.kraken_all_account_exit_runtime_patch")
+
+    def margin_extra_buffer(account, symbol):
+        captured["account"] = account
+        captured["symbol"] = symbol
+        return 0.002
+
+    module._margin_extra_buffer = margin_extra_buffer
+    assert patch._patch_exit_runtime(module)
+    assert module._margin_extra_buffer("user:tania_gilbert:kraken", "AIR-EUR") == 0.002
+    assert captured == {"account": "tania_gilbert", "symbol": "AIR-EUR"}
+
+
+def test_platform_supervisor_identity_uses_platform_margin_ledger_key():
+    captured = {}
+    module = types.ModuleType("bot.kraken_all_account_exit_runtime_patch.platform")
+
+    def margin_extra_buffer(account, symbol):
+        captured["account"] = account
+        return 0.002
+
+    module._margin_extra_buffer = margin_extra_buffer
+    assert patch._patch_exit_runtime(module)
+    module._margin_extra_buffer("platform:kraken", "SOL-USD")
+    assert captured["account"] == "platform"

--- a/bot/tests/test_pipeline_order_submitter_exit_context.py
+++ b/bot/tests/test_pipeline_order_submitter_exit_context.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_explicit_exit_context_reaches_pipeline_without_platform_balance_leak():
+    captured = {}
+
+    class PipelineRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Pipeline:
+        def execute(self, request):
+            captured["request"] = request
+            return SimpleNamespace(
+                success=True,
+                fill_price=0.011,
+                filled_size_usd=request.size_usd,
+                broker="kraken",
+                error="",
+            )
+
+    pipeline = Pipeline()
+    execution_pipeline = types.ModuleType("bot.execution_pipeline")
+    execution_pipeline.PipelineRequest = PipelineRequest
+    execution_pipeline.get_execution_pipeline = lambda: pipeline
+
+    authority_context = types.ModuleType("bot.execution_authority_context")
+    authority_context.assert_distributed_writer_authority = lambda: None
+
+    margin_engine = types.ModuleType("bot.kraken_margin_engine")
+
+    @contextmanager
+    def margin_account_scope(account_id, adapter=None):
+        captured["scope_account"] = account_id
+        yield SimpleNamespace()
+
+    margin_engine.margin_account_scope = margin_account_scope
+
+    capital_authority = types.ModuleType("bot.capital_authority")
+
+    class Authority:
+        def get_per_broker(self, key):
+            # Deliberately expose a platform total.  The submitter must not use it
+            # to size an explicit user exit.
+            return 225.0 if key == "kraken" else 0.0
+
+        def is_registered(self, key):
+            return key == "kraken"
+
+    capital_authority.get_capital_authority = lambda: Authority()
+
+    fake_bot = types.ModuleType("bot")
+    fake_bot.__path__ = []
+    fake_bot.execution_pipeline = execution_pipeline
+    fake_bot.execution_authority_context = authority_context
+    fake_bot.kraken_margin_engine = margin_engine
+    fake_bot.capital_authority = capital_authority
+
+    root_capital_authority = types.ModuleType("capital_authority")
+    root_capital_authority.get_capital_authority = capital_authority.get_capital_authority
+
+    modules = {
+        "bot": fake_bot,
+        "bot.execution_pipeline": execution_pipeline,
+        "bot.execution_authority_context": authority_context,
+        "bot.kraken_margin_engine": margin_engine,
+        "bot.capital_authority": capital_authority,
+        "capital_authority": root_capital_authority,
+    }
+
+    with patch.dict(sys.modules, modules, clear=False):
+        spec = importlib.util.spec_from_file_location(
+            "pipeline_order_submitter_exit_under_test",
+            BOT_DIR / "pipeline_order_submitter.py",
+        )
+        assert spec is not None and spec.loader is not None
+        submitter = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(submitter)
+
+        class KrakenBroker:
+            NAME = "Kraken"
+            broker_type = SimpleNamespace(value="kraken")
+            account_identifier = "USER:tania_gilbert"
+            _last_known_balance = 104.31
+
+            def get_current_price(self, symbol):
+                assert symbol == "AIREUR"
+                return 0.011
+
+        result = submitter.submit_market_order_via_pipeline(
+            broker=KrakenBroker(),
+            symbol="AIREUR",
+            side="sell",
+            quantity=100.0,
+            size_type="base",
+            strategy="KrakenAccountExit:fee_adjusted_break_even",
+            intent_type="exit",
+            account_id_override="tania_gilbert",
+            position_effect="close",
+            metadata_override={"closing_position": True},
+        )
+
+    request = captured["request"]
+    assert result["status"] == "filled"
+    assert request.account_id == "tania_gilbert"
+    assert request.intent_type == "exit"
+    assert request.position_effect == "close"
+    assert request.side == "sell"
+    assert request.available_balance_usd == 104.31
+    assert request.available_balance_usd != 225.0
+    assert request.metadata["closing_position"] is True
+    assert captured["scope_account"] == "tania_gilbert"


### PR DESCRIPTION
## Purpose

Keep the platform, Daivon, Tania, and every configured Kraken account independently authenticated and able to close its own positions. Normal exits prefer net profit, then fee-adjusted break-even. Profit is not guaranteed: emergency stop-loss and critical-margin reduction can still realize a loss to prevent a larger loss.

## Confirmed defects fixed

- A live trading thread was treated as proof that its exact Kraken adapter remained privately authenticated.
- The legacy auto-exit worker was process-global and could monitor the wrong broker/account in a multi-account runtime.
- User exits could inherit platform capital or platform account identity.
- A sell-to-close could be rejected as a new unsupported short.
- Entry-only risk, allocation, throttling, and state gates could block legitimate risk-reducing exits.
- Exit-only recovery cycles could be auto-promoted into full entry scans by the trade-cycle convergence layer.
- Critical margin health could block the very `reduce_only` close needed to lower exposure.
- AIR and other assets were assumed to have USD/USDT pairs instead of resolving an actually listed Kraken pair.
- An explicitly unverified adopted cost basis could be used to claim a false profit or break-even exit.
- A failed writer-authority check could fall back into a legacy `FORCE_TRADE` state-gate bypass.
- The first exit wrapper disabled the downstream slippage guard and execution observer.
- Margin financing-cost lookup used supervisor labels instead of canonical account ledger keys.

## Repairs

- Exact per-adapter private `TradeBalance` health probes and reconnects for every platform/user Kraken account.
- Connection handoff now requires both a live account thread and healthy private Kraken access.
- Account connection matrix telemetry for all configured Kraken adapters.
- Account-local position scanning and exit decisions instead of one process-global Kraken monitor.
- Explicit pipeline context: `account_id`, `intent_type=exit`, `position_effect=close`, and margin `reduce_only` where applicable.
- User exits use the exact user broker balance and never fall back to the platform-only capital key.
- Writer-authorized live exits can bypass entry-state gates while broker authentication, ECEL, exchange minimums, writer fencing, downstream slippage protection, execution observation, and broker acknowledgement remain fail-closed.
- Missing writer authority is a hard denial—even when `FORCE_TRADE` is set—to prevent duplicate unfenced exits.
- Exit recovery cycles remain Phase-2/position-management-only and cannot create new entries.
- Private-authenticated `reduce_only` margin exits remain allowed during low/critical margin health; permission/authentication failures remain blocked.
- Dynamic Kraken `AssetPairs` resolution across USD, USDT, USDC, and EUR quotes, including AIR.
- Fee-adjusted break-even and net-profit targets, with a profit-lock trail.
- Margin financing buffer is looked up through canonical account keys (`platform`, `daivon_frazier`, `tania_gilbert`).
- Explicitly unverified cost basis is blocked from automatic profit/break-even exits pending reconciliation.
- Non-Kraken legacy auto-exit behavior is restored and preserved.

## Default exit policy

- Estimated Kraken round-trip cost buffer: 0.8%
- Additional margin exit buffer: 0.2%
- Net profit target above costs: 0.4%
- Fee-adjusted break-even becomes eligible after 60 minutes
- Profit-lock trailing distance: 0.35%

All values remain environment-configurable.

## Regression coverage

- Per-adapter private account health and stale-thread rejection
- Platform/user identity normalization
- No platform-balance leakage into Tania/Daivon exits
- AIR fallback pair resolution
- Net-profit and fee-adjusted break-even decisions
- Emergency stop-loss availability
- Explicit exit request context
- Exit-only cycle promotion guard
- Critical-margin reduce-only permission
- Entry-only gate bypass/restoration
- Writer-authorized state-gate bypass and hard writer denial
- Dry-run protection
- Unverified cost-basis rejection
- Downstream slippage guard and execution observer preservation
- Canonical margin-cost account lookup
- Kraken-only global monitor redirection while preserving non-Kraken monitoring

## Expected deployment markers

- `KRAKEN_ALL_ACCOUNT_EXIT_RUNTIME_INSTALLED`
- `KRAKEN_EXIT_SAFETY_CONVERGENCE_INSTALLED`
- `KRAKEN_EXIT_FINAL_GUARDS_INSTALLED`
- `KRAKEN_EXIT_EXECUTION_SAFETY_INSTALLED`
- `KRAKEN_EXIT_MARGIN_COST_PATCH_INSTALLED`
- `KRAKEN_ALL_ACCOUNT_CONNECTION_MATRIX`
- `KRAKEN_ACCOUNT_PRIVATE_READY`
- `KRAKEN_EXIT_PAIR_RESOLVED`
- `KRAKEN_ACCOUNT_EXIT_EVALUATED`
- `KRAKEN_ACCOUNT_EXIT_TRIGGER`
- `KRAKEN_EXIT_ACCOUNT_CONTEXT`
- `ACCOUNT_EXIT_STATE_GATE_BYPASSED`
- `ACCOUNT_EXIT_ENTRY_GATES_BYPASSED_SAFELY`
- `ACCOUNT_EXIT_WRITER_AUTHORITY_DENIED`
- `KRAKEN_ACCOUNT_EXIT_ORDER_ACK`
- `KRAKEN_EXIT_SKIPPED_UNVERIFIED_COST_BASIS`

## CI infrastructure status

GitHub continues to create workflow jobs that terminate before checkout or test execution. The preflight job exposes no steps and no log URL (`steps=None`, `logs_url=None`), so the red Actions state contains no actionable repository-code failure.