### PR TITLE
Make Kraken recovery exit-only and eliminate recursive scans

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -132,6 +132,15 @@ def _install_scan_wrapper_convergence() -> None:
     )
 
 
+def _install_scan_reentrant_delegate_repair() -> None:
+    _install_module(
+        "bot.scan_reentrant_delegate_repair_patch",
+        "scan_reentrant_delegate_repair_patch",
+        "SCAN_REENTRANT_DELEGATE_REPAIR",
+        "20260714-scan-delegate-v1",
+    )
+
+
 def _install_strategy_backrefs() -> None:
     _install_module("bot.strategy_broker_backref_patch", "strategy_broker_backref_patch", "BROKER_BOOL_GUARD_STRATEGY_BACKREF", "20260705d")
 
@@ -150,6 +159,15 @@ def _install_kraken_equity_runtime() -> None:
 
 def _install_kraken_equity_metadata_guard() -> None:
     _install_module("bot.kraken_equity_metadata_guard_patch", "kraken_equity_metadata_guard_patch", "KRAKEN_EQUITY_METADATA_GUARD", "20260714-kraken-equity-metadata-v1")
+
+
+def _install_kraken_synthetic_equity_scrub() -> None:
+    _install_module(
+        "bot.kraken_synthetic_equity_position_scrub_patch",
+        "kraken_synthetic_equity_position_scrub_patch",
+        "KRAKEN_SYNTHETIC_EQUITY_SCRUB",
+        "20260714-kraken-synthetic-equity-scrub-v1",
+    )
 
 
 def _install_kraken_equity_double_count_guard() -> None:
@@ -180,6 +198,15 @@ def _install_kraken_exit_margin_cost() -> None:
     _install_module("bot.kraken_exit_margin_cost_patch", "kraken_exit_margin_cost_patch", "KRAKEN_EXIT_MARGIN_COST", "20260713-kraken-exit-margin-cost-v1")
 
 
+def _install_kraken_exit_only_recovery_guard() -> None:
+    _install_module(
+        "bot.kraken_exit_only_recovery_phase_guard_patch",
+        "kraken_exit_only_recovery_phase_guard_patch",
+        "KRAKEN_EXIT_ONLY_RECOVERY_GUARD",
+        "20260714-kraken-exit-only-recovery-v1",
+    )
+
+
 def _install_kraken_profit_realization_guard() -> None:
     _install_module("bot.kraken_profit_realization_guard_patch", "kraken_profit_realization_guard_patch", "KRAKEN_PROFIT_REALIZATION_GUARD", "20260714-kraken-profit-realization-v1")
 
@@ -189,18 +216,21 @@ def _install_coinbase_pem_quarantine() -> None:
 
 
 def _install_runtime_release_manifest() -> None:
-    _install_module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch", "RUNTIME_RELEASE_MANIFEST", "20260714-runtime-convergence-v6")
+    _install_module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch", "RUNTIME_RELEASE_MANIFEST", "20260714-runtime-convergence-v7")
 
 
 def install_import_hook() -> None:
-    # Order matters: converge scan ownership first, reconcile exact state, constrain
-    # equity metadata, then install execution and profit-realization guards. Publish
-    # the release manifest only after every critical layer has been requested.
+    # Order matters. Converge scan ownership and delegated reentry first. Install
+    # synthetic-metadata filtering before dynamic Kraken equity hydration so no early
+    # balance cycle can create CANONICAL_EQUITY-USD. Make recovery exit-only before
+    # profit realization, then publish the strict release manifest last.
     _install_scan_wrapper_convergence()
+    _install_scan_reentrant_delegate_repair()
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
-    _install_kraken_equity_runtime()
     _install_kraken_equity_metadata_guard()
+    _install_kraken_equity_runtime()
+    _install_kraken_synthetic_equity_scrub()
     _install_kraken_equity_double_count_guard()
     _install_kraken_margin_auto_runtime()
     _install_kraken_all_account_exit_runtime()
@@ -208,6 +238,7 @@ def install_import_hook() -> None:
     _install_kraken_exit_final_guards()
     _install_kraken_exit_execution_safety()
     _install_kraken_exit_margin_cost()
+    _install_kraken_exit_only_recovery_guard()
     _install_kraken_profit_realization_guard()
     _install_coinbase_pem_quarantine()
     _install_strategy_backrefs()

