### PR TITLE
Correct broker-local Render readiness reporting

### DIFF
--- a/bot/broker_bool_guard_patch.py
+++ b/bot/broker_bool_guard_patch.py
@@ -141,6 +141,15 @@ def _install_scan_reentrant_delegate_repair() -> None:
     )
 
 
+def _install_broker_local_readiness_contract() -> None:
+    _install_module(
+        "broker_local_readiness_contract_patch",
+        "broker_local_readiness_contract_patch",
+        "BROKER_LOCAL_READINESS_CONTRACT",
+        "20260714-broker-local-readiness-v1",
+    )
+
+
 def _install_strategy_backrefs() -> None:
     _install_module("bot.strategy_broker_backref_patch", "strategy_broker_backref_patch", "BROKER_BOOL_GUARD_STRATEGY_BACKREF", "20260705d")
 
@@ -216,16 +225,18 @@ def _install_coinbase_pem_quarantine() -> None:
 
 
 def _install_runtime_release_manifest() -> None:
-    _install_module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch", "RUNTIME_RELEASE_MANIFEST", "20260714-runtime-convergence-v7")
+    _install_module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch", "RUNTIME_RELEASE_MANIFEST", "20260714-runtime-convergence-v8")
 
 
 def install_import_hook() -> None:
-    # Order matters. Converge scan ownership and delegated reentry first. Install
-    # synthetic-metadata filtering before dynamic Kraken equity hydration so no early
-    # balance cycle can create CANONICAL_EQUITY-USD. Make recovery exit-only before
-    # profit realization, then publish the strict release manifest last.
+    # Order matters. Converge scan ownership and delegated reentry first, then
+    # normalize broker-local readiness before publishing any release/readiness state.
+    # Install synthetic-metadata filtering before dynamic Kraken equity hydration so
+    # no early balance cycle can create CANONICAL_EQUITY-USD. Make recovery exit-only
+    # before profit realization, then publish the strict release manifest last.
     _install_scan_wrapper_convergence()
     _install_scan_reentrant_delegate_repair()
+    _install_broker_local_readiness_contract()
     _install_trade_cycle_convergence_repair()
     _install_position_sync_runtime_repair()
     _install_kraken_equity_metadata_guard()

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,18 +10,20 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260714-runtime-convergence-v7"
+RELEASE_ID = "20260714-runtime-convergence-v8"
 _INSTALLED = False
 _LOCK = threading.RLock()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 # Installation order is intentional. The canonical owner is installed first and
-# its delegated-reentry helper is patched immediately afterward. The Kraken
-# metadata filter is installed before dynamic equity hydration so no early balance
-# cycle can classify enriched accounting fields as assets. Exit recovery is made
+# its delegated-reentry helper is patched immediately afterward. Broker-local
+# readiness is normalized before the strict release contract is published. Kraken
+# metadata filtering precedes dynamic equity hydration, and exit recovery is made
 # strictly exit-only before the final profit-realization guard is installed.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
+    ("broker_local_readiness_contract_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
@@ -41,11 +43,16 @@ _INSTALLERS = (
 
 _REQUIRED_FLAGS = {
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
+    "broker_local_readiness_contract": "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
     "kraken_equity_metadata_guard": "NIJA_KRAKEN_EQUITY_METADATA_GUARD_INSTALLED",
     "kraken_synthetic_equity_scrub": "NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED",
     "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
     "profit_realization_guard": "NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED",
 }
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in _TRUE
 
 
 def _deployment_sha() -> str:
@@ -84,6 +91,30 @@ def _scan_release_compatible(actual: str, expected: str) -> bool:
     return bool(actual and expected and actual == expected)
 
 
+def _readiness_contract_consistent() -> tuple[bool, str]:
+    policy = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "") or "").strip().lower()
+    missing = str(os.environ.get("NIJA_REQUIRED_VENUES_MISSING", "") or "").strip().strip(",")
+    required_ready = _truthy(os.environ.get("NIJA_REQUIRED_VENUES_READY"))
+    global_ready = _truthy(
+        os.environ.get(
+            "NIJA_GLOBAL_TRADING_READY",
+            os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0"),
+        )
+    )
+    active = str(os.environ.get("NIJA_ACTIVE_LIVE_VENUES", "") or "").strip().strip(",")
+
+    if policy not in {"broker_local", "global_all_required", "optional"}:
+        return False, f"invalid_policy:{policy or 'missing'}"
+    if missing and required_ready:
+        return False, f"contradiction:missing={missing};required_ready=1"
+    if global_ready and not active:
+        return False, "contradiction:global_ready=1;active_live_venues=missing"
+    return True, (
+        f"policy={policy};required_ready={int(required_ready)};missing={missing or 'none'};"
+        f"global_ready={int(global_ready)};active={active or 'none'}"
+    )
+
+
 def _audit() -> tuple[bool, dict[str, str]]:
     results: dict[str, str] = {}
     ready = True
@@ -109,6 +140,10 @@ def _audit() -> tuple[bool, dict[str, str]]:
             results[label] = value or "missing"
         else:
             results[label] = "ready"
+
+    contract_ok, contract_reason = _readiness_contract_consistent()
+    results["readiness_contract"] = contract_reason
+    ready = ready and contract_ok
     return ready, results
 
 
