### PR TITLE
Eliminate recursive risk-sizing wrappers and fail closed

### DIFF
--- a/bot/downstream_risk_governor_equity_repair_patch.py
+++ b/bot/downstream_risk_governor_equity_repair_patch.py
@@ -1,103 +1,79 @@
+"""Converged downstream equity and pre-dispatch risk-sizing repair.
+
+The legacy implementation repeatedly wrapped ``ExecutionPipeline.execute`` whenever
+another runtime guard became the outermost wrapper.  The broker-local readiness
+monitor then wrapped the risk wrapper again, producing an ever-growing alternating
+chain and eventually ``maximum recursion depth exceeded``.  The legacy exception
+handler also failed open and dispatched the original entry request.
+
+This implementation is chain-aware and idempotent.  It exposes ``__wrapped__`` on
+every wrapper, detects its marker anywhere in the chain, blocks recursive entry
+re-entry, and fails closed when live entry sizing cannot be verified.  Exit/reduce
+requests bypass the entry-sizing layer unchanged.
+"""
 from __future__ import annotations
 
-import importlib
 import logging
 import os
 import sys
 import threading
 import time
 from dataclasses import is_dataclass, replace
+from functools import wraps
 from types import ModuleType
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger("nija.downstream_risk_governor_equity_repair")
-_ORIGINAL_IMPORT_MODULE: Optional[Callable[..., Any]] = None
-_PATCHED = False
-_MONITOR_STARTED = False
-_INSTALL_LOCK = threading.Lock()
-_PIPELINE_PATCHED = False
-_PRE_TRADE_RISK_PATCHED = False
-_EXECUTION_ENGINE_TAXONOMY_PATCHED = False
+_MARKER = "20260714-downstream-risk-v2"
 _TRUTHY = {"1", "true", "yes", "on", "y", "enabled"}
+_INSTALL_LOCK = threading.RLock()
+_TLS = threading.local()
+_MONITOR_STARTED = False
+
+_DOWNSTREAM_ATTR = "_nija_downstream_risk_governor_equity_v2"
+_PIPELINE_ATTR = "_nija_pre_dispatch_risk_sizing_v2"
+_PRETRADE_ATTR = "_nija_pre_trade_strict_headroom_v2"
+_TAXONOMY_ATTR = "_nija_broker_specific_taxonomy_v2"
+
+_PATCH_STATE = {
+    "downstream": False,
+    "pipeline": False,
+    "pretrade": False,
+    "taxonomy": False,
+}
 
 
-# ---------------------------------------------------------------------------
-# Existing downstream risk-governor equity repair
-# ---------------------------------------------------------------------------
-
-def _live_equity_usd() -> float:
-    best = 0.0
-    try:
-        try:
-            from bot.capital_authority import get_capital_authority
-        except ImportError:
-            from capital_authority import get_capital_authority  # type: ignore[import]
-        ca = get_capital_authority()
-        for attr in ("total_capital", "real_capital"):
-            try:
-                best = max(best, float(getattr(ca, attr, 0.0) or 0.0))
-            except Exception:
-                pass
-        for meth in ("get_real_capital", "get_usable_capital"):
-            getter = getattr(ca, meth, None)
-            if callable(getter):
-                try:
-                    best = max(best, float(getter() or 0.0))
-                except Exception:
-                    pass
-    except Exception:
-        pass
-    return best
-
-
-def _install_on_downstream_blocker_guard(module: ModuleType) -> bool:
-    global _PATCHED
-    cls = getattr(module, "DownstreamBlockerGuard", None)
-    if not isinstance(cls, type):
-        return False
-    original = getattr(cls, "check_risk_governor", None)
-    if not callable(original):
-        return False
-    if getattr(original, "_nija_downstream_risk_governor_equity_repair_wrapped", False):
-        _PATCHED = True
-        return True
-
-    def _patched_check_risk_governor(self: Any, symbol: str, proposed_risk_usd: float, portfolio_value: float = 0.0, volatility_ratio: float = 1.0):
-        live_equity = _live_equity_usd()
-        incoming = float(portfolio_value or 0.0)
-        repaired_value = max(incoming, live_equity)
-        if live_equity > 0.0 and repaired_value > incoming:
-            logger.critical(
-                "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_APPLIED symbol=%s proposed_risk_usd=%.2f incoming_portfolio_value=%.2f live_equity_usd=%.2f repaired_portfolio_value=%.2f",
-                symbol,
-                float(proposed_risk_usd or 0.0),
-                incoming,
-                live_equity,
-                repaired_value,
-            )
-            print(
-                f"[NIJA-PRINT] DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_APPLIED | symbol={symbol} proposed=${float(proposed_risk_usd or 0.0):.2f} portfolio_value=${repaired_value:.2f}",
-                flush=True,
-            )
-        return original(self, symbol, proposed_risk_usd, repaired_value, volatility_ratio)
-
-    setattr(_patched_check_risk_governor, "_nija_downstream_risk_governor_equity_repair_wrapped", True)
-    setattr(cls, "check_risk_governor", _patched_check_risk_governor)
-    _PATCHED = True
-    logger.warning("DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_PATCHED module=%s", getattr(module, "__name__", "<unknown>"))
-    return True
-
-
-# ---------------------------------------------------------------------------
-# July 6/7 live-execution fix: broker-aware exposure-headroom sizing before
-# ECEL/broker dispatch.
-# ---------------------------------------------------------------------------
-
-def _truthy(name: str, default: bool = True) -> bool:
+def _truthy(name: str, default: bool = False) -> bool:
     raw = os.environ.get(name)
     if raw is None:
         return default
     return str(raw).strip().lower() in _TRUTHY
+
+
+def _live_runtime() -> bool:
+    return not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
+
+
+def _chain_contains(func: Any, attr: str) -> tuple[bool, bool, int]:
+    """Return (marker_found, cycle_detected, depth) for an explicit wrapper chain."""
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            return False, True, depth
+        seen.add(ident)
+        if bool(getattr(current, attr, False)):
+            return True, False, depth
+        nxt = getattr(current, "__wrapped__", None)
+        if not callable(nxt):
+            return False, False, depth
+        current = nxt
+        depth += 1
+        if depth >= 4096:
+            return False, True, depth
+    return False, False, depth
 
 
 def _coerce_float(value: Any, default: float = 0.0) -> float:
@@ -106,7 +82,7 @@ def _coerce_float(value: Any, default: float = 0.0) -> float:
             return default
         if isinstance(value, str):
             value = value.replace("$", "").replace(",", "").strip()
-            if value == "":
+            if not value:
                 return default
         return float(value)
     except Exception:
@@ -116,7 +92,7 @@ def _coerce_float(value: Any, default: float = 0.0) -> float:
 def _float_env(*names: str, default: float = 0.0) -> float:
     for name in names:
         raw = os.environ.get(name)
-        if raw is None or str(raw).strip() == "":
+        if raw is None or not str(raw).strip():
             continue
         try:
             value = float(str(raw).strip())
@@ -127,15 +103,34 @@ def _float_env(*names: str, default: float = 0.0) -> float:
     return default
 
 
-def _request_symbol(request: Any = None, fallback: str = "") -> str:
+def _live_equity_usd() -> float:
+    best = 0.0
     try:
-        return str(getattr(request, "symbol", fallback) or fallback).strip().upper()
+        try:
+            from bot.capital_authority import get_capital_authority
+        except ImportError:
+            from capital_authority import get_capital_authority  # type: ignore[import]
+        authority = get_capital_authority()
+        for attr in ("total_capital", "real_capital"):
+            best = max(best, _coerce_float(getattr(authority, attr, 0.0), 0.0))
+        for method_name in ("get_real_capital", "get_usable_capital"):
+            method = getattr(authority, method_name, None)
+            if callable(method):
+                best = max(best, _coerce_float(method(), 0.0))
     except Exception:
-        return str(fallback or "").strip().upper()
+        return best
+    return best
+
+
+def _request_symbol(request: Any = None, fallback: str = "") -> str:
+    return str(getattr(request, "symbol", fallback) or fallback).strip().upper()
 
 
 def _request_broker(request: Any = None) -> str:
-    for attr in ("broker", "broker_name", "selected_broker", "venue", "exchange"):
+    for attr in (
+        "preferred_broker", "broker", "broker_name", "selected_broker",
+        "execution_broker", "venue", "exchange",
+    ):
         try:
             value = getattr(request, attr, None)
             raw = getattr(value, "value", value)
@@ -143,23 +138,20 @@ def _request_broker(request: Any = None) -> str:
             if text:
                 return text
         except Exception:
-            pass
+            continue
     return ""
 
 
 def _infer_broker_for_min_notional(request: Any = None, *, symbol: str = "") -> str:
     broker = _request_broker(request)
-    if any(key in broker for key in ("okx", "coinbase", "kraken")):
-        return "okx" if "okx" in broker else "coinbase" if "coinbase" in broker else "kraken"
+    for name in ("okx", "coinbase", "kraken"):
+        if name in broker:
+            return name
     sym = _request_symbol(request, symbol)
-    # When the active route selected OKX, USDT pairs are usually OKX-native. This
-    # avoids applying the global Kraken $23.10 floor to OKX entries that can fill
-    # at the OKX $10 floor.
     if sym.endswith("-USDT") and str(os.environ.get("NIJA_LAST_ENTRY_BROKER", "")).lower() != "coinbase":
         return "okx"
-    if sym.endswith("-USD") or sym.endswith("-USDC"):
-        if _float_env("COINBASE_MIN_ORDER_USD", default=0.0) > 0:
-            return "coinbase"
+    if sym.endswith(("-USD", "-USDC")) and _float_env("COINBASE_MIN_ORDER_USD", default=0.0) > 0:
+        return "coinbase"
     return broker or "auto"
 
 
@@ -170,67 +162,78 @@ def _minimum_live_notional_usd(request: Any = None, *, symbol: str = "") -> floa
     if broker == "coinbase":
         return max(0.01, _float_env("COINBASE_MIN_ORDER_USD", "NIJA_COINBASE_MIN_ORDER_USD", default=1.0))
     if broker == "kraken":
-        return max(0.01, _float_env("KRAKEN_MIN_NOTIONAL_USD", "NIJA_KRAKEN_MIN_NOTIONAL_USD", "MIN_TRADE_USD", default=23.0))
+        return max(
+            0.01,
+            _float_env(
+                "KRAKEN_MIN_NOTIONAL_USD", "NIJA_KRAKEN_MIN_NOTIONAL_USD",
+                "MIN_TRADE_USD", default=23.0,
+            ),
+        )
     return max(
         0.01,
         _float_env(
-            "NIJA_MIN_EXPOSURE_HEADROOM_TRADE_USD",
-            "MIN_TRADE_USD",
-            "MIN_NOTIONAL_USD",
-            "MIN_NOTIONAL_OVERRIDE",
-            default=1.0,
+            "NIJA_MIN_EXPOSURE_HEADROOM_TRADE_USD", "MIN_TRADE_USD",
+            "MIN_NOTIONAL_USD", "MIN_NOTIONAL_OVERRIDE", default=1.0,
         ),
     )
 
 
 def _entry_increases_exposure(request: Any) -> bool:
     side = str(getattr(request, "side", "") or "").strip().lower()
