### PR TITLE
Fix stale runtime, scan recursion, Kraken valuation, and Coinbase PEM failures

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -123,96 +123,77 @@ def _install_module(primary: str, fallback: str, label: str, marker: str) -> Non
         logger.warning("%s_INSTALL_FAILED marker=%s error=%s", label, marker, exc)
 
 
-def _install_strategy_backrefs() -> None:
+def _install_scan_wrapper_convergence() -> None:
     _install_module(
-        "bot.strategy_broker_backref_patch",
-        "strategy_broker_backref_patch",
-        "BROKER_BOOL_GUARD_STRATEGY_BACKREF",
-        "20260705d",
+        "scan_wrapper_convergence_repair_patch",
+        "scan_wrapper_convergence_repair_patch",
+        "SCAN_WRAPPER_CONVERGENCE",
+        "20260713-scan-wrapper-v2",
     )
+
+
+def _install_strategy_backrefs() -> None:
+    _install_module("bot.strategy_broker_backref_patch", "strategy_broker_backref_patch", "BROKER_BOOL_GUARD_STRATEGY_BACKREF", "20260705d")
 
 
 def _install_trade_cycle_convergence_repair() -> None:
-    _install_module(
-        "bot.trade_cycle_convergence_repair_patch",
-        "trade_cycle_convergence_repair_patch",
-        "TRADE_CYCLE_CONVERGENCE",
-        "20260713a",
-    )
+    _install_module("bot.trade_cycle_convergence_repair_patch", "trade_cycle_convergence_repair_patch", "TRADE_CYCLE_CONVERGENCE", "20260713a")
 
 
 def _install_position_sync_runtime_repair() -> None:
-    _install_module(
-        "bot.position_sync_runtime_repair_patch",
-        "position_sync_runtime_repair_patch",
-        "POSITION_SYNC_RUNTIME_REPAIR",
-        "20260713-position-sync-v2",
-    )
+    _install_module("bot.position_sync_runtime_repair_patch", "position_sync_runtime_repair_patch", "POSITION_SYNC_RUNTIME_REPAIR", "20260713-position-sync-v2")
+
+
+def _install_kraken_equity_runtime() -> None:
+    _install_module("bot.kraken_equity_runtime_patch", "kraken_equity_runtime_patch", "KRAKEN_EQUITY_RUNTIME", "20260713-kraken-equity-v2")
 
 
 def _install_kraken_margin_auto_runtime() -> None:
-    _install_module(
-        "bot.kraken_margin_auto_runtime_patch",
-        "kraken_margin_auto_runtime_patch",
-        "KRAKEN_MARGIN_AUTO_RUNTIME",
-        "20260713-kraken-margin-v1",
-    )
+    _install_module("bot.kraken_margin_auto_runtime_patch", "kraken_margin_auto_runtime_patch", "KRAKEN_MARGIN_AUTO_RUNTIME", "20260713-kraken-margin-v1")
 
 
 def _install_kraken_all_account_exit_runtime() -> None:
-    _install_module(
-        "bot.kraken_all_account_exit_runtime_patch",
-        "kraken_all_account_exit_runtime_patch",
-        "KRAKEN_ALL_ACCOUNT_EXIT_RUNTIME",
-        "20260713-kraken-all-account-exit-v1",
-    )
+    _install_module("bot.kraken_all_account_exit_runtime_patch", "kraken_all_account_exit_runtime_patch", "KRAKEN_ALL_ACCOUNT_EXIT_RUNTIME", "20260713-kraken-all-account-exit-v1")
 
 
 def _install_kraken_exit_safety_convergence() -> None:
-    _install_module(
-        "bot.kraken_exit_safety_convergence_patch",
-        "kraken_exit_safety_convergence_patch",
-        "KRAKEN_EXIT_SAFETY_CONVERGENCE",
-        "20260713-kraken-exit-safety-v1",
-    )
+    _install_module("bot.kraken_exit_safety_convergence_patch", "kraken_exit_safety_convergence_patch", "KRAKEN_EXIT_SAFETY_CONVERGENCE", "20260713-kraken-exit-safety-v1")
 
 
 def _install_kraken_exit_final_guards() -> None:
-    _install_module(
-        "bot.kraken_exit_final_guards_patch",
-        "kraken_exit_final_guards_patch",
-        "KRAKEN_EXIT_FINAL_GUARDS",
-        "20260713-kraken-exit-final-guards-v1",
-    )
+    _install_module("bot.kraken_exit_final_guards_patch", "kraken_exit_final_guards_patch", "KRAKEN_EXIT_FINAL_GUARDS", "20260713-kraken-exit-final-guards-v1")
 
 
 def _install_kraken_exit_execution_safety() -> None:
-    _install_module(
-        "bot.kraken_exit_execution_safety_patch",
-        "kraken_exit_execution_safety_patch",
-        "KRAKEN_EXIT_EXECUTION_SAFETY",
-        "20260713-kraken-exit-execution-safety-v1",
-    )
+    _install_module("bot.kraken_exit_execution_safety_patch", "kraken_exit_execution_safety_patch", "KRAKEN_EXIT_EXECUTION_SAFETY", "20260713-kraken-exit-execution-safety-v1")
 
 
 def _install_kraken_exit_margin_cost() -> None:
-    _install_module(
-        "bot.kraken_exit_margin_cost_patch",
-        "kraken_exit_margin_cost_patch",
-        "KRAKEN_EXIT_MARGIN_COST",
-        "20260713-kraken-exit-margin-cost-v1",
-    )
+    _install_module("bot.kraken_exit_margin_cost_patch", "kraken_exit_margin_cost_patch", "KRAKEN_EXIT_MARGIN_COST", "20260713-kraken-exit-margin-cost-v1")
+
+
+def _install_coinbase_pem_quarantine() -> None:
+    _install_module("bot.coinbase_pem_quarantine_patch", "coinbase_pem_quarantine_patch", "COINBASE_PEM_QUARANTINE", "20260713-coinbase-pem-v1")
+
+
+def _install_runtime_release_manifest() -> None:
+    _install_module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch", "RUNTIME_RELEASE_MANIFEST", "20260713-runtime-convergence-v3")
 
 
 def install_import_hook() -> None:
+    # Order matters: unwrap scan recursion first, then account state/valuation,
+    # then execution and exit surfaces.  Publish the release manifest last.
+    _install_scan_wrapper_convergence()
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
+    _install_kraken_equity_runtime()
     _install_kraken_margin_auto_runtime()
     _install_kraken_all_account_exit_runtime()
     _install_kraken_exit_safety_convergence()
     _install_kraken_exit_final_guards()
     _install_kraken_exit_execution_safety()
     _install_kraken_exit_margin_cost()
+    _install_coinbase_pem_quarantine()
     _install_strategy_backrefs()
     try:
         module = importlib.import_module("bot.broker_independent_live_execution_patch")
@@ -221,8 +202,10 @@ def install_import_hook() -> None:
             module = importlib.import_module("broker_independent_live_execution_patch")
         except Exception as exc:
             logger.warning("BROKER_BOOL_GUARD_IMPORT_WAIT marker=20260705d error=%s", exc)
+            _install_runtime_release_manifest()
             return
     _install_collector_override(module)
+    _install_runtime_release_manifest()
 
 
 def install() -> None:

--- a/bot/coinbase_pem_quarantine_patch.py
+++ b/bot/coinbase_pem_quarantine_patch.py
@@ -86,9 +86,10 @@ def _normalize_pem(secret: str) -> str:
 
 def _validate_pem(secret: str) -> Tuple[bool, str]:
     normalized = _normalize_pem(secret)
-    if "-----BEGIN " not in normalized or " PRIVATE KEY-----" not in normalized:
+    if "-----BEGIN " not in normalized or "PRIVATE KEY-----" not in normalized.splitlines()[0]:
         return False, "pem_header_missing"
-    if "-----END " not in normalized or " PRIVATE KEY-----" not in normalized.rsplit("-----END ", 1)[-1]:
+    footer = normalized.rstrip().splitlines()[-1] if normalized.strip() else ""
+    if not footer.startswith("-----END ") or "PRIVATE KEY-----" not in footer:
         return False, "pem_footer_missing"
     try:
         from cryptography.hazmat.primitives import serialization
@@ -152,8 +153,6 @@ def _preflight(instance: Any) -> Tuple[bool, str]:
 
 
 def _empty_for(method_name: str):
-    if method_name in {"get_available_markets", "get_tradable_symbols"}:
-        return []
     return []
 
 