@@ -158,4 +193,5 @@ __all__ = [
     "_deployment_sha",
     "_expected_scan_wrapper_release",
     "_scan_release_compatible",
+    "_readiness_contract_consistent",
 ]

--- a/bot/tests/test_broker_local_readiness_contract_patch.py
+++ b/bot/tests/test_broker_local_readiness_contract_patch.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import broker_local_readiness_contract_patch as contract
+
+
+def _module(monkeypatch, *, missing, statuses, strict=True):
+    module = ModuleType("secondary_venue_strict_readiness_patch")
+    module.strict_mode_enabled = lambda: strict
+
+    def refresh_readiness(*, force_log=False):
+        del force_log
+        return True, list(missing), dict(statuses)
+
+    module.refresh_readiness = refresh_readiness
+    return module
+
+
+def _clear(monkeypatch):
+    for name in (
+        "NIJA_SECONDARY_VENUE_POLICY",
+        "NIJA_REQUIRED_VENUES_READY",
+        "NIJA_MULTI_BROKER_TRADING_READY",
+        "NIJA_GLOBAL_TRADING_READY",
+        "NIJA_ACTIVE_LIVE_VENUES",
+        "NIJA_REQUIRED_VENUES_MISSING",
+        "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_missing_secondaries_are_reported_not_ready_while_kraken_is_global_ready(monkeypatch):
+    _clear(monkeypatch)
+    module = _module(
+        monkeypatch,
+        missing=["coinbase", "okx"],
+        statuses={
+            "kraken": {"ready": True},
+            "coinbase": {"ready": False},
+            "okx": {"ready": False},
+        },
+    )
+
+    assert contract._patch_module(module) is True
+    global_ready, missing, statuses = module.refresh_readiness(force_log=True)
+
+    assert global_ready is True
+    assert missing == ["coinbase", "okx"]
+    assert statuses["kraken"]["ready"] is True
+    assert contract.os.environ["NIJA_SECONDARY_VENUE_POLICY"] == "broker_local"
+    assert contract.os.environ["NIJA_REQUIRED_VENUES_READY"] == "0"
+    assert contract.os.environ["NIJA_GLOBAL_TRADING_READY"] == "1"
+    assert contract.os.environ["NIJA_MULTI_BROKER_TRADING_READY"] == "1"
+    assert contract.os.environ["NIJA_ACTIVE_LIVE_VENUES"] == "kraken"
+    assert contract.os.environ["NIJA_REQUIRED_VENUES_MISSING"] == "coinbase,okx"
+
+
+def test_no_active_broker_is_globally_not_ready(monkeypatch):
+    _clear(monkeypatch)
+    module = _module(
+        monkeypatch,
+        missing=["coinbase", "okx"],
+        statuses={
+            "coinbase": {"ready": False},
+            "okx": {"ready": False},
+        },
+    )
+
+    contract._patch_module(module)
+    global_ready, _missing, _statuses = module.refresh_readiness()
+
+    assert global_ready is False
+    assert contract.os.environ["NIJA_REQUIRED_VENUES_READY"] == "0"
+    assert contract.os.environ["NIJA_GLOBAL_TRADING_READY"] == "0"
+    assert contract.os.environ["NIJA_ACTIVE_LIVE_VENUES"] == ""
+
+
+def test_all_required_ready_reports_both_required_and_global_ready(monkeypatch):
+    _clear(monkeypatch)
+    module = _module(
+        monkeypatch,
+        missing=[],
+        statuses={
+            "kraken": {"ready": True},
+            "coinbase": {"ready": True},
+            "okx": {"ready": True},
+        },
+    )
+
+    contract._patch_module(module)
+    global_ready, missing, _statuses = module.refresh_readiness()
+
+    assert global_ready is True
+    assert missing == []
+    assert contract.os.environ["NIJA_REQUIRED_VENUES_READY"] == "1"
+    assert contract.os.environ["NIJA_GLOBAL_TRADING_READY"] == "1"
+    assert contract.os.environ["NIJA_ACTIVE_LIVE_VENUES"] == "coinbase,kraken,okx"

--- a/bot/tests/test_render_liveness_readiness.py
+++ b/bot/tests/test_render_liveness_readiness.py
@@ -19,9 +19,14 @@ def _reset(monkeypatch, tmp_path):
         "NIJA_RUNTIME_TRADING_STATE",
         "NIJA_RUNTIME_EXECUTION_AUTHORITY",
         "NIJA_REQUIRE_SECONDARY_VENUES_READY",
+        "NIJA_SECONDARY_VENUE_POLICY",
         "NIJA_REQUIRED_VENUES_READY",
+        "NIJA_GLOBAL_TRADING_READY",
+        "NIJA_MULTI_BROKER_TRADING_READY",
         "NIJA_REQUIRED_LIVE_VENUES",
         "NIJA_REQUIRED_VENUES_MISSING",
+        "NIJA_ACTIVE_LIVE_VENUES",
+        "NIJA_DEGRADED_LIVE_VENUES",
         "NIJA_COINBASE_ACTIVATION_STATE",
         "NIJA_COINBASE_CONNECTED",
         "NIJA_COINBASE_TRADING_READY",
@@ -35,26 +40,53 @@ def _reset(monkeypatch, tmp_path):
     return state_file
 
 
-def test_readiness_is_false_until_required_venues_are_ready(monkeypatch, tmp_path):
+def test_broker_local_readiness_allows_healthy_kraken_when_secondaries_are_missing(monkeypatch, tmp_path):
     _reset(monkeypatch, tmp_path)
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_MULTI_BROKER_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
+
+    ready, details = server._readiness()
+
+    assert ready is True
+    assert details["status"] == "ready"
+    assert details["secondary_venue_policy"] == "broker_local"
+    assert details["required_venues_ready"] is False
+    assert details["global_trading_ready"] is True
+    assert details["required_venues_missing"] == "coinbase,okx"
+    assert details["active_live_venues"] == "kraken"
+    assert details["readiness_source"] == "process_env"
+
+
+def test_global_all_required_policy_blocks_until_required_venues_are_ready(monkeypatch, tmp_path):
+    _reset(monkeypatch, tmp_path)
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "global_all_required")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
 
     ready, details = server._readiness()
 
     assert ready is False
     assert details["status"] == "not_ready"