-    intent = str(getattr(request, "intent_type", "") or "entry").strip().lower()
+    intent = str(getattr(request, "intent_type", "entry") or "entry").strip().lower()
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
     reduce_only = bool(getattr(request, "reduce_only", False))
-    if reduce_only or intent in {"reduce", "exit", "close"}:
+    if reduce_only or intent in {"reduce", "exit", "close", "liquidate", "liquidation"}:
+        return False
+    if effect in {"reduce", "exit", "close"}:
         return False
     return side in {"buy", "long"}
 
 
 def _resolve_available_balance_usd(request: Any) -> float:
-    available = _coerce_float(getattr(request, "available_balance_usd", None), 0.0)
-    if available > 0:
-        return available
+    for attr in ("available_balance_usd", "buying_power_usd", "spendable_quote_usd"):
+        value = _coerce_float(getattr(request, attr, None), 0.0)
+        if value > 0:
+            return value
     return _live_equity_usd()
 
 
 def _replace_request_size(request: Any, new_size_usd: float) -> Any:
-    new_size_usd = max(0.0, float(new_size_usd))
+    size = max(0.0, float(new_size_usd))
     if is_dataclass(request):
-        fields: dict[str, Any] = {"size_usd": new_size_usd}
+        fields: dict[str, Any] = {"size_usd": size}
         if hasattr(request, "notional_usd"):
-            fields["notional_usd"] = new_size_usd
+            fields["notional_usd"] = size
         return replace(request, **fields)
     try:
         import copy
         cloned = copy.copy(request)
-        setattr(cloned, "size_usd", new_size_usd)
-        if hasattr(cloned, "notional_usd"):
-            setattr(cloned, "notional_usd", new_size_usd)
-        return cloned
     except Exception:
-        setattr(request, "size_usd", new_size_usd)
-        if hasattr(request, "notional_usd"):
-            setattr(request, "notional_usd", new_size_usd)
-        return request
+        cloned = request
+    setattr(cloned, "size_usd", size)
+    if hasattr(cloned, "notional_usd"):
+        setattr(cloned, "notional_usd", size)
+    return cloned
 
 
-def _pipeline_deny(module: ModuleType, request: Any, t_start: float, reason: str, *, size_usd: Optional[float] = None) -> Any:
+def _pipeline_deny(
+    module: ModuleType,
+    request: Any,
+    started: float,
+    reason: str,
+    *,
+    size_usd: Optional[float] = None,
+) -> Any:
     result_cls = getattr(module, "PipelineResult", None)
     if not callable(result_cls):
-        return None
+        raise RuntimeError(reason)
     return result_cls(
         success=False,
         symbol=str(getattr(request, "symbol", "") or ""),
         side=str(getattr(request, "side", "") or ""),
         size_usd=float(size_usd if size_usd is not None else getattr(request, "size_usd", 0.0) or 0.0),
         error=reason,
-        latency_ms=(time.monotonic() - t_start) * 1000.0,
+        latency_ms=(time.monotonic() - started) * 1000.0,
     )
 
 
@@ -238,342 +241,350 @@ def _headroom_safety_buffer(headroom_usd: float) -> float:
     return max(0.01, min(0.10, max(0.0, headroom_usd) * 0.001))
 
 
-def _install_on_execution_pipeline(module: ModuleType) -> bool:
-    global _PIPELINE_PATCHED
-    cls = getattr(module, "ExecutionPipeline", None)
-    if not isinstance(cls, type):
+def _entry_fail_closed(module: ModuleType, request: Any, started: float, reason: str) -> Any:
+    logger.critical(
+        "PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_CLOSED marker=%s symbol=%s side=%s reason=%s",
+        _MARKER,
+        _request_symbol(request),
+        getattr(request, "side", ""),
+        reason,
+    )
+    return _pipeline_deny(module, request, started, reason)
+
+
+def _install_on_downstream_blocker_guard(module: ModuleType) -> bool:
+    cls = getattr(module, "DownstreamBlockerGuard", None)
+    current = getattr(cls, "check_risk_governor", None) if isinstance(cls, type) else None
+    if not callable(current):
         return False
-    original = getattr(cls, "execute", None)
-    if not callable(original):
+    found, cycle, _depth = _chain_contains(current, _DOWNSTREAM_ATTR)
+    if cycle:
+        logger.critical("DOWNSTREAM_RISK_WRAPPER_CHAIN_CYCLE marker=%s component=governor", _MARKER)
         return False
-    if getattr(original, "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a", False):
-        _PIPELINE_PATCHED = True
+    if found:
+        _PATCH_STATE["downstream"] = True
         return True
 