--- a/bot/kraken_exit_only_recovery_phase_guard_patch.py
+++ b/bot/kraken_exit_only_recovery_phase_guard_patch.py
@@ -1,0 +1,253 @@
+"""Keep Kraken account recovery strictly position-management and exit-only.
+
+``account_exit_management_recovery_patch`` historically called
+``TradingStrategy.run_cycle(user_mode=True)`` after adopting positions.  That path
+still enters ``NijaCoreLoop.run_scan_phase`` and can collide with the normal
+independent Kraken trader, even though recovery explicitly disallows entries.
+
+The account-local Kraken exit runtime already performs private-authenticated,
+verified-cost-basis profit/break-even and emergency exit evaluation.  This guard
+therefore performs adoption/snapshot refresh and invokes that direct exit scanner
+without entering Phase 3.  Non-Kraken recovery behavior is unchanged.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+logger = logging.getLogger("nija.kraken_exit_only_recovery_phase_guard")
+_MARKER = "20260714-kraken-exit-only-recovery-v1"
+_PATCH_ATTR = "_nija_kraken_exit_only_recovery_phase_guard_v1"
+_LOCK = threading.RLock()
+_ORIGINAL_IMPORT = None
+_PATCHED: set[tuple[str, int]] = set()
+_LAST_SYNC: dict[tuple[int, str], float] = {}
+_SYNC_LOCK = threading.RLock()
+
+
+def _is_kraken(broker: Any) -> bool:
+    if broker is None:
+        return False
+    values = (
+        type(broker).__name__,
+        getattr(broker, "NAME", ""),
+        getattr(getattr(broker, "broker_type", None), "value", getattr(broker, "broker_type", "")),
+        getattr(broker, "exchange", ""),
+    )
+    return any("kraken" in str(value or "").lower() for value in values)
+
+
+def _safe_count(module: ModuleType, name: str, broker: Any) -> int:
+    method = getattr(module, name, None)
+    if not callable(method):
+        return 0
+    try:
+        return max(0, int(method(broker) or 0))
+    except Exception:
+        return 0
+
+
+def _adopt_positions(strategy: Any, identity: str, broker: Any) -> tuple[int, int]:
+    positions = 0
+    orders = 0
+    adopter = getattr(strategy, "adopt_existing_positions", None)
+    if callable(adopter):
+        try:
+            status = adopter(
+                broker=broker,
+                broker_name=identity,
+                account_id=str(identity or "platform:kraken").upper().replace(":", "_"),
+            ) or {}
+            if isinstance(status, Mapping):
+                positions = max(
+                    int(status.get("positions_found", 0) or 0),
+                    int(status.get("positions_adopted", 0) or 0),
+                )
+                orders = max(0, int(status.get("open_orders_count", 0) or 0))
+        except Exception as exc:
+            logger.warning(
+                "KRAKEN_EXIT_ONLY_ADOPTION_FAILED marker=%s account=%s error=%s",
+                _MARKER,
+                identity,
+                exc,
+            )
+    return positions, orders
+
+
+def _refresh_exact_snapshot(strategy: Any, broker: Any, identity: str) -> None:
+    interval = max(5.0, float(os.environ.get("NIJA_KRAKEN_EXIT_ONLY_SYNC_INTERVAL_S", "30") or 30))
+    key = (id(broker), str(identity or ""))
+    now = time.monotonic()
+    with _SYNC_LOCK:
+        previous = _LAST_SYNC.get(key, 0.0)
+        if now - previous < interval:
+            return
+        _LAST_SYNC[key] = now
+    try:
+        try:
+            from bot.startup_position_sync import sync_exchange_positions_on_startup
+        except ImportError:
+            from startup_position_sync import sync_exchange_positions_on_startup  # type: ignore[import]
+        sync_exchange_positions_on_startup(strategy)
+        logger.info(
+            "KRAKEN_EXIT_ONLY_POSITION_SNAPSHOT_REFRESHED marker=%s account=%s",
+            _MARKER,
+            identity,
+        )
+    except Exception as exc:
+        logger.warning(
+            "KRAKEN_EXIT_ONLY_POSITION_SNAPSHOT_REFRESH_FAILED marker=%s account=%s error=%s",
+            _MARKER,
+            identity,
+            exc,
+        )
+
+
+def _scan_exits(trader: Any, identity: str, broker: Any) -> int:
+    for name in (
+        "bot.kraken_all_account_exit_runtime_patch",
+        "kraken_all_account_exit_runtime_patch",
+    ):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        scanner = getattr(module, "_scan_account_exits", None)
+        if callable(scanner):
+            return max(0, int(scanner(trader, identity, broker) or 0))
+    raise RuntimeError("kraken_all_account_exit_scanner_unavailable")
+
+
+def _patch_recovery_module(module: ModuleType) -> bool:
+    current = getattr(module, "_adopt_and_manage", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def adopt_and_manage(trader: Any, identity: str, broker: Any):
+        if not _is_kraken(broker):
+            return current(trader, identity, broker)
+
+        strategy = getattr(trader, "trading_strategy", None)
+        positions = _safe_count(module, "_position_count", broker)
+        orders = _safe_count(module, "_open_order_count", broker)
+        if strategy is not None:
+            adopted_positions, adopted_orders = _adopt_positions(strategy, identity, broker)
+            positions = max(positions, adopted_positions)
+            orders = max(orders, adopted_orders)
+            _refresh_exact_snapshot(strategy, broker, identity)
+
+        exits = 0
+        try:
+            exits = _scan_exits(trader, identity, broker)
+        except Exception as exc:
+            logger.exception(
+                "KRAKEN_EXIT_ONLY_DIRECT_SCAN_FAILED marker=%s account=%s error=%s",
+                _MARKER,
+                identity,
+                exc,
+            )
+
+        positions = max(positions, _safe_count(module, "_position_count", broker))
+        orders = max(orders, _safe_count(module, "_open_order_count", broker))
+        logger.critical(
+            "KRAKEN_EXIT_ONLY_RECOVERY_CYCLE marker=%s account=%s positions=%d open_orders=%d exits=%d "
+            "entries_allowed=false phase3_skipped=true direct_exit_scanner=true",
+            _MARKER,
+            identity,
+            positions,
+            orders,
+            exits,
+        )
+        return positions, orders
+
+    setattr(adopt_and_manage, _PATCH_ATTR, True)
+    setattr(adopt_and_manage, "__wrapped__", current)
+    module._adopt_and_manage = adopt_and_manage
+    os.environ["NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED"] = "1"
+    logger.critical(
+        "KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED marker=%s phase3_skipped=true",
+        _MARKER,
+    )
+    return True
+
+
+def _patch_module(module: ModuleType) -> bool:
+    name = str(getattr(module, "__name__", ""))
+    key = (name, id(module))
+    if key in _PATCHED:
+        return True
+    if not name.endswith("account_exit_management_recovery_patch"):
+        return False
+    changed = _patch_recovery_module(module)
+    if changed:
+        _PATCHED.add(key)
+    return changed
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                changed = _patch_module(module) or changed
+            except Exception:
+                continue
+    for name in (
+        "account_exit_management_recovery_patch",
+        "bot.account_exit_management_recovery_patch",
+    ):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(module, ModuleType):
+            changed = _patch_module(module) or changed
+    return changed
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is None:
+            _ORIGINAL_IMPORT = builtins.__import__
+            local = threading.local()
+
+            def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+                if getattr(local, "active", False):
+                    return module
+                local.active = True
+                try:
+                    _patch_loaded()
+                finally:
+                    local.active = False
+                return module
+
+            builtins.__import__ = guarded_import  # type: ignore[assignment]
+    if not _patch_loaded():
+        raise RuntimeError("account_exit_management_recovery_not_patchable")
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_is_kraken",
+    "_patch_recovery_module",
+    "_scan_exits",
+]

--- a/bot/kraken_synthetic_equity_position_scrub_patch.py
+++ b/bot/kraken_synthetic_equity_position_scrub_patch.py
@@ -1,0 +1,229 @@
+"""Remove synthetic accounting metadata before Kraken position classification.
+
+The canonical balance cache may contain fields such as ``canonical_equity`` and
+``total_funds``.  They are accounting metadata, not exchange assets.  This patch
+scrubs those keys from cached balance payloads *before* any Kraken ``get_positions``
+or balance wrapper can classify them, and filters any legacy synthetic rows from
+returned position snapshots.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+logger = logging.getLogger("nija.kraken_synthetic_equity_scrub")
+_MARKER = "20260714-kraken-synthetic-equity-scrub-v1"
+_PATCH_ATTR = "_nija_kraken_synthetic_equity_scrub_v1"
+_LOCK = threading.RLock()
+_ORIGINAL_IMPORT = None
+_PATCHED: set[tuple[str, int]] = set()
+
+_EXPLICIT = {
+    "CANONICAL_EQUITY", "CANONICAL_TOTAL", "TOTAL_FUNDS", "TOTAL_BALANCE",
+    "TOTAL_EQUITY", "EQUITY", "PORTFOLIO_VALUE", "ACCOUNT_EQUITY",
+    "HELD_EXCLUDED_FROM_EQUITY_SUM", "CRYPTO_USD", "NON_USD_USD",
+    "USD_HELD", "USDT_HELD", "USDC_HELD", "TOTAL_HELD",
+}
+_PREFIXES = (
+    "CANONICAL_", "TOTAL_", "AVAILABLE_", "BROKER_", "CAPITAL_",
+    "UPDATED_", "OPEN_EXPOSURE_", "RESERVE_", "HELD_EXCLUDED_", "LAST_",
+)
+_SUFFIXES = (
+    "_EQUITY", "_BALANCE", "_FUNDS", "_CAPITAL", "_EXPOSURE",
+    "_VALUE", "_COUNT", "_COMPLETENESS", "_UPDATED",
+)
+_CACHE_ATTRS = (
+    "_last_raw_balances", "last_raw_balances", "_raw_balances", "raw_balances",
+    "_balance_payload", "balance_payload", "_balance_cache", "balance_cache",
+)
+
+
+def _metadata_name(value: Any) -> bool:
+    name = str(value or "").strip().upper().replace("-USD", "")
+    if not name:
+        return True
+    if name in _EXPLICIT:
+        return True
+    if "_" not in name:
+        return False
+    return name.startswith(_PREFIXES) or name.endswith(_SUFFIXES)
+
+
+def _scrub_mapping(payload: Mapping[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    cleaned: dict[str, Any] = {}
+    removed: list[str] = []
+    for key, value in payload.items():
+        if _metadata_name(key):
+            removed.append(str(key))
+            continue
+        if isinstance(value, Mapping):
+            nested, nested_removed = _scrub_mapping(value)
+            cleaned[key] = nested
+            removed.extend(f"{key}.{item}" for item in nested_removed)
+        else:
+            cleaned[key] = value
+    return cleaned, removed
+
+
+def _scrub_instance(instance: Any) -> list[str]:
+    removed: list[str] = []
+    for attr in _CACHE_ATTRS:
+        payload = getattr(instance, attr, None)
+        if not isinstance(payload, Mapping):
+            continue
+        cleaned, fields = _scrub_mapping(payload)
+        if fields:
+            try:
+                setattr(instance, attr, cleaned)
+                removed.extend(fields)
+            except Exception:
+                continue
+    if removed:
+        logger.warning(
+            "KRAKEN_SYNTHETIC_EQUITY_CACHE_SCRUBBED marker=%s fields=%s fake_positions_prevented=true",
+            _MARKER,
+            sorted(set(removed)),
+        )
+    return removed
+
+
+def _filter_rows(rows: Any) -> Any:
+    if not isinstance(rows, list):
+        return rows
+    kept = []
+    removed = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            kept.append(row)
+            continue
+        symbol = row.get("symbol") or row.get("asset") or row.get("currency")
+        if _metadata_name(symbol):
+            removed.append(str(symbol))
+            continue
+        kept.append(row)
+    if removed:
+        logger.warning(
+            "KRAKEN_SYNTHETIC_POSITION_REMOVED marker=%s symbols=%s exchange_position=false",
+            _MARKER,
+            sorted(set(removed)),
+        )
+    return kept
+
+
+def _is_kraken_class(cls: type) -> bool:
+    return "kraken" in cls.__name__.lower()
+
+
+def _patch_class(cls: type) -> bool:
+    key = (f"{cls.__module__}.{cls.__name__}", id(cls))
+    if key in _PATCHED:
+        return True
+    if not _is_kraken_class(cls):
+        return False
+
+    changed = False
+    current_positions = getattr(cls, "get_positions", None)
+    if callable(current_positions) and not getattr(current_positions, _PATCH_ATTR, False):
+        @wraps(current_positions)
+        def get_positions(self: Any, *args: Any, **kwargs: Any):
+            _scrub_instance(self)
+            return _filter_rows(current_positions(self, *args, **kwargs))
+
+        setattr(get_positions, _PATCH_ATTR, True)
+        setattr(get_positions, "__wrapped__", current_positions)
+        cls.get_positions = get_positions
+        changed = True
+
+    current_balance = getattr(cls, "get_account_balance", None)
+    if callable(current_balance) and not getattr(current_balance, _PATCH_ATTR, False):
+        @wraps(current_balance)
+        def get_account_balance(self: Any, *args: Any, **kwargs: Any):
+            _scrub_instance(self)
+            result = current_balance(self, *args, **kwargs)
+            _scrub_instance(self)
+            return result
+
+        setattr(get_account_balance, _PATCH_ATTR, True)
+        setattr(get_account_balance, "__wrapped__", current_balance)
+        cls.get_account_balance = get_account_balance
+        changed = True
+
+    if changed:
+        _PATCHED.add(key)
+        logger.critical(
+            "KRAKEN_SYNTHETIC_EQUITY_POSITION_SCRUB_INSTALLED marker=%s class=%s",
+            _MARKER,
+            cls.__name__,
+        )
+    return changed
+
+
+def _patch_module(module: ModuleType) -> bool:
+    changed = False
+    for name in dir(module):
+        try:
+            obj = getattr(module, name)
+        except Exception:
+            continue
+        if isinstance(obj, type):
+            changed = _patch_class(obj) or changed
+    return changed
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for module in tuple(sys.modules.values()):
+        if isinstance(module, ModuleType):
+            try:
+                changed = _patch_module(module) or changed
+            except Exception:
+                continue
+    for name in ("bot.broker_manager", "broker_manager", "bot.kraken_broker", "kraken_broker"):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        changed = _patch_module(module) or changed
+    return changed
+
+
+def install_import_hook() -> None:
+    global _ORIGINAL_IMPORT
+    _patch_loaded()
+    with _LOCK:
+        if _ORIGINAL_IMPORT is None:
+            _ORIGINAL_IMPORT = builtins.__import__
+            local = threading.local()
+
+            def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+                if getattr(local, "active", False):
+                    return module
+                local.active = True
+                try:
+                    _patch_loaded()
+                finally:
+                    local.active = False
+                return module
+
+            builtins.__import__ = guarded_import  # type: ignore[assignment]
+    _patch_loaded()
+    os.environ["NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED"] = "1"
+    logger.critical("KRAKEN_SYNTHETIC_EQUITY_SCRUB_RUNTIME_INSTALLED marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install", "install_import_hook", "_metadata_name", "_scrub_mapping",
+    "_scrub_instance", "_filter_rows", "_patch_class",
+]

--- a/bot/kraken_synthetic_equity_position_scrub_patch.py
+++ b/bot/kraken_synthetic_equity_position_scrub_patch.py
@@ -1,10 +1,10 @@
 """Remove synthetic accounting metadata before Kraken position classification.
 
 The canonical balance cache may contain fields such as ``canonical_equity`` and
-``total_funds``.  They are accounting metadata, not exchange assets.  This patch
-scrubs those keys from cached balance payloads *before* any Kraken ``get_positions``
-or balance wrapper can classify them, and filters any legacy synthetic rows from
-returned position snapshots.
+``held_excluded_from_equity_sum``. They are accounting metadata, not exchange assets.
+This patch removes only synthetic cache fields before Kraken position classification
+and filters legacy synthetic rows from returned position snapshots. Authoritative
+totals such as ``total_funds`` and ``equity`` remain available to balance accounting.
 """
 from __future__ import annotations
 
@@ -25,17 +25,31 @@ _LOCK = threading.RLock()
 _ORIGINAL_IMPORT = None
 _PATCHED: set[tuple[str, int]] = set()
 
-_EXPLICIT = {
+# These fields are safe to remove from an enriched cache. They are not used by the
+# canonical total helpers and have previously been misclassified as exchange assets.
+_CACHE_REMOVE_EXPLICIT = {
+    "CANONICAL_EQUITY",
+    "CANONICAL_TOTAL",
+    "HELD_EXCLUDED_FROM_EQUITY_SUM",
+}
+_CACHE_REMOVE_PREFIXES = (
+    "CANONICAL_",
+    "HELD_EXCLUDED_",
+)
+
+# Position rows use a broader metadata classifier. Total/equity fields must never
+# become tradable symbols, even though they remain valid balance payload fields.
+_POSITION_METADATA_EXPLICIT = {
     "CANONICAL_EQUITY", "CANONICAL_TOTAL", "TOTAL_FUNDS", "TOTAL_BALANCE",
     "TOTAL_EQUITY", "EQUITY", "PORTFOLIO_VALUE", "ACCOUNT_EQUITY",
     "HELD_EXCLUDED_FROM_EQUITY_SUM", "CRYPTO_USD", "NON_USD_USD",
     "USD_HELD", "USDT_HELD", "USDC_HELD", "TOTAL_HELD",
 }
-_PREFIXES = (
+_POSITION_PREFIXES = (
     "CANONICAL_", "TOTAL_", "AVAILABLE_", "BROKER_", "CAPITAL_",
     "UPDATED_", "OPEN_EXPOSURE_", "RESERVE_", "HELD_EXCLUDED_", "LAST_",
 )
-_SUFFIXES = (
+_POSITION_SUFFIXES = (
     "_EQUITY", "_BALANCE", "_FUNDS", "_CAPITAL", "_EXPOSURE",
     "_VALUE", "_COUNT", "_COMPLETENESS", "_UPDATED",
 )
@@ -45,22 +59,38 @@ _CACHE_ATTRS = (
 )
 
 
-def _metadata_name(value: Any) -> bool:
-    name = str(value or "").strip().upper().replace("-USD", "")
+def _normalized_name(value: Any) -> str:
+    name = str(value or "").strip().upper()
+    for suffix in ("-USD", "/USD", "_USD"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name
+
+
+def _cache_metadata_name(value: Any) -> bool:
+    name = _normalized_name(value)
     if not name:
         return True
-    if name in _EXPLICIT:
+    return name in _CACHE_REMOVE_EXPLICIT or name.startswith(_CACHE_REMOVE_PREFIXES)
+
+
+def _metadata_name(value: Any) -> bool:
+    name = _normalized_name(value)
+    if not name:
+        return True
+    if name in _POSITION_METADATA_EXPLICIT:
         return True
     if "_" not in name:
         return False
-    return name.startswith(_PREFIXES) or name.endswith(_SUFFIXES)
+    return name.startswith(_POSITION_PREFIXES) or name.endswith(_POSITION_SUFFIXES)
 
 
 def _scrub_mapping(payload: Mapping[str, Any]) -> tuple[dict[str, Any], list[str]]:
     cleaned: dict[str, Any] = {}
     removed: list[str] = []
     for key, value in payload.items():
-        if _metadata_name(key):
+        if _cache_metadata_name(key):
             removed.append(str(key))
             continue
         if isinstance(value, Mapping):
@@ -179,12 +209,14 @@ def _patch_module(module: ModuleType) -> bool:
 
 def _patch_loaded() -> bool:
     changed = False
-    for module in tuple(sys.modules.values()):
-        if isinstance(module, ModuleType):
-            try:
-                changed = _patch_module(module) or changed
-            except Exception:
-                continue
+    suffixes = ("broker_manager", "kraken_broker", "broker_integration", "execution_engine")
+    for name, module in tuple(sys.modules.items()):
+        if not name.endswith(suffixes) or not isinstance(module, ModuleType):
+            continue
+        try:
+            changed = _patch_module(module) or changed
+        except Exception:
+            continue
     for name in ("bot.broker_manager", "broker_manager", "bot.kraken_broker", "kraken_broker"):
         try:
             module = importlib.import_module(name)
@@ -206,6 +238,8 @@ def install_import_hook() -> None:
                 module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
                 if getattr(local, "active", False):
                     return module
+                if not str(name or "").endswith(("broker_manager", "kraken_broker", "broker_integration", "execution_engine")):
+                    return module
                 local.active = True
                 try:
                     _patch_loaded()
@@ -224,6 +258,6 @@ def install() -> None:
 
 
 __all__ = [
-    "install", "install_import_hook", "_metadata_name", "_scrub_mapping",
-    "_scrub_instance", "_filter_rows", "_patch_class",
+    "install", "install_import_hook", "_cache_metadata_name", "_metadata_name",
+    "_scrub_mapping", "_scrub_instance", "_filter_rows", "_patch_class",
 ]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -15,16 +15,18 @@ _INSTALLED = False
 _LOCK = threading.RLock()
 
 # Installation order is intentional. The canonical owner is installed first and
-# its delegated-reentry helper is patched immediately afterward. Cost-basis
-# compatibility precedes exact snapshot reconciliation. Kraken exit recovery is
-# made strictly exit-only before the final profit-realization guard is installed.
+# its delegated-reentry helper is patched immediately afterward. The Kraken
+# metadata filter is installed before dynamic equity hydration so no early balance
+# cycle can classify enriched accounting fields as assets. Exit recovery is made
+# strictly exit-only before the final profit-realization guard is installed.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
-    ("bot.kraken_equity_runtime_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
+    ("bot.kraken_equity_runtime_patch", "install_import_hook"),
+    ("bot.kraken_synthetic_equity_position_scrub_patch", "install_import_hook"),
     ("bot.kraken_equity_double_count_guard_patch", "install_import_hook"),
     ("bot.kraken_margin_auto_runtime_patch", "install_import_hook"),
     ("bot.kraken_all_account_exit_runtime_patch", "install_import_hook"),
@@ -40,6 +42,7 @@ _INSTALLERS = (
 _REQUIRED_FLAGS = {
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
     "kraken_equity_metadata_guard": "NIJA_KRAKEN_EQUITY_METADATA_GUARD_INSTALLED",
+    "kraken_synthetic_equity_scrub": "NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED",
     "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
     "profit_realization_guard": "NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED",
 }

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,17 +10,17 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260714-runtime-convergence-v6"
+RELEASE_ID = "20260714-runtime-convergence-v7"
 _INSTALLED = False
 _LOCK = threading.RLock()
 
-# Installation order is intentional. Cost-basis compatibility must be active
-# before exact snapshots reconcile legacy positions. Dynamic Kraken valuation is
-# installed before the metadata and double-count guards that constrain its output.
-# Profit realization is installed after every account/exit guard so it sees the
-# final verified-cost and writer-authorized decision chain.
+# Installation order is intentional. The canonical owner is installed first and
+# its delegated-reentry helper is patched immediately afterward. Cost-basis
+# compatibility precedes exact snapshot reconciliation. Kraken exit recovery is
+# made strictly exit-only before the final profit-realization guard is installed.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
+    ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_runtime_patch", "install_import_hook"),
@@ -32,9 +32,17 @@ _INSTALLERS = (
     ("bot.kraken_exit_final_guards_patch", "install_import_hook"),
     ("bot.kraken_exit_execution_safety_patch", "install_import_hook"),
     ("bot.kraken_exit_margin_cost_patch", "install_import_hook"),
+    ("bot.kraken_exit_only_recovery_phase_guard_patch", "install_import_hook"),
     ("bot.kraken_profit_realization_guard_patch", "install_import_hook"),
     ("bot.coinbase_pem_quarantine_patch", "install_import_hook"),
 )
+
+_REQUIRED_FLAGS = {
+    "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
+    "kraken_equity_metadata_guard": "NIJA_KRAKEN_EQUITY_METADATA_GUARD_INSTALLED",
+    "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
+    "profit_realization_guard": "NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED",
+}
 
 
 def _deployment_sha() -> str:
@@ -59,15 +67,7 @@ def _invoke(module_name: str, function_name: str) -> tuple[bool, str]:
 
 
 def _expected_scan_wrapper_release() -> str:
-    """Read the release contract from the installed scan-owner module itself.
-
-    The previous manifest hard-coded an older release string. A legitimate scan
-    owner upgrade from ``20260713-scan-wrapper-v2`` to ``20260714a`` therefore
-    made the entire runtime fail closed even though every installer succeeded.
-    Binding the audit to the module's own marker keeps the contract strict without
-    making routine compatible upgrades look unsafe.
-    """
-
+    """Read the strict scan-owner release contract from the installed module."""
     try:
         module = importlib.import_module("scan_wrapper_convergence_repair_patch")
         return str(getattr(module, "_MARKER", "") or "").strip()
@@ -99,12 +99,13 @@ def _audit() -> tuple[bool, dict[str, str]]:
     else:
         results["scan_wrapper_release"] = scan_release
 
-    profit_guard = str(os.environ.get("NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED", "") or "").strip()
-    if profit_guard != "1":
-        ready = False
-        results["profit_realization_guard"] = profit_guard or "missing"
-    else:
-        results["profit_realization_guard"] = "ready"
+    for label, flag in _REQUIRED_FLAGS.items():
+        value = str(os.environ.get(flag, "") or "").strip()
+        if value != "1":
+            ready = False
+            results[label] = value or "missing"
+        else:
+            results[label] = "ready"
     return ready, results
 
 

--- a/bot/scan_reentrant_delegate_repair_patch.py
+++ b/bot/scan_reentrant_delegate_repair_patch.py
@@ -1,17 +1,16 @@
 """Recover legitimate same-thread scan delegation without disabling scan ownership.
 
-The canonical scan owner intentionally suppresses a true recursive call.  Some legacy
-wrappers, however, capture an older canonical method and delegate through it after a
-newer canonical owner has already acquired the same account lock.  Both wrappers use
-the same process-wide scan state, so that legitimate delegation looks recursive and
-returns ``scored=0, blocked=1``.
+The canonical scan owner intentionally suppresses a true recursive call. Some legacy
+wrappers capture an older canonical method and delegate through it after a newer
+canonical owner has already acquired the same account lock. Both owners share the
+same process-wide state, so that legitimate delegation looks recursive and returns
+``scored=0, blocked=1``.
 
-This patch changes only the canonical owner's *reentry recovery helper*.  During
-normal installation/canonicalization the existing strict known-wrapper unwrapping is
-preserved.  During an active ``run_scan_phase`` reentry, the helper may continue down
-explicit ``__wrapped__`` links and narrowly named closure-held originals to reach the
-real core scan exactly once.  Risk gates and telemetry wrappers already entered by
-the outer call are not re-entered or bypassed globally.
+This patch changes only the canonical owner's reentry recovery helper. The first
+reentry bypass executes the canonical instance's existing base unchanged, preserving
+all remaining risk and telemetry wrappers exactly once. Only if that base itself
+re-enters the owner does a narrowly constrained explicit-wrapper/closure walk select
+the deepest callable target. Normal installation canonicalization remains strict.
 """
 from __future__ import annotations
 
@@ -30,6 +29,7 @@ _MARKER = "20260714-scan-delegate-v1"
 _PATCH_ATTR = "_nija_scan_reentrant_delegate_repair_v1"
 _LOCK = threading.RLock()
 _WATCHDOG_STARTED = False
+_TLS = threading.local()
 
 _CLOSURE_ORIGINAL_NAMES = (
     "original_run_scan_phase",
@@ -99,6 +99,21 @@ def _caller_is_active_scan() -> bool:
         del frame
 
 
+def _preserving_delegate(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Return a one-shot bypass that executes *func* with its wrapper chain intact."""
+    @wraps(func)
+    def delegated(*args: Any, **kwargs: Any):
+        previous = bool(getattr(_TLS, "recovering", False))
+        _TLS.recovering = True
+        try:
+            return func(*args, **kwargs)
+        finally:
+            _TLS.recovering = previous
+
+    setattr(delegated, "_nija_scan_preserving_delegate", True)
+    return delegated
+
+
 def _patch_module(module: ModuleType) -> bool:
     current = getattr(module, "_unwrap_known", None)
     if not callable(current):
@@ -112,6 +127,18 @@ def _patch_module(module: ModuleType) -> bool:
         if cycle or not _caller_is_active_scan() or not callable(resolved):
             return resolved, depth, cycle
 
+        if not bool(getattr(_TLS, "recovering", False)):
+            delegated = _preserving_delegate(resolved)
+            logger.critical(
+                "SCAN_REENTRANT_DELEGATION_RECOVERED marker=%s base=%s target=preserving_delegate removed_layers=%d",
+                _MARKER,
+                getattr(resolved, "__qualname__", getattr(resolved, "__name__", "unknown")),
+                depth + 1,
+            )
+            return delegated, depth + 1, False
+
+        # A second owner reentry from inside the preserved base indicates another
+        # captured canonical layer. Walk only explicit wrapper/closure links now.
         delegated, extra_depth, delegated_cycle = _unwrap_delegate(resolved)
         if delegated_cycle:
             logger.error(
@@ -123,7 +150,7 @@ def _patch_module(module: ModuleType) -> bool:
             return resolved, depth, True
         if callable(delegated) and delegated is not resolved and extra_depth > 0:
             logger.critical(
-                "SCAN_REENTRANT_DELEGATION_RECOVERED marker=%s base=%s target=%s removed_layers=%d",
+                "SCAN_REENTRANT_CAPTURED_OWNER_UNWRAPPED marker=%s base=%s target=%s removed_layers=%d",
                 _MARKER,
                 getattr(resolved, "__qualname__", getattr(resolved, "__name__", "unknown")),
                 getattr(delegated, "__qualname__", getattr(delegated, "__name__", "unknown")),
@@ -190,5 +217,6 @@ __all__ = [
     "install_import_hook",
     "_closure_original",
     "_unwrap_delegate",
+    "_preserving_delegate",
     "_patch_module",
 ]

--- a/bot/scan_reentrant_delegate_repair_patch.py
+++ b/bot/scan_reentrant_delegate_repair_patch.py
@@ -1,0 +1,194 @@
+"""Recover legitimate same-thread scan delegation without disabling scan ownership.
+
+The canonical scan owner intentionally suppresses a true recursive call.  Some legacy
+wrappers, however, capture an older canonical method and delegate through it after a
+newer canonical owner has already acquired the same account lock.  Both wrappers use
+the same process-wide scan state, so that legitimate delegation looks recursive and
+returns ``scored=0, blocked=1``.
+
+This patch changes only the canonical owner's *reentry recovery helper*.  During
+normal installation/canonicalization the existing strict known-wrapper unwrapping is
+preserved.  During an active ``run_scan_phase`` reentry, the helper may continue down
+explicit ``__wrapped__`` links and narrowly named closure-held originals to reach the
+real core scan exactly once.  Risk gates and telemetry wrappers already entered by
+the outer call are not re-entered or bypassed globally.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.scan_reentrant_delegate_repair")
+_MARKER = "20260714-scan-delegate-v1"
+_PATCH_ATTR = "_nija_scan_reentrant_delegate_repair_v1"
+_LOCK = threading.RLock()
+_WATCHDOG_STARTED = False
+
+_CLOSURE_ORIGINAL_NAMES = (
+    "original_run_scan_phase",
+    "original_scan_phase",
+    "original_method",
+    "wrapped_run_scan_phase",
+    "wrapped",
+    "original",
+    "base",
+)
+
+
+def _closure_original(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    """Return a narrowly identified wrapped scan function from *func*'s closure."""
+    try:
+        code = getattr(func, "__code__", None)
+        closure = tuple(getattr(func, "__closure__", ()) or ())
+        freevars = tuple(getattr(code, "co_freevars", ()) or ())
+        values = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+    except Exception:
+        return None
+
+    for name in _CLOSURE_ORIGINAL_NAMES:
+        candidate = values.get(name)
+        if callable(candidate):
+            return candidate
+    return None
+
+
+def _next_delegate(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    wrapped = getattr(func, "__wrapped__", None)
+    if callable(wrapped):
+        return wrapped
+    return _closure_original(func)
+
+
+def _unwrap_delegate(func: Callable[..., Any]) -> tuple[Callable[..., Any], int, bool]:
+    """Walk explicit wrapper/delegate links to the deepest callable target."""
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    cycle = False
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            cycle = True
+            break
+        seen.add(ident)
+        nxt = _next_delegate(current)
+        if not callable(nxt):
+            break
+        current = nxt
+        depth += 1
+        if depth >= 4096:
+            cycle = True
+            break
+    return current, depth, cycle
+
+
+def _caller_is_active_scan() -> bool:
+    """True only when the canonical wrapper is asking for reentry recovery."""
+    frame = inspect.currentframe()
+    try:
+        caller = frame.f_back.f_back if frame and frame.f_back else None
+        return bool(caller and caller.f_code.co_name == "run_scan_phase")
+    finally:
+        del frame
+
+
+def _patch_module(module: ModuleType) -> bool:
+    current = getattr(module, "_unwrap_known", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def unwrap_known(func: Callable[..., Any]):
+        resolved, depth, cycle = current(func)
+        if cycle or not _caller_is_active_scan() or not callable(resolved):
+            return resolved, depth, cycle
+
+        delegated, extra_depth, delegated_cycle = _unwrap_delegate(resolved)
+        if delegated_cycle:
+            logger.error(
+                "SCAN_REENTRANT_DELEGATE_CYCLE marker=%s base=%s depth=%d",
+                _MARKER,
+                getattr(resolved, "__qualname__", getattr(resolved, "__name__", "unknown")),
+                depth + extra_depth,
+            )
+            return resolved, depth, True
+        if callable(delegated) and delegated is not resolved and extra_depth > 0:
+            logger.critical(
+                "SCAN_REENTRANT_DELEGATION_RECOVERED marker=%s base=%s target=%s removed_layers=%d",
+                _MARKER,
+                getattr(resolved, "__qualname__", getattr(resolved, "__name__", "unknown")),
+                getattr(delegated, "__qualname__", getattr(delegated, "__name__", "unknown")),
+                depth + extra_depth,
+            )
+            return delegated, depth + extra_depth, False
+        return resolved, depth, cycle
+
+    setattr(unwrap_known, _PATCH_ATTR, True)
+    setattr(unwrap_known, "__wrapped__", current)
+    module._unwrap_known = unwrap_known
+    os.environ["NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED"] = "1"
+    logger.critical(
+        "SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED marker=%s strict_install_unwrap_preserved=true",
+        _MARKER,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in (
+        "scan_wrapper_convergence_repair_patch",
+        "nija.scan_wrapper_convergence_repair_patch",
+    ):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(module, ModuleType):
+            changed = _patch_module(module) or changed
+    return changed
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            _patch_loaded()
+        except Exception as exc:
+            logger.warning("SCAN_REENTRANT_DELEGATE_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
+        time.sleep(0.5)
+
+
+def install_import_hook() -> None:
+    global _WATCHDOG_STARTED
+    with _LOCK:
+        if not _patch_loaded():
+            raise RuntimeError("scan_wrapper_convergence_repair_not_patchable")
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="ScanReentrantDelegateRepair",
+                daemon=True,
+            ).start()
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_closure_original",
+    "_unwrap_delegate",
+    "_patch_module",
+]

--- a/bot/tests/test_kraken_exit_only_recovery_phase_guard.py
+++ b/bot/tests/test_kraken_exit_only_recovery_phase_guard.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "kraken_exit_only_recovery_guard_under_test",
+        BOT_DIR / "kraken_exit_only_recovery_phase_guard_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class KrakenBroker:
+    broker_type = "kraken"
+
+
+class CoinbaseBroker:
+    broker_type = "coinbase"
+
+
+def test_kraken_recovery_skips_full_run_cycle_and_calls_direct_exit_scan(monkeypatch):
+    module = _load()
+    calls = {"original": 0, "exit_scan": 0, "sync": 0, "adopt": 0}
+
+    def original(trader, identity, broker):
+        calls["original"] += 1
+        return 99, 99
+
+    recovery = SimpleNamespace(
+        __name__="account_exit_management_recovery_patch",
+        _adopt_and_manage=original,
+        _position_count=lambda broker: 2,
+        _open_order_count=lambda broker: 0,
+    )
+
+    class Strategy:
+        def adopt_existing_positions(self, **kwargs):
+            calls["adopt"] += 1
+            return {"positions_found": 2, "positions_adopted": 2, "open_orders_count": 0}
+
+    trader = SimpleNamespace(trading_strategy=Strategy())
+    monkeypatch.setattr(module, "_scan_exits", lambda trader, identity, broker: calls.__setitem__("exit_scan", calls["exit_scan"] + 1) or 1)
+    monkeypatch.setattr(module, "_refresh_exact_snapshot", lambda strategy, broker, identity: calls.__setitem__("sync", calls["sync"] + 1))
+
+    assert module._patch_recovery_module(recovery) is True
+    positions, orders = recovery._adopt_and_manage(trader, "platform:kraken", KrakenBroker())
+
+    assert positions == 2
+    assert orders == 0
+    assert calls == {"original": 0, "exit_scan": 1, "sync": 1, "adopt": 1}
+
+
+def test_non_kraken_recovery_behavior_is_unchanged():
+    module = _load()
+    calls = {"original": 0}
+
+    def original(trader, identity, broker):
+        calls["original"] += 1
+        return 3, 4
+
+    recovery = SimpleNamespace(
+        __name__="account_exit_management_recovery_patch",
+        _adopt_and_manage=original,
+        _position_count=lambda broker: 0,
+        _open_order_count=lambda broker: 0,
+    )
+    module._patch_recovery_module(recovery)
+
+    assert recovery._adopt_and_manage(SimpleNamespace(), "platform:coinbase", CoinbaseBroker()) == (3, 4)
+    assert calls["original"] == 1

--- a/bot/tests/test_kraken_synthetic_equity_position_scrub_patch.py
+++ b/bot/tests/test_kraken_synthetic_equity_position_scrub_patch.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "kraken_synthetic_equity_scrub_under_test",
+        BOT_DIR / "kraken_synthetic_equity_position_scrub_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scrub_mapping_removes_accounting_metadata_but_preserves_assets():
+    module = _load()
+    cleaned, removed = module._scrub_mapping(
+        {
+            "ZUSD": "100.00",
+            "SOL": "1.25",
+            "AIR": "2901.0",
+            "CANONICAL_EQUITY": 230.32,
+            "TOTAL_FUNDS": 230.32,
+            "result": {
+                "ETH": "0.5",
+                "HELD_EXCLUDED_FROM_EQUITY_SUM": True,
+            },
+        }
+    )
+
+    assert cleaned["ZUSD"] == "100.00"
+    assert cleaned["SOL"] == "1.25"
+    assert cleaned["AIR"] == "2901.0"
+    assert cleaned["result"]["ETH"] == "0.5"
+    assert "CANONICAL_EQUITY" not in cleaned
+    assert "TOTAL_FUNDS" not in cleaned
+    assert "CANONICAL_EQUITY" in removed
+    assert "result.HELD_EXCLUDED_FROM_EQUITY_SUM" in removed
+
+
+def test_filter_rows_removes_only_synthetic_positions():
+    module = _load()
+    rows = [
+        {"symbol": "CANONICAL_EQUITY-USD", "quantity": 230.32},
+        {"symbol": "SOL-USD", "quantity": 1.0},
+        {"symbol": "XDC-USD", "quantity": 72.8198},
+    ]
+
+    filtered = module._filter_rows(rows)
+    assert [row["symbol"] for row in filtered] == ["SOL-USD", "XDC-USD"]
+
+
+def test_real_underscore_free_kraken_assets_are_not_metadata():
+    module = _load()
+    for symbol in ("SOL", "ETH", "AIR", "XDC", "TNSR", "MOVR", "ORCA"):
+        assert module._metadata_name(symbol) is False

--- a/bot/tests/test_kraken_synthetic_equity_position_scrub_patch.py
+++ b/bot/tests/test_kraken_synthetic_equity_position_scrub_patch.py
@@ -18,7 +18,7 @@ def _load():
     return module
 
 
-def test_scrub_mapping_removes_accounting_metadata_but_preserves_assets():
+def test_scrub_mapping_removes_only_synthetic_cache_metadata():
     module = _load()
     cleaned, removed = module._scrub_mapping(
         {
@@ -27,6 +27,8 @@ def test_scrub_mapping_removes_accounting_metadata_but_preserves_assets():
             "AIR": "2901.0",
             "CANONICAL_EQUITY": 230.32,
             "TOTAL_FUNDS": 230.32,
+            "EQUITY": 230.32,
+            "CRYPTO_USD": 30.32,
             "result": {
                 "ETH": "0.5",
                 "HELD_EXCLUDED_FROM_EQUITY_SUM": True,
@@ -37,17 +39,21 @@ def test_scrub_mapping_removes_accounting_metadata_but_preserves_assets():
     assert cleaned["ZUSD"] == "100.00"
     assert cleaned["SOL"] == "1.25"
     assert cleaned["AIR"] == "2901.0"
+    assert cleaned["TOTAL_FUNDS"] == 230.32
+    assert cleaned["EQUITY"] == 230.32
+    assert cleaned["CRYPTO_USD"] == 30.32
     assert cleaned["result"]["ETH"] == "0.5"
     assert "CANONICAL_EQUITY" not in cleaned
-    assert "TOTAL_FUNDS" not in cleaned
     assert "CANONICAL_EQUITY" in removed
     assert "result.HELD_EXCLUDED_FROM_EQUITY_SUM" in removed
 
 
-def test_filter_rows_removes_only_synthetic_positions():
+def test_filter_rows_removes_accounting_fields_when_presented_as_positions():
     module = _load()
     rows = [
         {"symbol": "CANONICAL_EQUITY-USD", "quantity": 230.32},
+        {"symbol": "TOTAL_FUNDS-USD", "quantity": 230.32},
+        {"symbol": "EQUITY-USD", "quantity": 230.32},
         {"symbol": "SOL-USD", "quantity": 1.0},
         {"symbol": "XDC-USD", "quantity": 72.8198},
     ]
@@ -56,7 +62,8 @@ def test_filter_rows_removes_only_synthetic_positions():
     assert [row["symbol"] for row in filtered] == ["SOL-USD", "XDC-USD"]
 
 
-def test_real_underscore_free_kraken_assets_are_not_metadata():
+def test_real_kraken_assets_are_not_metadata():
     module = _load()
-    for symbol in ("SOL", "ETH", "AIR", "XDC", "TNSR", "MOVR", "ORCA"):
+    for symbol in ("SOL", "ETH", "AIR", "XDC", "TNSR", "MOVR", "ORCA", "1INCH"):
         assert module._metadata_name(symbol) is False
+        assert module._cache_metadata_name(symbol) is False

--- a/bot/tests/test_scan_reentrant_delegate_repair_patch.py
+++ b/bot/tests/test_scan_reentrant_delegate_repair_patch.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "scan_reentrant_delegate_repair_under_test",
+        BOT_DIR / "scan_reentrant_delegate_repair_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_active_scan_reentry_continues_to_leaf_wrapper_target(monkeypatch):
+    module = _load()
+
+    def leaf(self=None):
+        return "scanned"
+
+    def legacy_wrapper(self=None):
+        return "wrapper"
+
+    legacy_wrapper.__wrapped__ = leaf
+
+    def original_unwrap(func):
+        return func, 0, False
+
+    target = SimpleNamespace(_unwrap_known=original_unwrap)
+    assert module._patch_module(target) is True
+
+    def run_scan_phase():
+        return target._unwrap_known(legacy_wrapper)
+
+    resolved, depth, cycle = run_scan_phase()
+    assert resolved is leaf
+    assert depth == 1
+    assert cycle is False
+
+
+def test_install_time_unwrap_remains_strict_and_unchanged():
+    module = _load()
+
+    def leaf():
+        return None
+
+    def legacy_wrapper():
+        return None
+
+    legacy_wrapper.__wrapped__ = leaf
+
+    def original_unwrap(func):
+        return func, 0, False
+
+    target = SimpleNamespace(_unwrap_known=original_unwrap)
+    module._patch_module(target)
+
+    def install_path():
+        return target._unwrap_known(legacy_wrapper)
+
+    resolved, depth, cycle = install_path()
+    assert resolved is legacy_wrapper
+    assert depth == 0
+    assert cycle is False
+
+
+def test_closure_held_original_is_recovered():
+    module = _load()
+
+    def leaf(self=None):
+        return "leaf"
+
+    original_run_scan_phase = leaf
+
+    def legacy_wrapper(self=None):
+        return original_run_scan_phase(self)
+
+    resolved, depth, cycle = module._unwrap_delegate(legacy_wrapper)
+    assert resolved is leaf
+    assert depth == 1
+    assert cycle is False

--- a/bot/tests/test_scan_reentrant_delegate_repair_patch.py
+++ b/bot/tests/test_scan_reentrant_delegate_repair_patch.py
@@ -19,14 +19,17 @@ def _load():
     return module
 
 
-def test_active_scan_reentry_continues_to_leaf_wrapper_target(monkeypatch):
+def test_active_scan_reentry_preserves_remaining_wrapper_chain():
     module = _load()
+    calls = []
 
     def leaf(self=None):
+        calls.append("leaf")
         return "scanned"
 
     def legacy_wrapper(self=None):
-        return "wrapper"
+        calls.append("wrapper")
+        return leaf(self)
 
     legacy_wrapper.__wrapped__ = leaf
 
@@ -40,6 +43,39 @@ def test_active_scan_reentry_continues_to_leaf_wrapper_target(monkeypatch):
         return target._unwrap_known(legacy_wrapper)
 
     resolved, depth, cycle = run_scan_phase()
+    assert resolved is not legacy_wrapper
+    assert getattr(resolved, "_nija_scan_preserving_delegate", False) is True
+    assert resolved(None) == "scanned"
+    assert calls == ["wrapper", "leaf"]
+    assert depth == 1
+    assert cycle is False
+
+
+def test_nested_recovery_can_unwrap_captured_owner_to_leaf():
+    module = _load()
+
+    def leaf(self=None):
+        return "leaf"
+
+    def captured_owner(self=None):
+        return leaf(self)
+
+    captured_owner.__wrapped__ = leaf
+
+    def original_unwrap(func):
+        return func, 0, False
+
+    target = SimpleNamespace(_unwrap_known=original_unwrap)
+    module._patch_module(target)
+    module._TLS.recovering = True
+    try:
+        def run_scan_phase():
+            return target._unwrap_known(captured_owner)
+
+        resolved, depth, cycle = run_scan_phase()
+    finally:
+        module._TLS.recovering = False
+
     assert resolved is leaf
     assert depth == 1
     assert cycle is False


### PR DESCRIPTION
## Runtime evidence

The July 14 Render log reaches Phase 3 with 820 symbols but immediately emits `REENTRANT_SCAN_SUPPRESSED marker=20260714a identity=platform:kraken reason=true_recursive_call`, ending with `scored=0 entered=0 blocked=1` and no execution attempts. The same process still classifies `CANONICAL_EQUITY` as a Kraken asset and creates `CANONICAL_EQUITY-USD`.

The recursion occurs while the account-exit recovery path is running. That recovery path disallows entries but still invokes the full `TradingStrategy.run_cycle(user_mode=True)`, which enters Phase 3 and collides with the normal independent Kraken trader.

## Repairs

### Strictly exit-only Kraken recovery

- Kraken account recovery no longer invokes the full strategy cycle.
- It adopts positions, refreshes the exact exchange snapshot on a bounded interval, and invokes the account-local Kraken exit scanner directly.
- Phase 3 is skipped and entries remain disabled.
- Non-Kraken recovery behavior is unchanged.

### Delegated scan reentry recovery

- The canonical owner remains the single account-scoped scan lock.
- Legitimate same-thread delegation through a captured older canonical owner is recovered rather than returned as `blocked=1`.
- The first bypass preserves the remaining risk and telemetry wrapper chain exactly once.
- A second captured owner is unwrapped only through explicit `__wrapped__` links or narrowly named closure-held originals.
- True cycles and overlapping cross-thread calls remain fail-closed.

### Synthetic Kraken equity prevention

- Metadata filtering is installed before dynamic Kraken equity hydration so an early balance cycle cannot create a fake asset.
- Existing enriched caches are scrubbed of only synthetic fields such as `canonical_equity` and `held_excluded_from_equity_sum`.
- Authoritative totals including `total_funds`, `total_balance`, `equity`, and `crypto_usd` remain intact.
- Legacy fake position rows such as `CANONICAL_EQUITY-USD` are removed while real assets such as SOL, ETH, AIR, XDC, TNSR, MOVR, ORCA, and 1INCH remain eligible.

## Runtime contract

The release manifest is bumped to `20260714-runtime-convergence-v7` and requires all of the following before `ready=true`:

- delegated-scan recovery
- Kraken metadata guard
- synthetic-equity cache/position scrub
- exit-only Kraken recovery
- confirmed net-positive profit realization

## Profit-taking preservation

The v6 confirmed-profit policy remains active:

- 0.8% estimated round-trip cost buffer
- 0.15% slippage reserve
- at least 0.4% estimated net profit above adjusted break-even for normal take-profit exits
- fee-adjusted break-even only after the configured hold period
- position tracker cleared only after terminal Kraken fill confirmation
- emergency stop-loss and critical-margin reductions remain authoritative

## Regression coverage

- active same-thread delegation preserves remaining wrappers
- nested captured owner reaches the leaf scan without suppression
- install-time canonicalization stays strict
- Kraken recovery calls direct exit scanning and never the full strategy cycle
- non-Kraken recovery remains unchanged
- synthetic cache fields are removed without deleting authoritative totals
- fake accounting position rows are filtered while real Kraken assets remain available

## Expected Render proof

- `NIJA_RUNTIME_RELEASE_MANIFEST release=20260714-runtime-convergence-v7 ... ready=true`
- `SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED`
- `KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED`
- `KRAKEN_EXIT_ONLY_RECOVERY_CYCLE ... phase3_skipped=true direct_exit_scanner=true`
- `KRAKEN_SYNTHETIC_EQUITY_SCRUB_RUNTIME_INSTALLED`
- no recurring `CANONICAL_EQUITY-USD`
- no recurring `REENTRANT_SCAN_SUPPRESSED ... reason=true_recursive_call`
- `KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED`

No writer fencing, private Kraken authentication, verified cost basis, ECEL validation, exchange minimum, slippage, margin-health, stop-loss, or broker acknowledgement control is bypassed.

## CI infrastructure status

The current imports-smoke job terminated before repository checkout or test execution. GitHub reports `steps=None` and no job log URL, so the red Actions state contains no actionable code-level failure.