-    assert details["required_venues_missing"] == "coinbase,okx"
-    assert details["readiness_source"] == "process_env"
+    assert details["venue_policy_ready"] is False
 
 
-def test_readiness_requires_live_state_and_writer_authority(monkeypatch, tmp_path):
+def test_readiness_requires_live_state_writer_authority_and_any_live_venue(monkeypatch, tmp_path):
     _reset(monkeypatch, tmp_path)
-    monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
-    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "1")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
 
@@ -66,13 +98,22 @@ def test_readiness_requires_live_state_and_writer_authority(monkeypatch, tmp_pat
     ready, _details = server._readiness()
     assert ready is False
 
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "0")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "")
+    ready, _details = server._readiness()
+    assert ready is False
 
-def test_readiness_passes_with_live_authority_and_both_venues(monkeypatch, tmp_path):
+
+def test_readiness_passes_with_all_required_venues_ready(monkeypatch, tmp_path):
     _reset(monkeypatch, tmp_path)
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "global_all_required")
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "1")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken,coinbase,okx")
     monkeypatch.setenv("NIJA_COINBASE_ACTIVATION_STATE", "ready")
     monkeypatch.setenv("NIJA_COINBASE_CONNECTED", "1")
     monkeypatch.setenv("NIJA_COINBASE_TRADING_READY", "1")
@@ -88,27 +129,30 @@ def test_readiness_passes_with_live_authority_and_both_venues(monkeypatch, tmp_p
     assert details["okx_trading_ready"] == "1"
 
 
-def test_bridge_file_overrides_stale_liveness_process_environment(monkeypatch, tmp_path):
+def test_bridge_normalizes_contradictory_required_venue_state(monkeypatch, tmp_path):
     state_file = _reset(monkeypatch, tmp_path)
     monkeypatch.setenv("RENDER", "true")
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
     monkeypatch.setenv("NIJA_REQUIRE_SECONDARY_VENUES_READY", "true")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    # Simulate the exact contradictory legacy environment from the deployment log.
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "1")
-    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "")
-    monkeypatch.setenv("NIJA_COINBASE_ACTIVATION_STATE", "ready")
-    monkeypatch.setenv("NIJA_COINBASE_CONNECTED", "1")
-    monkeypatch.setenv("NIJA_COINBASE_TRADING_READY", "1")
-    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "ready")
-    monkeypatch.setenv("NIJA_OKX_CONNECTED", "1")
-    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
 
-    bridge.publish_once()
+    payload = bridge.publish_once()
 
-    # Simulate the separate HTTP process retaining its old startup environment.
+    assert payload["required_venues_ready"] == "0"
+    assert payload["global_trading_ready"] == "1"
+    assert payload["secondary_venue_policy"] == "broker_local"
+    assert payload["active_live_venues"] == "kraken"
+
+    # Simulate the separate HTTP process retaining stale startup environment.
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
-    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "0")
 
     ready, details = server._readiness()
 