-    def _patched_execute(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
-        t_start = time.monotonic()
-        if not _truthy("NIJA_PRE_DISPATCH_RISK_SIZING_PATCH_ENABLED", True):
-            return original(self, request, *args, **kwargs)
+    @wraps(current)
+    def check_risk_governor(
+        self: Any,
+        symbol: str,
+        proposed_risk_usd: float,
+        portfolio_value: float = 0.0,
+        volatility_ratio: float = 1.0,
+    ) -> Any:
+        live_equity = _live_equity_usd()
+        incoming = _coerce_float(portfolio_value, 0.0)
+        repaired = max(incoming, live_equity)
+        if live_equity > incoming:
+            logger.critical(
+                "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_APPLIED marker=%s symbol=%s proposed_risk_usd=%.2f incoming_portfolio_value=%.2f live_equity_usd=%.2f repaired_portfolio_value=%.2f",
+                _MARKER, symbol, _coerce_float(proposed_risk_usd), incoming, live_equity, repaired,
+            )
+        return current(self, symbol, proposed_risk_usd, repaired, volatility_ratio)
 
+    setattr(check_risk_governor, _DOWNSTREAM_ATTR, True)
+    setattr(check_risk_governor, "__wrapped__", current)
+    cls.check_risk_governor = check_risk_governor
+    _PATCH_STATE["downstream"] = True
+    logger.warning("DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return True
+
+
+def _install_on_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    current = getattr(cls, "execute", None) if isinstance(cls, type) else None
+    if not callable(current):
+        return False
+    found, cycle, depth = _chain_contains(current, _PIPELINE_ATTR)
+    if cycle:
+        logger.critical(
+            "PRE_DISPATCH_RISK_WRAPPER_CHAIN_CYCLE marker=%s module=%s depth=%d action=fail_closed",
+            _MARKER, module.__name__, depth,
+        )
+        os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "0"
+        return False
+    if found:
+        _PATCH_STATE["pipeline"] = True
+        os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "1"
+        return True
+
+    @wraps(current)
+    def execute(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+        started = time.monotonic()
+        if not _entry_increases_exposure(request):
+            return current(self, request, *args, **kwargs)
+
+        token = (id(self), threading.get_ident())
+        active = getattr(_TLS, "active_entries", set())
+        if token in active:
+            return _entry_fail_closed(
+                module,
+                request,
+                started,
+                "PRE_DISPATCH_RISK_REENTRANCY_BLOCKED",
+            )
+
+        active = set(active)
+        active.add(token)
+        _TLS.active_entries = active
+        dispatch_request = request
         try:
             normalize = getattr(module, "normalize_pipeline_request", None)
-            working_request = normalize(request) if callable(normalize) else request
-            if not _entry_increases_exposure(working_request):
-                return original(self, request, *args, **kwargs)
+            working = normalize(request) if callable(normalize) else request
+            requested = _coerce_float(getattr(working, "size_usd", 0.0), 0.0)
+            if requested <= 0.0:
+                return _entry_fail_closed(module, working, started, "PRE_DISPATCH_INVALID_ENTRY_SIZE")
 
             risk_engine = getattr(self, "_pre_trade_risk_engine", None)
             get_headroom = getattr(risk_engine, "get_remaining_headroom_usd", None)
-            requested_size = _coerce_float(getattr(working_request, "size_usd", 0.0), 0.0)
-            if not callable(get_headroom) or requested_size <= 0.0:
-                return original(self, request, *args, **kwargs)
+            if not callable(get_headroom):
+                if _live_runtime():
+                    return _entry_fail_closed(module, working, started, "PRE_DISPATCH_RISK_ENGINE_UNAVAILABLE")
+                return current(self, request, *args, **kwargs)
 
-            account_id = str(getattr(working_request, "account_id", "default") or "default")
-            available_balance = _resolve_available_balance_usd(working_request)
-            headroom = max(0.0, _coerce_float(get_headroom(account_id, available_balance), 0.0))
-            symbol = _request_symbol(working_request)
-            min_notional = _minimum_live_notional_usd(working_request, symbol=symbol)
-            inferred_broker = _infer_broker_for_min_notional(working_request, symbol=symbol)
+            account_id = str(getattr(working, "account_id", "default") or "default")
+            available = _resolve_available_balance_usd(working)
+            if available <= 0.0 and _live_runtime():
+                return _entry_fail_closed(module, working, started, "PRE_DISPATCH_CAPITAL_SIGNAL_UNAVAILABLE")
 
-            # If there is no reliable capital signal yet, preserve the legacy path;
-            # the regular pre-trade risk engine and capital gates still run next.
-            if available_balance <= 0.0 and headroom <= 0.0:
-                logger.warning(
-                    "PRE_DISPATCH_EXPOSURE_HEADROOM_CHECK_SKIPPED account=%s symbol=%s reason=no_available_balance_or_headroom_signal requested_size_usd=%.2f",
-                    account_id,
-                    symbol,
-                    requested_size,
-                )
-                return original(self, request, *args, **kwargs)
+            headroom = max(0.0, _coerce_float(get_headroom(account_id, available), 0.0))
+            symbol = _request_symbol(working)
+            minimum = _minimum_live_notional_usd(working, symbol=symbol)
+            broker = _infer_broker_for_min_notional(working, symbol=symbol)
 
             logger.info(
-                "PRE_DISPATCH_EXPOSURE_HEADROOM_CHECK account=%s symbol=%s side=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f inferred_broker=%s available_balance_usd=%.2f",
-                account_id,
-                symbol,
-                getattr(working_request, "side", ""),
-                requested_size,
-                headroom,
-                min_notional,
-                inferred_broker,
-                available_balance,
+                "PRE_DISPATCH_EXPOSURE_HEADROOM_CHECK marker=%s account=%s symbol=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f broker=%s available_balance_usd=%.2f",
+                _MARKER, account_id, symbol, requested, headroom, minimum, broker, available,
             )
 
-            if headroom + 0.01 >= requested_size:
-                return original(self, request, *args, **kwargs)
-
-            safe_size = max(0.0, headroom - _headroom_safety_buffer(headroom))
-            if safe_size < min_notional:
-                reason = (
-                    "PreTradeRiskEngine reject: GLOBAL_EXPOSURE_CAP_HEADROOM_EXHAUSTED "
-                    f"requested_size_usd={requested_size:.2f} headroom_usd={headroom:.2f} "
-                    f"min_notional_usd={min_notional:.2f} broker={inferred_broker}"
-                )
+            if headroom + 0.01 < requested:
+                safe_size = max(0.0, headroom - _headroom_safety_buffer(headroom))
+                if safe_size < minimum:
+                    return _entry_fail_closed(
+                        module,
+                        working,
+                        started,
+                        "PreTradeRiskEngine reject: GLOBAL_EXPOSURE_CAP_HEADROOM_EXHAUSTED "
+                        f"requested_size_usd={requested:.2f} headroom_usd={headroom:.2f} "
+                        f"min_notional_usd={minimum:.2f} broker={broker}",
+                    )
+                dispatch_request = _replace_request_size(working, safe_size)
                 logger.warning(
-                    "PRE_DISPATCH_EXPOSURE_HEADROOM_REJECT account=%s symbol=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f inferred_broker=%s action=skip_before_ecel",
-                    account_id,
-                    symbol,
-                    requested_size,
-                    headroom,
-                    min_notional,
-                    inferred_broker,
+                    "PRE_DISPATCH_EXPOSURE_HEADROOM_CLIPPED marker=%s account=%s symbol=%s requested_size_usd=%.2f clipped_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f broker=%s",
+                    _MARKER, account_id, symbol, requested, safe_size, headroom, minimum, broker,
                 )
-                denied = _pipeline_deny(module, working_request, t_start, reason, size_usd=requested_size)
-                if denied is not None:
-                    return denied
-                return original(self, request, *args, **kwargs)
-
-            resized_request = _replace_request_size(working_request, safe_size)
-            logger.warning(
-                "PRE_DISPATCH_EXPOSURE_HEADROOM_CLIP_BROKER_AWARE marker=20260707a account=%s symbol=%s requested_size_usd=%.2f clipped_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f inferred_broker=%s action=resize_before_ecel",
-                account_id,
-                symbol,
-                requested_size,
-                safe_size,
-                headroom,
-                min_notional,
-                inferred_broker,
-            )
-            return original(self, resized_request, *args, **kwargs)
+            else:
+                dispatch_request = working
         except Exception as exc:
-            logger.warning("PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_OPEN error=%s", exc)
-            return original(self, request, *args, **kwargs)
+            if _live_runtime():
+                return _entry_fail_closed(
+                    module,
+                    request,
+                    started,
+                    f"PRE_DISPATCH_RISK_SIZING_ERROR:{type(exc).__name__}:{exc}",
+                )
+            dispatch_request = request
 
-    setattr(_patched_execute, "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a", True)
-    setattr(cls, "execute", _patched_execute)
-    _PIPELINE_PATCHED = True
-    logger.warning("PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED marker=20260707a module=%s", getattr(module, "__name__", "<unknown>"))
+        try:
+            return current(self, dispatch_request, *args, **kwargs)
+        except RecursionError as exc:
+            return _entry_fail_closed(
+                module,
+                dispatch_request,
+                started,
+                f"PRE_DISPATCH_EXECUTION_CHAIN_RECURSION:{exc}",
+            )
+        finally:
+            remaining = set(getattr(_TLS, "active_entries", set()))
+            remaining.discard(token)
+            _TLS.active_entries = remaining
+
+    setattr(execute, _PIPELINE_ATTR, True)
+    setattr(execute, "__wrapped__", current)
+    cls.execute = execute
+    _PATCH_STATE["pipeline"] = True
+    os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "1"
+    logger.critical(
+        "PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED marker=%s module=%s chain_aware=true fail_closed=true exits_bypass=true",
+        _MARKER, module.__name__,
+    )
     return True
 
 
 def _install_on_pre_trade_risk_engine(module: ModuleType) -> bool:
-    global _PRE_TRADE_RISK_PATCHED
     cls = getattr(module, "PreTradeRiskEngine", None)
     decision_cls = getattr(module, "PreTradeRiskDecision", None)
-    if not isinstance(cls, type) or not callable(decision_cls):
+    current = getattr(cls, "assess", None) if isinstance(cls, type) else None
+    if not callable(current) or not callable(decision_cls):
         return False
-    original = getattr(cls, "assess", None)
-    if not callable(original):
+    found, cycle, _depth = _chain_contains(current, _PRETRADE_ATTR)
+    if cycle:
+        logger.critical("PRE_TRADE_RISK_WRAPPER_CHAIN_CYCLE marker=%s", _MARKER)
         return False
-    if getattr(original, "_nija_strict_headroom_assess_wrapped_20260707a", False):
-        _PRE_TRADE_RISK_PATCHED = True
+    if found:
+        _PATCH_STATE["pretrade"] = True
         return True
 
-    def _patched_assess(self: Any, *args: Any, **kwargs: Any) -> Any:
-        decision = original(self, *args, **kwargs)
+    @wraps(current)
+    def assess(self: Any, *args: Any, **kwargs: Any) -> Any:
+        decision = current(self, *args, **kwargs)
+        if not bool(getattr(decision, "approved", False)):
+            return decision
         try:
-            if not getattr(decision, "approved", False):
+            intent = str(kwargs.get("intent_type") or "entry").lower()
+            if kwargs.get("reduce_only") or intent in {"reduce", "exit", "close"}:
                 return decision
             requested = _coerce_float(kwargs.get("size_usd"), 0.0)
             details = dict(getattr(decision, "details", {}) or {})
-            headroom = details.get("remaining_headroom_usd")
-            if headroom is None:
+            headroom_raw = details.get("remaining_headroom_usd")
+            if requested <= 0.0 or headroom_raw is None:
                 return decision
-            headroom_f = max(0.0, _coerce_float(headroom, 0.0))
-            cap_base = _coerce_float(details.get("cap_base_usd"), 0.0)
-            current_total = _coerce_float(details.get("total_exposure_usd", details.get("current_total_exposure_usd")), 0.0)
-            if cap_base <= 0.0 and current_total <= 0.0:
+            headroom = max(0.0, _coerce_float(headroom_raw, 0.0))
+            if requested <= headroom + 0.01:
                 return decision
-            if requested > 0.0 and requested > headroom_f + 0.01:
-                account_id = str(kwargs.get("account_id") or details.get("account_id") or "default")
-                symbol = str(kwargs.get("symbol") or "")
-                min_notional = _minimum_live_notional_usd(symbol=symbol)
-                # If headroom can still support the active broker's executable
-                # minimum, allow the pipeline wrapper to clip before broker dispatch
-                # instead of hard rejecting a near-headroom order.
-                if headroom_f >= min_notional:
-                    details["requested_size_usd"] = requested
-                    details["max_approved_size_usd"] = headroom_f
-                    details["action_required"] = "clip_before_execution_pipeline_dispatch"
-                    details["broker_aware_min_notional_usd"] = min_notional
-                    logger.warning(
-                        "PRE_TRADE_RISK_STRICT_HEADROOM_ALLOW_FOR_CLIP marker=20260707a account=%s symbol=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f",
-                        account_id,
-                        symbol,
-                        requested,
-                        headroom_f,
-                        min_notional,
-                    )
-                    return decision_cls(approved=True, reason="approved_headroom_clip_required", details=details)
-                details["requested_size_usd"] = requested
-                details["max_approved_size_usd"] = headroom_f
-                details["action_required"] = "downsize_before_execution_pipeline_dispatch"
-                logger.warning(
-                    "PRE_TRADE_RISK_STRICT_HEADROOM_REJECT account=%s symbol=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f action=reject_direct_caller",
-                    account_id,
-                    symbol,
-                    requested,
-                    headroom_f,
-                    min_notional,
-                )
+            symbol = str(kwargs.get("symbol") or "")
+            minimum = _minimum_live_notional_usd(symbol=symbol)
+            details.update(
+                requested_size_usd=requested,
+                max_approved_size_usd=headroom,
+                broker_aware_min_notional_usd=minimum,
+            )
+            if headroom >= minimum:
+                details["action_required"] = "clip_before_execution_pipeline_dispatch"
+                return decision_cls(approved=True, reason="approved_headroom_clip_required", details=details)
+            details["action_required"] = "downsize_before_execution_pipeline_dispatch"
+            return decision_cls(
+                approved=False,
+                reason="GLOBAL_EXPOSURE_CAP_HEADROOM_REQUIRES_DOWNSIZE",
+                details=details,
+            )
+        except Exception as exc:
+            if _live_runtime():
                 return decision_cls(
                     approved=False,
-                    reason=f"account={account_id} reason=GLOBAL_EXPOSURE_CAP_HEADROOM_REQUIRES_DOWNSIZE",
-                    details=details,
+                    reason=f"PRE_TRADE_HEADROOM_VALIDATION_ERROR:{type(exc).__name__}",
+                    details={"error": str(exc), "fail_closed": True},
                 )
-        except Exception as exc:
-            logger.debug("PreTradeRisk strict-headroom wrapper skipped: %s", exc)
-        return decision
+            return decision
 
-    setattr(_patched_assess, "_nija_strict_headroom_assess_wrapped_20260707a", True)
-    setattr(cls, "assess", _patched_assess)
-    _PRE_TRADE_RISK_PATCHED = True
-    logger.warning("PRE_DISPATCH_RISK_SIZING_PRE_TRADE_ENGINE_PATCHED marker=20260707a module=%s", getattr(module, "__name__", "<unknown>"))
+    setattr(assess, _PRETRADE_ATTR, True)
+    setattr(assess, "__wrapped__", current)
+    cls.assess = assess
+    _PATCH_STATE["pretrade"] = True
+    logger.warning("PRE_TRADE_STRICT_HEADROOM_PATCHED marker=%s module=%s", _MARKER, module.__name__)
     return True
 
-
-# ---------------------------------------------------------------------------
-# Broker-specific error taxonomy: Kraken classifier only for Kraken failures.
-# ---------------------------------------------------------------------------
 
 def _manual_failure_details(broker_response: Any = None, exc: Optional[Exception] = None) -> dict[str, str]:
     response = broker_response if isinstance(broker_response, dict) else {}
     status = str(response.get("status") or ("exception" if exc else "unknown")).lower()
-    raw_error = response.get("error", "")
-    raw_message = response.get("message", "")
-    if isinstance(raw_error, (list, tuple)):
-        error = ", ".join(str(item) for item in raw_error if item)
-    else:
-        error = str(raw_error or "")
-    message = str(raw_message or "")
-    if exc is not None and not error:
-        error = str(exc)
-    combined = " | ".join(part for part in (error, message) if part).strip() or "Unknown execution failure"
-    normalized = combined.lower()
-
+    error = response.get("error", "")
+    if isinstance(error, (list, tuple)):
+        error = ", ".join(str(item) for item in error if item)
+    message = str(response.get("message") or "")
+    detail = " | ".join(part for part in (str(error or ""), message, str(exc or "")) if part) or "Unknown execution failure"
+    normalized = detail.lower()
     hint = "Inspect broker rejection payload"
-    if "too small" in normalized or "minimum" in normalized or "min notional" in normalized:
+    if any(term in normalized for term in ("too small", "minimum", "min notional")):
         hint = "Check minimum order size / exchange notional floor"
-    elif "insufficient" in normalized or "fund" in normalized or "balance" in normalized:
+    elif any(term in normalized for term in ("insufficient", "fund", "balance")):
         hint = "Check per-broker available balance and fee-adjusted sizing"
-    elif "unsupported" in normalized or "invalid product" in normalized or "symbol" in normalized:
-        hint = "Check symbol support / exchange restrictions"
-    elif "nonce" in normalized or "signature" in normalized:
-        hint = "Check broker nonce or API signature path"
-    elif "geographic" in normalized or "region" in normalized or "jurisdiction" in normalized:
-        hint = "Check exchange geographic restrictions for this symbol"
-    elif "exposure" in normalized or "risk" in normalized or "cap" in normalized:
+    elif any(term in normalized for term in ("exposure", "risk", "cap")):
         hint = "Check pre-trade exposure/risk caps before broker dispatch"
-
-    error_code = (error or message or status or "UNKNOWN_REJECTION")[:120].upper().replace(" ", "_")
-    return {"status": status, "error_code": error_code, "detail": combined, "hint": hint}
+    code = (str(error or message or status or "UNKNOWN_REJECTION"))[:120].upper().replace(" ", "_")
+    return {"status": status, "error_code": code, "detail": detail, "hint": hint}
 
 
 def _install_on_execution_engine(module: ModuleType) -> bool:
-    global _EXECUTION_ENGINE_TAXONOMY_PATCHED
     cls = getattr(module, "ExecutionEngine", None)
-    if not isinstance(cls, type):
+    current = getattr(cls, "_extract_order_failure_details", None) if isinstance(cls, type) else None
+    if not callable(current):
         return False
-    original = getattr(cls, "_extract_order_failure_details", None)
-    if not callable(original):
+    found, cycle, _depth = _chain_contains(current, _TAXONOMY_ATTR)
+    if cycle:
         return False
-    if getattr(original, "_nija_broker_specific_taxonomy_wrapped", False):
-        _EXECUTION_ENGINE_TAXONOMY_PATCHED = True
+    if found:
+        _PATCH_STATE["taxonomy"] = True
         return True
 
-    def _patched_extract_order_failure_details(self: Any, broker_response: Any = None, exc: Optional[Exception] = None) -> dict[str, str]:
-        broker_label = "unknown"
+    @wraps(current)
+    def extract(self: Any, broker_response: Any = None, exc: Optional[Exception] = None) -> dict[str, str]:
+        label = "unknown"
         try:
-            broker_label = str(self._get_broker_label()).strip().lower()
+            label = str(self._get_broker_label()).strip().lower()
         except Exception:
             pass
-        if broker_label == "kraken":
-            return original(self, broker_response=broker_response, exc=exc)
+        if label == "kraken":
+            return current(self, broker_response=broker_response, exc=exc)
         details = _manual_failure_details(broker_response=broker_response, exc=exc)
-        details["broker"] = broker_label
+        details["broker"] = label
         return details
 
-    setattr(_patched_extract_order_failure_details, "_nija_broker_specific_taxonomy_wrapped", True)
-    setattr(cls, "_extract_order_failure_details", _patched_extract_order_failure_details)
-    _EXECUTION_ENGINE_TAXONOMY_PATCHED = True
-    logger.warning("EXECUTION_FAILURE_TAXONOMY_PATCHED module=%s non_kraken_uses=generic_classifier", getattr(module, "__name__", "<unknown>"))
+    setattr(extract, _TAXONOMY_ATTR, True)
+    setattr(extract, "__wrapped__", current)
+    cls._extract_order_failure_details = extract
+    _PATCH_STATE["taxonomy"] = True
     return True
 
 
 def _try_patch_loaded() -> bool:
     patched = False
-    for name in ("bot.downstream_blocker_guard", "downstream_blocker_guard"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _install_on_downstream_blocker_guard(module) or patched
-    for name in ("bot.execution_pipeline", "execution_pipeline"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _install_on_execution_pipeline(module) or patched
-    for name in ("bot.pre_trade_risk_engine", "pre_trade_risk_engine"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _install_on_pre_trade_risk_engine(module) or patched
-    for name in ("bot.execution_engine", "execution_engine"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _install_on_execution_engine(module) or patched
+    targets = (
+        (("bot.downstream_blocker_guard", "downstream_blocker_guard"), _install_on_downstream_blocker_guard),
+        (("bot.execution_pipeline", "execution_pipeline"), _install_on_execution_pipeline),
+        (("bot.pre_trade_risk_engine", "pre_trade_risk_engine"), _install_on_pre_trade_risk_engine),
+        (("bot.execution_engine", "execution_engine"), _install_on_execution_engine),
+    )
+    for names, installer in targets:
+        for name in names:
+            module = sys.modules.get(name)
+            if isinstance(module, ModuleType):
+                patched = installer(module) or patched
     return patched
 
 
-def _patch_named_module(name: str, module: Any) -> None:
-    if not isinstance(module, ModuleType):
-        return
-    if name in {"bot.downstream_blocker_guard", "downstream_blocker_guard"}:
-        _install_on_downstream_blocker_guard(module)
-    elif name in {"bot.execution_pipeline", "execution_pipeline"}:
-        _install_on_execution_pipeline(module)
-    elif name in {"bot.pre_trade_risk_engine", "pre_trade_risk_engine"}:
-        _install_on_pre_trade_risk_engine(module)
-    elif name in {"bot.execution_engine", "execution_engine"}:
-        _install_on_execution_engine(module)
-
-
-def _start_monitor() -> None:
-    global _MONITOR_STARTED
-    if _MONITOR_STARTED:
-        return
-    _MONITOR_STARTED = True
-
-    def _monitor() -> None:
-        deadline = time.time() + float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "240") or "240")
-        while time.time() < deadline:
+def _monitor() -> None:
+    deadline = time.monotonic() + max(60.0, float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600))
+    while time.monotonic() < deadline:
+        try:
             _try_patch_loaded()
-            if _PATCHED and _PIPELINE_PATCHED and _PRE_TRADE_RISK_PATCHED and _EXECUTION_ENGINE_TAXONOMY_PATCHED:
+            if all(_PATCH_STATE.values()):
+                os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = "1"
                 return
-            time.sleep(0.25)
-        logger.warning(
-            "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_MONITOR_EXPIRED downstream=%s pipeline=%s pre_trade_risk=%s execution_taxonomy=%s",
-            _PATCHED,
-            _PIPELINE_PATCHED,
-            _PRE_TRADE_RISK_PATCHED,
-            _EXECUTION_ENGINE_TAXONOMY_PATCHED,
-        )
-
-    threading.Thread(target=_monitor, name="downstream-risk-governor-equity-repair-monitor", daemon=True).start()
-    logger.warning("DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_MONITOR_STARTED")
+        except Exception:
+            logger.exception("DOWNSTREAM_RISK_V2_MONITOR_ERROR marker=%s", _MARKER)
+        time.sleep(0.10)
+    os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = "0"
+    logger.critical("DOWNSTREAM_RISK_V2_MONITOR_EXPIRED marker=%s state=%s", _MARKER, _PATCH_STATE)
 
 
 def install_import_hook() -> None:
-    global _ORIGINAL_IMPORT_MODULE
+    global _MONITOR_STARTED
     with _INSTALL_LOCK:
         _try_patch_loaded()
-        _start_monitor()
-        if _ORIGINAL_IMPORT_MODULE is not None:
-            logger.warning(
-                "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_INSTALL_COMPLETE already_installed=True downstream=%s pipeline=%s pre_trade_risk=%s execution_taxonomy=%s",
-                _PATCHED,
-                _PIPELINE_PATCHED,
-                _PRE_TRADE_RISK_PATCHED,
-                _EXECUTION_ENGINE_TAXONOMY_PATCHED,
-            )
-            return
-        _ORIGINAL_IMPORT_MODULE = importlib.import_module
-
-        def _wrapped_import_module(name: str, package: str | None = None):
-            module = _ORIGINAL_IMPORT_MODULE(name, package)  # type: ignore[misc]
-            _patch_named_module(name, module)
-            _try_patch_loaded()
-            return module
-
-        importlib.import_module = _wrapped_import_module  # type: ignore[assignment]
-        logger.warning(
-            "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_INSTALL_COMPLETE downstream=%s pipeline=%s pre_trade_risk=%s execution_taxonomy=%s",
-            _PATCHED,
-            _PIPELINE_PATCHED,
-            _PRE_TRADE_RISK_PATCHED,
-            _EXECUTION_ENGINE_TAXONOMY_PATCHED,
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(target=_monitor, name="downstream-risk-v2-monitor", daemon=True).start()
+        os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED"] = "1"
+        os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED"] = "1"
+        logger.critical(
+            "DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED marker=%s chain_aware=true fail_closed=true exits_bypass=true state=%s",
+            _MARKER, _PATCH_STATE,
         )
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_chain_contains",
+    "_entry_increases_exposure",
+    "_install_on_execution_pipeline",
+    "_install_on_pre_trade_risk_engine",
+    "_install_on_downstream_blocker_guard",
+    "_minimum_live_notional_usd",
+]

--- a/bot/downstream_risk_governor_equity_repair_patch.py
+++ b/bot/downstream_risk_governor_equity_repair_patch.py
@@ -1,15 +1,14 @@
-"""Converged downstream equity and pre-dispatch risk-sizing repair.
+"""Chain-aware, fail-closed downstream equity and risk-sizing convergence.
 
-The legacy implementation repeatedly wrapped ``ExecutionPipeline.execute`` whenever
-another runtime guard became the outermost wrapper.  The broker-local readiness
-monitor then wrapped the risk wrapper again, producing an ever-growing alternating
-chain and eventually ``maximum recursion depth exceeded``.  The legacy exception
-handler also failed open and dispatched the original entry request.
+The former patch and the broker-local readiness patch repeatedly became each
+other's outer wrapper. Because the former exposed no ``__wrapped__`` link and only
+checked the outer function, the chain grew until ``maximum recursion depth
+exceeded``. It then failed open and dispatched the original entry request.
 
-This implementation is chain-aware and idempotent.  It exposes ``__wrapped__`` on
-every wrapper, detects its marker anywhere in the chain, blocks recursive entry
-re-entry, and fails closed when live entry sizing cannot be verified.  Exit/reduce
-requests bypass the entry-sizing layer unchanged.
+This replacement detects its marker anywhere in an explicit wrapper chain, exposes
+``__wrapped__`` on every wrapper, blocks same-thread entry reentry, and fails closed
+when live entry sizing cannot be verified. Exit/reduce requests bypass this entry
+sizing layer unchanged.
 """
 from __future__ import annotations
 
@@ -21,12 +20,12 @@ import time
 from dataclasses import is_dataclass, replace
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger("nija.downstream_risk_governor_equity_repair")
 _MARKER = "20260714-downstream-risk-v2"
-_TRUTHY = {"1", "true", "yes", "on", "y", "enabled"}
-_INSTALL_LOCK = threading.RLock()
+_TRUE = {"1", "true", "yes", "on", "y", "enabled"}
+_LOCK = threading.RLock()
 _TLS = threading.local()
 _MONITOR_STARTED = False
 
@@ -34,20 +33,12 @@ _DOWNSTREAM_ATTR = "_nija_downstream_risk_governor_equity_v2"
 _PIPELINE_ATTR = "_nija_pre_dispatch_risk_sizing_v2"
 _PRETRADE_ATTR = "_nija_pre_trade_strict_headroom_v2"
 _TAXONOMY_ATTR = "_nija_broker_specific_taxonomy_v2"
-
-_PATCH_STATE = {
-    "downstream": False,
-    "pipeline": False,
-    "pretrade": False,
-    "taxonomy": False,
-}
+_STATE = {"downstream": False, "pipeline": False, "pretrade": False, "taxonomy": False}
 
 
 def _truthy(name: str, default: bool = False) -> bool:
     raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return str(raw).strip().lower() in _TRUTHY
+    return default if raw is None else str(raw).strip().lower() in _TRUE
 
 
 def _live_runtime() -> bool:
@@ -55,10 +46,7 @@ def _live_runtime() -> bool:
 
 
 def _chain_contains(func: Any, attr: str) -> tuple[bool, bool, int]:
-    """Return (marker_found, cycle_detected, depth) for an explicit wrapper chain."""
-    current = func
-    seen: set[int] = set()
-    depth = 0
+    current, seen, depth = func, set(), 0
     while callable(current):
         ident = id(current)
         if ident in seen:
@@ -66,10 +54,9 @@ def _chain_contains(func: Any, attr: str) -> tuple[bool, bool, int]:
         seen.add(ident)
         if bool(getattr(current, attr, False)):
             return True, False, depth
-        nxt = getattr(current, "__wrapped__", None)
-        if not callable(nxt):
+        current = getattr(current, "__wrapped__", None)
+        if not callable(current):
             return False, False, depth
-        current = nxt
         depth += 1
         if depth >= 4096:
             return False, True, depth
@@ -112,13 +99,13 @@ def _live_equity_usd() -> float:
             from capital_authority import get_capital_authority  # type: ignore[import]
         authority = get_capital_authority()
         for attr in ("total_capital", "real_capital"):
-            best = max(best, _coerce_float(getattr(authority, attr, 0.0), 0.0))
-        for method_name in ("get_real_capital", "get_usable_capital"):
-            method = getattr(authority, method_name, None)
+            best = max(best, _coerce_float(getattr(authority, attr, 0.0)))
+        for name in ("get_real_capital", "get_usable_capital"):
+            method = getattr(authority, name, None)
             if callable(method):
-                best = max(best, _coerce_float(method(), 0.0))
+                best = max(best, _coerce_float(method()))
     except Exception:
-        return best
+        pass
     return best
 
 
@@ -131,18 +118,14 @@ def _request_broker(request: Any = None) -> str:
         "preferred_broker", "broker", "broker_name", "selected_broker",
         "execution_broker", "venue", "exchange",
     ):
-        try:
-            value = getattr(request, attr, None)
-            raw = getattr(value, "value", value)
-            text = str(raw or "").strip().lower()
-            if text:
-                return text
-        except Exception:
-            continue
+        value = getattr(request, attr, None)
+        text = str(getattr(value, "value", value) or "").strip().lower()
+        if text:
+            return text
     return ""
 
 
-def _infer_broker_for_min_notional(request: Any = None, *, symbol: str = "") -> str:
+def _infer_broker(request: Any = None, *, symbol: str = "") -> str:
     broker = _request_broker(request)
     for name in ("okx", "coinbase", "kraken"):
         if name in broker:
@@ -150,80 +133,66 @@ def _infer_broker_for_min_notional(request: Any = None, *, symbol: str = "") -> 
     sym = _request_symbol(request, symbol)
     if sym.endswith("-USDT") and str(os.environ.get("NIJA_LAST_ENTRY_BROKER", "")).lower() != "coinbase":
         return "okx"
-    if sym.endswith(("-USD", "-USDC")) and _float_env("COINBASE_MIN_ORDER_USD", default=0.0) > 0:
+    if sym.endswith(("-USD", "-USDC")) and _float_env("COINBASE_MIN_ORDER_USD") > 0:
         return "coinbase"
     return broker or "auto"
 
 
 def _minimum_live_notional_usd(request: Any = None, *, symbol: str = "") -> float:
-    broker = _infer_broker_for_min_notional(request, symbol=symbol)
+    broker = _infer_broker(request, symbol=symbol)
     if broker == "okx":
         return max(0.01, _float_env("OKX_MIN_ORDER_USD", "NIJA_OKX_MIN_ORDER_USD", default=10.0))
     if broker == "coinbase":
         return max(0.01, _float_env("COINBASE_MIN_ORDER_USD", "NIJA_COINBASE_MIN_ORDER_USD", default=1.0))
     if broker == "kraken":
-        return max(
-            0.01,
-            _float_env(
-                "KRAKEN_MIN_NOTIONAL_USD", "NIJA_KRAKEN_MIN_NOTIONAL_USD",
-                "MIN_TRADE_USD", default=23.0,
-            ),
-        )
-    return max(
-        0.01,
-        _float_env(
-            "NIJA_MIN_EXPOSURE_HEADROOM_TRADE_USD", "MIN_TRADE_USD",
-            "MIN_NOTIONAL_USD", "MIN_NOTIONAL_OVERRIDE", default=1.0,
-        ),
-    )
+        return max(0.01, _float_env("KRAKEN_MIN_NOTIONAL_USD", "NIJA_KRAKEN_MIN_NOTIONAL_USD", "MIN_TRADE_USD", default=23.0))
+    return max(0.01, _float_env("NIJA_MIN_EXPOSURE_HEADROOM_TRADE_USD", "MIN_TRADE_USD", "MIN_NOTIONAL_USD", "MIN_NOTIONAL_OVERRIDE", default=1.0))
 
 
 def _entry_increases_exposure(request: Any) -> bool:
-    side = str(getattr(request, "side", "") or "").strip().lower()
-    intent = str(getattr(request, "intent_type", "entry") or "entry").strip().lower()
-    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
-    reduce_only = bool(getattr(request, "reduce_only", False))
-    if reduce_only or intent in {"reduce", "exit", "close", "liquidate", "liquidation"}:
+    side = str(getattr(request, "side", "") or "").lower()
+    intent = str(getattr(request, "intent_type", "entry") or "entry").lower()
+    effect = str(getattr(request, "position_effect", "") or "").lower()
+    if bool(getattr(request, "reduce_only", False)):
+        return False
+    if intent in {"reduce", "exit", "close", "liquidate", "liquidation"}:
         return False
     if effect in {"reduce", "exit", "close"}:
         return False
     return side in {"buy", "long"}
 
 
-def _resolve_available_balance_usd(request: Any) -> float:
+def _available_balance(request: Any) -> float:
     for attr in ("available_balance_usd", "buying_power_usd", "spendable_quote_usd"):
-        value = _coerce_float(getattr(request, attr, None), 0.0)
+        value = _coerce_float(getattr(request, attr, None))
         if value > 0:
             return value
     return _live_equity_usd()
 
 
-def _replace_request_size(request: Any, new_size_usd: float) -> Any:
-    size = max(0.0, float(new_size_usd))
+def _replace_size(request: Any, size: float) -> Any:
+    size = max(0.0, float(size))
     if is_dataclass(request):
-        fields: dict[str, Any] = {"size_usd": size}
+        fields = {"size_usd": size}
         if hasattr(request, "notional_usd"):
             fields["notional_usd"] = size
         return replace(request, **fields)
     try:
         import copy
-        cloned = copy.copy(request)
+        result = copy.copy(request)
     except Exception:
-        cloned = request
-    setattr(cloned, "size_usd", size)
-    if hasattr(cloned, "notional_usd"):
-        setattr(cloned, "notional_usd", size)
-    return cloned
+        result = request
+    setattr(result, "size_usd", size)
+    if hasattr(result, "notional_usd"):
+        setattr(result, "notional_usd", size)
+    return result
 
 
-def _pipeline_deny(
-    module: ModuleType,
-    request: Any,
-    started: float,
-    reason: str,
-    *,
-    size_usd: Optional[float] = None,
-) -> Any:
+def _deny(module: ModuleType, request: Any, started: float, reason: str) -> Any:
+    logger.critical(
+        "PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_CLOSED marker=%s symbol=%s side=%s reason=%s",
+        _MARKER, _request_symbol(request), getattr(request, "side", ""), reason,
+    )
     result_cls = getattr(module, "PipelineResult", None)
     if not callable(result_cls):
         raise RuntimeError(reason)
@@ -231,25 +200,10 @@ def _pipeline_deny(
         success=False,
         symbol=str(getattr(request, "symbol", "") or ""),
         side=str(getattr(request, "side", "") or ""),
-        size_usd=float(size_usd if size_usd is not None else getattr(request, "size_usd", 0.0) or 0.0),
+        size_usd=_coerce_float(getattr(request, "size_usd", 0.0)),
         error=reason,
         latency_ms=(time.monotonic() - started) * 1000.0,
     )
-
-
-def _headroom_safety_buffer(headroom_usd: float) -> float:
-    return max(0.01, min(0.10, max(0.0, headroom_usd) * 0.001))
-
-
-def _entry_fail_closed(module: ModuleType, request: Any, started: float, reason: str) -> Any:
-    logger.critical(
-        "PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_CLOSED marker=%s symbol=%s side=%s reason=%s",
-        _MARKER,
-        _request_symbol(request),
-        getattr(request, "side", ""),
-        reason,
-    )
-    return _pipeline_deny(module, request, started, reason)
 
 
 def _install_on_downstream_blocker_guard(module: ModuleType) -> bool:
@@ -257,37 +211,29 @@ def _install_on_downstream_blocker_guard(module: ModuleType) -> bool:
     current = getattr(cls, "check_risk_governor", None) if isinstance(cls, type) else None
     if not callable(current):
         return False
-    found, cycle, _depth = _chain_contains(current, _DOWNSTREAM_ATTR)
+    found, cycle, _ = _chain_contains(current, _DOWNSTREAM_ATTR)
     if cycle:
-        logger.critical("DOWNSTREAM_RISK_WRAPPER_CHAIN_CYCLE marker=%s component=governor", _MARKER)
         return False
     if found:
-        _PATCH_STATE["downstream"] = True
+        _STATE["downstream"] = True
         return True
 
     @wraps(current)
-    def check_risk_governor(
-        self: Any,
-        symbol: str,
-        proposed_risk_usd: float,
-        portfolio_value: float = 0.0,
-        volatility_ratio: float = 1.0,
-    ) -> Any:
-        live_equity = _live_equity_usd()
-        incoming = _coerce_float(portfolio_value, 0.0)
-        repaired = max(incoming, live_equity)
-        if live_equity > incoming:
+    def check(self: Any, symbol: str, proposed_risk_usd: float, portfolio_value: float = 0.0, volatility_ratio: float = 1.0) -> Any:
+        incoming = _coerce_float(portfolio_value)
+        live = _live_equity_usd()
+        repaired = max(incoming, live)
+        if live > incoming:
             logger.critical(
-                "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_APPLIED marker=%s symbol=%s proposed_risk_usd=%.2f incoming_portfolio_value=%.2f live_equity_usd=%.2f repaired_portfolio_value=%.2f",
-                _MARKER, symbol, _coerce_float(proposed_risk_usd), incoming, live_equity, repaired,
+                "DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_APPLIED marker=%s symbol=%s incoming=%.2f live=%.2f repaired=%.2f",
+                _MARKER, symbol, incoming, live, repaired,
             )
         return current(self, symbol, proposed_risk_usd, repaired, volatility_ratio)
 
-    setattr(check_risk_governor, _DOWNSTREAM_ATTR, True)
-    setattr(check_risk_governor, "__wrapped__", current)
-    cls.check_risk_governor = check_risk_governor
-    _PATCH_STATE["downstream"] = True
-    logger.warning("DOWNSTREAM_RISK_GOVERNOR_EQUITY_REPAIR_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    setattr(check, _DOWNSTREAM_ATTR, True)
+    check.__wrapped__ = current
+    cls.check_risk_governor = check
+    _STATE["downstream"] = True
     return True
 
 
@@ -298,14 +244,11 @@ def _install_on_execution_pipeline(module: ModuleType) -> bool:
         return False
     found, cycle, depth = _chain_contains(current, _PIPELINE_ATTR)
     if cycle:
-        logger.critical(
-            "PRE_DISPATCH_RISK_WRAPPER_CHAIN_CYCLE marker=%s module=%s depth=%d action=fail_closed",
-            _MARKER, module.__name__, depth,
-        )
+        logger.critical("PRE_DISPATCH_RISK_WRAPPER_CHAIN_CYCLE marker=%s module=%s depth=%d", _MARKER, module.__name__, depth)
         os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "0"
         return False
     if found:
-        _PATCH_STATE["pipeline"] = True
+        _STATE["pipeline"] = True
         os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "1"
         return True
 
@@ -316,94 +259,74 @@ def _install_on_execution_pipeline(module: ModuleType) -> bool:
             return current(self, request, *args, **kwargs)
 
         token = (id(self), threading.get_ident())
-        active = getattr(_TLS, "active_entries", set())
+        active = set(getattr(_TLS, "active_entries", set()))
         if token in active:
-            return _entry_fail_closed(
-                module,
-                request,
-                started,
-                "PRE_DISPATCH_RISK_REENTRANCY_BLOCKED",
-            )
-
-        active = set(active)
+            return _deny(module, request, started, "PRE_DISPATCH_RISK_REENTRANCY_BLOCKED")
         active.add(token)
         _TLS.active_entries = active
-        dispatch_request = request
+
         try:
-            normalize = getattr(module, "normalize_pipeline_request", None)
-            working = normalize(request) if callable(normalize) else request
-            requested = _coerce_float(getattr(working, "size_usd", 0.0), 0.0)
-            if requested <= 0.0:
-                return _entry_fail_closed(module, working, started, "PRE_DISPATCH_INVALID_ENTRY_SIZE")
-
-            risk_engine = getattr(self, "_pre_trade_risk_engine", None)
-            get_headroom = getattr(risk_engine, "get_remaining_headroom_usd", None)
-            if not callable(get_headroom):
-                if _live_runtime():
-                    return _entry_fail_closed(module, working, started, "PRE_DISPATCH_RISK_ENGINE_UNAVAILABLE")
-                return current(self, request, *args, **kwargs)
-
-            account_id = str(getattr(working, "account_id", "default") or "default")
-            available = _resolve_available_balance_usd(working)
-            if available <= 0.0 and _live_runtime():
-                return _entry_fail_closed(module, working, started, "PRE_DISPATCH_CAPITAL_SIGNAL_UNAVAILABLE")
-
-            headroom = max(0.0, _coerce_float(get_headroom(account_id, available), 0.0))
-            symbol = _request_symbol(working)
-            minimum = _minimum_live_notional_usd(working, symbol=symbol)
-            broker = _infer_broker_for_min_notional(working, symbol=symbol)
-
-            logger.info(
-                "PRE_DISPATCH_EXPOSURE_HEADROOM_CHECK marker=%s account=%s symbol=%s requested_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f broker=%s available_balance_usd=%.2f",
-                _MARKER, account_id, symbol, requested, headroom, minimum, broker, available,
-            )
-
-            if headroom + 0.01 < requested:
-                safe_size = max(0.0, headroom - _headroom_safety_buffer(headroom))
-                if safe_size < minimum:
-                    return _entry_fail_closed(
-                        module,
-                        working,
-                        started,
-                        "PreTradeRiskEngine reject: GLOBAL_EXPOSURE_CAP_HEADROOM_EXHAUSTED "
-                        f"requested_size_usd={requested:.2f} headroom_usd={headroom:.2f} "
-                        f"min_notional_usd={minimum:.2f} broker={broker}",
-                    )
-                dispatch_request = _replace_request_size(working, safe_size)
-                logger.warning(
-                    "PRE_DISPATCH_EXPOSURE_HEADROOM_CLIPPED marker=%s account=%s symbol=%s requested_size_usd=%.2f clipped_size_usd=%.2f headroom_usd=%.2f min_notional_usd=%.2f broker=%s",
-                    _MARKER, account_id, symbol, requested, safe_size, headroom, minimum, broker,
-                )
-            else:
-                dispatch_request = working
-        except Exception as exc:
-            if _live_runtime():
-                return _entry_fail_closed(
-                    module,
-                    request,
-                    started,
-                    f"PRE_DISPATCH_RISK_SIZING_ERROR:{type(exc).__name__}:{exc}",
-                )
             dispatch_request = request
+            try:
+                normalize = getattr(module, "normalize_pipeline_request", None)
+                working = normalize(request) if callable(normalize) else request
+                requested = _coerce_float(getattr(working, "size_usd", 0.0))
+                if requested <= 0:
+                    return _deny(module, working, started, "PRE_DISPATCH_INVALID_ENTRY_SIZE")
 
-        try:
-            return current(self, dispatch_request, *args, **kwargs)
-        except RecursionError as exc:
-            return _entry_fail_closed(
-                module,
-                dispatch_request,
-                started,
-                f"PRE_DISPATCH_EXECUTION_CHAIN_RECURSION:{exc}",
-            )
+                engine = getattr(self, "_pre_trade_risk_engine", None)
+                headroom_fn = getattr(engine, "get_remaining_headroom_usd", None)
+                if not callable(headroom_fn):
+                    if _live_runtime():
+                        return _deny(module, working, started, "PRE_DISPATCH_RISK_ENGINE_UNAVAILABLE")
+                    return current(self, request, *args, **kwargs)
+
+                account = str(getattr(working, "account_id", "default") or "default")
+                available = _available_balance(working)
+                if available <= 0 and _live_runtime():
+                    return _deny(module, working, started, "PRE_DISPATCH_CAPITAL_SIGNAL_UNAVAILABLE")
+                headroom = max(0.0, _coerce_float(headroom_fn(account, available)))
+                symbol = _request_symbol(working)
+                minimum = _minimum_live_notional_usd(working, symbol=symbol)
+                broker = _infer_broker(working, symbol=symbol)
+
+                logger.info(
+                    "PRE_DISPATCH_EXPOSURE_HEADROOM_CHECK marker=%s account=%s symbol=%s requested=%.2f headroom=%.2f minimum=%.2f broker=%s available=%.2f",
+                    _MARKER, account, symbol, requested, headroom, minimum, broker, available,
+                )
+                if headroom + 0.01 < requested:
+                    safe = max(0.0, headroom - max(0.01, min(0.10, headroom * 0.001)))
+                    if safe < minimum:
+                        return _deny(
+                            module, working, started,
+                            "GLOBAL_EXPOSURE_CAP_HEADROOM_EXHAUSTED "
+                            f"requested={requested:.2f} headroom={headroom:.2f} minimum={minimum:.2f} broker={broker}",
+                        )
+                    dispatch_request = _replace_size(working, safe)
+                    logger.warning(
+                        "PRE_DISPATCH_EXPOSURE_HEADROOM_CLIPPED marker=%s account=%s symbol=%s requested=%.2f clipped=%.2f headroom=%.2f minimum=%.2f broker=%s",
+                        _MARKER, account, symbol, requested, safe, headroom, minimum, broker,
+                    )
+                else:
+                    dispatch_request = working
+            except Exception as exc:
+                if _live_runtime():
+                    return _deny(module, request, started, f"PRE_DISPATCH_RISK_SIZING_ERROR:{type(exc).__name__}:{exc}")
+                dispatch_request = request
+
+            try:
+                return current(self, dispatch_request, *args, **kwargs)
+            except RecursionError as exc:
+                return _deny(module, dispatch_request, started, f"PRE_DISPATCH_EXECUTION_CHAIN_RECURSION:{exc}")
         finally:
             remaining = set(getattr(_TLS, "active_entries", set()))
             remaining.discard(token)
             _TLS.active_entries = remaining
 
     setattr(execute, _PIPELINE_ATTR, True)
-    setattr(execute, "__wrapped__", current)
+    execute.__wrapped__ = current
     cls.execute = execute
-    _PATCH_STATE["pipeline"] = True
+    _STATE["pipeline"] = True
     os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "1"
     logger.critical(
         "PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED marker=%s module=%s chain_aware=true fail_closed=true exits_bypass=true",
@@ -418,12 +341,11 @@ def _install_on_pre_trade_risk_engine(module: ModuleType) -> bool:
     current = getattr(cls, "assess", None) if isinstance(cls, type) else None
     if not callable(current) or not callable(decision_cls):
         return False
-    found, cycle, _depth = _chain_contains(current, _PRETRADE_ATTR)
+    found, cycle, _ = _chain_contains(current, _PRETRADE_ATTR)
     if cycle:
-        logger.critical("PRE_TRADE_RISK_WRAPPER_CHAIN_CYCLE marker=%s", _MARKER)
         return False
     if found:
-        _PATCH_STATE["pretrade"] = True
+        _STATE["pretrade"] = True
         return True
 
     @wraps(current)
@@ -432,68 +354,33 @@ def _install_on_pre_trade_risk_engine(module: ModuleType) -> bool:
         if not bool(getattr(decision, "approved", False)):
             return decision
         try:
-            intent = str(kwargs.get("intent_type") or "entry").lower()
-            if kwargs.get("reduce_only") or intent in {"reduce", "exit", "close"}:
+            if kwargs.get("reduce_only") or str(kwargs.get("intent_type") or "entry").lower() in {"reduce", "exit", "close"}:
                 return decision
-            requested = _coerce_float(kwargs.get("size_usd"), 0.0)
+            requested = _coerce_float(kwargs.get("size_usd"))
             details = dict(getattr(decision, "details", {}) or {})
-            headroom_raw = details.get("remaining_headroom_usd")
-            if requested <= 0.0 or headroom_raw is None:
+            raw = details.get("remaining_headroom_usd")
+            if requested <= 0 or raw is None:
                 return decision
-            headroom = max(0.0, _coerce_float(headroom_raw, 0.0))
+            headroom = max(0.0, _coerce_float(raw))
             if requested <= headroom + 0.01:
                 return decision
-            symbol = str(kwargs.get("symbol") or "")
-            minimum = _minimum_live_notional_usd(symbol=symbol)
-            details.update(
-                requested_size_usd=requested,
-                max_approved_size_usd=headroom,
-                broker_aware_min_notional_usd=minimum,
-            )
+            minimum = _minimum_live_notional_usd(symbol=str(kwargs.get("symbol") or ""))
+            details.update(requested_size_usd=requested, max_approved_size_usd=headroom, broker_aware_min_notional_usd=minimum)
             if headroom >= minimum:
                 details["action_required"] = "clip_before_execution_pipeline_dispatch"
                 return decision_cls(approved=True, reason="approved_headroom_clip_required", details=details)
             details["action_required"] = "downsize_before_execution_pipeline_dispatch"
-            return decision_cls(
-                approved=False,
-                reason="GLOBAL_EXPOSURE_CAP_HEADROOM_REQUIRES_DOWNSIZE",
-                details=details,
-            )
+            return decision_cls(approved=False, reason="GLOBAL_EXPOSURE_CAP_HEADROOM_REQUIRES_DOWNSIZE", details=details)
         except Exception as exc:
             if _live_runtime():
-                return decision_cls(
-                    approved=False,
-                    reason=f"PRE_TRADE_HEADROOM_VALIDATION_ERROR:{type(exc).__name__}",
-                    details={"error": str(exc), "fail_closed": True},
-                )
+                return decision_cls(approved=False, reason=f"PRE_TRADE_HEADROOM_VALIDATION_ERROR:{type(exc).__name__}", details={"error": str(exc), "fail_closed": True})
             return decision
 
     setattr(assess, _PRETRADE_ATTR, True)
-    setattr(assess, "__wrapped__", current)
+    assess.__wrapped__ = current
     cls.assess = assess
-    _PATCH_STATE["pretrade"] = True
-    logger.warning("PRE_TRADE_STRICT_HEADROOM_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    _STATE["pretrade"] = True
     return True
-
-
-def _manual_failure_details(broker_response: Any = None, exc: Optional[Exception] = None) -> dict[str, str]:
-    response = broker_response if isinstance(broker_response, dict) else {}
-    status = str(response.get("status") or ("exception" if exc else "unknown")).lower()
-    error = response.get("error", "")
-    if isinstance(error, (list, tuple)):
-        error = ", ".join(str(item) for item in error if item)
-    message = str(response.get("message") or "")
-    detail = " | ".join(part for part in (str(error or ""), message, str(exc or "")) if part) or "Unknown execution failure"
-    normalized = detail.lower()
-    hint = "Inspect broker rejection payload"
-    if any(term in normalized for term in ("too small", "minimum", "min notional")):
-        hint = "Check minimum order size / exchange notional floor"
-    elif any(term in normalized for term in ("insufficient", "fund", "balance")):
-        hint = "Check per-broker available balance and fee-adjusted sizing"
-    elif any(term in normalized for term in ("exposure", "risk", "cap")):
-        hint = "Check pre-trade exposure/risk caps before broker dispatch"
-    code = (str(error or message or status or "UNKNOWN_REJECTION"))[:120].upper().replace(" ", "_")
-    return {"status": status, "error_code": code, "detail": detail, "hint": hint}
 
 
 def _install_on_execution_engine(module: ModuleType) -> bool:
@@ -501,35 +388,45 @@ def _install_on_execution_engine(module: ModuleType) -> bool:
     current = getattr(cls, "_extract_order_failure_details", None) if isinstance(cls, type) else None
     if not callable(current):
         return False
-    found, cycle, _depth = _chain_contains(current, _TAXONOMY_ATTR)
+    found, cycle, _ = _chain_contains(current, _TAXONOMY_ATTR)
     if cycle:
         return False
     if found:
-        _PATCH_STATE["taxonomy"] = True
+        _STATE["taxonomy"] = True
         return True
 
     @wraps(current)
     def extract(self: Any, broker_response: Any = None, exc: Optional[Exception] = None) -> dict[str, str]:
-        label = "unknown"
         try:
             label = str(self._get_broker_label()).strip().lower()
         except Exception:
-            pass
+            label = "unknown"
         if label == "kraken":
             return current(self, broker_response=broker_response, exc=exc)
-        details = _manual_failure_details(broker_response=broker_response, exc=exc)
-        details["broker"] = label
-        return details
+        response = broker_response if isinstance(broker_response, dict) else {}
+        status = str(response.get("status") or ("exception" if exc else "unknown")).lower()
+        error = response.get("error", "")
+        if isinstance(error, (list, tuple)):
+            error = ", ".join(str(item) for item in error if item)
+        message = str(response.get("message") or "")
+        detail = " | ".join(part for part in (str(error or ""), message, str(exc or "")) if part) or "Unknown execution failure"
+        return {
+            "status": status,
+            "error_code": str(error or message or status or "UNKNOWN_REJECTION")[:120].upper().replace(" ", "_"),
+            "detail": detail,
+            "hint": "Inspect broker rejection payload",
+            "broker": label,
+        }
 
     setattr(extract, _TAXONOMY_ATTR, True)
-    setattr(extract, "__wrapped__", current)
+    extract.__wrapped__ = current
     cls._extract_order_failure_details = extract
-    _PATCH_STATE["taxonomy"] = True
+    _STATE["taxonomy"] = True
     return True
 
 
 def _try_patch_loaded() -> bool:
-    patched = False
+    changed = False
     targets = (
         (("bot.downstream_blocker_guard", "downstream_blocker_guard"), _install_on_downstream_blocker_guard),
         (("bot.execution_pipeline", "execution_pipeline"), _install_on_execution_pipeline),
@@ -540,8 +437,8 @@ def _try_patch_loaded() -> bool:
         for name in names:
             module = sys.modules.get(name)
             if isinstance(module, ModuleType):
-                patched = installer(module) or patched
-    return patched
+                changed = installer(module) or changed
+    return changed
 
 
 def _monitor() -> None:
@@ -549,19 +446,19 @@ def _monitor() -> None:
     while time.monotonic() < deadline:
         try:
             _try_patch_loaded()
-            if all(_PATCH_STATE.values()):
+            if all(_STATE.values()):
                 os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = "1"
                 return
         except Exception:
             logger.exception("DOWNSTREAM_RISK_V2_MONITOR_ERROR marker=%s", _MARKER)
         time.sleep(0.10)
     os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = "0"
-    logger.critical("DOWNSTREAM_RISK_V2_MONITOR_EXPIRED marker=%s state=%s", _MARKER, _PATCH_STATE)
+    logger.critical("DOWNSTREAM_RISK_V2_MONITOR_EXPIRED marker=%s state=%s", _MARKER, _STATE)
 
 
 def install_import_hook() -> None:
     global _MONITOR_STARTED
-    with _INSTALL_LOCK:
+    with _LOCK:
         _try_patch_loaded()
         if not _MONITOR_STARTED:
             _MONITOR_STARTED = True
@@ -570,7 +467,7 @@ def install_import_hook() -> None:
         os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED"] = "1"
         logger.critical(
             "DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED marker=%s chain_aware=true fail_closed=true exits_bypass=true state=%s",
-            _MARKER, _PATCH_STATE,
+            _MARKER, _STATE,
         )
 
 
@@ -579,12 +476,7 @@ def install() -> None:
 
 
 __all__ = [
-    "install",
-    "install_import_hook",
-    "_chain_contains",
-    "_entry_increases_exposure",
-    "_install_on_execution_pipeline",
-    "_install_on_pre_trade_risk_engine",
-    "_install_on_downstream_blocker_guard",
-    "_minimum_live_notional_usd",
+    "install", "install_import_hook", "_chain_contains", "_entry_increases_exposure",
+    "_install_on_execution_pipeline", "_install_on_pre_trade_risk_engine",
+    "_install_on_downstream_blocker_guard", "_minimum_live_notional_usd",
 ]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,20 +10,16 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260714-runtime-convergence-v8"
+RELEASE_ID = "20260714-runtime-convergence-v9"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
-# Installation order is intentional. The canonical owner is installed first and
-# its delegated-reentry helper is patched immediately afterward. Broker-local
-# readiness is normalized before the strict release contract is published. Kraken
-# metadata filtering precedes dynamic equity hydration, and exit recovery is made
-# strictly exit-only before the final profit-realization guard is installed.
 _INSTALLERS = (
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("broker_local_readiness_contract_patch", "install_import_hook"),
+    ("bot.downstream_risk_governor_equity_repair_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
@@ -44,6 +40,9 @@ _INSTALLERS = (
 _REQUIRED_FLAGS = {
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
     "broker_local_readiness_contract": "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
+    "downstream_risk_v2_installed": "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED",
+    "pre_dispatch_risk_fail_closed": "NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED",
+    "pre_dispatch_risk_ready": "NIJA_PRE_DISPATCH_RISK_SIZING_READY",
     "kraken_equity_metadata_guard": "NIJA_KRAKEN_EQUITY_METADATA_GUARD_INSTALLED",
     "kraken_synthetic_equity_scrub": "NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED",
     "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
@@ -77,7 +76,6 @@ def _invoke(module_name: str, function_name: str) -> tuple[bool, str]:
 
 
 def _expected_scan_wrapper_release() -> str:
-    """Read the strict scan-owner release contract from the installed module."""
     try:
         module = importlib.import_module("scan_wrapper_convergence_repair_patch")
         return str(getattr(module, "_MARKER", "") or "").strip()
@@ -96,13 +94,9 @@ def _readiness_contract_consistent() -> tuple[bool, str]:
     missing = str(os.environ.get("NIJA_REQUIRED_VENUES_MISSING", "") or "").strip().strip(",")
     required_ready = _truthy(os.environ.get("NIJA_REQUIRED_VENUES_READY"))
     global_ready = _truthy(
-        os.environ.get(
-            "NIJA_GLOBAL_TRADING_READY",
-            os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0"),
-        )
+        os.environ.get("NIJA_GLOBAL_TRADING_READY", os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0"))
     )
     active = str(os.environ.get("NIJA_ACTIVE_LIVE_VENUES", "") or "").strip().strip(",")
-
     if policy not in {"broker_local", "global_all_required", "optional"}:
         return False, f"invalid_policy:{policy or 'missing'}"
     if missing and required_ready:
@@ -127,9 +121,7 @@ def _audit() -> tuple[bool, dict[str, str]]:
     expected_scan_release = _expected_scan_wrapper_release()
     if not _scan_release_compatible(scan_release, expected_scan_release):
         ready = False
-        results["scan_wrapper_release"] = (
-            f"actual={scan_release or 'missing'};expected={expected_scan_release or 'missing'}"
-        )
+        results["scan_wrapper_release"] = f"actual={scan_release or 'missing'};expected={expected_scan_release or 'missing'}"
     else:
         results["scan_wrapper_release"] = scan_release
 
@@ -152,11 +144,7 @@ def _publish(ready: bool, details: dict[str, str]) -> None:
     os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
     logger.critical(
         "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
-        RELEASE_ID,
-        _deployment_sha(),
-        str(ready).lower(),
-        os.getpid(),
-        details,
+        RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
     )
     if not ready:
         logger.critical(
@@ -187,11 +175,7 @@ def install_import_hook() -> None:
 
 
 __all__ = [
-    "RELEASE_ID",
-    "install_import_hook",
-    "_audit",
-    "_deployment_sha",
-    "_expected_scan_wrapper_release",
-    "_scan_release_compatible",
+    "RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
+    "_expected_scan_wrapper_release", "_scan_release_compatible",
     "_readiness_contract_consistent",
 ]

--- a/bot/tests/test_downstream_risk_governor_equity_repair_v2.py
+++ b/bot/tests/test_downstream_risk_governor_equity_repair_v2.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import bot.downstream_risk_governor_equity_repair_patch as patch
+
+
+class Result:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class RiskEngine:
+    def __init__(self, headroom=100.0, error=None):
+        self.headroom = headroom
+        self.error = error
+
+    def get_remaining_headroom_usd(self, account_id, available_balance):
+        if self.error:
+            raise self.error
+        return self.headroom
+
+
+def _request(**overrides):
+    values = dict(
+        symbol="BTC-USD",
+        side="buy",
+        size_usd=25.0,
+        intent_type="entry",
+        reduce_only=False,
+        account_id="platform",
+        preferred_broker="kraken",
+        available_balance_usd=100.0,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _module(base_execute):
+    module = ModuleType("bot.execution_pipeline")
+    module.PipelineResult = Result
+    module.normalize_pipeline_request = lambda request: request
+    module.ExecutionPipeline = type("ExecutionPipeline", (), {"execute": base_execute})
+    return module
+
+
+def test_chain_marker_prevents_rewrapping_when_another_guard_is_outer(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+
+    def base(self, request):
+        return "executed"
+
+    module = _module(base)
+    assert patch._install_on_execution_pipeline(module) is True
+    risk_wrapper = module.ExecutionPipeline.execute
+
+    def broker_local_outer(self, request):
+        return risk_wrapper(self, request)
+
+    broker_local_outer.__wrapped__ = risk_wrapper
+    module.ExecutionPipeline.execute = broker_local_outer
+
+    before = module.ExecutionPipeline.execute
+    assert patch._install_on_execution_pipeline(module) is True
+    assert module.ExecutionPipeline.execute is before
+    found, cycle, depth = patch._chain_contains(before, patch._PIPELINE_ATTR)
+    assert found is True
+    assert cycle is False
+    assert depth == 1
+
+
+def test_same_thread_recursive_entry_is_denied_not_recurred(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+
+    def recursive_base(self, request):
+        return self.execute(request)
+
+    module = _module(recursive_base)
+    patch._install_on_execution_pipeline(module)
+    pipeline = module.ExecutionPipeline()
+    pipeline._pre_trade_risk_engine = RiskEngine(headroom=100.0)
+
+    result = pipeline.execute(_request())
+
+    assert result.success is False
+    assert result.error == "PRE_DISPATCH_RISK_REENTRANCY_BLOCKED"
+
+
+def test_risk_sizing_exception_fails_closed_and_releases_token(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    calls = []
+
+    def base(self, request):
+        calls.append(request.size_usd)
+        return "executed"
+
+    module = _module(base)
+    patch._install_on_execution_pipeline(module)
+    pipeline = module.ExecutionPipeline()
+    pipeline._pre_trade_risk_engine = RiskEngine(error=RuntimeError("boom"))
+
+    denied = pipeline.execute(_request())
+    assert denied.success is False
+    assert denied.error.startswith("PRE_DISPATCH_RISK_SIZING_ERROR:RuntimeError:boom")
+
+    pipeline._pre_trade_risk_engine = RiskEngine(headroom=100.0)
+    assert pipeline.execute(_request()) == "executed"
+    assert calls == [25.0]
+
+
+def test_live_entry_without_risk_engine_fails_closed(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+
+    def base(self, request):
+        raise AssertionError("entry must not dispatch")
+
+    module = _module(base)
+    patch._install_on_execution_pipeline(module)
+    result = module.ExecutionPipeline().execute(_request())
+
+    assert result.success is False
+    assert result.error == "PRE_DISPATCH_RISK_ENGINE_UNAVAILABLE"
+
+
+def test_exit_bypasses_entry_sizing_and_reaches_original(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    calls = []
+
+    def base(self, request):
+        calls.append((request.side, request.intent_type, request.reduce_only))
+        return "exit-dispatched"
+
+    module = _module(base)
+    patch._install_on_execution_pipeline(module)
+    pipeline = module.ExecutionPipeline()
+
+    result = pipeline.execute(_request(side="sell", intent_type="exit", reduce_only=True))
+
+    assert result == "exit-dispatched"
+    assert calls == [("sell", "exit", True)]
+
+
+def test_entry_is_clipped_to_verified_headroom(monkeypatch):
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("KRAKEN_MIN_NOTIONAL_USD", "10")
+    calls = []
+
+    def base(self, request):
+        calls.append(request.size_usd)
+        return "executed"
+
+    module = _module(base)
+    patch._install_on_execution_pipeline(module)
+    pipeline = module.ExecutionPipeline()
+    pipeline._pre_trade_risk_engine = RiskEngine(headroom=20.0)
+
+    assert pipeline.execute(_request(size_usd=25.0)) == "executed"
+    assert len(calls) == 1
+    assert 19.8 <= calls[0] < 20.0

--- a/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
+++ b/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
@@ -15,8 +15,14 @@ def _clear(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_v8_release_id():
-    assert manifest.RELEASE_ID == "20260714-runtime-convergence-v8"
+def test_v9_release_id():
+    assert manifest.RELEASE_ID == "20260714-runtime-convergence-v9"
+
+
+def test_v9_requires_fail_closed_risk_sizing_flags():
+    assert manifest._REQUIRED_FLAGS["downstream_risk_v2_installed"] == "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_fail_closed"] == "NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED"
+    assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_ready"] == "NIJA_PRE_DISPATCH_RISK_SIZING_READY"
 
 
 def test_contract_accepts_broker_local_kraken_with_missing_secondaries(monkeypatch):


### PR DESCRIPTION
## Runtime evidence

The July 14 Render process repeatedly emitted:

```text
PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_OPEN error=maximum recursion depth exceeded
```

The warning appeared dozens of times per second while the broker-local execution pipeline patch was also being installed.

## Root cause

`downstream_risk_governor_equity_repair_patch` and `secondary_venue_strict_readiness_patch` both wrap `ExecutionPipeline.execute`.

The legacy risk wrapper:

- checked only the outermost function for its marker,
- did not expose `__wrapped__`,
- was reinstalled whenever another guard became outermost,
- alternated with the broker-local wrapper until the chain exceeded Python's recursion limit,
- then caught the error and failed open by dispatching the original entry request.

## Repairs

### Chain-aware idempotent wrappers

Every replacement wrapper now:

- exposes `__wrapped__`,
- searches the complete explicit wrapper chain for its marker,
- refuses cyclic wrapper chains,
- installs at most once even when another risk, readiness, routing or telemetry guard is outermost.

### Entry risk failures fail closed

Live exposure-increasing entries are denied when:

- the pre-trade risk engine is unavailable,
- capital/equity cannot be verified,
- the requested size is invalid,
- headroom calculation raises,
- exposure headroom cannot support the broker minimum,
- the execution wrapper re-enters on the same thread,
- the downstream execution chain raises `RecursionError`.

The old `PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_OPEN` path no longer exists.

### Exits remain independent

Sell/reduce/close/liquidation requests bypass this entry-sizing layer and proceed to the existing writer-authority, broker, margin, stop-loss and exit guards unchanged.

### Safe clipping

When verified headroom is below the request but still above the target broker's executable minimum, the request is cloned and clipped before ECEL/broker dispatch. The original request is not mutated.

### Thread-local cleanup

The same-thread reentry token is released in an outer `finally` block on success, denial and exception. One rejected order cannot poison later valid cycles.

### v9 release contract

The runtime manifest is bumped to `20260714-runtime-convergence-v9` and cannot report `ready=true` unless all of these are present:

- `NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED=1`
- `NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED=1`
- `NIJA_PRE_DISPATCH_RISK_SIZING_READY=1`

All prior scan convergence, broker-local readiness, Kraken equity, exit-only recovery and profit-realization guards remain required.

## Regression coverage

- another outer wrapper does not trigger reinstallation,
- same-thread recursive entry is denied rather than recursed,
- risk-engine exceptions fail closed,
- the reentry token is released after denial,
- live entry without a risk engine cannot dispatch,
- exits bypass entry sizing,
- verified headroom clips an entry without falling below broker minimum.

## Expected Render proof

```text
DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED marker=20260714-downstream-risk-v2
PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED ... chain_aware=true fail_closed=true exits_bypass=true
NIJA_RUNTIME_RELEASE_MANIFEST release=20260714-runtime-convergence-v9 ... ready=true
```

The repeated `PRE_DISPATCH_RISK_SIZING_PATCH_FAIL_OPEN` and `maximum recursion depth exceeded` messages must disappear.

## CI infrastructure status

The imports-smoke workflow terminated before repository checkout or test execution. GitHub returned `steps=None` and no job log URL, so the red workflow state contains no actionable code-level test failure.