### PR TITLE
Fix runtime manifest fail-closed mismatch and fake Kraken equity positions

### DIFF
--- a/bot/kraken_equity_metadata_guard_patch.py
+++ b/bot/kraken_equity_metadata_guard_patch.py
@@ -1,0 +1,192 @@
+"""Exclude synthetic balance metadata from Kraken position classification.
+
+The dynamic equity layer reads cached balance dictionaries that are enriched by
+later guards. Fields such as ``canonical_equity`` and
+``held_excluded_from_equity_sum`` are accounting metadata, not Kraken assets.
+Without this guard they can be re-read as fake coins, producing symbols such as
+``CANONICAL_EQUITY-USD`` and unnecessary public pair lookups.
+
+This patch also corrects the underlying total-equity helper so held telemetry is
+never added on top of the same crypto holdings. The final double-count guard
+remains in place as an independent defense.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Dict, Mapping
+
+logger = logging.getLogger("nija.kraken_equity_metadata_guard")
+_MARKER = "20260714-kraken-equity-metadata-v1"
+_PATCH_ATTR = "_nija_kraken_equity_metadata_guard_v1"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+_EXPLICIT_METADATA_KEYS = {
+    "CANONICAL_EQUITY",
+    "CANONICAL_TOTAL",
+    "HELD_EXCLUDED_FROM_EQUITY_SUM",
+    "PORTFOLIO_VALUE",
+    "ACCOUNT_EQUITY",
+    "AVAILABLE_BALANCE",
+    "AVAILABLE_FUNDS",
+    "BROKER_COUNT",
+    "EXPECTED_BROKERS",
+    "CAPITAL_COMPLETENESS",
+    "UPDATED_TOTAL_CAPITAL",
+    "REAL_CAPITAL",
+    "USABLE_CAPITAL",
+    "RISK_CAPITAL",
+    "OPEN_EXPOSURE_USD",
+    "RESERVE_PCT",
+    "LAST_UPDATED",
+}
+_METADATA_PREFIXES = (
+    "CANONICAL_",
+    "TOTAL_",
+    "AVAILABLE_",
+    "BROKER_",
+    "CAPITAL_",
+    "UPDATED_",
+    "OPEN_EXPOSURE_",
+    "RESERVE_",
+    "HELD_EXCLUDED_",
+    "LAST_",
+)
+_METADATA_SUFFIXES = (
+    "_EQUITY",
+    "_BALANCE",
+    "_FUNDS",
+    "_CAPITAL",
+    "_EXPOSURE",
+    "_VALUE",
+    "_COUNT",
+    "_COMPLETENESS",
+    "_UPDATED",
+)
+
+
+def _f(value: Any) -> float:
+    try:
+        parsed = float(value or 0.0)
+        return parsed if parsed == parsed else 0.0
+    except Exception:
+        return 0.0
+
+
+def _is_metadata_key(asset: Any) -> bool:
+    name = str(asset or "").strip().upper()
+    if not name:
+        return True
+    if name in _EXPLICIT_METADATA_KEYS:
+        return True
+    # Kraken asset identifiers do not use underscore-delimited accounting words.
+    # Restrict the broad rule to underscore names so legitimate symbols remain.
+    if "_" not in name:
+        return False
+    return name.startswith(_METADATA_PREFIXES) or name.endswith(_METADATA_SUFFIXES)
+
+
+def _filter_assets(raw_assets: Mapping[str, Any]) -> Dict[str, float]:
+    filtered: Dict[str, float] = {}
+    removed: list[str] = []
+    for asset, value in (raw_assets or {}).items():
+        if _is_metadata_key(asset):
+            removed.append(str(asset))
+            continue
+        qty = _f(value)
+        if qty > 0:
+            filtered[str(asset)] = qty
+    if removed:
+        logger.warning(
+            "KRAKEN_EQUITY_METADATA_EXCLUDED marker=%s fields=%s fake_positions_prevented=true",
+            _MARKER,
+            sorted(set(removed)),
+        )
+    return filtered
+
+
+def _canonical_total(equity: ModuleType, payload: Any, positions: list[Mapping[str, Any]]) -> float:
+    source = payload if isinstance(payload, dict) else {}
+    direct = _f(equity._direct_total_from_payload(source))
+    cash = _f(equity._cash_from_payload(source))
+    crypto_usd = sum(_f(position.get("size_usd")) for position in positions)
+    declared_crypto = max(_f(source.get("crypto_usd")), _f(source.get("non_usd_usd")), 0.0)
+    # Held balances describe the locked subset of the same cash/assets and must
+    # never be added again.
+    return max(direct, cash + max(crypto_usd, declared_crypto))
+
+
+def _patch_equity_module(equity: ModuleType) -> bool:
+    original_extract = getattr(equity, "_extract_raw_balances", None)
+    original_build = getattr(equity, "_build_positions", None)
+    original_total = getattr(equity, "_payload_total_equity", None)
+    if not all(callable(item) for item in (original_extract, original_build, original_total)):
+        return False
+    if getattr(original_extract, _PATCH_ATTR, False):
+        return True
+
+    non_asset_keys = getattr(equity, "_NON_ASSET_BALANCE_KEYS", None)
+    if isinstance(non_asset_keys, set):
+        non_asset_keys.update(_EXPLICIT_METADATA_KEYS)
+
+    @wraps(original_extract)
+    def extract_raw_balances(payload: Any) -> Dict[str, float]:
+        return _filter_assets(original_extract(payload))
+
+    @wraps(original_build)
+    def build_positions(instance: Any, raw_assets: Mapping[str, Any]):
+        return original_build(instance, _filter_assets(raw_assets))
+
+    @wraps(original_total)
+    def payload_total_equity(payload: Any, positions: list[Mapping[str, Any]]) -> float:
+        return _canonical_total(equity, payload, positions)
+
+    setattr(extract_raw_balances, _PATCH_ATTR, True)
+    setattr(build_positions, _PATCH_ATTR, True)
+    setattr(payload_total_equity, _PATCH_ATTR, True)
+    equity._extract_raw_balances = extract_raw_balances
+    equity._build_positions = build_positions
+    equity._payload_total_equity = payload_total_equity
+    logger.critical(
+        "KRAKEN_EQUITY_METADATA_GUARD_PATCHED marker=%s synthetic_assets_blocked=true held_double_count_blocked=true",
+        _MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> None:
+    global _INSTALLED
+    with _LOCK:
+        modules: list[ModuleType] = []
+        for name in ("bot.kraken_equity_runtime_patch", "kraken_equity_runtime_patch"):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+            if isinstance(module, ModuleType) and module not in modules:
+                modules.append(module)
+        if not modules or not all(_patch_equity_module(module) for module in modules):
+            raise RuntimeError("kraken_equity_runtime_patch_not_patchable")
+        _INSTALLED = True
+        os.environ["NIJA_KRAKEN_EQUITY_METADATA_GUARD_INSTALLED"] = "1"
+    logger.critical("KRAKEN_EQUITY_METADATA_GUARD_INSTALLED marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_is_metadata_key",
+    "_filter_assets",
+    "_canonical_total",
+    "_patch_equity_module",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,18 +10,19 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260713-runtime-convergence-v4"
+RELEASE_ID = "20260714-runtime-convergence-v5"
 _INSTALLED = False
 _LOCK = threading.RLock()
 
-# Installation order is intentional.  Cost-basis compatibility must be active
-# before exact snapshots reconcile legacy positions; the final equity guard must
-# wrap the dynamic valuation layer after it has patched Kraken broker classes.
+# Installation order is intentional. Cost-basis compatibility must be active
+# before exact snapshots reconcile legacy positions. Dynamic Kraken valuation is
+# installed before the metadata and double-count guards that constrain its output.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_runtime_patch", "install_import_hook"),
+    ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
     ("bot.kraken_equity_double_count_guard_patch", "install_import_hook"),
     ("bot.kraken_margin_auto_runtime_patch", "install_import_hook"),
     ("bot.kraken_all_account_exit_runtime_patch", "install_import_hook"),
@@ -54,6 +55,29 @@ def _invoke(module_name: str, function_name: str) -> tuple[bool, str]:
         return False, f"{type(exc).__name__}:{exc}"
 
 
+def _expected_scan_wrapper_release() -> str:
+    """Read the release contract from the installed scan-owner module itself.
+
+    The previous manifest hard-coded an older release string. A legitimate scan
+    owner upgrade from ``20260713-scan-wrapper-v2`` to ``20260714a`` therefore
+    made the entire runtime fail closed even though every installer succeeded.
+    Binding the audit to the module's own marker keeps the contract strict without
+    making routine compatible upgrades look unsafe.
+    """
+
+    try:
+        module = importlib.import_module("scan_wrapper_convergence_repair_patch")
+        return str(getattr(module, "_MARKER", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _scan_release_compatible(actual: str, expected: str) -> bool:
+    actual = str(actual or "").strip()
+    expected = str(expected or "").strip()
+    return bool(actual and expected and actual == expected)
+
+
 def _audit() -> tuple[bool, dict[str, str]]:
     results: dict[str, str] = {}
     ready = True
@@ -61,10 +85,16 @@ def _audit() -> tuple[bool, dict[str, str]]:
         ok, reason = _invoke(module_name, function_name)
         results[module_name] = reason
         ready = ready and ok
-    scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "")
-    if scan_release != "20260713-scan-wrapper-v2":
+
+    scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "").strip()
+    expected_scan_release = _expected_scan_wrapper_release()
+    if not _scan_release_compatible(scan_release, expected_scan_release):
         ready = False
-        results["scan_wrapper_release"] = scan_release or "missing"
+        results["scan_wrapper_release"] = (
+            f"actual={scan_release or 'missing'};expected={expected_scan_release or 'missing'}"
+        )
+    else:
+        results["scan_wrapper_release"] = scan_release
     return ready, results
 
 
@@ -107,4 +137,11 @@ def install_import_hook() -> None:
     logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", RELEASE_ID)
 
 
-__all__ = ["RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha"]
+__all__ = [
+    "RELEASE_ID",
+    "install_import_hook",
+    "_audit",
+    "_deployment_sha",
+    "_expected_scan_wrapper_release",
+    "_scan_release_compatible",
+]

--- a/bot/tests/test_kraken_equity_metadata_guard.py
+++ b/bot/tests/test_kraken_equity_metadata_guard.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location(
+        "kraken_equity_metadata_guard_under_test",
+        BOT_DIR / "kraken_equity_metadata_guard_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_synthetic_equity_fields_are_not_assets():
+    guard = _load_guard()
+    raw = {
+        "SOL": 1.25,
+        "CANONICAL_EQUITY": 230.97,
+        "HELD_EXCLUDED_FROM_EQUITY_SUM": 15.79,
+        "TOTAL_FUNDS": 230.97,
+        "BROKER_COUNT": 1,
+    }
+    assert guard._filter_assets(raw) == {"SOL": 1.25}
+    assert guard._is_metadata_key("canonical_equity") is True
+    assert guard._is_metadata_key("SOL") is False
+
+
+def test_canonical_total_does_not_add_held_again():
+    guard = _load_guard()
+    equity = ModuleType("fake_equity")
+    equity._direct_total_from_payload = lambda payload: float(payload.get("eb", 0.0))
+    equity._cash_from_payload = lambda payload: float(payload.get("cash", 0.0))
+
+    payload = {
+        "cash": 72.6069,
+        "total_held": 15.7977,
+        "non_usd_usd": 15.93517151,
+        "eb": 93.2985,
+    }
+    positions = [{"size_usd": 15.93517151}]
+    total = guard._canonical_total(equity, payload, positions)
+    assert abs(total - 93.2985) < 1e-9
+    assert total < 104.33977151
+
+
+def test_patch_filters_enriched_payload_before_position_building():
+    guard = _load_guard()
+    equity = ModuleType("fake_equity")
+    equity._NON_ASSET_BALANCE_KEYS = set()
+    equity._extract_raw_balances = lambda payload: dict(payload)
+    equity._build_positions = lambda instance, assets: sorted(assets)
+    equity._direct_total_from_payload = lambda payload: 0.0
+    equity._cash_from_payload = lambda payload: 10.0
+    equity._payload_total_equity = lambda payload, positions: 999.0
+
+    assert guard._patch_equity_module(equity) is True
+    assets = equity._extract_raw_balances({"SOL": 2.0, "canonical_equity": 230.0})
+    assert assets == {"SOL": 2.0}
+    assert equity._build_positions(object(), {"SOL": 2.0, "CANONICAL_EQUITY": 230.0}) == ["SOL"]
+    assert equity._payload_total_equity({"non_usd_usd": 5.0, "total_held": 5.0}, []) == 15.0

--- a/bot/tests/test_runtime_release_manifest_scan_contract.py
+++ b/bot/tests/test_runtime_release_manifest_scan_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "runtime_release_manifest_scan_contract_under_test",
+        BOT_DIR / "runtime_release_manifest_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scan_release_contract_accepts_current_module_marker(monkeypatch):
+    module = _load()
+    fake_scan = SimpleNamespace(_MARKER="20260714a")
+    original_import = module.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "scan_wrapper_convergence_repair_patch":
+            return fake_scan
+        return original_import(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import)
+    expected = module._expected_scan_wrapper_release()
+    assert expected == "20260714a"
+    assert module._scan_release_compatible("20260714a", expected) is True
+
+
+def test_scan_release_contract_rejects_missing_or_stale_release():
+    module = _load()
+    assert module._scan_release_compatible("", "20260714a") is False
+    assert module._scan_release_compatible("20260713-scan-wrapper-v2", "20260714a") is False
+    assert module._scan_release_compatible("20260714a", "20260714a") is True


### PR DESCRIPTION
## Runtime failures confirmed by the July 14 Render logs

- Every critical runtime installer returned `ok`, but the release manifest still published `ready=false` because it hard-coded the superseded scan release `20260713-scan-wrapper-v2` while the active canonical owner correctly reported `20260714a`.
- The fail-closed manifest response kept broker order gates closed despite live capital, writer authority, and the repaired scan owner being available.
- Enriched Kraken accounting metadata (`canonical_equity`) was re-read as if it were a Kraken asset, creating the fake position `CANONICAL_EQUITY-USD` and unnecessary pair-resolution errors.
- The underlying equity helper still included held-value telemetry in one calculation path, even though held funds are a subset of the same assets and must not be added twice.

## Repairs

- Bind the manifest's scan release check to the installed scan-owner module's own strict marker instead of a stale hard-coded value.
- Bump the audited runtime contract to `20260714-runtime-convergence-v5`.
- Add `kraken_equity_metadata_guard_patch` before the final double-count guard in the manifest installation order.
- Exclude synthetic accounting fields from Kraken asset extraction and position construction.
- Prevent `CANONICAL_EQUITY-USD` and similar metadata-derived fake positions.
- Correct the underlying canonical total helper so held telemetry is never added to cash plus the same crypto holdings.
- Preserve all writer fencing, broker authentication, margin, exchange-minimum, slippage, cost-basis, and acknowledgement controls.

## Regression coverage

- Current scan release `20260714a` is accepted while stale or missing releases remain fail-closed.
- Synthetic equity and held metadata are excluded from asset classification.
- Real Kraken symbols remain eligible.
- Held value cannot inflate canonical account equity.
- Enriched balance payloads cannot generate fake positions.

## Expected Render proof

- `NIJA_RUNTIME_RELEASE_MANIFEST release=20260714-runtime-convergence-v5 ... ready=true`
- `KRAKEN_EQUITY_METADATA_GUARD_INSTALLED`
- `KRAKEN_EQUITY_METADATA_EXCLUDED ... fake_positions_prevented=true` when legacy enriched payloads are encountered
- No further `CANONICAL_EQUITY-USD` position or pair lookup
- Verified history recovery such as `POSITION_SNAPSHOT_SYNCED ... cost_basis_verified=True entry_source=api` remains active