--- a/bot/coinbase_pem_quarantine_patch.py
+++ b/bot/coinbase_pem_quarantine_patch.py
@@ -1,0 +1,262 @@
+"""Normalize or quarantine malformed Coinbase Advanced Trade PEM credentials.
+
+A malformed CDP private key previously reached the Coinbase SDK on every market
+refresh, producing repeated ``MalformedFraming`` errors.  This patch repairs the
+common literal-``\\n`` formatting problem.  If the exact credential still cannot
+be parsed, Coinbase is marked configuration-failed and all product/balance
+surfaces fail quietly and deterministically while Kraken remains independent.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("nija.coinbase_pem_quarantine")
+_MARKER = "20260713-coinbase-pem-v1"
+_PATCH_ATTR = "_nija_coinbase_pem_quarantine_v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+_LAST_LOG: dict[int, float] = {}
+
+_KEY_ENV_NAMES = (
+    "COINBASE_PLATFORM_API_KEY", "COINBASE_API_KEY", "COINBASE_ADVANCED_API_KEY",
+)
+_SECRET_ENV_NAMES = (
+    "COINBASE_PLATFORM_API_SECRET", "COINBASE_API_SECRET", "COINBASE_ADVANCED_API_SECRET",
+    "COINBASE_PRIVATE_KEY",
+)
+_SECRET_ATTRS = ("api_secret", "secret", "private_key", "api_key_secret", "coinbase_api_secret")
+_KEY_ATTRS = ("api_key", "key", "api_key_name", "coinbase_api_key")
+_PRODUCT_METHODS = (
+    "get_all_products", "get_products", "list_products", "fetch_products",
+    "get_available_markets", "get_tradable_symbols",
+)
+
+
+def _first_text(values) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _credential_pair(instance: Any) -> Tuple[str, str, Optional[str]]:
+    key = _first_text([getattr(instance, attr, "") for attr in _KEY_ATTRS] + [os.environ.get(name, "") for name in _KEY_ENV_NAMES])
+    secret_attr: Optional[str] = None
+    secret = ""
+    for attr in _SECRET_ATTRS:
+        value = str(getattr(instance, attr, "") or "").strip()
+        if value:
+            secret, secret_attr = value, attr
+            break
+    if not secret:
+        secret = _first_text(os.environ.get(name, "") for name in _SECRET_ENV_NAMES)
+    return key, secret, secret_attr
+
+
+def _is_cdp_key(key: str, secret: str) -> bool:
+    key_text = str(key or "").lower()
+    secret_text = str(secret or "").upper()
+    return (
+        "organizations/" in key_text
+        or "/apikeys/" in key_text
+        or "BEGIN PRIVATE KEY" in secret_text
+        or "BEGIN EC PRIVATE KEY" in secret_text
+    )
+
+
+def _normalize_pem(secret: str) -> str:
+    text = str(secret or "").strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        text = text[1:-1].strip()
+    text = text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.strip() for line in text.split("\n") if line.strip()]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _validate_pem(secret: str) -> Tuple[bool, str]:
+    normalized = _normalize_pem(secret)
+    if "-----BEGIN " not in normalized or " PRIVATE KEY-----" not in normalized:
+        return False, "pem_header_missing"
+    if "-----END " not in normalized or " PRIVATE KEY-----" not in normalized.rsplit("-----END ", 1)[-1]:
+        return False, "pem_footer_missing"
+    try:
+        from cryptography.hazmat.primitives import serialization
+        serialization.load_pem_private_key(normalized.encode("utf-8"), password=None)
+        return True, "pem_parse_ok"
+    except Exception as exc:
+        return False, f"pem_parse_failed:{type(exc).__name__}"
+
+
+def _apply_normalized_secret(instance: Any, normalized: str, secret_attr: Optional[str]) -> None:
+    if secret_attr:
+        try:
+            setattr(instance, secret_attr, normalized)
+        except Exception:
+            pass
+    for name in _SECRET_ENV_NAMES:
+        if str(os.environ.get(name, "") or "").strip():
+            os.environ[name] = normalized
+
+
+def _mark_quarantined(instance: Any, reason: str) -> None:
+    for attr, value in (
+        ("connected", False),
+        ("client", None),
+        ("_nija_coinbase_config_quarantined", True),
+        ("_nija_coinbase_config_reason", reason),
+        ("_last_known_balance", 0.0),
+    ):
+        try:
+            setattr(instance, attr, value)
+        except Exception:
+            pass
+    now = time.monotonic()
+    if now - _LAST_LOG.get(id(instance), 0.0) >= 300.0:
+        _LAST_LOG[id(instance)] = now
+        logger.error(
+            "COINBASE_CREDENTIAL_QUARANTINED marker=%s reason=%s action=disable_coinbase_only kraken_unaffected=true",
+            _MARKER, reason,
+        )
+
+
+def _preflight(instance: Any) -> Tuple[bool, str]:
+    key, secret, secret_attr = _credential_pair(instance)
+    if not key or not secret:
+        return False, "credentials_missing"
+    if not _is_cdp_key(key, secret):
+        return True, "legacy_non_pem_credential"
+    normalized = _normalize_pem(secret)
+    valid, reason = _validate_pem(normalized)
+    if valid:
+        _apply_normalized_secret(instance, normalized, secret_attr)
+        try:
+            setattr(instance, "_nija_coinbase_config_quarantined", False)
+            setattr(instance, "_nija_coinbase_config_reason", "")
+        except Exception:
+            pass
+        logger.info("COINBASE_PEM_NORMALIZED marker=%s parse_ok=true", _MARKER)
+        return True, reason
+    _mark_quarantined(instance, reason)
+    return False, reason
+
+
+def _empty_for(method_name: str):
+    if method_name in {"get_available_markets", "get_tradable_symbols"}:
+        return []
+    return []
+
+
+def _patch_class(cls: type) -> bool:
+    current_connect = getattr(cls, "connect", None)
+    if not callable(current_connect) or getattr(current_connect, _PATCH_ATTR, False):
+        return False
+    original_connect = current_connect
+
+    @wraps(original_connect)
+    def connect(self: Any, *args: Any, **kwargs: Any):
+        allowed, reason = _preflight(self)
+        if not allowed:
+            logger.warning("COINBASE_CONNECT_SKIPPED marker=%s reason=%s", _MARKER, reason)
+            return False
+        try:
+            result = original_connect(self, *args, **kwargs)
+        except Exception as exc:
+            text = str(exc).lower()
+            if any(token in text for token in ("malformedframing", "unable to load pem", "private key")):
+                _mark_quarantined(self, f"sdk_rejected_pem:{type(exc).__name__}")
+                return False
+            raise
+        if not result and getattr(self, "_nija_coinbase_config_quarantined", False):
+            return False
+        return result
+
+    setattr(connect, _PATCH_ATTR, True)
+    setattr(connect, "__wrapped__", original_connect)
+    setattr(cls, "connect", connect)
+
+    for method_name in _PRODUCT_METHODS:
+        current = getattr(cls, method_name, None)
+        if not callable(current) or getattr(current, _PATCH_ATTR, False):
+            continue
+
+        def guarded(self: Any, *args: Any, _original=current, _name=method_name, **kwargs: Any):
+            if getattr(self, "_nija_coinbase_config_quarantined", False):
+                _mark_quarantined(self, str(getattr(self, "_nija_coinbase_config_reason", "invalid_pem")))
+                return _empty_for(_name)
+            try:
+                return _original(self, *args, **kwargs)
+            except Exception as exc:
+                text = str(exc).lower()
+                if any(token in text for token in ("malformedframing", "unable to load pem", "private key")):
+                    _mark_quarantined(self, f"sdk_rejected_pem:{type(exc).__name__}")
+                    return _empty_for(_name)
+                raise
+
+        setattr(guarded, _PATCH_ATTR, True)
+        setattr(guarded, "__wrapped__", current)
+        setattr(cls, method_name, guarded)
+
+    logger.warning("COINBASE_PEM_QUARANTINE_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    changed = False
+    for name in dir(module):
+        cls = getattr(module, name, None)
+        if isinstance(cls, type) and "coinbase" in name.lower():
+            changed = _patch_class(cls) or changed
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType) and str(getattr(module, "__name__", "")).endswith(("broker_manager", "broker_integration")):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("COINBASE_PEM_QUARANTINE_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = ["install_import_hook", "_normalize_pem", "_validate_pem", "_preflight", "_patch_class"]

--- a/bot/kraken_equity_double_count_guard_patch.py
+++ b/bot/kraken_equity_double_count_guard_patch.py
@@ -1,0 +1,184 @@
+"""Final Kraken equity guard that excludes held-value double counting.
+
+Kraken asset balances already include assets tied to open orders.  Adding a
+separate ``held`` amount to the same crypto holdings inflated Tania's $93.26
+exchange equity to $104.32 and inflated the platform total similarly.  The
+canonical total is now exchange equity or cash plus dynamically priced assets;
+held value is telemetry only and is never added a second time.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+logger = logging.getLogger("nija.kraken_equity_double_count_guard")
+_MARKER = "20260713-kraken-equity-double-count-v1"
+_PATCH_ATTR = "_nija_kraken_equity_double_count_v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+
+
+def _f(value: Any) -> float:
+    try:
+        parsed = float(value or 0.0)
+        return parsed if parsed == parsed else 0.0
+    except Exception:
+        return 0.0
+
+
+def _exchange_equity(payload: Mapping[str, Any]) -> float:
+    values = []
+    for key in ("eb", "e", "equivalent_balance", "exchange_equity"):
+        values.append(_f(payload.get(key)))
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        for key in ("eb", "e", "equivalent_balance", "exchange_equity"):
+            values.append(_f(result.get(key)))
+    return max([0.0] + values)
+
+
+def _value_from_result(value: Any) -> float:
+    if isinstance(value, Mapping):
+        for key in ("total_funds", "total_balance", "total_equity", "equity", "available_balance", "balance"):
+            parsed = _f(value.get(key))
+            if parsed > 0:
+                return parsed
+        return 0.0
+    return _f(value)
+
+
+def _canonical(instance: Any, fallback: float) -> tuple[float, float, float, float]:
+    try:
+        from bot import kraken_equity_runtime_patch as equity
+    except ImportError:
+        import kraken_equity_runtime_patch as equity  # type: ignore[import]
+
+    payload = equity._call_balance_payload(instance, allow_live_probe=False)
+    raw_assets = equity._extract_raw_balances(payload)
+    positions = equity._build_positions(instance, raw_assets)
+    cash = equity._cash_from_payload(payload)
+    crypto = sum(_f(row.get("size_usd")) for row in positions)
+    exchange = _exchange_equity(payload)
+    computed = cash + crypto
+
+    if exchange > 0 and computed > 0:
+        total = max(exchange, computed)
+    elif exchange > 0:
+        total = exchange
+    elif computed > 0:
+        total = computed
+    else:
+        total = fallback
+    return total, exchange, cash, crypto
+
+
+def _patch_class(cls: type) -> bool:
+    current = getattr(cls, "get_account_balance", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return False
+    original = current
+
+    @wraps(original)
+    def get_account_balance(self: Any, *args: Any, **kwargs: Any):
+        value = original(self, *args, **kwargs)
+        fallback = _value_from_result(value)
+        canonical, exchange, cash, crypto = _canonical(self, fallback)
+        held = 0.0
+        try:
+            from bot import kraken_equity_runtime_patch as equity
+            payload = equity._call_balance_payload(self, allow_live_probe=False)
+            held = max(_f(payload.get("usd_held")), _f(payload.get("total_held")))
+        except Exception:
+            pass
+        try:
+            self._last_known_balance = canonical
+            payload = getattr(self, "_last_raw_balances", None)
+            if isinstance(payload, dict):
+                payload["total_funds"] = canonical
+                payload["canonical_equity"] = canonical
+                payload["held_excluded_from_equity_sum"] = held
+        except Exception:
+            pass
+        logger.critical(
+            "KRAKEN_EQUITY_DOUBLE_COUNT_PREVENTED marker=%s account=%s fallback=$%.2f "
+            "exchange=$%.2f cash=$%.2f crypto=$%.2f held_not_added=$%.2f canonical=$%.2f",
+            _MARKER,
+            getattr(self, "account_identifier", getattr(self, "account_id", "unknown")),
+            fallback,
+            exchange,
+            cash,
+            crypto,
+            held,
+            canonical,
+        )
+        if isinstance(value, Mapping):
+            result = dict(value)
+            result["total_balance"] = canonical
+            result["total_funds"] = canonical
+            result["canonical_equity"] = canonical
+            return result
+        return canonical
+
+    setattr(get_account_balance, _PATCH_ATTR, True)
+    setattr(get_account_balance, "__wrapped__", original)
+    setattr(cls, "get_account_balance", get_account_balance)
+    logger.warning("KRAKEN_EQUITY_DOUBLE_COUNT_GUARD_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    changed = False
+    for name in dir(module):
+        cls = getattr(module, name, None)
+        if isinstance(cls, type) and "kraken" in name.lower():
+            changed = _patch_class(cls) or changed
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType) and str(getattr(module, "__name__", "")).endswith(("broker_manager", "broker_integration", "kraken_broker")):
+            try:
+                _patch_module(module)
+            except Exception:
+                continue
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            local.active = True
+            try:
+                _patch_loaded()
+            finally:
+                local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("KRAKEN_EQUITY_DOUBLE_COUNT_GUARD_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = ["install_import_hook", "_exchange_equity", "_canonical", "_patch_class"]

--- a/bot/kraken_equity_runtime_patch.py
+++ b/bot/kraken_equity_runtime_patch.py
@@ -1,53 +1,39 @@
-"""Kraken total-equity hydration patch.
+"""Kraken total-equity hydration and dynamic asset valuation.
 
-This layer classifies non-cash Kraken holdings for visibility while keeping
-balance reads idempotent. It never mutates PositionTracker during a balance read,
-never recursively calls the wrapped get_account_balance method, and never adds
-crypto value twice when the broker already returned total account equity.
+Balance reads remain idempotent and never mutate PositionTracker.  Non-cash
+assets are valued through Kraken's public ``AssetPairs`` and ``Ticker`` endpoints
+when the broker's convenience price methods do not support the asset's actual
+quote pair.  This repairs assets such as AIR that were excluded after a single
+hard-coded AIR-USDT lookup failed.
 """
 
 from __future__ import annotations
 
 import builtins
 import logging
+import time
 from functools import wraps
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 logger = logging.getLogger("nija.kraken_equity_patch")
-_PATCHED_ATTR = "__nija_kraken_equity_patch__"
+_PATCHED_ATTR = "__nija_kraken_equity_patch_v2__"
+_MARKER = "20260713-kraken-equity-v2"
 _CASH_ASSETS = {"USD", "ZUSD", "USDT", "USDC", "ZEUR", "EUR", "USDG", "USAT"}
 _ASSET_ALIASES = {
-    "XXBT": "BTC",
-    "XBT": "BTC",
+    "XXBT": "XBT",
+    "BTC": "XBT",
+    "XBT": "XBT",
     "XETH": "ETH",
     "ZUSD": "USD",
     "ZEUR": "EUR",
 }
 _NON_ASSET_BALANCE_KEYS = {
-    "ERROR",
-    "RESULT",
-    "EB",
-    "TB",
-    "M",
-    "UV",
-    "N",
-    "C",
-    "V",
-    "E",
-    "MF",
-    "MFO",
-    "TOTAL_FUNDS",
-    "TOTAL_BALANCE",
-    "TOTAL_EQUITY",
-    "EQUITY",
-    "TRADING_BALANCE",
-    "USD_HELD",
-    "USDT_HELD",
-    "USDC_HELD",
-    "TOTAL_HELD",
-    "NON_USD_USD",
-    "CRYPTO_USD",
+    "ERROR", "RESULT", "EB", "TB", "M", "UV", "N", "C", "V", "E", "MF", "MFO",
+    "TOTAL_FUNDS", "TOTAL_BALANCE", "TOTAL_EQUITY", "EQUITY", "TRADING_BALANCE",
+    "USD_HELD", "USDT_HELD", "USDC_HELD", "TOTAL_HELD", "NON_USD_USD", "CRYPTO_USD",
 }
+_PAIR_CACHE: Dict[Tuple[int, str], Tuple[float, Optional[Tuple[str, str]]]] = {}
+_PRICE_CACHE: Dict[Tuple[int, str], Tuple[float, float, str]] = {}
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:
@@ -68,7 +54,6 @@ def _is_cash(asset: str) -> bool:
 
 
 def _extract_raw_balances(payload: Any) -> Dict[str, float]:
-    """Extract positive non-cash asset quantities from Kraken balance payloads."""
     if not isinstance(payload, dict):
         return {}
     candidates: list[dict] = []
@@ -77,7 +62,6 @@ def _extract_raw_balances(payload: Any) -> Dict[str, float]:
         if isinstance(value, dict):
             candidates.append(value)
     candidates.append(payload)
-
     out: Dict[str, float] = {}
     for data in candidates:
         for asset, value in data.items():
@@ -93,19 +77,13 @@ def _extract_raw_balances(payload: Any) -> Dict[str, float]:
 
 
 def _call_balance_payload(instance: Any, *, allow_live_probe: bool = True) -> dict:
-    """Return cached balance metadata, optionally probing non-recursive helpers."""
     for attr in (
-        "_last_raw_balances",
-        "last_raw_balances",
-        "_raw_balances",
-        "raw_balances",
-        "_balance_payload",
-        "balance_payload",
+        "_last_raw_balances", "last_raw_balances", "_raw_balances", "raw_balances",
+        "_balance_payload", "balance_payload",
     ):
         cached = getattr(instance, attr, None)
         if isinstance(cached, dict):
             return cached
-
     methods = ["get_balance_snapshot", "get_portfolio_breakdown", "get_balances"]
     if allow_live_probe:
         methods.append("get_account_balance")
@@ -129,15 +107,117 @@ def _call_balance_payload(instance: Any, *, allow_live_probe: bool = True) -> di
     return {}
 
 
-def _price_asset(instance: Any, asset: str) -> float:
+def _public_call(instance: Any, method: str, params: Optional[Dict[str, Any]] = None) -> dict:
+    custom = getattr(instance, "_kraken_public_api_call", None)
+    if callable(custom):
+        result = custom(method, params or {})
+        return result if isinstance(result, dict) else {}
+    api = getattr(instance, "api", None)
+    query_public = getattr(api, "query_public", None)
+    if callable(query_public):
+        result = query_public(method, params or {})
+        return result if isinstance(result, dict) else {}
+    query_public = getattr(instance, "query_public", None)
+    if callable(query_public):
+        result = query_public(method, params or {})
+        return result if isinstance(result, dict) else {}
+    return {}
+
+
+def _quote_from_pair_row(row: Mapping[str, Any], fallback: str) -> str:
+    quote = _asset_name(str(row.get("quote") or ""))
+    if quote:
+        return quote
+    wsname = str(row.get("wsname") or "").upper()
+    if "/" in wsname:
+        return _asset_name(wsname.rsplit("/", 1)[1])
+    for candidate in ("USDT", "USDC", "USD", "EUR"):
+        if fallback.upper().endswith(candidate):
+            return candidate
+    return "USD"
+
+
+def _resolve_asset_pair(instance: Any, asset: str) -> Optional[Tuple[str, str]]:
     base = _asset_name(asset)
+    key = (id(instance), base)
+    now = time.monotonic()
+    cached = _PAIR_CACHE.get(key)
+    if cached and now - cached[0] < 1800.0:
+        return cached[1]
+    candidates = [f"{base}{quote}" for quote in ("USD", "USDT", "USDC", "EUR")]
+    for candidate in candidates:
+        try:
+            payload = _public_call(instance, "AssetPairs", {"pair": candidate})
+            errors = payload.get("error") or [] if isinstance(payload, dict) else ["invalid"]
+            result = payload.get("result", {}) if isinstance(payload, dict) else {}
+            if errors or not isinstance(result, Mapping) or not result:
+                continue
+            row = next(iter(result.values()))
+            if not isinstance(row, Mapping):
+                continue
+            pair = str(row.get("altname") or candidate)
+            quote = _quote_from_pair_row(row, candidate)
+            resolved = (pair, quote)
+            _PAIR_CACHE[key] = (now, resolved)
+            logger.info(
+                "KRAKEN_ASSET_PAIR_RESOLVED marker=%s asset=%s pair=%s quote=%s",
+                _MARKER, base, pair, quote,
+            )
+            return resolved
+        except Exception:
+            continue
+    _PAIR_CACHE[key] = (now, None)
+    logger.warning(
+        "KRAKEN_ASSET_PAIR_UNRESOLVED marker=%s asset=%s candidates=%s",
+        _MARKER, base, candidates,
+    )
+    return None
+
+
+def _ticker_last(payload: Any) -> float:
+    if not isinstance(payload, Mapping):
+        return 0.0
+    result = payload.get("result", payload)
+    if not isinstance(result, Mapping) or not result:
+        return 0.0
+    row = next(iter(result.values()))
+    if not isinstance(row, Mapping):
+        return 0.0
+    for key in ("c", "last", "price", "close"):
+        value = row.get(key)
+        if isinstance(value, (list, tuple)) and value:
+            value = value[0]
+        price = _safe_float(value)
+        if price > 0:
+            return price
+    return 0.0
+
+
+def _quote_to_usd(instance: Any, quote: str) -> float:
+    quote = _asset_name(quote)
+    if quote in {"USD", "USDT", "USDC"}:
+        return 1.0
+    if quote != "EUR":
+        return 0.0
+    for pair in ("EURUSD", "ZEURZUSD"):
+        price = _ticker_last(_public_call(instance, "Ticker", {"pair": pair}))
+        if price > 0:
+            return price
+    return 0.0
+
+
+def _price_asset(instance: Any, asset: str) -> Tuple[float, str, str]:
+    base = _asset_name(asset)
+    cache_key = (id(instance), base)
+    now = time.monotonic()
+    cached = _PRICE_CACHE.get(cache_key)
+    if cached and now - cached[0] < 30.0:
+        return cached[1], cached[2], "cache"
+
     pairs = [
-        f"{base}-USD",
-        f"{base}/USD",
-        f"{base}USD",
-        f"{base}-USDT",
-        f"{base}/USDT",
-        f"{base}USDT",
+        f"{base}-USD", f"{base}/USD", f"{base}USD",
+        f"{base}-USDT", f"{base}/USDT", f"{base}USDT",
+        f"{base}-USDC", f"{base}/USDC", f"{base}USDC",
     ]
     for method_name in ("get_current_price", "get_price", "fetch_price", "get_ticker_price"):
         method = getattr(instance, method_name, None)
@@ -147,48 +227,47 @@ def _price_asset(instance: Any, asset: str) -> float:
             try:
                 price = _safe_float(method(pair))
                 if price > 0:
-                    return price
+                    _PRICE_CACHE[cache_key] = (now, price, pair)
+                    return price, pair, f"broker.{method_name}"
             except Exception:
                 continue
-    for method_name in ("get_ticker", "fetch_ticker", "ticker"):
-        method = getattr(instance, method_name, None)
-        if not callable(method):
-            continue
-        for pair in pairs:
-            try:
-                ticker = method(pair)
-                if not isinstance(ticker, dict):
-                    continue
-                for key in ("last", "price", "c", "close"):
-                    value = ticker.get(key)
-                    if isinstance(value, (list, tuple)) and value:
-                        value = value[0]
-                    price = _safe_float(value)
-                    if price > 0:
-                        return price
-            except Exception:
-                continue
-    return 0.0
+
+    resolved = _resolve_asset_pair(instance, base)
+    if resolved:
+        pair, quote = resolved
+        native = _ticker_last(_public_call(instance, "Ticker", {"pair": pair}))
+        conversion = _quote_to_usd(instance, quote)
+        usd_price = native * conversion if native > 0 and conversion > 0 else 0.0
+        if usd_price > 0:
+            _PRICE_CACHE[cache_key] = (now, usd_price, pair)
+            logger.info(
+                "KRAKEN_ASSET_USD_PRICE_RESOLVED marker=%s asset=%s pair=%s quote=%s native=%.12f usd=%.12f",
+                _MARKER, base, pair, quote, native, usd_price,
+            )
+            return usd_price, pair, "kraken_public"
+
+    logger.warning("KRAKEN_ASSET_USD_PRICE_MISSING marker=%s asset=%s", _MARKER, base)
+    return 0.0, "", "unavailable"
 
 
 def _build_positions(instance: Any, raw_assets: Dict[str, float]) -> list[Dict[str, Any]]:
     positions: list[Dict[str, Any]] = []
     for asset, qty in raw_assets.items():
-        price = _price_asset(instance, asset)
+        price, pair, source = _price_asset(instance, asset)
         size_usd = qty * price if price > 0 else 0.0
-        positions.append(
-            {
-                "symbol": f"{asset}-USD",
-                "asset": asset,
-                "currency": asset,
-                "quantity": qty,
-                "side": "long",
-                "current_price": price,
-                "size_usd": size_usd,
-                "source": "kraken.crypto_balance",
-                "status": "active_position",
-            }
-        )
+        positions.append({
+            "symbol": f"{asset}-USD",
+            "asset": asset,
+            "currency": asset,
+            "quantity": qty,
+            "side": "long",
+            "current_price": price,
+            "size_usd": size_usd,
+            "price_pair": pair,
+            "price_source": source,
+            "source": "kraken.crypto_balance",
+            "status": "active_position",
+        })
     return positions
 
 
@@ -212,14 +291,8 @@ def _cash_from_payload(payload: dict) -> float:
 def _direct_total_from_payload(payload: dict) -> float:
     totals = []
     for key in (
-        "total_funds",
-        "total_balance",
-        "total_equity",
-        "equity",
-        "portfolio_value",
-        "account_equity",
-        "eb",
-        "e",
+        "total_funds", "total_balance", "total_equity", "equity", "portfolio_value",
+        "account_equity", "eb", "e",
     ):
         if key in payload:
             totals.append(_safe_float(payload.get(key)))
@@ -236,23 +309,23 @@ def _payload_total_equity(payload: dict, positions: list[Dict[str, Any]]) -> flo
         payload = {}
     direct = _direct_total_from_payload(payload)
     cash = _cash_from_payload(payload)
-    held = max(
-        _safe_float(payload.get("usd_held")),
-        _safe_float(payload.get("total_held")),
-        0.0,
-    )
+    held = max(_safe_float(payload.get("usd_held")), _safe_float(payload.get("total_held")), 0.0)
     crypto_usd = sum(_safe_float(position.get("size_usd")) for position in positions)
-    declared_crypto = max(
-        _safe_float(payload.get("crypto_usd")),
-        _safe_float(payload.get("non_usd_usd")),
-        0.0,
-    )
-    computed = cash + held + max(crypto_usd, declared_crypto)
-    return max(direct, computed)
+    declared_crypto = max(_safe_float(payload.get("crypto_usd")), _safe_float(payload.get("non_usd_usd")), 0.0)
+    return max(direct, cash + held + max(crypto_usd, declared_crypto))
+
+
+def _balance_total(value: Any) -> float:
+    if isinstance(value, Mapping):
+        for key in ("total_funds", "total_balance", "total_equity", "equity", "available_balance", "balance"):
+            parsed = _safe_float(value.get(key))
+            if parsed > 0:
+                return parsed
+        return 0.0
+    return _safe_float(value)
 
 
 def _cache_position_snapshot(instance: Any, positions: list[Dict[str, Any]]) -> None:
-    """Cache visibility only; PositionTracker reconciliation happens elsewhere."""
     try:
         setattr(instance, "_last_kraken_position_snapshot", tuple(dict(item) for item in positions))
         setattr(instance, "_last_kraken_position_snapshot_count", len(positions))
@@ -276,8 +349,7 @@ def _patch_kraken_class(cls: type) -> bool:
             except Exception as exc:
                 logger.warning("KRAKEN_EQUITY_POSITION_CLASSIFICATION original get_positions failed: %s", exc)
         payload = _call_balance_payload(self, allow_live_probe=False)
-        raw_assets = _extract_raw_balances(payload)
-        positions = _build_positions(self, raw_assets)
+        positions = _build_positions(self, _extract_raw_balances(payload))
         seen = {str(item.get("symbol", "")).upper() for item in existing}
         for position in positions:
             if str(position.get("symbol", "")).upper() not in seen:
@@ -285,7 +357,8 @@ def _patch_kraken_class(cls: type) -> bool:
         _cache_position_snapshot(self, positions)
         if positions:
             logger.warning(
-                "KRAKEN_CRYPTO_POSITIONS_CLASSIFIED count=%d total_crypto_usd=%.2f symbols=%s tracker_mutation=false",
+                "KRAKEN_CRYPTO_POSITIONS_CLASSIFIED marker=%s count=%d total_crypto_usd=%.2f symbols=%s tracker_mutation=false",
+                _MARKER,
                 len(positions),
                 sum(_safe_float(item.get("size_usd")) for item in positions),
                 ",".join(str(item.get("symbol")) for item in positions),
@@ -298,11 +371,10 @@ def _patch_kraken_class(cls: type) -> bool:
     if callable(original_get_account_balance):
         @wraps(original_get_account_balance)
         def get_account_balance(self: Any, *args: Any, **kwargs: Any):
-            base_total = _safe_float(original_get_account_balance(self, *args, **kwargs))
-            # Do not call get_account_balance again from payload discovery.
+            original_value = original_get_account_balance(self, *args, **kwargs)
+            base_total = _balance_total(original_value)
             payload = _call_balance_payload(self, allow_live_probe=False)
-            raw_assets = _extract_raw_balances(payload)
-            positions = _build_positions(self, raw_assets)
+            positions = _build_positions(self, _extract_raw_balances(payload))
             authoritative_total = _payload_total_equity(payload, positions)
             final_total = max(base_total, authoritative_total)
             _cache_position_snapshot(self, positions)
@@ -310,21 +382,26 @@ def _patch_kraken_class(cls: type) -> bool:
                 setattr(self, "_last_known_balance", final_total)
                 try:
                     enriched_payload = dict(payload)
-                    enriched_payload["crypto_usd"] = sum(
-                        _safe_float(item.get("size_usd")) for item in positions
-                    )
+                    enriched_payload["crypto_usd"] = sum(_safe_float(item.get("size_usd")) for item in positions)
                     enriched_payload["total_funds"] = final_total
+                    enriched_payload["crypto_positions"] = positions
                     setattr(self, "_last_raw_balances", enriched_payload)
                 except Exception:
                     pass
             logger.warning(
-                "KRAKEN_EQUITY_CANONICAL base_total=%.2f payload_total=%.2f final_total=%.2f "
+                "KRAKEN_EQUITY_CANONICAL marker=%s base_total=%.2f payload_total=%.2f final_total=%.2f "
                 "crypto_usd=%.2f double_count_prevented=true tracker_mutation=false",
+                _MARKER,
                 base_total,
                 authoritative_total,
                 final_total,
                 sum(_safe_float(item.get("size_usd")) for item in positions),
             )
+            if isinstance(original_value, Mapping):
+                updated = dict(original_value)
+                updated["total_balance"] = max(_safe_float(updated.get("total_balance")), final_total)
+                updated["total_funds"] = max(_safe_float(updated.get("total_funds")), final_total)
+                return updated
             return final_total
 
         setattr(cls, "get_account_balance", get_account_balance)
@@ -338,18 +415,19 @@ def _patch_kraken_class(cls: type) -> bool:
                 try:
                     positions = get_positions(self)
                     logger.warning(
-                        "KRAKEN_STARTUP_POSITION_VISIBILITY positions=%d symbols=%s tracker_mutation=false",
+                        "KRAKEN_STARTUP_POSITION_VISIBILITY marker=%s positions=%d symbols=%s tracker_mutation=false",
+                        _MARKER,
                         len(positions),
                         ",".join(str(item.get("symbol")) for item in positions if isinstance(item, dict)),
                     )
                 except Exception as exc:
-                    logger.warning("KRAKEN_STARTUP_POSITION_VISIBILITY_ERROR error=%s", exc)
+                    logger.warning("KRAKEN_STARTUP_POSITION_VISIBILITY_ERROR marker=%s error=%s", _MARKER, exc)
             return result
 
         setattr(cls, "connect", connect)
 
     setattr(cls, _PATCHED_ATTR, True)
-    logger.warning("KRAKEN_EQUITY_HYDRATION_PATCHED class=%s canonical_total=true", cls.__name__)
+    logger.warning("KRAKEN_EQUITY_HYDRATION_PATCHED marker=%s class=%s canonical_total=true dynamic_pairs=true", _MARKER, cls.__name__)
     return True
 
 
@@ -366,15 +444,13 @@ def _patch_module(module: Any) -> bool:
 
 def install_import_hook() -> None:
     import sys
-
     for name, module in list(sys.modules.items()):
         if name.endswith(("broker_manager", "kraken_broker", "broker_integration", "execution_engine")):
             try:
                 _patch_module(module)
             except Exception:
                 continue
-
-    if getattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED", False):
+    if getattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED_V2", False):
         return
     original_import = builtins.__import__
     hook_local = __import__("threading").local()
@@ -394,12 +470,15 @@ def install_import_hook() -> None:
         return module
 
     builtins.__import__ = guarded_import
-    setattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED", True)
+    setattr(builtins, "_NIJA_KRAKEN_EQUITY_PATCH_HOOK_INSTALLED_V2", True)
+    logger.critical("KRAKEN_EQUITY_RUNTIME_INSTALLED marker=%s dynamic_pairs=true", _MARKER)
 
 
 __all__ = [
     "install_import_hook",
     "_extract_raw_balances",
     "_payload_total_equity",
+    "_resolve_asset_pair",
+    "_price_asset",
     "_patch_kraken_class",
 ]

--- a/bot/position_cost_basis_legacy_repair_patch.py
+++ b/bot/position_cost_basis_legacy_repair_patch.py
@@ -1,0 +1,123 @@
+"""Preserve legitimate legacy NIJA execution cost basis during reconciliation.
+
+Older tracker rows predate the explicit ``cost_basis_verified`` field.  A positive
+entry owned by NIJA strategy execution should remain trusted; startup-adopted or
+broker-existing rows remain unverified unless Kraken history supplies a price.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Mapping
+
+logger = logging.getLogger("nija.position_cost_basis_legacy_repair")
+_MARKER = "20260713-cost-basis-legacy-v1"
+_PATCH_ATTR = "_nija_legacy_verified_cost_basis_v1"
+_ORIGINAL_IMPORT = None
+_LOCK = threading.RLock()
+_PATCHED: set[tuple[str, int]] = set()
+
+
+def _f(value: Any) -> float:
+    try:
+        parsed = float(value or 0.0)
+        return parsed if parsed == parsed else 0.0
+    except Exception:
+        return 0.0
+
+
+def _legacy_execution_verified(position: Any) -> bool:
+    if not isinstance(position, Mapping):
+        return False
+    if position.get("cost_basis_verified") is not None:
+        return position.get("cost_basis_verified") is True
+    if _f(position.get("entry_price")) <= 0:
+        return False
+    source = str(position.get("position_source") or "").strip().lower()
+    strategy = str(position.get("strategy") or "").strip().upper()
+    entry_source = str(position.get("entry_price_source") or "").strip().lower()
+    if entry_source in {"execution", "api", "trade_history", "closed_orders", "fills"}:
+        return True
+    if source in {"nija_strategy", "strategy_execution", "execution"} and strategy not in {"STARTUP_SYNC", "BROKER_SYNC"}:
+        return True
+    return False
+
+
+def _patch_class(cls: type) -> bool:
+    current = getattr(cls, "_existing_verified", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return False
+    original = current
+
+    def existing_verified(inner_cls, position):
+        try:
+            if original(position):
+                return True
+        except TypeError:
+            if original(inner_cls, position):
+                return True
+        verified = _legacy_execution_verified(position)
+        if verified:
+            logger.info(
+                "LEGACY_EXECUTION_COST_BASIS_PRESERVED marker=%s symbol=%s entry=%s",
+                _MARKER,
+                position.get("symbol", "unknown") if isinstance(position, Mapping) else "unknown",
+                position.get("entry_price") if isinstance(position, Mapping) else None,
+            )
+        return verified
+
+    setattr(existing_verified, _PATCH_ATTR, True)
+    setattr(cls, "_existing_verified", classmethod(existing_verified))
+    logger.warning("POSITION_COST_BASIS_LEGACY_REPAIR_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    key = (str(getattr(module, "__name__", "")), id(module))
+    if key in _PATCHED:
+        return True
+    cls = getattr(module, "PositionTracker", None)
+    changed = _patch_class(cls) if isinstance(cls, type) else False
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> None:
+    for name in ("bot.position_tracker", "position_tracker"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch_module(module)
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is not None:
+            return
+        _ORIGINAL_IMPORT = builtins.__import__
+        local = threading.local()
+
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+            if getattr(local, "active", False):
+                return module
+            if name.endswith("position_tracker"):
+                local.active = True
+                try:
+                    _patch_loaded()
+                finally:
+                    local.active = False
+            return module
+
+        builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    logger.critical("POSITION_COST_BASIS_LEGACY_REPAIR_INSTALLED marker=%s", _MARKER)
+
+
+__all__ = ["install_import_hook", "_legacy_execution_verified", "_patch_class"]

--- a/bot/position_tracker.py
+++ b/bot/position_tracker.py
@@ -1,7 +1,9 @@
-"""
-NIJA Position Tracker
+"""NIJA Position Tracker.
 
-Persistent, thread-safe storage for position entry prices and P&L tracking.
+Persistent, thread-safe position storage with an explicit distinction between a
+verified cost basis and a temporary adoption mark.  A current market price may be
+used for visibility, but it is never represented as a real entry price and is
+never persisted to EntryPriceStore as execution truth.
 """
 
 from __future__ import annotations
@@ -20,6 +22,14 @@ try:
     ENTRY_PRICE_STORE_AVAILABLE = True
 except Exception:
     ENTRY_PRICE_STORE_AVAILABLE = False
+
+_VERIFIED_SOURCES = {
+    "api", "execution", "trade_history", "closed_orders", "fills",
+    "manual_verified", "reconstructed_verified_cost_basis",
+}
+_UNVERIFIED_SOURCE_TOKENS = {
+    "estimated", "adoption", "override", "reconciliation_required", "unknown", "missing",
+}
 
 
 class PositionTracker:
@@ -41,6 +51,28 @@ class PositionTracker:
             return default
         return parsed if parsed == parsed else default
 
+    @staticmethod
+    def _source_verified(source: str, price: float) -> bool:
+        text = str(source or "").strip().lower()
+        if price <= 0:
+            return False
+        if text in _VERIFIED_SOURCES:
+            return True
+        if any(token in text for token in _UNVERIFIED_SOURCE_TOKENS):
+            return False
+        return False
+
+    @classmethod
+    def _existing_verified(cls, position: Optional[Dict]) -> bool:
+        if not position:
+            return False
+        explicit = position.get("cost_basis_verified")
+        if explicit is not None:
+            return explicit is True
+        price = cls._safe_float(position.get("entry_price"))
+        source = str(position.get("entry_price_source") or position.get("position_source") or "")
+        return cls._source_verified(source, price)
+
     def _load_positions(self) -> None:
         try:
             if os.path.exists(self.storage_file):
@@ -59,10 +91,7 @@ class PositionTracker:
             parent = os.path.dirname(self.storage_file)
             if parent:
                 os.makedirs(parent, exist_ok=True)
-            payload = {
-                "positions": self.positions,
-                "last_updated": datetime.now().isoformat(),
-            }
+            payload = {"positions": self.positions, "last_updated": datetime.now().isoformat()}
             temp_file = self.storage_file + ".tmp"
             with open(temp_file, "w", encoding="utf-8") as handle:
                 json.dump(payload, handle, indent=2)
@@ -71,15 +100,10 @@ class PositionTracker:
             logger.error("Error saving positions: %s", exc)
 
     def _persist_entry_price(self, symbol: str, price: float, quantity: float, source: str) -> None:
-        if not ENTRY_PRICE_STORE_AVAILABLE or price <= 0:
+        if not ENTRY_PRICE_STORE_AVAILABLE or price <= 0 or not self._source_verified(source, price):
             return
         try:
-            get_entry_price_store().save(
-                symbol,
-                price,
-                source=source,
-                quantity=quantity,
-            )
+            get_entry_price_store().save(symbol, price, source=source, quantity=quantity)
         except Exception as exc:
             logger.debug("[PositionTracker] entry_price_store save failed for %s: %s", symbol, exc)
 
@@ -100,10 +124,12 @@ class PositionTracker:
             size_usd = self._safe_float(size_usd)
             if not symbol or quantity <= 0:
                 return False
+            fill_verified = entry_price > 0
+            now = datetime.now().isoformat()
 
             with self.lock:
-                if symbol in self.positions:
-                    existing = self.positions[symbol]
+                existing = self.positions.get(symbol)
+                if existing:
                     old_qty = self._safe_float(existing.get("quantity"))
                     old_price = self._safe_float(existing.get("entry_price"))
                     old_size = self._safe_float(existing.get("size_usd"))
@@ -111,43 +137,55 @@ class PositionTracker:
                     total_cost = (old_qty * old_price) + (quantity * entry_price)
                     avg_price = total_cost / total_qty if total_qty > 0 else entry_price
                     total_size = old_size + size_usd
+                    verified = self._existing_verified(existing) and fill_verified
+                    entry_source = "execution" if verified else "execution_price_missing_or_mixed"
                     self.positions[symbol] = {
                         "entry_price": avg_price,
                         "quantity": total_qty,
                         "size_usd": total_size,
-                        "first_entry_time": existing.get("first_entry_time", datetime.now().isoformat()),
-                        "last_entry_time": datetime.now().isoformat(),
+                        "first_entry_time": existing.get("first_entry_time", now),
+                        "last_entry_time": now,
                         "strategy": strategy,
                         "num_adds": int(existing.get("num_adds", 0) or 0) + 1,
                         "previous_profit_pct": self._safe_float(existing.get("previous_profit_pct")),
                         "position_source": existing.get("position_source", position_source),
+                        "entry_price_source": entry_source,
+                        "cost_basis_verified": verified,
+                        "auto_exit_blocked": not verified,
+                        "auto_exit_block_reason": "" if verified else "unverified_cost_basis",
                     }
-                    logger.info("Updated position %s: avg_entry=$%.2f, qty=%.8f", symbol, avg_price, total_qty)
+                    logger.info("Updated position %s: avg_entry=$%.2f, qty=%.8f verified=%s", symbol, avg_price, total_qty, verified)
                 else:
+                    verified = fill_verified
+                    entry_source = "execution" if verified else "execution_price_missing"
                     self.positions[symbol] = {
                         "entry_price": entry_price,
                         "quantity": quantity,
                         "size_usd": size_usd,
-                        "first_entry_time": datetime.now().isoformat(),
-                        "last_entry_time": datetime.now().isoformat(),
+                        "first_entry_time": now,
+                        "last_entry_time": now,
                         "strategy": strategy,
                         "num_adds": 0,
                         "previous_profit_pct": 0.0,
                         "position_source": position_source,
+                        "entry_price_source": entry_source,
+                        "cost_basis_verified": verified,
+                        "auto_exit_blocked": not verified,
+                        "auto_exit_block_reason": "" if verified else "unverified_cost_basis",
                     }
                     logger.info(
-                        "Tracking new position %s: entry=$%.2f, qty=%.8f, source=%s",
-                        symbol,
-                        entry_price,
-                        quantity,
-                        position_source,
+                        "Tracking new position %s: entry=$%.2f, qty=%.8f, source=%s verified=%s",
+                        symbol, entry_price, quantity, position_source, verified,
                     )
-
                 self._save_positions()
-                effective = self._safe_float(self.positions[symbol].get("entry_price"))
-                final_qty = self._safe_float(self.positions[symbol].get("quantity"))
+                final = self.positions[symbol]
+                effective = self._safe_float(final.get("entry_price"))
+                final_qty = self._safe_float(final.get("quantity"))
+                final_source = str(final.get("entry_price_source") or "")
+                final_verified = final.get("cost_basis_verified") is True
 
-            self._persist_entry_price(symbol, effective, final_qty, "execution")
+            if final_verified:
+                self._persist_entry_price(symbol, effective, final_qty, final_source)
             return True
         except Exception as exc:
             logger.error("Error tracking entry for %s: %s", symbol, exc)
@@ -164,13 +202,7 @@ class PositionTracker:
         position_source: str = "broker_existing",
         entry_price_source: str = "override",
     ) -> bool:
-        """Reconcile an exact broker snapshot without treating it as a new fill.
-
-        Broker balance/position hydration is idempotent. It must replace the live
-        quantity rather than add it to the tracker each time a balance is read.
-        This method also repairs the common zero-price dilution failure where the
-        stored quantity was duplicated while the original cost basis stayed flat.
-        """
+        """Reconcile an exact broker snapshot without treating it as a new fill."""
         try:
             symbol = str(symbol or "").strip()
             quantity = self._safe_float(quantity)
@@ -185,31 +217,39 @@ class PositionTracker:
                 old_qty = self._safe_float((existing or {}).get("quantity"))
                 old_entry = self._safe_float((existing or {}).get("entry_price"))
                 old_cost = self._safe_float((existing or {}).get("size_usd"))
-
+                old_verified = self._existing_verified(existing)
                 repaired_from_cost = False
+
                 if supplied_entry > 0:
                     effective_entry = supplied_entry
-                elif existing and old_cost > 0 and quantity > 0:
-                    # Reconstruct the undiluted entry price after duplicate snapshot
-                    # additions: original cost basis / actual broker quantity.
+                    effective_source = str(entry_price_source or "override")
+                    verified = self._source_verified(effective_source, effective_entry)
+                elif existing and old_cost > 0 and quantity > 0 and old_verified:
                     effective_entry = old_cost / quantity
+                    effective_source = "reconstructed_verified_cost_basis"
+                    verified = True
                     repaired_from_cost = True
-                elif old_entry > 0:
+                elif old_entry > 0 and old_verified:
                     effective_entry = old_entry
+                    effective_source = str((existing or {}).get("entry_price_source") or "execution")
+                    verified = True
                 elif current_price > 0:
                     effective_entry = current_price
+                    effective_source = "estimated_from_adoption_mark"
+                    verified = False
                 elif broker_value > 0:
                     effective_entry = broker_value / quantity
+                    effective_source = "estimated_from_broker_market_value"
+                    verified = False
                 else:
                     effective_entry = 0.0
+                    effective_source = "reconciliation_required"
+                    verified = False
 
                 cost_basis_usd = quantity * effective_entry if effective_entry > 0 else broker_value
                 now = datetime.now().isoformat()
-                original_source = (existing or {}).get("position_source")
-                original_strategy = (existing or {}).get("strategy")
-                source = original_source or position_source
-                chosen_strategy = original_strategy or strategy
-
+                source = (existing or {}).get("position_source") or position_source
+                chosen_strategy = (existing or {}).get("strategy") or strategy
                 self.positions[symbol] = {
                     "entry_price": effective_entry,
                     "quantity": quantity,
@@ -220,6 +260,10 @@ class PositionTracker:
                     "num_adds": int((existing or {}).get("num_adds", 0) or 0),
                     "previous_profit_pct": self._safe_float((existing or {}).get("previous_profit_pct")),
                     "position_source": source,
+                    "entry_price_source": effective_source,
+                    "cost_basis_verified": verified,
+                    "auto_exit_blocked": not verified,
+                    "auto_exit_block_reason": "" if verified else "unverified_cost_basis:reconciliation_required",
                     "last_broker_snapshot_value_usd": broker_value,
                     "last_broker_snapshot_price": current_price,
                 }
@@ -229,27 +273,22 @@ class PositionTracker:
                 existing is None
                 or abs(old_qty - quantity) > max(1e-10, quantity * 1e-8)
                 or abs(old_entry - effective_entry) > max(1e-8, abs(effective_entry) * 1e-8)
+                or old_verified != verified
             )
             logger.warning(
-                "POSITION_SNAPSHOT_SYNCED symbol=%s old_qty=%.8f new_qty=%.8f "
-                "old_entry=$%.8f new_entry=$%.8f cost_basis=$%.2f broker_value=$%.2f "
-                "changed=%s repaired_from_cost=%s",
-                symbol,
-                old_qty,
-                quantity,
-                old_entry,
-                effective_entry,
-                cost_basis_usd,
-                broker_value,
-                changed,
-                repaired_from_cost,
+                "POSITION_SNAPSHOT_SYNCED symbol=%s old_qty=%.8f new_qty=%.8f old_entry=$%.8f "
+                "new_entry=$%.8f cost_basis=$%.2f broker_value=$%.2f changed=%s "
+                "repaired_from_cost=%s cost_basis_verified=%s entry_source=%s",
+                symbol, old_qty, quantity, old_entry, effective_entry, cost_basis_usd,
+                broker_value, changed, repaired_from_cost, verified, effective_source,
             )
-            self._persist_entry_price(
-                symbol,
-                effective_entry,
-                quantity,
-                entry_price_source if supplied_entry > 0 else "override",
-            )
+            if verified:
+                self._persist_entry_price(symbol, effective_entry, quantity, effective_source)
+            else:
+                logger.critical(
+                    "POSITION_COST_BASIS_RECONCILIATION_REQUIRED symbol=%s qty=%.8f adoption_mark=$%.8f source=%s auto_exit_blocked=true",
+                    symbol, quantity, effective_entry, effective_source,
+                )
             return True
         except Exception as exc:
             logger.error("Error synchronizing broker snapshot for %s: %s", symbol, exc)
@@ -261,7 +300,6 @@ class PositionTracker:
                 if symbol not in self.positions:
                     logger.warning("Attempted to exit untracked position: %s", symbol)
                     return False
-
                 if exit_quantity is None:
                     del self.positions[symbol]
                     logger.info("Removed position %s (full exit)", symbol)
@@ -279,14 +317,8 @@ class PositionTracker:
                         remaining_size = self._safe_float(position.get("size_usd")) * (remaining_qty / quantity)
                         position["quantity"] = remaining_qty
                         position["size_usd"] = remaining_size
-                        logger.info(
-                            "Reduced position %s: remaining_qty=%.8f, remaining_size=$%.2f",
-                            symbol,
-                            remaining_qty,
-                            remaining_size,
-                        )
+                        logger.info("Reduced position %s: remaining_qty=%.8f, remaining_size=$%.2f", symbol, remaining_qty, remaining_size)
                 self._save_positions()
-
             if full_exit and ENTRY_PRICE_STORE_AVAILABLE:
                 try:
                     get_entry_price_store().clear(symbol)
@@ -327,6 +359,8 @@ class PositionTracker:
             "pnl_dollars": pnl_dollars,
             "pnl_percent": pnl_pct,
             "previous_profit_pct": previous_profit,
+            "cost_basis_verified": position.get("cost_basis_verified") is True,
+            "entry_price_source": position.get("entry_price_source"),
         }
 
     def get_all_positions(self) -> List[str]:

--- a/bot/position_tracker.py
+++ b/bot/position_tracker.py
@@ -1,7 +1,7 @@
 """NIJA Position Tracker.
 
 Persistent, thread-safe position storage with an explicit distinction between a
-verified cost basis and a temporary adoption mark.  A current market price may be
+verified cost basis and a temporary adoption mark. A current market price may be
 used for visibility, but it is never represented as a real entry price and is
 never persisted to EntryPriceStore as execution truth.
 """
@@ -70,8 +70,16 @@ class PositionTracker:
         if explicit is not None:
             return explicit is True
         price = cls._safe_float(position.get("entry_price"))
-        source = str(position.get("entry_price_source") or position.get("position_source") or "")
-        return cls._source_verified(source, price)
+        entry_source = str(position.get("entry_price_source") or "")
+        if cls._source_verified(entry_source, price):
+            return True
+        position_source = str(position.get("position_source") or "").strip().lower()
+        strategy = str(position.get("strategy") or "").strip().upper()
+        return bool(
+            price > 0
+            and position_source in {"nija_strategy", "strategy_execution", "execution"}
+            and strategy not in {"STARTUP_SYNC", "BROKER_SYNC"}
+        )
 
     def _load_positions(self) -> None:
         try:
@@ -116,7 +124,12 @@ class PositionTracker:
         strategy: str = "APEX_v7.1",
         position_source: str = "nija_strategy",
     ) -> bool:
-        """Record an actual additive trade fill."""
+        """Record an actual additive trade fill.
+
+        A zero-price/zero-value additive row is retained only for compatibility
+        with old corrupted snapshot files. It does not erase a previously
+        verified cost basis; exact snapshot reconciliation will restore quantity.
+        """
         try:
             symbol = str(symbol or "").strip()
             entry_price = self._safe_float(entry_price)
@@ -125,6 +138,7 @@ class PositionTracker:
             if not symbol or quantity <= 0:
                 return False
             fill_verified = entry_price > 0
+            legacy_zero_snapshot = entry_price <= 0 and size_usd <= 0
             now = datetime.now().isoformat()
 
             with self.lock:
@@ -133,12 +147,16 @@ class PositionTracker:
                     old_qty = self._safe_float(existing.get("quantity"))
                     old_price = self._safe_float(existing.get("entry_price"))
                     old_size = self._safe_float(existing.get("size_usd"))
+                    old_verified = self._existing_verified(existing)
                     total_qty = old_qty + quantity
                     total_cost = (old_qty * old_price) + (quantity * entry_price)
                     avg_price = total_cost / total_qty if total_qty > 0 else entry_price
                     total_size = old_size + size_usd
-                    verified = self._existing_verified(existing) and fill_verified
-                    entry_source = "execution" if verified else "execution_price_missing_or_mixed"
+                    verified = old_verified and (fill_verified or legacy_zero_snapshot)
+                    if verified and legacy_zero_snapshot:
+                        entry_source = str(existing.get("entry_price_source") or "execution")
+                    else:
+                        entry_source = "execution" if verified else "execution_price_missing_or_mixed"
                     self.positions[symbol] = {
                         "entry_price": avg_price,
                         "quantity": total_qty,
@@ -154,7 +172,10 @@ class PositionTracker:
                         "auto_exit_blocked": not verified,
                         "auto_exit_block_reason": "" if verified else "unverified_cost_basis",
                     }
-                    logger.info("Updated position %s: avg_entry=$%.2f, qty=%.8f verified=%s", symbol, avg_price, total_qty, verified)
+                    logger.info(
+                        "Updated position %s: avg_entry=$%.2f, qty=%.8f verified=%s legacy_zero_snapshot=%s",
+                        symbol, avg_price, total_qty, verified, legacy_zero_snapshot,
+                    )
                 else:
                     verified = fill_verified
                     entry_source = "execution" if verified else "execution_price_missing"

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -1,0 +1,105 @@
+"""NIJA runtime release manifest and critical repair convergence audit."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from typing import Callable
+
+logger = logging.getLogger("nija.runtime_release_manifest")
+RELEASE_ID = "20260713-runtime-convergence-v3"
+_INSTALLED = False
+_LOCK = threading.RLock()
+
+_INSTALLERS = (
+    ("scan_wrapper_convergence_repair_patch", "install"),
+    ("bot.kraken_equity_runtime_patch", "install_import_hook"),
+    ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
+    ("bot.kraken_margin_auto_runtime_patch", "install_import_hook"),
+    ("bot.kraken_all_account_exit_runtime_patch", "install_import_hook"),
+    ("bot.kraken_exit_safety_convergence_patch", "install_import_hook"),
+    ("bot.kraken_exit_final_guards_patch", "install_import_hook"),
+    ("bot.kraken_exit_execution_safety_patch", "install_import_hook"),
+    ("bot.kraken_exit_margin_cost_patch", "install_import_hook"),
+    ("bot.coinbase_pem_quarantine_patch", "install_import_hook"),
+)
+
+
+def _deployment_sha() -> str:
+    for name in (
+        "RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "SOURCE_VERSION", "RENDER_GIT_COMMIT",
+        "HEROKU_SLUG_COMMIT",
+    ):
+        value = str(os.environ.get(name, "") or "").strip()
+        if value:
+            return value
+    return "unknown"
+
+
+def _invoke(module_name: str, function_name: str) -> tuple[bool, str]:
+    try:
+        module = importlib.import_module(module_name)
+        installer: Callable = getattr(module, function_name)
+        installer()
+        return True, "ok"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}:{exc}"
+
+
+def _audit() -> tuple[bool, dict[str, str]]:
+    results: dict[str, str] = {}
+    ready = True
+    for module_name, function_name in _INSTALLERS:
+        ok, reason = _invoke(module_name, function_name)
+        results[module_name] = reason
+        ready = ready and ok
+    scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "")
+    if scan_release != "20260713-scan-wrapper-v2":
+        ready = False
+        results["scan_wrapper_release"] = scan_release or "missing"
+    return ready, results
+
+
+def _publish(ready: bool, details: dict[str, str]) -> None:
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
+    logger.critical(
+        "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
+        RELEASE_ID,
+        _deployment_sha(),
+        str(ready).lower(),
+        os.getpid(),
+        details,
+    )
+    if not ready:
+        logger.critical(
+            "RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed",
+            RELEASE_ID,
+        )
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            ready, details = _audit()
+            _publish(ready, details)
+        except Exception as exc:
+            logger.critical("RUNTIME_RELEASE_AUDIT_FAILED release=%s error=%s", RELEASE_ID, exc)
+        time.sleep(max(30.0, float(os.environ.get("NIJA_RUNTIME_RELEASE_AUDIT_INTERVAL_S", "120") or 120)))
+
+
+def install_import_hook() -> None:
+    global _INSTALLED
+    with _LOCK:
+        ready, details = _audit()
+        _publish(ready, details)
+        if not _INSTALLED:
+            _INSTALLED = True
+            threading.Thread(target=_watchdog, name="RuntimeReleaseManifest", daemon=True).start()
+    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", RELEASE_ID)
+
+
+__all__ = ["RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha"]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,14 +10,19 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260713-runtime-convergence-v3"
+RELEASE_ID = "20260713-runtime-convergence-v4"
 _INSTALLED = False
 _LOCK = threading.RLock()
 
+# Installation order is intentional.  Cost-basis compatibility must be active
+# before exact snapshots reconcile legacy positions; the final equity guard must
+# wrap the dynamic valuation layer after it has patched Kraken broker classes.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
-    ("bot.kraken_equity_runtime_patch", "install_import_hook"),
+    ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
+    ("bot.kraken_equity_runtime_patch", "install_import_hook"),
+    ("bot.kraken_equity_double_count_guard_patch", "install_import_hook"),
     ("bot.kraken_margin_auto_runtime_patch", "install_import_hook"),
     ("bot.kraken_all_account_exit_runtime_patch", "install_import_hook"),
     ("bot.kraken_exit_safety_convergence_patch", "install_import_hook"),

--- a/bot/tests/test_coinbase_pem_quarantine.py
+++ b/bot/tests/test_coinbase_pem_quarantine.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "coinbase_pem_quarantine_under_test",
+        BOT_DIR / "coinbase_pem_quarantine_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_private_key_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+def test_literal_newlines_are_normalized_and_valid_key_is_accepted():
+    module = _load()
+    pem = _valid_private_key_pem()
+
+    class CoinbaseBroker:
+        api_key = "organizations/test/apiKeys/test"
+        api_secret = pem.replace("\n", "\\n")
+        connected = False
+        client = None
+
+    broker = CoinbaseBroker()
+    allowed, reason = module._preflight(broker)
+    assert allowed is True
+    assert reason == "pem_parse_ok"
+    assert "\\n" not in broker.api_secret
+    assert broker.api_secret.startswith("-----BEGIN PRIVATE KEY-----\n")
+
+
+def test_malformed_key_is_quarantined_without_touching_other_brokers():
+    module = _load()
+
+    class CoinbaseBroker:
+        api_key = "organizations/test/apiKeys/test"
+        api_secret = "-----BEGIN PRIVATE KEY-----\\nnot-base64\\n-----END PRIVATE KEY-----"
+        connected = True
+        client = object()
+        _last_known_balance = 123.0
+
+    broker = CoinbaseBroker()
+    allowed, reason = module._preflight(broker)
+    assert allowed is False
+    assert reason.startswith("pem_parse_failed:")
+    assert broker.connected is False
+    assert broker.client is None
+    assert broker._last_known_balance == 0.0
+    assert broker._nija_coinbase_config_quarantined is True
+
+
+def test_quarantined_product_reader_returns_empty_instead_of_rethrowing_pem_error():
+    module = _load()
+
+    class CoinbaseBroker:
+        api_key = "organizations/test/apiKeys/test"
+        api_secret = "-----BEGIN PRIVATE KEY-----\\nbad\\n-----END PRIVATE KEY-----"
+        connected = True
+        client = object()
+
+        def connect(self):
+            raise ValueError("Unable to load PEM file: MalformedFraming")
+
+        def get_all_products(self):
+            raise ValueError("Unable to load PEM file: MalformedFraming")
+
+    assert module._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+    assert broker.connect() is False
+    assert broker.get_all_products() == []

--- a/bot/tests/test_kraken_equity_double_count_guard.py
+++ b/bot/tests/test_kraken_equity_double_count_guard.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, BOT_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_exchange_equity_reader_ignores_synthetic_total_funds():
+    guard = _load("kraken_equity_guard_under_test", "kraken_equity_double_count_guard_patch.py")
+    payload = {
+        "total_funds": 104.3227,
+        "usd_held": 15.7872,
+        "result": {"eb": "93.2666", "e": "77.4794"},
+    }
+    assert abs(guard._exchange_equity(payload) - 93.2666) < 1e-9
+
+
+def test_canonical_equity_does_not_add_held_value_to_crypto_twice():
+    guard = _load("kraken_equity_guard_canonical_under_test", "kraken_equity_double_count_guard_patch.py")
+
+    fake_equity = types.ModuleType("bot.kraken_equity_runtime_patch")
+    fake_equity._call_balance_payload = lambda instance, allow_live_probe=False: {
+        "result": {"ZUSD": "72.6069", "eb": "93.2666", "e": "77.4794"},
+        "usd_held": 15.7872,
+        "total_funds": 104.3227,
+    }
+    fake_equity._extract_raw_balances = lambda payload: {"AIR": 2901.96202531}
+    fake_equity._build_positions = lambda instance, assets: [{"size_usd": 15.9286}]
+    fake_equity._cash_from_payload = lambda payload: 72.6069
+
+    fake_bot = types.ModuleType("bot")
+    fake_bot.kraken_equity_runtime_patch = fake_equity
+    old_bot = sys.modules.get("bot")
+    old_equity = sys.modules.get("bot.kraken_equity_runtime_patch")
+    try:
+        sys.modules["bot"] = fake_bot
+        sys.modules["bot.kraken_equity_runtime_patch"] = fake_equity
+        total, exchange, cash, crypto = guard._canonical(object(), 104.3227)
+    finally:
+        if old_bot is None:
+            sys.modules.pop("bot", None)
+        else:
+            sys.modules["bot"] = old_bot
+        if old_equity is None:
+            sys.modules.pop("bot.kraken_equity_runtime_patch", None)
+        else:
+            sys.modules["bot.kraken_equity_runtime_patch"] = old_equity
+
+    assert abs(exchange - 93.2666) < 1e-9
+    assert abs(cash - 72.6069) < 1e-9
+    assert abs(crypto - 15.9286) < 1e-9
+    assert abs(total - 93.2666) < 1e-9
+    assert total < 104.3227

--- a/bot/tests/test_kraken_equity_dynamic_pair.py
+++ b/bot/tests/test_kraken_equity_dynamic_pair.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "kraken_equity_dynamic_under_test",
+        BOT_DIR / "kraken_equity_runtime_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeAPI:
+    def __init__(self):
+        self.calls = []
+
+    def query_public(self, method, params=None):
+        params = dict(params or {})
+        self.calls.append((method, params))
+        pair = params.get("pair")
+        if method == "AssetPairs":
+            if pair == "AIREUR":
+                return {
+                    "error": [],
+                    "result": {
+                        "AIREUR": {
+                            "altname": "AIREUR",
+                            "wsname": "AIR/EUR",
+                            "quote": "ZEUR",
+                        }
+                    },
+                }
+            return {"error": ["EQuery:Unknown asset pair"], "result": {}}
+        if method == "Ticker" and pair == "AIREUR":
+            return {"error": [], "result": {"AIREUR": {"c": ["0.004", "1"]}}}
+        if method == "Ticker" and pair in {"EURUSD", "ZEURZUSD"}:
+            return {"error": [], "result": {"EURUSD": {"c": ["1.10", "1"]}}}
+        return {"error": ["not mocked"], "result": {}}
+
+
+class FakeKraken:
+    def __init__(self):
+        self.api = FakeAPI()
+
+
+def test_air_falls_back_to_actual_eur_pair_and_converts_to_usd():
+    module = _load()
+    broker = FakeKraken()
+    price, pair, source = module._price_asset(broker, "AIR")
+    assert pair == "AIREUR"
+    assert source == "kraken_public"
+    assert abs(price - 0.0044) < 1e-12
+    assert ("AssetPairs", {"pair": "AIRUSD"}) in broker.api.calls
+    assert ("AssetPairs", {"pair": "AIREUR"}) in broker.api.calls
+
+
+def test_dynamic_asset_value_is_included_without_tracker_mutation():
+    module = _load()
+    broker = FakeKraken()
+    positions = module._build_positions(broker, {"AIR": 2901.96202531})
+    assert len(positions) == 1
+    assert positions[0]["price_pair"] == "AIREUR"
+    assert positions[0]["size_usd"] > 12.0
+    total = module._payload_total_equity(
+        {"result": {"ZUSD": "72.6069"}, "total_funds": 88.39},
+        positions,
+    )
+    assert total > 88.39

--- a/bot/tests/test_kraken_equity_dynamic_pair.py
+++ b/bot/tests/test_kraken_equity_dynamic_pair.py
@@ -70,7 +70,7 @@ def test_dynamic_asset_value_is_included_without_tracker_mutation():
     assert positions[0]["price_pair"] == "AIREUR"
     assert positions[0]["size_usd"] > 12.0
     total = module._payload_total_equity(
-        {"result": {"ZUSD": "72.6069"}, "total_funds": 88.39},
+        {"result": {"ZUSD": "72.6069"}, "total_funds": 72.6069},
         positions,
     )
-    assert total > 88.39
+    assert total > 85.0

--- a/bot/tests/test_position_cost_basis_legacy_repair.py
+++ b/bot/tests/test_position_cost_basis_legacy_repair.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "position_cost_basis_legacy_under_test",
+        BOT_DIR / "position_cost_basis_legacy_repair_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_positive_nija_strategy_entry_is_preserved_as_legacy_execution():
+    module = _load()
+    assert module._legacy_execution_verified({
+        "entry_price": 125.50,
+        "position_source": "nija_strategy",
+        "strategy": "APEX_v7.1",
+    }) is True
+
+
+def test_startup_adoption_is_not_promoted_to_verified_cost_basis():
+    module = _load()
+    assert module._legacy_execution_verified({
+        "entry_price": 125.50,
+        "position_source": "broker_existing",
+        "strategy": "STARTUP_SYNC",
+    }) is False
+
+
+def test_explicit_unverified_flag_wins_over_legacy_inference():
+    module = _load()
+    assert module._legacy_execution_verified({
+        "entry_price": 125.50,
+        "position_source": "nija_strategy",
+        "strategy": "APEX_v7.1",
+        "cost_basis_verified": False,
+    }) is False

--- a/bot/tests/test_position_tracker_cost_basis_verification.py
+++ b/bot/tests/test_position_tracker_cost_basis_verification.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "position_tracker_cost_basis_under_test",
+        BOT_DIR / "position_tracker.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.ENTRY_PRICE_STORE_AVAILABLE = False
+    return module
+
+
+def test_current_price_adoption_mark_is_not_claimed_as_real_entry():
+    module = _load()
+    with tempfile.TemporaryDirectory() as tmp:
+        tracker = module.PositionTracker(str(Path(tmp) / "positions.json"))
+        assert tracker.sync_position_snapshot(
+            symbol="AAVE-USD",
+            quantity=0.03487477,
+            entry_price=0.0,
+            current_price=175.0,
+            size_usd=6.10,
+            entry_price_source="override",
+        )
+        row = tracker.get_position("AAVE-USD")
+        assert row["entry_price"] == 175.0
+        assert row["entry_price_source"] == "estimated_from_adoption_mark"
+        assert row["cost_basis_verified"] is False
+        assert row["auto_exit_blocked"] is True
+        assert "unverified_cost_basis" in row["auto_exit_block_reason"]
+
+
+def test_api_entry_price_is_verified_and_exit_eligible():
+    module = _load()
+    with tempfile.TemporaryDirectory() as tmp:
+        tracker = module.PositionTracker(str(Path(tmp) / "positions.json"))
+        assert tracker.sync_position_snapshot(
+            symbol="AVAX-USD",
+            quantity=0.3899519381,
+            entry_price=22.50,
+            current_price=24.00,
+            size_usd=9.36,
+            entry_price_source="api",
+        )
+        row = tracker.get_position("AVAX-USD")
+        assert row["entry_price"] == 22.50
+        assert row["entry_price_source"] == "api"
+        assert row["cost_basis_verified"] is True
+        assert row["auto_exit_blocked"] is False
+
+
+def test_unverified_old_market_mark_is_not_promoted_by_later_snapshot():
+    module = _load()
+    with tempfile.TemporaryDirectory() as tmp:
+        tracker = module.PositionTracker(str(Path(tmp) / "positions.json"))
+        tracker.sync_position_snapshot(
+            symbol="CELO-USD",
+            quantity=35.34862,
+            current_price=0.42,
+            size_usd=14.85,
+        )
+        tracker.sync_position_snapshot(
+            symbol="CELO-USD",
+            quantity=35.34862,
+            current_price=0.43,
+            size_usd=15.20,
+        )
+        row = tracker.get_position("CELO-USD")
+        assert row["cost_basis_verified"] is False
+        assert row["entry_price_source"] == "estimated_from_adoption_mark"
+        assert row["entry_price"] == 0.43

--- a/bot/tests/test_scan_wrapper_broker_slot_unwrap.py
+++ b/bot/tests/test_scan_wrapper_broker_slot_unwrap.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "scan_wrapper_convergence_under_test",
+        ROOT / "scan_wrapper_convergence_repair_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _result(scored: int = 1):
+    return SimpleNamespace(
+        symbols_scored=scored,
+        entries_taken=0,
+        entries_blocked=0,
+        exits_taken=0,
+        next_interval=15,
+        errors=[],
+        metadata={},
+    )
+
+
+def test_closure_held_broker_slot_base_is_unwrapped():
+    patch = _load()
+
+    def base(self, *args, **kwargs):
+        return _result(7)
+
+    original_run_scan_phase = base
+
+    def broker_slot_wrapper(self, *args, **kwargs):
+        return original_run_scan_phase(self, *args, **kwargs)
+
+    broker_slot_wrapper._nija_broker_slot_scoped = True
+    resolved, depth, cycle = patch._unwrap_known(broker_slot_wrapper)
+    assert resolved is base
+    assert depth == 1
+    assert cycle is False
+
+
+def test_canonical_wrapper_executes_user_scan_once_without_reentry_block():
+    patch = _load()
+    calls = []
+
+    def base(self, *args, **kwargs):
+        calls.append(kwargs.get("broker"))
+        return _result(11)
+
+    original_run_scan_phase = base
+
+    def broker_slot_wrapper(self, *args, **kwargs):
+        return original_run_scan_phase(self, *args, **kwargs)
+
+    broker_slot_wrapper._nija_broker_slot_scoped = True
+
+    class NijaCoreLoop:
+        run_scan_phase = broker_slot_wrapper
+
+    module = ModuleType("bot.nija_core_loop")
+    module.NijaCoreLoop = NijaCoreLoop
+    assert patch._patch_core_loop(module) is True
+
+    broker = SimpleNamespace(
+        account_identifier="USER:tania_gilbert",
+        broker_type=SimpleNamespace(value="kraken"),
+    )
+    result = NijaCoreLoop().run_scan_phase(broker=broker)
+    assert result.symbols_scored == 11
+    assert result.entries_blocked == 0
+    assert calls == [broker]

--- a/scan_wrapper_convergence_repair_patch.py
+++ b/scan_wrapper_convergence_repair_patch.py
@@ -1,10 +1,12 @@
-"""Canonicalize NIJA scan wrappers to prevent recursive wrapper stacking.
+"""Canonicalize NIJA scan wrappers without suppressing legitimate account scans.
 
 Legacy runtime watchdogs independently wrapped ``NijaCoreLoop.run_scan_phase``.
-Each wrapper only recognized its own marker, so the watchdogs alternated wrappers
-until calls exceeded Python's recursion limit. This repair unwraps known NIJA
-scan wrappers to the original implementation and installs one canonical wrapper
-that provides both account serialization and the required result contract.
+The broker-slot wrapper from ``startup_runtime_safety`` did not expose
+``__wrapped__`` and was not listed as a known wrapper.  The canonical wrapper
+therefore captured that wrapper as its base; the broker-slot wrapper then called
+back into the canonical method and every user cycle was returned as
+``duplicate_scan_suppressed``.  This module now unwraps both explicit
+``__wrapped__`` chains and the legacy closure-held broker-slot base.
 """
 from __future__ import annotations
 
@@ -17,7 +19,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.scan_wrapper_convergence_repair")
-_MARKER = "20260712h"
+_MARKER = "20260713-scan-wrapper-v2"
 _LOCK = threading.RLock()
 
 
@@ -44,24 +46,26 @@ _KNOWN_WRAPPER_MARKERS = (
     "_nija_account_scan_serialized",
     "_nija_final_result_contract",
     "_nija_scan_wrapper_canonical_h",
+    "_nija_scan_wrapper_canonical_v2",
+    "_nija_broker_slot_scoped",
 )
 
 
-def _duplicate_result() -> SimpleNamespace:
+def _duplicate_result(reason: str = "duplicate_scan_suppressed") -> SimpleNamespace:
     return SimpleNamespace(
         symbols_scored=0,
         entries_taken=0,
         entries_blocked=1,
         exits_taken=0,
         next_interval=max(5, int(float(os.getenv("NIJA_DUPLICATE_SCAN_NEXT_INTERVAL_S", "15") or 15))),
-        errors=["duplicate_scan_suppressed"],
-        metadata={"duplicate_scan": True},
+        errors=[reason],
+        metadata={"duplicate_scan": True, "reason": reason},
     )
 
 
 def _coerce_result(result: Any) -> Any:
     if result is None:
-        return _duplicate_result()
+        return _duplicate_result("scan_returned_none")
     if isinstance(result, tuple):
         scored = int(result[0] or 0) if len(result) > 0 else 0
         blocked = int(result[1] or 0) if len(result) > 1 else 0
@@ -83,35 +87,30 @@ def _coerce_result(result: Any) -> Any:
             _MARKER,
             type(result).__name__,
         )
-        return _duplicate_result()
+        return _duplicate_result("invalid_scan_result")
     return result
 
 
 def _broker_identity(broker: Any, owner: Any = None) -> str:
     source = broker or owner
-
     account = ""
     for obj in (broker, owner):
         if obj is None:
             continue
-        for attr in ("account_id", "user_id", "account_name", "owner_id"):
+        for attr in ("account_identifier", "account_id", "user_id", "account_name", "owner_id"):
             value = getattr(obj, attr, None)
             if value:
                 account = str(value).strip().lower().replace(" ", "_")
                 break
         if account:
             break
-
     if not account:
         if source is not None:
             account_type = getattr(source, "account_type", None)
             account = str(getattr(account_type, "value", account_type) or "platform").strip().lower()
         else:
             account = "platform"
-
-    if not account:
-        account = "platform"
-
+    account = account or "platform"
     text_parts = []
     for attr in ("broker_type", "broker_name", "name", "exchange", "exchange_name"):
         try:
@@ -129,6 +128,33 @@ def _is_known_wrapper(func: Callable[..., Any]) -> bool:
     return any(bool(getattr(func, marker, False)) for marker in _KNOWN_WRAPPER_MARKERS)
 
 
+def _closure_wrapped(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    """Recover a wrapped function stored only in a legacy closure.
+
+    ``startup_runtime_safety._run_scan_phase_broker_scoped`` captured
+    ``original_run_scan_phase`` but did not set ``__wrapped__``.  Inspecting the
+    named free variable is safe and specific; arbitrary callable closure cells are
+    never selected.
+    """
+    if not getattr(func, "_nija_broker_slot_scoped", False):
+        return None
+    try:
+        freevars = tuple(getattr(func, "__code__").co_freevars)
+        closure = tuple(getattr(func, "__closure__", ()) or ())
+        mapping = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+        candidate = mapping.get("original_run_scan_phase")
+        return candidate if callable(candidate) else None
+    except Exception:
+        return None
+
+
+def _next_wrapped(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    wrapped = getattr(func, "__wrapped__", None)
+    if callable(wrapped):
+        return wrapped
+    return _closure_wrapped(func)
+
+
 def _unwrap_known(func: Callable[..., Any]) -> tuple[Callable[..., Any], int, bool]:
     current = func
     seen: set[int] = set()
@@ -140,7 +166,7 @@ def _unwrap_known(func: Callable[..., Any]) -> tuple[Callable[..., Any], int, bo
             cycle = True
             break
         seen.add(ident)
-        wrapped = getattr(current, "__wrapped__", None)
+        wrapped = _next_wrapped(current)
         if not callable(wrapped):
             break
         current = wrapped
@@ -158,7 +184,7 @@ def _patch_core_loop(module: ModuleType) -> bool:
     current = getattr(cls, "run_scan_phase", None)
     if not callable(current):
         return False
-    if getattr(current, "_nija_scan_wrapper_canonical_h", False):
+    if getattr(current, "_nija_scan_wrapper_canonical_v2", False):
         return False
 
     base, depth, cycle = _unwrap_known(current)
@@ -181,33 +207,35 @@ def _patch_core_loop(module: ModuleType) -> bool:
             or (args[0] if args else None)
         )
         key = _broker_identity(broker, self)
-
         with _SCAN_STATES_GUARD:
             state = _SCAN_STATES.setdefault(key, ScanState())
-
         current_thread_id = threading.get_ident()
 
-        # Prevent accidental recursive calls from the same scan owner.
         if state.owner_thread_id == current_thread_id:
+            # A legacy closure wrapper can survive initial import ordering.  Make
+            # one final attempt to bypass that wrapper and invoke its true base.
+            recovered, recovered_depth, recovered_cycle = _unwrap_known(base)
+            if callable(recovered) and recovered is not base and not recovered_cycle:
+                logger.critical(
+                    "SCAN_REENTRANT_WRAPPER_RECOVERED marker=%s identity=%s removed_layers=%d",
+                    _MARKER,
+                    key,
+                    recovered_depth,
+                )
+                return _coerce_result(recovered(self, *args, **kwargs))
             logger.error(
-                "REENTRANT_SCAN_SUPPRESSED marker=%s identity=%s",
+                "REENTRANT_SCAN_SUPPRESSED marker=%s identity=%s reason=true_recursive_call",
                 _MARKER,
                 key,
             )
-            return _duplicate_result()
+            return _duplicate_result("true_recursive_scan_suppressed")
 
-        owner_timeout = max(
-            0.1,
-            float(os.getenv("NIJA_ACCOUNT_SCAN_LOCK_TIMEOUT_S", "1.0") or 1.0),
-        )
-
-        # Become the authoritative scan owner.
+        owner_timeout = max(0.1, float(os.getenv("NIJA_ACCOUNT_SCAN_LOCK_TIMEOUT_S", "1.0") or 1.0))
         if state.lock.acquire(timeout=owner_timeout):
             try:
                 state.owner_thread_id = current_thread_id
                 state.started_at = time.monotonic()
                 state.complete.clear()
-
                 result = _coerce_result(base(self, *args, **kwargs))
                 state.result = result
                 return result
@@ -216,23 +244,10 @@ def _patch_core_loop(module: ModuleType) -> bool:
                 state.complete.set()
                 state.lock.release()
 
-        # Another legitimate scan is active.
-        # Wait for it and reuse its result rather than reporting a blocked cycle.
-        wait_timeout = max(
-            5.0,
-            float(os.getenv("NIJA_DUPLICATE_SCAN_RESULT_WAIT_S", "45") or 45),
-        )
-
+        wait_timeout = max(5.0, float(os.getenv("NIJA_DUPLICATE_SCAN_RESULT_WAIT_S", "45") or 45))
         if state.complete.wait(timeout=wait_timeout) and state.result is not None:
-            logger.info(
-                "DUPLICATE_SCAN_RESULT_REUSED marker=%s identity=%s",
-                _MARKER,
-                key,
-            )
+            logger.info("DUPLICATE_SCAN_RESULT_REUSED marker=%s identity=%s", _MARKER, key)
             return state.result
-
-        # The owner appears stalled. Fail closed without crashing or pretending
-        # that the strategy evaluated the market.
         logger.error(
             "SCAN_OWNER_TIMEOUT marker=%s identity=%s owner_thread=%s age_s=%.2f",
             _MARKER,
@@ -240,10 +255,10 @@ def _patch_core_loop(module: ModuleType) -> bool:
             state.owner_thread_id,
             max(0.0, time.monotonic() - state.started_at),
         )
-        return _duplicate_result()
+        return _duplicate_result("scan_owner_timeout")
 
-    # Satisfy every legacy watchdog so no older patch wraps this function again.
     run_scan_phase._nija_scan_wrapper_canonical_h = True  # type: ignore[attr-defined]
+    run_scan_phase._nija_scan_wrapper_canonical_v2 = True  # type: ignore[attr-defined]
     run_scan_phase._nija_account_scan_serialized_e = True  # type: ignore[attr-defined]
     run_scan_phase._nija_final_result_contract_e = True  # type: ignore[attr-defined]
     run_scan_phase._nija_account_scan_serialized = True  # type: ignore[attr-defined]
@@ -251,7 +266,7 @@ def _patch_core_loop(module: ModuleType) -> bool:
     run_scan_phase.__wrapped__ = base  # type: ignore[attr-defined]
     setattr(cls, "run_scan_phase", run_scan_phase)
     logger.critical(
-        "SCAN_WRAPPER_CANONICALIZED marker=%s removed_layers=%d cycle_detected=%s base=%s",
+        "SCAN_WRAPPER_CANONICALIZED marker=%s removed_layers=%d cycle_detected=%s base=%s broker_slot_unwrap=true",
         _MARKER,
         depth,
         str(cycle).lower(),
@@ -287,8 +302,16 @@ def install() -> bool:
             _WATCHDOG_STARTED = True
             threading.Thread(target=_watchdog, name="ScanWrapperCanonicalWatchdog", daemon=True).start()
         os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] = "1"
+        os.environ["NIJA_SCAN_WRAPPER_RELEASE"] = _MARKER
         logger.critical("SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED marker=%s", _MARKER)
         return True
 
 
-__all__ = ["install", "_coerce_result", "_unwrap_known", "_patch_core_loop", "_broker_identity"]
+__all__ = [
+    "install",
+    "_coerce_result",
+    "_unwrap_known",
+    "_closure_wrapped",
+    "_patch_core_loop",
+    "_broker_identity",
+]


### PR DESCRIPTION
## Runtime failures proven by the July 13 logs

- Daivon and Tania cycles were returned as `REENTRANT_SCAN_SUPPRESSED`, producing `scored=0 entered=0 blocked=1 exited=0`.
- The live process was still running superseded additive position adoption (`skip_existing`, `Updated position`) instead of the merged exact snapshot reconciler.
- Tania's AIR balance could not be valued after a single assumed `AIR-USDT` lookup failed.
- Kraken equity added held value on top of crypto holdings already included in account equity, inflating totals such as $93.26 to $104.32.
- Positions with missing entry history were represented using current price without explicit unverified-cost metadata.
- Coinbase repeatedly invoked the SDK with a malformed PEM and emitted `MalformedFraming` on every product refresh.
- The process did not publish a reliable release/deployment manifest, making a stale Railway process difficult to distinguish from current `main`.

## Repairs

- Unwrap the closure-held broker-slot scan wrapper and execute the real account scan exactly once.
- Preserve duplicate-scan serialization while restricting suppression to true recursive calls.
- Resolve Kraken asset quote pairs dynamically through public `AssetPairs` and `Ticker` across USD, USDT, USDC, and EUR.
- Exclude held-value telemetry from the canonical equity sum so crypto cannot be counted twice.
- Distinguish verified execution/API cost basis from temporary adoption marks.
- Preserve previously verified basis through legacy zero-price duplicate snapshots so exact quantity repair still works.
- Block automatic profit/break-even exits for unverified cost basis while preserving legitimate legacy NIJA execution entries.
- Normalize Coinbase PEM secrets containing literal escaped newlines.
- Quarantine Coinbase only when the exact PEM remains invalid, stopping repeated SDK exceptions while Kraken remains operational.
- Publish and continuously audit `NIJA_RUNTIME_RELEASE_MANIFEST` with deployment SHA, process ID, repair status, and release ID `20260713-runtime-convergence-v4`.

## Safety

- No signal, profitability, exchange-minimum, writer-fencing, margin-health, or acknowledgement control is bypassed.
- Unknown entry prices are not fabricated as profit.
- Invalid Coinbase and OKX credentials are not invented; affected venues remain independently excluded.
- The repair removes a false scan blocker but does not force trades when no strategy signal qualifies.

## Regression coverage

- Broker-slot closure unwrapping and one-pass account scans.
- AIR fallback to an actual EUR pair and USD conversion.
- Held-value/crypto double-count prevention.
- Verified versus unverified cost basis behavior.
- Legacy duplicate-cost repair and legitimate execution preservation.
- Coinbase escaped-newline PEM normalization and malformed-key quarantine.

## Expected fresh-deployment markers

- `NIJA_RUNTIME_RELEASE_MANIFEST release=20260713-runtime-convergence-v4 ... ready=true`
- `SCAN_WRAPPER_CANONICALIZED ... broker_slot_unwrap=true`
- `KRAKEN_ASSET_PAIR_RESOLVED`
- `KRAKEN_ASSET_USD_PRICE_RESOLVED`
- `KRAKEN_EQUITY_DOUBLE_COUNT_PREVENTED`
- `POSITION_SNAPSHOT_SYNCED ... cost_basis_verified=`
- `POSITION_COST_BASIS_RECONCILIATION_REQUIRED` where history is unavailable
- `COINBASE_PEM_NORMALIZED` or `COINBASE_CREDENTIAL_QUARANTINED`

## CI infrastructure status

The latest preflight and imports-smoke jobs were terminated before checkout or test execution. GitHub reports `steps=None` and no job log URL, so the red Actions state contains no actionable repository-code failure.