@@ -117,6 +161,8 @@ def test_bridge_file_overrides_stale_liveness_process_environment(monkeypatch, t
     assert details["readiness_source"] == "shared_file"
     assert details["state"] == "LIVE_ACTIVE"
     assert details["writer_authority"] == "1"
+    assert details["required_venues_ready"] is False
+    assert details["global_trading_ready"] is True
 
 
 def test_render_without_fresh_shared_state_is_safely_not_ready(monkeypatch, tmp_path):
@@ -124,7 +170,7 @@ def test_render_without_fresh_shared_state_is_safely_not_ready(monkeypatch, tmp_
     monkeypatch.setenv("RENDER", "true")
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
-    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "1")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
 
     state_file.write_text(
         json.dumps(
@@ -133,7 +179,10 @@ def test_render_without_fresh_shared_state_is_safely_not_ready(monkeypatch, tmp_
                 "state": "LIVE_ACTIVE",
                 "writer_authority": "1",
                 "strict_secondary_venues": "true",
-                "required_venues_ready": "1",
+                "secondary_venue_policy": "broker_local",
+                "required_venues_ready": "0",
+                "global_trading_ready": "1",
+                "active_live_venues": "kraken",
             }
         ),
         encoding="utf-8",

--- a/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
+++ b/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import bot.runtime_release_manifest_patch as manifest
+
+
+def _clear(monkeypatch):
+    for name in (
+        "NIJA_SECONDARY_VENUE_POLICY",
+        "NIJA_REQUIRED_VENUES_MISSING",
+        "NIJA_REQUIRED_VENUES_READY",
+        "NIJA_GLOBAL_TRADING_READY",
+        "NIJA_MULTI_BROKER_TRADING_READY",
+        "NIJA_ACTIVE_LIVE_VENUES",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_v8_release_id():
+    assert manifest.RELEASE_ID == "20260714-runtime-convergence-v8"
+
+
+def test_contract_accepts_broker_local_kraken_with_missing_secondaries(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+
+    ok, reason = manifest._readiness_contract_consistent()
+
+    assert ok is True
+    assert "policy=broker_local" in reason
+    assert "required_ready=0" in reason
+    assert "global_ready=1" in reason
+    assert "active=kraken" in reason
+
+
+def test_contract_rejects_missing_required_venues_marked_ready(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "1")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+
+    ok, reason = manifest._readiness_contract_consistent()
+
+    assert ok is False
+    assert reason.startswith("contradiction:missing=")
+
+
+def test_contract_rejects_global_ready_without_active_venue(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
+    monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "")
+
+    ok, reason = manifest._readiness_contract_consistent()
+
+    assert ok is False
+    assert reason == "contradiction:global_ready=1;active_live_venues=missing"

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -21,20 +21,23 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
         "NIJA_FINAL_RUNTIME_CONVERGENCE_INSTALLED",
         "NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED",
+        "NIJA_SCAN_OWNER_OKX_AUTH_CONVERGENCE_INSTALLED",
         "NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED",
         "NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED",
         "NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
+        "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
         "NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED",
+        "NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED",
         "NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED",
         "NIJA_RENDER_READINESS_BRIDGE_INSTALLED",
     ):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_authority_repairs_before_broker_activation(monkeypatch):
+def test_source_bootstrap_installs_readiness_contract_before_recovery_and_bridge(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
@@ -51,10 +54,12 @@ def test_source_bootstrap_installs_authority_repairs_before_broker_activation(mo
         ("venue_readiness_execution_repair_patch", "venue", "install"),
         ("secondary_venue_activation_patch", "activator", "install"),
         ("secondary_venue_strict_readiness_patch", "strict", "install"),
+        ("broker_local_readiness_contract_patch", "broker_local_contract", "install"),
         ("account_exit_management_recovery_patch", "exit_recovery", "install_import_hook"),
         ("account_exit_recovery_bootstrap_patch", "exit_bootstrap", "install"),
         ("three_venue_execution_readiness", "stage", "install"),
         ("render_readiness_state_bridge", "bridge", "install"),
+        ("scan_owner_okx_auth_convergence_patch", "scan_owner", "install"),
     )
     modules = {}
     for module_name, label, installer_name in names:
@@ -78,13 +83,15 @@ def test_source_bootstrap_installs_authority_repairs_before_broker_activation(mo
     assert calls == [
         "writer", "generation_scope", "heartbeat_scope", "worker_position", "auth",
         "convergence", "convergence_v2", "auth_endpoint", "final_convergence",
-        "scan_wrapper", "venue", "activator", "strict", "exit_recovery",
-        "exit_bootstrap", "stage", "bridge",
+        "scan_wrapper", "venue", "activator", "strict", "broker_local_contract",
+        "exit_recovery", "exit_bootstrap", "stage", "bridge", "scan_owner",
     ]
-    assert source_bootstrap.installed_marker() == "20260713a"
+    assert calls.index("broker_local_contract") < calls.index("bridge")
+    assert source_bootstrap.installed_marker() == "20260714c"
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
 
@@ -105,6 +112,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/broker_local_readiness_contract_patch.py
+++ b/broker_local_readiness_contract_patch.py
@@ -1,7 +1,7 @@
 """Make NIJA broker-local readiness telemetry internally consistent.
 
 The secondary venue guard intentionally applies strict activation checks only to
-orders routed to the affected broker.  Its legacy global telemetry flag,
+orders routed to the affected broker. Its legacy global telemetry flag,
 ``NIJA_REQUIRED_VENUES_READY``, was always set to ``1`` to avoid blocking Kraken.
 That produced contradictory Render output when Coinbase and OKX were both missing.
 
@@ -29,6 +29,7 @@ _MARKER = "20260714-broker-local-readiness-v1"
 _PATCH_ATTR = "_nija_broker_local_readiness_contract_v1"
 _LOCK = threading.RLock()
 _INSTALLED = False
+_LAST_SIGNATURE = ""
 
 
 def _policy(strict: bool) -> str:
@@ -47,13 +48,15 @@ def _publish_contract(
     missing: list[str],
     statuses: dict[str, dict[str, Any]],
 ) -> bool:
+    global _LAST_SIGNATURE
     active = _active_venues(statuses)
     strict_fn = getattr(module, "strict_mode_enabled", None)
     strict = bool(strict_fn()) if callable(strict_fn) else False
+    policy = _policy(strict)
     all_required_ready = not missing
     any_live_ready = bool(active)
 
-    os.environ["NIJA_SECONDARY_VENUE_POLICY"] = _policy(strict)
+    os.environ["NIJA_SECONDARY_VENUE_POLICY"] = policy
     os.environ["NIJA_REQUIRED_VENUES_READY"] = "1" if all_required_ready else "0"
     os.environ["NIJA_MULTI_BROKER_TRADING_READY"] = "1" if any_live_ready else "0"
     os.environ["NIJA_GLOBAL_TRADING_READY"] = "1" if any_live_ready else "0"
@@ -61,16 +64,26 @@ def _publish_contract(
     os.environ["NIJA_REQUIRED_VENUES_MISSING"] = ",".join(missing)
     os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] = "1"
 
-    logger.warning(
-        "BROKER_LOCAL_READINESS_CONTRACT marker=%s policy=%s active=%s "
-        "required_ready=%s missing=%s global_ready=%s",
-        _MARKER,
-        _policy(strict),
-        ",".join(active) or "none",
-        str(all_required_ready).lower(),
-        ",".join(missing) or "none",
-        str(any_live_ready).lower(),
-    )
+    signature = "|".join((
+        policy,
+        ",".join(active),
+        ",".join(missing),
+        "1" if all_required_ready else "0",
+        "1" if any_live_ready else "0",
+    ))
+    if signature != _LAST_SIGNATURE:
+        _LAST_SIGNATURE = signature
+        log = logger.warning if missing or not any_live_ready else logger.info
+        log(
+            "BROKER_LOCAL_READINESS_CONTRACT marker=%s policy=%s active=%s "
+            "required_ready=%s missing=%s global_ready=%s",
+            _MARKER,
+            policy,
+            ",".join(active) or "none",
+            str(all_required_ready).lower(),
+            ",".join(missing) or "none",
+            str(any_live_ready).lower(),
+        )
     return any_live_ready
 
 
@@ -79,6 +92,7 @@ def _patch_module(module: ModuleType) -> bool:
     if not callable(current):
         return False
     if getattr(current, _PATCH_ATTR, False):
+        os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] = "1"
         return True
 
     @wraps(current)

--- a/broker_local_readiness_contract_patch.py
+++ b/broker_local_readiness_contract_patch.py
@@ -1,0 +1,134 @@
+"""Make NIJA broker-local readiness telemetry internally consistent.
+
+The secondary venue guard intentionally applies strict activation checks only to
+orders routed to the affected broker.  Its legacy global telemetry flag,
+``NIJA_REQUIRED_VENUES_READY``, was always set to ``1`` to avoid blocking Kraken.
+That produced contradictory Render output when Coinbase and OKX were both missing.
+
+This repair separates the two concepts:
+
+* ``NIJA_REQUIRED_VENUES_READY`` truthfully reports whether every configured
+  required secondary venue is ready.
+* ``NIJA_MULTI_BROKER_TRADING_READY`` and ``NIJA_GLOBAL_TRADING_READY`` report
+  whether at least one live venue is available for independent execution.
+* ``NIJA_SECONDARY_VENUE_POLICY=broker_local`` tells readiness consumers that
+  unavailable secondary venues must not globally block a healthy Kraken venue.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.broker_local_readiness_contract")
+_MARKER = "20260714-broker-local-readiness-v1"
+_PATCH_ATTR = "_nija_broker_local_readiness_contract_v1"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _policy(strict: bool) -> str:
+    return "broker_local" if strict else "optional"
+
+
+def _active_venues(statuses: dict[str, dict[str, Any]]) -> list[str]:
+    return sorted(
+        name for name, status in statuses.items()
+        if bool(status.get("ready"))
+    )
+
+
+def _publish_contract(
+    module: ModuleType,
+    missing: list[str],
+    statuses: dict[str, dict[str, Any]],
+) -> bool:
+    active = _active_venues(statuses)
+    strict_fn = getattr(module, "strict_mode_enabled", None)
+    strict = bool(strict_fn()) if callable(strict_fn) else False
+    all_required_ready = not missing
+    any_live_ready = bool(active)
+
+    os.environ["NIJA_SECONDARY_VENUE_POLICY"] = _policy(strict)
+    os.environ["NIJA_REQUIRED_VENUES_READY"] = "1" if all_required_ready else "0"
+    os.environ["NIJA_MULTI_BROKER_TRADING_READY"] = "1" if any_live_ready else "0"
+    os.environ["NIJA_GLOBAL_TRADING_READY"] = "1" if any_live_ready else "0"
+    os.environ["NIJA_ACTIVE_LIVE_VENUES"] = ",".join(active)
+    os.environ["NIJA_REQUIRED_VENUES_MISSING"] = ",".join(missing)
+    os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] = "1"
+
+    logger.warning(
+        "BROKER_LOCAL_READINESS_CONTRACT marker=%s policy=%s active=%s "
+        "required_ready=%s missing=%s global_ready=%s",
+        _MARKER,
+        _policy(strict),
+        ",".join(active) or "none",
+        str(all_required_ready).lower(),
+        ",".join(missing) or "none",
+        str(any_live_ready).lower(),
+    )
+    return any_live_ready
+
+
+def _patch_module(module: ModuleType) -> bool:
+    current = getattr(module, "refresh_readiness", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def refresh_readiness(*args: Any, **kwargs: Any):
+        _legacy_ready, missing, statuses = current(*args, **kwargs)
+        missing_list = list(missing or [])
+        status_map = dict(statuses or {})
+        global_ready = _publish_contract(module, missing_list, status_map)
+        return global_ready, missing_list, status_map
+
+    setattr(refresh_readiness, _PATCH_ATTR, True)
+    setattr(refresh_readiness, "__wrapped__", current)
+    module.refresh_readiness = refresh_readiness
+
+    def required_venues_ready() -> bool:
+        return bool(refresh_readiness()[0])
+
+    module.required_venues_ready = required_venues_ready
+    # Publish immediately so the readiness bridge cannot emit one contradictory
+    # snapshot between guard installation and the first monitor refresh.
+    try:
+        refresh_readiness(force_log=True)
+    except Exception as exc:
+        logger.warning(
+            "BROKER_LOCAL_READINESS_INITIAL_REFRESH_FAILED marker=%s error=%s",
+            _MARKER,
+            exc,
+        )
+    logger.critical("BROKER_LOCAL_READINESS_CONTRACT_INSTALLED marker=%s", _MARKER)
+    return True
+
+
+def install() -> None:
+    global _INSTALLED
+    with _LOCK:
+        module = importlib.import_module("secondary_venue_strict_readiness_patch")
+        if not _patch_module(module):
+            raise RuntimeError("secondary_venue_readiness_not_patchable")
+        _INSTALLED = True
+
+
+def install_import_hook() -> None:
+    install()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_policy",
+    "_active_venues",
+    "_publish_contract",
+    "_patch_module",
+]

--- a/render_liveness_server.py
+++ b/render_liveness_server.py
@@ -2,7 +2,7 @@
 
 ``/healthz`` reports process liveness so Render can complete a zero-downtime
 deployment while the replacement waits fail-closed for writer authority.
-``/readyz`` reports strict trading readiness.  Because this HTTP server is a
+``/readyz`` reports strict trading readiness. Because this HTTP server is a
 separate process, it reads an atomic state file published by the trading process
 instead of relying on stale inherited environment variables.
 """
@@ -81,6 +81,13 @@ def _read_shared_state() -> tuple[Optional[dict[str, Any]], Optional[float], str
         return None, None, f"read_error:{type(exc).__name__}"
 
 
+def _secondary_policy_from_env() -> str:
+    explicit = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "") or "").strip().lower()
+    if explicit in {"broker_local", "global_all_required", "optional"}:
+        return explicit
+    return "broker_local" if _truthy("NIJA_REQUIRE_SECONDARY_VENUES_READY") else "optional"
+
+
 def _environment_snapshot() -> dict[str, Any]:
     return {
         "state": os.environ.get("NIJA_RUNTIME_TRADING_STATE", "OFF"),
@@ -88,13 +95,23 @@ def _environment_snapshot() -> dict[str, Any]:
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "false"
         ),
+        "secondary_venue_policy": _secondary_policy_from_env(),
         "required_venues_ready": os.environ.get("NIJA_REQUIRED_VENUES_READY", "0"),
+        "global_trading_ready": os.environ.get(
+            "NIJA_GLOBAL_TRADING_READY",
+            os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0"),
+        ),
+        "multi_broker_trading_ready": os.environ.get(
+            "NIJA_MULTI_BROKER_TRADING_READY", "0"
+        ),
         "required_venues": os.environ.get(
             "NIJA_REQUIRED_LIVE_VENUES", "coinbase,okx"
         ),
         "required_venues_missing": os.environ.get(
             "NIJA_REQUIRED_VENUES_MISSING", ""
         ),
+        "active_live_venues": os.environ.get("NIJA_ACTIVE_LIVE_VENUES", ""),
+        "degraded_live_venues": os.environ.get("NIJA_DEGRADED_LIVE_VENUES", ""),
         "coinbase_activation_state": os.environ.get(
             "NIJA_COINBASE_ACTIVATION_STATE", "unknown"
         ),
@@ -123,9 +140,14 @@ def _safe_render_startup_snapshot() -> dict[str, Any]:
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "true"
         ),
+        "secondary_venue_policy": _secondary_policy_from_env(),
         "required_venues_ready": "0",
+        "global_trading_ready": "0",
+        "multi_broker_trading_ready": "0",
         "required_venues": required,
         "required_venues_missing": required,
+        "active_live_venues": "",
+        "degraded_live_venues": required,
         "coinbase_activation_state": "unknown",
         "coinbase_connected": "0",
         "coinbase_trading_ready": "0",
@@ -136,6 +158,24 @@ def _safe_render_startup_snapshot() -> dict[str, Any]:
         "okx_spendable_quote": "0",
         "commit": os.environ.get("GIT_COMMIT_SHORT", "unknown"),
     }
+
+
+def _normalised_policy(snapshot: dict[str, Any]) -> str:
+    explicit = str(snapshot.get("secondary_venue_policy") or "").strip().lower()
+    if explicit in {"broker_local", "global_all_required", "optional"}:
+        return explicit
+    return "broker_local" if _truthy_value(snapshot.get("strict_secondary_venues")) else "optional"
+
+
+def _global_ready_from_snapshot(snapshot: dict[str, Any], required_ready: bool) -> bool:
+    for key in ("global_trading_ready", "multi_broker_trading_ready"):
+        if key in snapshot:
+            return _truthy_value(snapshot.get(key))
+    active = str(snapshot.get("active_live_venues") or "").strip().strip(",")
+    if active:
+        return True
+    # Backward compatibility for old state files that predate broker-local fields.
+    return required_ready
 
 
 def _readiness() -> tuple[bool, dict[str, object]]:
@@ -156,19 +196,32 @@ def _readiness() -> tuple[bool, dict[str, object]]:
     writer_raw = str(snapshot.get("writer_authority") or "0")
     writer_ready = _truthy_value(writer_raw)
     strict = _truthy_value(snapshot.get("strict_secondary_venues"))
-    required_ready = (
-        _truthy_value(snapshot.get("required_venues_ready")) if strict else True
-    )
-    ready = state == "LIVE_ACTIVE" and writer_ready and required_ready
+    policy = _normalised_policy(snapshot)
+    required_ready = _truthy_value(snapshot.get("required_venues_ready"))
+    global_ready = _global_ready_from_snapshot(snapshot, required_ready)
+
+    if policy == "global_all_required":
+        venue_policy_ready = required_ready
+    else:
+        # broker_local and optional policies require at least one independently
+        # executable live venue but do not require every secondary venue.
+        venue_policy_ready = global_ready
+
+    ready = state == "LIVE_ACTIVE" and writer_ready and venue_policy_ready
 
     details: dict[str, object] = {
         "status": "ready" if ready else "not_ready",
         "state": state,
         "writer_authority": writer_raw,
         "strict_secondary_venues": strict,
+        "secondary_venue_policy": policy,
         "required_venues_ready": required_ready,
+        "global_trading_ready": global_ready,
+        "venue_policy_ready": venue_policy_ready,
         "required_venues": snapshot.get("required_venues", "coinbase,okx"),
         "required_venues_missing": snapshot.get("required_venues_missing", ""),
+        "active_live_venues": snapshot.get("active_live_venues", ""),
+        "degraded_live_venues": snapshot.get("degraded_live_venues", ""),
         "coinbase_activation_state": snapshot.get(
             "coinbase_activation_state", "unknown"
         ),

--- a/render_readiness_state_bridge.py
+++ b/render_readiness_state_bridge.py
@@ -17,10 +17,11 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("nija.render_readiness_bridge")
-_MARKER = "20260711b"
+_MARKER = "20260714c"
 _LOCK = threading.RLock()
 _INSTALLED = False
 _THREAD: threading.Thread | None = None
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 
 def _state_path() -> Path:
@@ -31,7 +32,40 @@ def _state_path() -> Path:
     return Path(str(raw or "/tmp/nija_render_readiness.json")).expanduser()
 
 
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _normalised_policy() -> str:
+    explicit = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "") or "").strip().lower()
+    if explicit in {"broker_local", "global_all_required", "optional"}:
+        return explicit
+    return "broker_local" if _truthy(os.environ.get("NIJA_REQUIRE_SECONDARY_VENUES_READY")) else "optional"
+
+
+def _required_missing() -> str:
+    return str(os.environ.get("NIJA_REQUIRED_VENUES_MISSING", "") or "").strip().strip(",")
+
+
+def _required_ready(missing: str) -> str:
+    # Missing required venues always means the required-venue set itself is not
+    # ready, even when broker-local policy permits another healthy venue to trade.
+    if missing:
+        return "0"
+    return "1" if _truthy(os.environ.get("NIJA_REQUIRED_VENUES_READY", "0")) else "0"
+
+
+def _global_ready() -> str:
+    for name in ("NIJA_GLOBAL_TRADING_READY", "NIJA_MULTI_BROKER_TRADING_READY"):
+        if name in os.environ:
+            return "1" if _truthy(os.environ.get(name)) else "0"
+    active = str(os.environ.get("NIJA_ACTIVE_LIVE_VENUES", "") or "").strip().strip(",")
+    return "1" if active else "0"
+
+
 def _payload() -> dict[str, Any]:
+    missing = _required_missing()
+    global_ready = _global_ready()
     return {
         "timestamp": time.time(),
         "pid": os.getpid(),
@@ -40,13 +74,16 @@ def _payload() -> dict[str, Any]:
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "false"
         ),
-        "required_venues_ready": os.environ.get("NIJA_REQUIRED_VENUES_READY", "0"),
+        "secondary_venue_policy": _normalised_policy(),
+        "required_venues_ready": _required_ready(missing),
+        "global_trading_ready": global_ready,
+        "multi_broker_trading_ready": global_ready,
         "required_venues": os.environ.get(
             "NIJA_REQUIRED_LIVE_VENUES", "coinbase,okx"
         ),
-        "required_venues_missing": os.environ.get(
-            "NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx"
-        ),
+        "required_venues_missing": missing,
+        "active_live_venues": os.environ.get("NIJA_ACTIVE_LIVE_VENUES", ""),
+        "degraded_live_venues": os.environ.get("NIJA_DEGRADED_LIVE_VENUES", ""),
         "coinbase_activation_state": os.environ.get(
             "NIJA_COINBASE_ACTIVATION_STATE", "unknown"
         ),
@@ -127,15 +164,16 @@ def install() -> None:
         _THREAD.start()
         os.environ["NIJA_RENDER_READINESS_BRIDGE_INSTALLED"] = "1"
         logger.warning(
-            "RENDER_READINESS_STATE_BRIDGE_INSTALLED marker=%s path=%s",
+            "RENDER_READINESS_STATE_BRIDGE_INSTALLED marker=%s path=%s policy=%s",
             _MARKER,
             _state_path(),
+            _normalised_policy(),
         )
         print(
             f"[NIJA-PRINT] RENDER_READINESS_STATE_BRIDGE_INSTALLED marker={_MARKER} "
-            f"path={_state_path()}",
+            f"path={_state_path()} policy={_normalised_policy()}",
             flush=True,
         )
 
 
-__all__ = ["install", "publish_once"]
+__all__ = ["install", "publish_once", "_payload"]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260713b"
+_MARKER = "20260714c"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -63,6 +63,7 @@ def _set_status(value: str) -> None:
         "NIJA_FINAL_WORKER_POSITION_COINBASE_REPAIR_INSTALLED",
         "NIJA_SECONDARY_VENUE_ACTIVATOR_INSTALLED",
         "NIJA_SECONDARY_VENUE_STRICT_GUARD_INSTALLED",
+        "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
         "NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED",
         "NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED",
@@ -92,6 +93,7 @@ def install() -> bool:
             _install_required("venue_readiness_execution_repair_patch")
             _install_required("secondary_venue_activation_patch")
             _install_required("secondary_venue_strict_readiness_patch")
+            _install_required("broker_local_readiness_contract_patch")
             _install_required("account_exit_management_recovery_patch")
             _install_required("account_exit_recovery_bootstrap_patch")
             _install_required("three_venue_execution_readiness")
@@ -111,6 +113,7 @@ def install() -> bool:
                 "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
                 "scan_wrapper_convergence=installed venue_repair=installed "
                 "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
+                "broker_local_readiness_contract=installed "
                 "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
                 "three_venue_stage_verifier=installed render_readiness_bridge=installed "
                 "scan_owner_okx_auth_convergence=installed source=main_pre_bot"


### PR DESCRIPTION
## Runtime evidence

Render deployed commit `31f08e063969` and repeatedly reported:

- `strict_secondary_venues=true`
- `required_venues_missing=coinbase,okx`
- `required_venues_ready=1`
- `state=LIVE_ACTIVE`
- `writer_authority=1`

The execution policy is intentionally broker-independent: unavailable Coinbase or OKX must block only orders routed to that venue, while healthy Kraken remains independently executable. The readiness endpoint was still interpreting the legacy strict flag as a global all-venues requirement and publishing contradictory telemetry.

## Fixes

### Separate required-set readiness from global trading readiness

- `NIJA_REQUIRED_VENUES_READY` now truthfully reports whether all configured required secondary venues are ready.
- `NIJA_GLOBAL_TRADING_READY` and `NIJA_MULTI_BROKER_TRADING_READY` report whether at least one independent live venue is ready.
- `NIJA_SECONDARY_VENUE_POLICY=broker_local` explicitly declares the execution policy.
- `NIJA_ACTIVE_LIVE_VENUES` identifies the healthy venues, such as `kraken`.

### Correct Render readiness semantics

Under `broker_local` policy, `/readyz` requires:

- `state=LIVE_ACTIVE`
- writer authority
- at least one active live venue

It does not require Coinbase and OKX to be ready before Kraken can keep the service ready. A separate `global_all_required` policy remains available and correctly requires every configured venue.

### Normalize the shared readiness file

The bridge now prevents contradictory snapshots. When `required_venues_missing=coinbase,okx`, it always publishes `required_venues_ready=0`, even if a stale legacy environment value says `1`. It separately publishes `global_trading_ready=1` and `active_live_venues=kraken` when Kraken is healthy.

### Strict v8 release contract

The manifest is bumped to `20260714-runtime-convergence-v8` and fails closed when:

- missing required venues are marked ready,
- global readiness is true without an active live venue,
- the broker-local readiness guard is absent,
- or any prior scan, Kraken equity, exit-only recovery, or profit-realization guard is missing.

### Startup ordering

The broker-local readiness contract installs immediately after the secondary-venue guard and before account recovery, Render state publication, and the final release manifest.

## Expected Render output

With Kraken ready and Coinbase/OKX unavailable:

```text
secondary_venue_policy=broker_local
strict_secondary_venues=true
required_venues_ready=0
required_venues_missing=coinbase,okx
global_trading_ready=1
active_live_venues=kraken
state=LIVE_ACTIVE
writer_authority=1
```

The service remains ready because Kraken is independently executable, while Coinbase and OKX remain accurately isolated and not ready.

## Regression coverage

- broker-local policy permits healthy Kraken with missing secondaries,
- global-all-required policy still blocks,
- no active venue remains fail-closed,
- stale shared state remains fail-closed,
- legacy contradictory bridge input is normalized,
- release audit rejects contradictory readiness fields,
- startup installs the contract before the bridge,
- readiness telemetry is logged only when state changes.

This does not fabricate Coinbase or OKX credentials. Invalid or missing credentials remain isolated to their venue and require valid operator-supplied keys to connect.

## CI infrastructure status

The imports-smoke workflow terminated before repository checkout or test execution. GitHub returned `steps=None` and no job log URL, so the red workflow state contains no actionable code-level test failure.