### PR TITLE
Converge startup module identity and bound live scan diagnostics

### DIFF
--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -21,6 +21,7 @@ _INSTALLERS = (
     ("broker_local_readiness_contract_patch", "install_import_hook"),
     ("bot.downstream_risk_governor_equity_repair_patch", "install_import_hook"),
     ("runtime_convergence_hardening_patch", "install"),
+    ("bot.zero_signal_streak_state_repair_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
@@ -42,6 +43,8 @@ _REQUIRED_FLAGS = {
     "module_identity_guard": "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
     "module_identity_ready": "NIJA_RUNTIME_MODULE_IDENTITY_READY",
     "core_loop_limits": "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED",
+    "zero_signal_state_repair": "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
+    "zero_signal_state_ready": "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
     "broker_local_readiness_contract": "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
     "downstream_risk_v2_installed": "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED",
@@ -116,11 +119,15 @@ def _readiness_contract_consistent() -> tuple[bool, str]:
 def _runtime_limits_consistent() -> tuple[bool, str]:
     try:
         streak = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "999") or 999))
+        stale = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100") or 100))
         stall = float(os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "0") or 0)
     except Exception as exc:
         return False, f"parse_error:{exc}"
-    ok = 2 <= streak <= 12 and stall >= 120.0
-    return ok, f"zero_signal_streak_cap={streak};run_cycle_stall_warn_s={stall:.1f}"
+    ok = 2 <= streak <= 12 and stale > streak and stall >= 120.0
+    return ok, (
+        f"zero_signal_streak_cap={streak};stale_threshold={stale};"
+        f"run_cycle_stall_warn_s={stall:.1f}"
+    )
 
 
 def _audit() -> tuple[bool, dict[str, str]]:

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -1,5 +1,4 @@
 """NIJA runtime release manifest and critical repair convergence audit."""
-
 from __future__ import annotations
 
 import importlib
@@ -10,16 +9,18 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260714-runtime-convergence-v9"
+RELEASE_ID = "20260714-runtime-convergence-v10"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 _INSTALLERS = (
+    ("runtime_module_identity_convergence_patch", "install_import_hook"),
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("broker_local_readiness_contract_patch", "install_import_hook"),
     ("bot.downstream_risk_governor_equity_repair_patch", "install_import_hook"),
+    ("runtime_convergence_hardening_patch", "install"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
@@ -38,6 +39,9 @@ _INSTALLERS = (
 )
 
 _REQUIRED_FLAGS = {
+    "module_identity_guard": "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
+    "module_identity_ready": "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+    "core_loop_limits": "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED",
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
     "broker_local_readiness_contract": "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
     "downstream_risk_v2_installed": "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED",
@@ -56,8 +60,8 @@ def _truthy(value: str | None) -> bool:
 
 def _deployment_sha() -> str:
     for name in (
-        "RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "SOURCE_VERSION", "RENDER_GIT_COMMIT",
-        "HEROKU_SLUG_COMMIT",
+        "RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "SOURCE_VERSION",
+        "RENDER_GIT_COMMIT", "HEROKU_SLUG_COMMIT",
     ):
         value = str(os.environ.get(name, "") or "").strip()
         if value:
@@ -109,6 +113,16 @@ def _readiness_contract_consistent() -> tuple[bool, str]:
     )
 
 
+def _runtime_limits_consistent() -> tuple[bool, str]:
+    try:
+        streak = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "999") or 999))
+        stall = float(os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "0") or 0)
+    except Exception as exc:
+        return False, f"parse_error:{exc}"
+    ok = 2 <= streak <= 12 and stall >= 120.0
+    return ok, f"zero_signal_streak_cap={streak};run_cycle_stall_warn_s={stall:.1f}"
+
+
 def _audit() -> tuple[bool, dict[str, str]]:
     results: dict[str, str] = {}
     ready = True
@@ -116,6 +130,15 @@ def _audit() -> tuple[bool, dict[str, str]]:
         ok, reason = _invoke(module_name, function_name)
         results[module_name] = reason
         ready = ready and ok
+
+    try:
+        identity = importlib.import_module("runtime_module_identity_convergence_patch")
+        identity_ready, identity_details = identity.audit()
+        results["module_identity_audit"] = str(identity_details)
+        ready = ready and bool(identity_ready)
+    except Exception as exc:
+        results["module_identity_audit"] = f"{type(exc).__name__}:{exc}"
+        ready = False
 
     scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "").strip()
     expected_scan_release = _expected_scan_wrapper_release()
@@ -132,6 +155,10 @@ def _audit() -> tuple[bool, dict[str, str]]:
             results[label] = value or "missing"
         else:
             results[label] = "ready"
+
+    limits_ok, limits_reason = _runtime_limits_consistent()
+    results["core_loop_runtime_limits"] = limits_reason
+    ready = ready and limits_ok
 
     contract_ok, contract_reason = _readiness_contract_consistent()
     results["readiness_contract"] = contract_reason
@@ -177,5 +204,5 @@ def install_import_hook() -> None:
 __all__ = [
     "RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
     "_expected_scan_wrapper_release", "_scan_release_compatible",
-    "_readiness_contract_consistent",
+    "_readiness_contract_consistent", "_runtime_limits_consistent",
 ]

--- a/bot/tests/test_runtime_module_identity_convergence_patch.py
+++ b/bot/tests/test_runtime_module_identity_convergence_patch.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import runtime_module_identity_convergence_patch as guard
+
+
+def _module(name: str, file_path: str, marker: str = "") -> ModuleType:
+    module = ModuleType(name)
+    module.__file__ = file_path
+    module._MARKER = marker
+    module.install_import_hook = lambda: None
+    return module
+
+
+def test_alias_is_bound_to_canonical_module_before_second_import(monkeypatch):
+    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
+    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    alias = _module(
+        alias_name,
+        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "20260714-downstream-risk-v2",
+    )
+    monkeypatch.setitem(sys.modules, alias_name, alias)
+    monkeypatch.delitem(sys.modules, canonical_name, raising=False)
+
+    ready, details = guard.canonicalize_loaded_patch_modules()
+
+    assert ready is True
+    assert sys.modules[canonical_name] is alias
+    assert sys.modules[alias_name] is alias
+    assert details[canonical_name] == "same_object"
+
+
+def test_duplicate_modules_select_v2_but_report_convergence_event(monkeypatch):
+    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
+    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    legacy = _module(
+        canonical_name,
+        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "20260707a",
+    )
+    v2 = _module(
+        alias_name,
+        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "20260714-downstream-risk-v2",
+    )
+    monkeypatch.setitem(sys.modules, canonical_name, legacy)
+    monkeypatch.setitem(sys.modules, alias_name, v2)
+
+    ready, _details = guard.canonicalize_loaded_patch_modules()
+
+    assert ready is False
+    assert sys.modules[canonical_name] is v2
+    assert sys.modules[alias_name] is v2
+
+
+def test_wrapper_chain_detects_v2_and_legacy_layers():
+    def leaf(self, request):
+        return None
+
+    def v2(self, request):
+        return leaf(self, request)
+
+    v2.__wrapped__ = leaf
+    setattr(v2, guard._V2_RISK_ATTR, True)
+
+    def legacy(self, request):
+        return v2(self, request)
+
+    legacy.__wrapped__ = v2
+    setattr(legacy, guard._LEGACY_RISK_ATTR, True)
+
+    current, old, cycle, depth = guard._wrapper_chain_status(legacy)
+
+    assert current is True
+    assert old is True
+    assert cycle is False
+    assert depth == 2
+
+
+def test_wrapper_chain_detects_cycle():
+    def first(self, request):
+        return None
+
+    def second(self, request):
+        return None
+
+    first.__wrapped__ = second
+    second.__wrapped__ = first
+
+    _current, _old, cycle, _depth = guard._wrapper_chain_status(first)
+
+    assert cycle is True
+
+
+def test_runtime_limits_cap_streak_and_raise_false_stall_threshold(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "999")
+    monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "30")
+
+    guard.normalize_runtime_limits()
+
+    assert guard.os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] == "12"
+    assert float(guard.os.environ["NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"]) == 120.0
+    assert guard.os.environ["NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"] == "1"
+
+
+def test_audit_rejects_legacy_execution_wrapper(monkeypatch):
+    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
+    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    downstream = _module(
+        alias_name,
+        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "20260714-downstream-risk-v2",
+    )
+    monkeypatch.setitem(sys.modules, alias_name, downstream)
+    monkeypatch.setitem(sys.modules, canonical_name, downstream)
+
+    pipeline = ModuleType("bot.execution_pipeline")
+
+    def execute(self, request):
+        return None
+
+    setattr(execute, guard._LEGACY_RISK_ATTR, True)
+    pipeline.ExecutionPipeline = type("ExecutionPipeline", (), {"execute": execute})
+    monkeypatch.setitem(sys.modules, "bot.execution_pipeline", pipeline)
+    monkeypatch.delitem(sys.modules, "execution_pipeline", raising=False)
+
+    ready, details = guard.audit()
+
+    assert ready is False
+    assert "legacy=True" in details["execution_pipeline_chain"]
+    assert guard.os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] == "0"

--- a/bot/tests/test_runtime_module_identity_convergence_patch.py
+++ b/bot/tests/test_runtime_module_identity_convergence_patch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import runtime_module_identity_convergence_patch as guard
 
@@ -14,13 +14,47 @@ def _module(name: str, file_path: str, marker: str = "") -> ModuleType:
     return module
 
 
+def _no_threads(monkeypatch):
+    monkeypatch.setattr(guard.threading, "enumerate", lambda: [])
+
+
+def test_unregistered_sitecustomize_module_is_recovered_from_monitor_thread(monkeypatch):
+    alias_name = guard._RISK_ALIAS
+    canonical_name = guard._RISK_CANONICAL
+    globals_dict = {
+        "__name__": alias_name,
+        "__file__": "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "_MARKER": guard._REQUIRED_RISK_MARKER,
+        "install_import_hook": lambda: None,
+    }
+
+    class Target:
+        __globals__ = globals_dict
+
+        def __call__(self):
+            return None
+
+    fake_thread = SimpleNamespace(name="downstream-risk-v2-monitor", _target=Target())
+    monkeypatch.setattr(guard.threading, "enumerate", lambda: [fake_thread])
+    monkeypatch.delitem(sys.modules, alias_name, raising=False)
+    monkeypatch.delitem(sys.modules, canonical_name, raising=False)
+
+    recovered = guard.recover_unregistered_patch_modules_from_threads()
+
+    assert canonical_name in recovered
+    assert isinstance(sys.modules[canonical_name], ModuleType)
+    assert sys.modules[alias_name] is sys.modules[canonical_name]
+    assert sys.modules[canonical_name]._MARKER == guard._REQUIRED_RISK_MARKER
+
+
 def test_alias_is_bound_to_canonical_module_before_second_import(monkeypatch):
-    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
-    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    _no_threads(monkeypatch)
+    alias_name = guard._RISK_ALIAS
+    canonical_name = guard._RISK_CANONICAL
     alias = _module(
         alias_name,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
-        "20260714-downstream-risk-v2",
+        guard._REQUIRED_RISK_MARKER,
     )
     monkeypatch.setitem(sys.modules, alias_name, alias)
     monkeypatch.delitem(sys.modules, canonical_name, raising=False)
@@ -30,12 +64,14 @@ def test_alias_is_bound_to_canonical_module_before_second_import(monkeypatch):
     assert ready is True
     assert sys.modules[canonical_name] is alias
     assert sys.modules[alias_name] is alias
-    assert details[canonical_name] == "same_object"
+    assert "same_object=true" in details[canonical_name]
+    assert guard._REQUIRED_RISK_MARKER in details[canonical_name]
 
 
 def test_duplicate_modules_select_v2_but_report_convergence_event(monkeypatch):
-    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
-    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    _no_threads(monkeypatch)
+    alias_name = guard._RISK_ALIAS
+    canonical_name = guard._RISK_CANONICAL
     legacy = _module(
         canonical_name,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
@@ -44,7 +80,7 @@ def test_duplicate_modules_select_v2_but_report_convergence_event(monkeypatch):
     v2 = _module(
         alias_name,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
-        "20260714-downstream-risk-v2",
+        guard._REQUIRED_RISK_MARKER,
     )
     monkeypatch.setitem(sys.modules, canonical_name, legacy)
     monkeypatch.setitem(sys.modules, alias_name, v2)
@@ -107,12 +143,13 @@ def test_runtime_limits_cap_streak_and_raise_false_stall_threshold(monkeypatch):
 
 
 def test_audit_rejects_legacy_execution_wrapper(monkeypatch):
-    alias_name = "nija_downstream_risk_governor_equity_repair_patch"
-    canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
+    _no_threads(monkeypatch)
+    alias_name = guard._RISK_ALIAS
+    canonical_name = guard._RISK_CANONICAL
     downstream = _module(
         alias_name,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
-        "20260714-downstream-risk-v2",
+        guard._REQUIRED_RISK_MARKER,
     )
     monkeypatch.setitem(sys.modules, alias_name, downstream)
     monkeypatch.setitem(sys.modules, canonical_name, downstream)

--- a/bot/tests/test_runtime_module_identity_convergence_patch.py
+++ b/bot/tests/test_runtime_module_identity_convergence_patch.py
@@ -16,13 +16,24 @@ def _module(name: str, file_path: str, marker: str = "") -> ModuleType:
 
 def _no_threads(monkeypatch):
     monkeypatch.setattr(guard.threading, "enumerate", lambda: [])
+    monkeypatch.delenv("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", raising=False)
+
+
+def _install_clean_risk_identity(monkeypatch):
+    downstream = _module(
+        guard._RISK_ALIAS,
+        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        guard._REQUIRED_RISK_MARKER,
+    )
+    monkeypatch.setitem(sys.modules, guard._RISK_ALIAS, downstream)
+    monkeypatch.setitem(sys.modules, guard._RISK_CANONICAL, downstream)
+    return downstream
 
 
 def test_unregistered_sitecustomize_module_is_recovered_from_monitor_thread(monkeypatch):
-    alias_name = guard._RISK_ALIAS
-    canonical_name = guard._RISK_CANONICAL
+    monkeypatch.delenv("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", raising=False)
     globals_dict = {
-        "__name__": alias_name,
+        "__name__": guard._RISK_ALIAS,
         "__file__": "/app/bot/downstream_risk_governor_equity_repair_patch.py",
         "_MARKER": guard._REQUIRED_RISK_MARKER,
         "install_import_hook": lambda: None,
@@ -36,60 +47,58 @@ def test_unregistered_sitecustomize_module_is_recovered_from_monitor_thread(monk
 
     fake_thread = SimpleNamespace(name="downstream-risk-v2-monitor", _target=Target())
     monkeypatch.setattr(guard.threading, "enumerate", lambda: [fake_thread])
-    monkeypatch.delitem(sys.modules, alias_name, raising=False)
-    monkeypatch.delitem(sys.modules, canonical_name, raising=False)
+    monkeypatch.delitem(sys.modules, guard._RISK_ALIAS, raising=False)
+    monkeypatch.delitem(sys.modules, guard._RISK_CANONICAL, raising=False)
 
     recovered = guard.recover_unregistered_patch_modules_from_threads()
 
-    assert canonical_name in recovered
-    assert isinstance(sys.modules[canonical_name], ModuleType)
-    assert sys.modules[alias_name] is sys.modules[canonical_name]
-    assert sys.modules[canonical_name]._MARKER == guard._REQUIRED_RISK_MARKER
+    assert guard._RISK_CANONICAL in recovered
+    assert isinstance(sys.modules[guard._RISK_CANONICAL], ModuleType)
+    assert sys.modules[guard._RISK_ALIAS] is sys.modules[guard._RISK_CANONICAL]
+    assert sys.modules[guard._RISK_CANONICAL]._MARKER == guard._REQUIRED_RISK_MARKER
+    assert "duplicate=false" in recovered[guard._RISK_CANONICAL]
 
 
 def test_alias_is_bound_to_canonical_module_before_second_import(monkeypatch):
     _no_threads(monkeypatch)
-    alias_name = guard._RISK_ALIAS
-    canonical_name = guard._RISK_CANONICAL
     alias = _module(
-        alias_name,
+        guard._RISK_ALIAS,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
         guard._REQUIRED_RISK_MARKER,
     )
-    monkeypatch.setitem(sys.modules, alias_name, alias)
-    monkeypatch.delitem(sys.modules, canonical_name, raising=False)
+    monkeypatch.setitem(sys.modules, guard._RISK_ALIAS, alias)
+    monkeypatch.delitem(sys.modules, guard._RISK_CANONICAL, raising=False)
 
     ready, details = guard.canonicalize_loaded_patch_modules()
 
     assert ready is True
-    assert sys.modules[canonical_name] is alias
-    assert sys.modules[alias_name] is alias
-    assert "same_object=true" in details[canonical_name]
-    assert guard._REQUIRED_RISK_MARKER in details[canonical_name]
+    assert sys.modules[guard._RISK_CANONICAL] is alias
+    assert sys.modules[guard._RISK_ALIAS] is alias
+    assert "same_object=true" in details[guard._RISK_CANONICAL]
+    assert guard._REQUIRED_RISK_MARKER in details[guard._RISK_CANONICAL]
 
 
-def test_duplicate_modules_select_v2_but_report_convergence_event(monkeypatch):
+def test_duplicate_modules_select_v2_and_latch_fail_closed(monkeypatch):
     _no_threads(monkeypatch)
-    alias_name = guard._RISK_ALIAS
-    canonical_name = guard._RISK_CANONICAL
     legacy = _module(
-        canonical_name,
+        guard._RISK_CANONICAL,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
         "20260707a",
     )
     v2 = _module(
-        alias_name,
+        guard._RISK_ALIAS,
         "/app/bot/downstream_risk_governor_equity_repair_patch.py",
         guard._REQUIRED_RISK_MARKER,
     )
-    monkeypatch.setitem(sys.modules, canonical_name, legacy)
-    monkeypatch.setitem(sys.modules, alias_name, v2)
+    monkeypatch.setitem(sys.modules, guard._RISK_CANONICAL, legacy)
+    monkeypatch.setitem(sys.modules, guard._RISK_ALIAS, v2)
 
     ready, _details = guard.canonicalize_loaded_patch_modules()
 
     assert ready is False
-    assert sys.modules[canonical_name] is v2
-    assert sys.modules[alias_name] is v2
+    assert sys.modules[guard._RISK_CANONICAL] is v2
+    assert sys.modules[guard._RISK_ALIAS] is v2
+    assert guard.os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] == "1"
 
 
 def test_wrapper_chain_detects_v2_and_legacy_layers():
@@ -131,28 +140,54 @@ def test_wrapper_chain_detects_cycle():
     assert cycle is True
 
 
-def test_runtime_limits_cap_streak_and_raise_false_stall_threshold(monkeypatch):
+def test_runtime_limits_cap_streak_normalize_stale_threshold_and_raise_timeout(monkeypatch):
     monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "999")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "10")
     monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "30")
 
     guard.normalize_runtime_limits()
 
     assert guard.os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] == "12"
+    assert guard.os.environ["NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD"] == "13"
     assert float(guard.os.environ["NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"]) == 120.0
     assert guard.os.environ["NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"] == "1"
 
 
+def test_audit_accepts_both_phase3_guards_in_any_wrapper_order(monkeypatch):
+    _no_threads(monkeypatch)
+    _install_clean_risk_identity(monkeypatch)
+    monkeypatch.delitem(sys.modules, "bot.execution_pipeline", raising=False)
+    monkeypatch.delitem(sys.modules, "execution_pipeline", raising=False)
+
+    core = ModuleType("bot.nija_core_loop")
+
+    def leaf(self, broker, snapshot, symbols, slots, streak=0):
+        return None
+
+    setattr(leaf, guard._ZERO_CAP_ATTR, True)
+
+    def outer(self, broker, snapshot, symbols, slots, streak=0):
+        return leaf(self, broker, snapshot, symbols, slots, streak)
+
+    outer.__wrapped__ = leaf
+    setattr(outer, guard._ZERO_STATE_ATTR, True)
+    core.NijaCoreLoop = type("NijaCoreLoop", (), {"_phase3_scan_and_enter": outer})
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
+
+    ready, details = guard.audit()
+
+    assert ready is True
+    assert "cap_guard=True" in details["zero_signal_streak_chain"]
+    assert "state_repair=True" in details["zero_signal_streak_chain"]
+    assert "cycle=False" in details["zero_signal_streak_chain"]
+
+
 def test_audit_rejects_legacy_execution_wrapper(monkeypatch):
     _no_threads(monkeypatch)
-    alias_name = guard._RISK_ALIAS
-    canonical_name = guard._RISK_CANONICAL
-    downstream = _module(
-        alias_name,
-        "/app/bot/downstream_risk_governor_equity_repair_patch.py",
-        guard._REQUIRED_RISK_MARKER,
-    )
-    monkeypatch.setitem(sys.modules, alias_name, downstream)
-    monkeypatch.setitem(sys.modules, canonical_name, downstream)
+    _install_clean_risk_identity(monkeypatch)
+    monkeypatch.delitem(sys.modules, "bot.nija_core_loop", raising=False)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
 
     pipeline = ModuleType("bot.execution_pipeline")
 

--- a/bot/tests/test_runtime_module_identity_repeated_audit.py
+++ b/bot/tests/test_runtime_module_identity_repeated_audit.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import runtime_module_identity_convergence_patch as guard
+
+
+def test_repeated_thread_recovery_reuses_same_module_without_duplicate_latch(monkeypatch):
+    monkeypatch.delenv("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", raising=False)
+    globals_dict = {
+        "__name__": guard._RISK_ALIAS,
+        "__file__": "/app/bot/downstream_risk_governor_equity_repair_patch.py",
+        "_MARKER": guard._REQUIRED_RISK_MARKER,
+        "install_import_hook": lambda: None,
+    }
+
+    class Target:
+        __globals__ = globals_dict
+
+        def __call__(self):
+            return None
+
+    thread = SimpleNamespace(name="downstream-risk-v2-monitor", _target=Target())
+    monkeypatch.setattr(guard.threading, "enumerate", lambda: [thread])
+    monkeypatch.delitem(sys.modules, guard._RISK_ALIAS, raising=False)
+    monkeypatch.delitem(sys.modules, guard._RISK_CANONICAL, raising=False)
+
+    first = guard.recover_unregistered_patch_modules_from_threads()
+    first_module = sys.modules[guard._RISK_CANONICAL]
+    second = guard.recover_unregistered_patch_modules_from_threads()
+
+    assert isinstance(first_module, ModuleType)
+    assert sys.modules[guard._RISK_ALIAS] is first_module
+    assert sys.modules[guard._RISK_CANONICAL] is first_module
+    assert "duplicate=false" in first[guard._RISK_CANONICAL]
+    assert "duplicate=false" in second[guard._RISK_CANONICAL]
+    assert guard.os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED") != "1"

--- a/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
+++ b/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
@@ -11,18 +11,46 @@ def _clear(monkeypatch):
         "NIJA_GLOBAL_TRADING_READY",
         "NIJA_MULTI_BROKER_TRADING_READY",
         "NIJA_ACTIVE_LIVE_VENUES",
+        "NIJA_ZERO_SIGNAL_STREAK_CAP",
+        "NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_v9_release_id():
-    assert manifest.RELEASE_ID == "20260714-runtime-convergence-v9"
+def test_v10_release_id():
+    assert manifest.RELEASE_ID == "20260714-runtime-convergence-v10"
 
 
-def test_v9_requires_fail_closed_risk_sizing_flags():
+def test_v10_requires_module_identity_and_fail_closed_risk_flags():
+    assert manifest._REQUIRED_FLAGS["module_identity_guard"] == "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["module_identity_ready"] == "NIJA_RUNTIME_MODULE_IDENTITY_READY"
+    assert manifest._REQUIRED_FLAGS["core_loop_limits"] == "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"
     assert manifest._REQUIRED_FLAGS["downstream_risk_v2_installed"] == "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED"
     assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_fail_closed"] == "NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED"
     assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_ready"] == "NIJA_PRE_DISPATCH_RISK_SIZING_READY"
+
+
+def test_runtime_limits_reject_streak_999_and_30_second_stall(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "999")
+    monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "30")
+
+    ok, reason = manifest._runtime_limits_consistent()
+
+    assert ok is False
+    assert "zero_signal_streak_cap=999" in reason
+    assert "run_cycle_stall_warn_s=30.0" in reason
+
+
+def test_runtime_limits_accept_bounded_streak_and_scan_appropriate_timeout(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120")
+
+    ok, reason = manifest._runtime_limits_consistent()
+
+    assert ok is True
+    assert "zero_signal_streak_cap=12" in reason
 
 
 def test_contract_accepts_broker_local_kraken_with_missing_secondaries(monkeypatch):

--- a/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
+++ b/bot/tests/test_runtime_release_manifest_v8_readiness_contract.py
@@ -12,6 +12,7 @@ def _clear(monkeypatch):
         "NIJA_MULTI_BROKER_TRADING_READY",
         "NIJA_ACTIVE_LIVE_VENUES",
         "NIJA_ZERO_SIGNAL_STREAK_CAP",
+        "NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD",
         "NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -21,10 +22,12 @@ def test_v10_release_id():
     assert manifest.RELEASE_ID == "20260714-runtime-convergence-v10"
 
 
-def test_v10_requires_module_identity_and_fail_closed_risk_flags():
+def test_v10_requires_module_identity_risk_and_streak_state_flags():
     assert manifest._REQUIRED_FLAGS["module_identity_guard"] == "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"
     assert manifest._REQUIRED_FLAGS["module_identity_ready"] == "NIJA_RUNTIME_MODULE_IDENTITY_READY"
     assert manifest._REQUIRED_FLAGS["core_loop_limits"] == "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"
+    assert manifest._REQUIRED_FLAGS["zero_signal_state_repair"] == "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["zero_signal_state_ready"] == "NIJA_ZERO_SIGNAL_STREAK_STATE_READY"
     assert manifest._REQUIRED_FLAGS["downstream_risk_v2_installed"] == "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED"
     assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_fail_closed"] == "NIJA_PRE_DISPATCH_RISK_SIZING_FAIL_CLOSED"
     assert manifest._REQUIRED_FLAGS["pre_dispatch_risk_ready"] == "NIJA_PRE_DISPATCH_RISK_SIZING_READY"
@@ -33,6 +36,7 @@ def test_v10_requires_module_identity_and_fail_closed_risk_flags():
 def test_runtime_limits_reject_streak_999_and_30_second_stall(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "999")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100")
     monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "30")
 
     ok, reason = manifest._runtime_limits_consistent()
@@ -42,15 +46,29 @@ def test_runtime_limits_reject_streak_999_and_30_second_stall(monkeypatch):
     assert "run_cycle_stall_warn_s=30.0" in reason
 
 
+def test_runtime_limits_reject_stale_threshold_below_cap(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "10")
+    monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120")
+
+    ok, reason = manifest._runtime_limits_consistent()
+
+    assert ok is False
+    assert "stale_threshold=10" in reason
+
+
 def test_runtime_limits_accept_bounded_streak_and_scan_appropriate_timeout(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100")
     monkeypatch.setenv("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120")
 
     ok, reason = manifest._runtime_limits_consistent()
 
     assert ok is True
     assert "zero_signal_streak_cap=12" in reason
+    assert "stale_threshold=100" in reason
 
 
 def test_contract_accepts_broker_local_kraken_with_missing_secondaries(monkeypatch):

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -17,6 +17,8 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_VENUE_READINESS_SOURCE_MARKER",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
         "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+        "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
+        "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
@@ -39,7 +41,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_module_identity_before_canonical_runtime_imports(monkeypatch):
+def test_source_bootstrap_installs_module_identity_and_streak_repair_before_core_runtime(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
@@ -50,6 +52,7 @@ def test_source_bootstrap_installs_module_identity_before_canonical_runtime_impo
         ("final_worker_position_coinbase_repair_patch", "worker_position", "install"),
         ("broker_auth_recovery_patch", "auth", "install"),
         ("runtime_convergence_hardening_patch", "convergence", "install"),
+        ("bot.zero_signal_streak_state_repair_patch", "zero_signal_state", "install"),
         ("runtime_convergence_v2_patch", "convergence_v2", "install"),
         ("runtime_auth_recursion_endpoint_repair_patch", "auth_endpoint", "install"),
         ("final_runtime_convergence_patch", "final_convergence", "install"),
@@ -87,15 +90,17 @@ def test_source_bootstrap_installs_module_identity_before_canonical_runtime_impo
     assert source_bootstrap.install() is True
     assert calls == [
         "writer", "module_identity", "generation_scope", "heartbeat_scope",
-        "worker_position", "auth", "convergence", "convergence_v2",
-        "auth_endpoint", "final_convergence", "scan_wrapper", "venue",
-        "activator", "strict", "broker_local_contract", "exit_recovery",
-        "exit_bootstrap", "stage", "bridge", "scan_owner",
+        "worker_position", "auth", "convergence", "zero_signal_state",
+        "convergence_v2", "auth_endpoint", "final_convergence", "scan_wrapper",
+        "venue", "activator", "strict", "broker_local_contract",
+        "exit_recovery", "exit_bootstrap", "stage", "bridge", "scan_owner",
     ]
     assert calls.index("module_identity") < calls.index("convergence")
+    assert calls.index("zero_signal_state") < calls.index("convergence_v2")
     assert calls.index("broker_local_contract") < calls.index("bridge")
     assert source_bootstrap.installed_marker() == "20260714d"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "1"
+    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
@@ -118,6 +123,8 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] == "0"
+    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] == "0"
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -15,6 +15,8 @@ def _reset_source_bootstrap(monkeypatch) -> None:
     for name in (
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_VENUE_READINESS_SOURCE_MARKER",
+        "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
+        "NIJA_RUNTIME_MODULE_IDENTITY_READY",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
@@ -37,11 +39,12 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_readiness_contract_before_recovery_and_bridge(monkeypatch):
+def test_source_bootstrap_installs_module_identity_before_canonical_runtime_imports(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
         ("prebot_writer_authority_fail_closed", "writer", "install"),
+        ("runtime_module_identity_convergence_patch", "module_identity", "install"),
         ("writer_generation_scope_repair_patch", "generation_scope", "install"),
         ("authority_heartbeat_generation_scope_patch", "heartbeat_scope", "install"),
         ("final_worker_position_coinbase_repair_patch", "worker_position", "install"),
@@ -65,6 +68,8 @@ def test_source_bootstrap_installs_readiness_contract_before_recovery_and_bridge
     for module_name, label, installer_name in names:
         module = ModuleType(module_name)
         setattr(module, installer_name, lambda label=label: calls.append(label))
+        if module_name == "runtime_module_identity_convergence_patch":
+            module.audit = lambda: (True, {"identity": "ready"})
         modules[module_name] = module
 
     real_import = source_bootstrap.importlib.import_module
@@ -81,17 +86,18 @@ def test_source_bootstrap_installs_readiness_contract_before_recovery_and_bridge
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == [
-        "writer", "generation_scope", "heartbeat_scope", "worker_position", "auth",
-        "convergence", "convergence_v2", "auth_endpoint", "final_convergence",
-        "scan_wrapper", "venue", "activator", "strict", "broker_local_contract",
-        "exit_recovery", "exit_bootstrap", "stage", "bridge", "scan_owner",
+        "writer", "module_identity", "generation_scope", "heartbeat_scope",
+        "worker_position", "auth", "convergence", "convergence_v2",
+        "auth_endpoint", "final_convergence", "scan_wrapper", "venue",
+        "activator", "strict", "broker_local_contract", "exit_recovery",
+        "exit_bootstrap", "stage", "bridge", "scan_owner",
     ]
+    assert calls.index("module_identity") < calls.index("convergence")
     assert calls.index("broker_local_contract") < calls.index("bridge")
-    assert source_bootstrap.installed_marker() == "20260714c"
+    assert source_bootstrap.installed_marker() == "20260714d"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
 
@@ -110,9 +116,9 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
         source_bootstrap.install()
 
     assert exc_info.value.code == 78
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] == "0"
     assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/bot/tests/test_zero_signal_streak_state_repair_patch.py
+++ b/bot/tests/test_zero_signal_streak_state_repair_patch.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import bot.zero_signal_streak_state_repair_patch as patch
+
+
+def _module(observed):
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def __init__(self, streak):
+            self._zero_signal_streak = streak
+
+        def _phase3_scan_and_enter(
+            self,
+            broker,
+            snapshot,
+            symbols,
+            available_slots,
+            zero_signal_streak=0,
+        ):
+            observed.append((self._zero_signal_streak, zero_signal_streak))
+            # Mirror the production post-scan no-entry update source behavior.
+            self._zero_signal_streak += 1
+            return 0, 0, 1, {}
+
+    module.NijaCoreLoop = NijaCoreLoop
+    return module
+
+
+def test_stale_999_state_is_reset_before_phase3(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100")
+    observed = []
+    module = _module(observed)
+
+    assert patch._install_on_core_loop(module) is True
+    loop = module.NijaCoreLoop(999)
+    result = loop._phase3_scan_and_enter(None, None, [], 1, 999)
+
+    assert result[:3] == (0, 0, 1)
+    assert observed == [(0, 0)]
+    assert loop._zero_signal_streak == 1
+    assert patch.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] == "1"
+
+
+def test_ordinary_long_streak_is_bounded_not_reset(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100")
+    observed = []
+    module = _module(observed)
+
+    patch._install_on_core_loop(module)
+    loop = module.NijaCoreLoop(20)
+    loop._phase3_scan_and_enter(None, None, [], 1, 20)
+
+    assert observed == [(12, 12)]
+    assert loop._zero_signal_streak == 13
+
+
+def test_next_cycle_rebounds_post_increment_state(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100")
+    observed = []
+    module = _module(observed)
+
+    patch._install_on_core_loop(module)
+    loop = module.NijaCoreLoop(20)
+    loop._phase3_scan_and_enter(None, None, [], 1, 20)
+    loop._phase3_scan_and_enter(None, None, [], 1, loop._zero_signal_streak)
+
+    assert observed == [(12, 12), (12, 12)]
+    assert loop._zero_signal_streak == 13
+
+
+def test_repair_value_contract():
+    assert patch._repair_value(999, 12, 100) == (0, "stale_sentinel_reset")
+    assert patch._repair_value(20, 12, 100) == (12, "bounded")
+    assert patch._repair_value(1, 12, 100) == (1, "unchanged")
+
+
+def test_install_is_chain_aware(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+    observed = []
+    module = _module(observed)
+
+    assert patch._install_on_core_loop(module) is True
+    first = module.NijaCoreLoop._phase3_scan_and_enter
+    assert patch._install_on_core_loop(module) is True
+    assert module.NijaCoreLoop._phase3_scan_and_enter is first

--- a/bot/zero_signal_streak_state_repair_patch.py
+++ b/bot/zero_signal_streak_state_repair_patch.py
@@ -1,0 +1,195 @@
+"""Repair stale and unbounded NijaCoreLoop zero-signal streak state.
+
+The core loop passes ``self._zero_signal_streak`` into Phase 3 and increments the
+instance field after every no-entry cycle. A stale sentinel such as 999 therefore
+becomes 1000, 1001, ... forever. Parameter-only clamping does not repair the source
+state and leaves dead-zone bypass permanently active.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.zero_signal_streak_state_repair")
+_MARKER = "20260714-zero-signal-state-v1"
+_ATTR = "_nija_zero_signal_state_repair_v1"
+_LOCK = threading.RLock()
+_STARTED = False
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default)) or default))
+    except Exception:
+        return default
+
+
+def _chain_contains(func: Any) -> tuple[bool, bool, int]:
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            return False, True, depth
+        seen.add(ident)
+        if bool(getattr(current, _ATTR, False)):
+            return True, False, depth
+        current = getattr(current, "__wrapped__", None)
+        if not callable(current):
+            return False, False, depth
+        depth += 1
+        if depth >= 4096:
+            return False, True, depth
+    return False, False, depth
+
+
+def _repair_value(raw: int, cap: int, stale_threshold: int) -> tuple[int, str]:
+    raw = max(0, int(raw))
+    cap = max(2, min(int(cap), 12))
+    stale_threshold = max(cap + 1, int(stale_threshold))
+    if raw >= stale_threshold:
+        return 0, "stale_sentinel_reset"
+    if raw > cap:
+        return cap, "bounded"
+    return raw, "unchanged"
+
+
+def _install_on_core_loop(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    current = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
+    if not callable(current):
+        return False
+    found, cycle, depth = _chain_contains(current)
+    if cycle:
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
+        logger.critical(
+            "ZERO_SIGNAL_STREAK_WRAPPER_CYCLE marker=%s module=%s depth=%d",
+            _MARKER,
+            module.__name__,
+            depth,
+        )
+        return False
+    if found:
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "1"
+        return True
+
+    @wraps(current)
+    def phase3(
+        self: Any,
+        broker: Any,
+        snapshot: Any,
+        symbols: Any,
+        available_slots: Any,
+        zero_signal_streak: int = 0,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        cap = max(2, min(_int_env("NIJA_ZERO_SIGNAL_STREAK_CAP", 12), 12))
+        stale_threshold = max(
+            cap + 1,
+            _int_env("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", 100),
+        )
+        try:
+            state_raw = int(getattr(self, "_zero_signal_streak", zero_signal_streak) or 0)
+        except Exception:
+            state_raw = int(zero_signal_streak or 0)
+        incoming = int(zero_signal_streak or 0)
+        authoritative_raw = max(state_raw, incoming)
+        repaired, reason = _repair_value(authoritative_raw, cap, stale_threshold)
+        if repaired != state_raw:
+            setattr(self, "_zero_signal_streak", repaired)
+        if reason != "unchanged" or incoming != repaired:
+            log = logger.critical if reason == "stale_sentinel_reset" else logger.warning
+            log(
+                "ZERO_SIGNAL_STREAK_STATE_REPAIRED marker=%s raw_state=%d incoming=%d repaired=%d cap=%d stale_threshold=%d reason=%s dead_zone_rearmed=%s",
+                _MARKER,
+                state_raw,
+                incoming,
+                repaired,
+                cap,
+                stale_threshold,
+                reason,
+                str(reason == "stale_sentinel_reset").lower(),
+            )
+        return current(
+            self,
+            broker,
+            snapshot,
+            symbols,
+            available_slots,
+            repaired,
+            *args,
+            **kwargs,
+        )
+
+    setattr(phase3, _ATTR, True)
+    phase3.__wrapped__ = current
+    cls._phase3_scan_and_enter = phase3
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "1"
+    logger.critical(
+        "ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED marker=%s module=%s cap_env=%s stale_threshold_env=%s",
+        _MARKER,
+        module.__name__,
+        os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "12"),
+        os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100"),
+    )
+    return True
+
+
+def _try_loaded() -> bool:
+    patched = False
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _install_on_core_loop(module) or patched
+    return patched
+
+
+def _watchdog() -> None:
+    deadline = time.monotonic() + max(
+        60.0,
+        float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600),
+    )
+    while time.monotonic() < deadline:
+        try:
+            if _try_loaded():
+                return
+        except Exception:
+            logger.exception("ZERO_SIGNAL_STREAK_STATE_REPAIR_RETRY marker=%s", _MARKER)
+        time.sleep(0.10)
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
+    logger.critical("ZERO_SIGNAL_STREAK_STATE_REPAIR_EXPIRED marker=%s", _MARKER)
+
+
+def install_import_hook() -> None:
+    global _STARTED
+    with _LOCK:
+        _try_loaded()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="ZeroSignalStreakStateRepair",
+                daemon=True,
+            ).start()
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"] = "1"
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_install_on_core_loop",
+    "_repair_value",
+    "_chain_contains",
+]

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -80,7 +80,13 @@ def _module_from_globals(alias: str, globals_dict: dict[str, Any]) -> ModuleType
 
 
 def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
-    """Recover sitecustomize modules from live ``Thread._target`` globals."""
+    """Recover sitecustomize modules from live ``Thread._target`` globals.
+
+    Once an alias and its canonical name are already bound to the same object,
+    subsequent watchdog audits reuse that object. A new proxy is created only for
+    the initial unregistered execution, so a healthy second audit is not mistaken
+    for a duplicate module execution.
+    """
     recovered: dict[str, str] = {}
     for thread in tuple(threading.enumerate()):
         target = getattr(thread, "_target", None)
@@ -91,16 +97,28 @@ def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
         if not alias or not canonical:
             continue
 
-        recovered_module = _module_from_globals(alias, globals_dict)
         existing_alias = sys.modules.get(alias)
         existing_canonical = sys.modules.get(canonical)
-        candidates = [recovered_module]
-        if isinstance(existing_alias, ModuleType):
-            candidates.append(existing_alias)
-        if isinstance(existing_canonical, ModuleType):
-            candidates.append(existing_canonical)
-        selected = max(candidates, key=_module_quality)
-        duplicate = len({id(item) for item in candidates}) > 1
+        duplicate = False
+
+        if (
+            isinstance(existing_alias, ModuleType)
+            and existing_alias is existing_canonical
+        ):
+            selected = existing_alias
+        elif isinstance(existing_alias, ModuleType) and existing_canonical is None:
+            selected = existing_alias
+        elif existing_alias is None and existing_canonical is None:
+            selected = _module_from_globals(alias, globals_dict)
+        else:
+            recovered_module = _module_from_globals(alias, globals_dict)
+            candidates = [recovered_module]
+            if isinstance(existing_alias, ModuleType):
+                candidates.append(existing_alias)
+            if isinstance(existing_canonical, ModuleType):
+                candidates.append(existing_canonical)
+            selected = max(candidates, key=_module_quality)
+            duplicate = len({id(item) for item in candidates}) > 1
 
         sys.modules[alias] = selected
         sys.modules[canonical] = selected

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -1,0 +1,216 @@
+"""Canonicalize startup patch modules before live trading imports begin.
+
+sitecustomize historically loaded files from ``bot/`` under private ``nija_*``
+aliases. Later runtime bootstraps imported the same files as ``bot.*``, executing
+them twice and creating independent monitors and wrapper registries. This caused
+alternating ExecutionPipeline wrappers, unbounded zero-signal streaks and duplicate
+recovery threads.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.runtime_module_identity_convergence")
+_MARKER = "20260714-module-identity-v1"
+_LOCK = threading.RLock()
+_STARTED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LEGACY_RISK_ATTR = "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a"
+_V2_RISK_ATTR = "_nija_pre_dispatch_risk_sizing_v2"
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _live() -> bool:
+    return not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
+
+
+def _bot_canonical_name(module: ModuleType) -> str:
+    path = str(getattr(module, "__file__", "") or "")
+    if not path:
+        return ""
+    resolved = Path(path)
+    if resolved.suffix != ".py" or resolved.parent.name != "bot":
+        return ""
+    return f"bot.{resolved.stem}"
+
+
+def _module_quality(module: ModuleType) -> tuple[int, int]:
+    marker = str(getattr(module, "_MARKER", "") or "")
+    score = 0
+    if "downstream-risk-v2" in marker:
+        score += 100
+    if callable(getattr(module, "install_import_hook", None)):
+        score += 10
+    if callable(getattr(module, "install", None)):
+        score += 5
+    return score, len(vars(module))
+
+
+def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
+    details: dict[str, str] = {}
+    ready = True
+    for alias, module in list(sys.modules.items()):
+        if not alias.startswith("nija_") or not isinstance(module, ModuleType):
+            continue
+        canonical = _bot_canonical_name(module)
+        if not canonical:
+            continue
+        existing = sys.modules.get(canonical)
+        selected = module
+        if isinstance(existing, ModuleType) and existing is not module:
+            selected = max((existing, module), key=_module_quality)
+            ready = False
+            logger.critical(
+                "DUPLICATE_PATCH_MODULE_CONVERGED marker=%s canonical=%s alias=%s selected_marker=%s",
+                _MARKER,
+                canonical,
+                alias,
+                getattr(selected, "_MARKER", "unknown"),
+            )
+        sys.modules[canonical] = selected
+        sys.modules[alias] = selected
+        details[canonical] = "same_object"
+    return ready, details
+
+
+def _wrapper_chain_status(func: Any) -> tuple[bool, bool, bool, int]:
+    current = func
+    seen: set[int] = set()
+    legacy = current_v2 = cycle = False
+    depth = 0
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            cycle = True
+            break
+        seen.add(ident)
+        legacy = legacy or bool(getattr(current, _LEGACY_RISK_ATTR, False))
+        current_v2 = current_v2 or bool(getattr(current, _V2_RISK_ATTR, False))
+        nxt = getattr(current, "__wrapped__", None)
+        if not callable(nxt):
+            break
+        current = nxt
+        depth += 1
+        if depth >= 4096:
+            cycle = True
+            break
+    return current_v2, legacy, cycle, depth
+
+
+def normalize_runtime_limits() -> None:
+    try:
+        cap = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "12") or 12))
+    except Exception:
+        cap = 12
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] = str(min(max(cap, 2), 12))
+
+    try:
+        timeout = float(os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120") or 120)
+    except Exception:
+        timeout = 120.0
+    os.environ["NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"] = str(max(timeout, 120.0))
+    os.environ["NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"] = "1"
+
+
+def audit() -> tuple[bool, dict[str, str]]:
+    modules_ready, details = canonicalize_loaded_patch_modules()
+    normalize_runtime_limits()
+    ready = modules_ready
+
+    alias = sys.modules.get("nija_downstream_risk_governor_equity_repair_patch")
+    canonical = sys.modules.get("bot.downstream_risk_governor_equity_repair_patch")
+    if alias is not None or canonical is not None:
+        same = alias is canonical and isinstance(canonical, ModuleType)
+        marker = str(getattr(canonical, "_MARKER", "") or "") if same else "identity_mismatch"
+        details["downstream_risk_module"] = f"same={same};marker={marker or 'missing'}"
+        ready = ready and same and marker == "20260714-downstream-risk-v2"
+
+    pipeline = sys.modules.get("bot.execution_pipeline") or sys.modules.get("execution_pipeline")
+    if isinstance(pipeline, ModuleType):
+        cls = getattr(pipeline, "ExecutionPipeline", None)
+        execute = getattr(cls, "execute", None) if isinstance(cls, type) else None
+        v2, legacy, cycle, depth = _wrapper_chain_status(execute)
+        details["execution_pipeline_chain"] = (
+            f"v2={v2};legacy={legacy};cycle={cycle};depth={depth}"
+        )
+        ready = ready and v2 and not legacy and not cycle
+        if legacy or cycle:
+            os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "0"
+
+    core = sys.modules.get("bot.nija_core_loop") or sys.modules.get("nija_core_loop")
+    if isinstance(core, ModuleType):
+        cls = getattr(core, "NijaCoreLoop", None)
+        phase3 = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
+        capped = bool(getattr(phase3, "_nija_zero_streak_cap_e", False))
+        details["zero_signal_streak_guard"] = f"installed={capped}"
+        ready = ready and capped
+
+    os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1" if ready else "0"
+    return ready, details
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            ready, details = audit()
+            logger.log(
+                logging.INFO if ready else logging.CRITICAL,
+                "RUNTIME_MODULE_IDENTITY_AUDIT marker=%s ready=%s details=%s",
+                _MARKER,
+                str(ready).lower(),
+                details,
+            )
+        except Exception as exc:
+            os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
+            logger.critical("RUNTIME_MODULE_IDENTITY_AUDIT_FAILED marker=%s error=%s", _MARKER, exc)
+        time.sleep(max(2.0, float(os.environ.get("NIJA_MODULE_IDENTITY_AUDIT_S", "10") or 10)))
+
+
+def install() -> None:
+    global _STARTED
+    with _LOCK:
+        ready, details = audit()
+        os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] = "1"
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="RuntimeModuleIdentityGuard", daemon=True).start()
+        logger.critical(
+            "RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=%s ready=%s limits=streak:%s,stall:%s details=%s",
+            _MARKER,
+            str(ready).lower(),
+            os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP"),
+            os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"),
+            details,
+        )
+        if _live() and not ready and any(
+            isinstance(sys.modules.get(name), ModuleType)
+            for name in ("bot.execution_pipeline", "execution_pipeline")
+        ):
+            logger.critical(
+                "RUNTIME_MODULE_IDENTITY_UNSAFE marker=%s action=release_manifest_fail_closed",
+                _MARKER,
+            )
+
+
+def install_import_hook() -> None:
+    install()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "audit",
+    "canonicalize_loaded_patch_modules",
+    "normalize_runtime_limits",
+    "_wrapper_chain_status",
+]

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -6,7 +6,7 @@ Later runtime bootstraps imported the same files as ``bot.*``, executing them a
 second time and creating independent monitor flags and wrapper registries.
 
 The active monitor thread retains the original module globals even when the
-module was not registered.  This guard reconstructs one module object from that
+module was not registered. This guard reconstructs one module object from that
 thread target, binds both names to it, and prevents the canonical import from
 executing the source again.
 """
@@ -28,6 +28,8 @@ _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _LEGACY_RISK_ATTR = "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a"
 _V2_RISK_ATTR = "_nija_pre_dispatch_risk_sizing_v2"
+_ZERO_CAP_ATTR = "_nija_zero_streak_cap_e"
+_ZERO_STATE_ATTR = "_nija_zero_signal_state_repair_v1"
 _REQUIRED_RISK_MARKER = "20260714-downstream-risk-v2"
 _RISK_ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
 _RISK_CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
@@ -78,13 +80,7 @@ def _module_from_globals(alias: str, globals_dict: dict[str, Any]) -> ModuleType
 
 
 def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
-    """Recover sitecustomize modules from live Thread._target globals.
-
-    ``threading.Thread`` retains the target function while it is alive. Functions
-    retain the exact globals dictionary from the unregistered module execution,
-    so copying that dictionary into a ModuleType provides a stable import object
-    while all functions continue sharing their original mutable state.
-    """
+    """Recover sitecustomize modules from live ``Thread._target`` globals."""
     recovered: dict[str, str] = {}
     for thread in tuple(threading.enumerate()):
         target = getattr(thread, "_target", None)
@@ -95,37 +91,40 @@ def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
         if not alias or not canonical:
             continue
 
+        recovered_module = _module_from_globals(alias, globals_dict)
         existing_alias = sys.modules.get(alias)
         existing_canonical = sys.modules.get(canonical)
+        candidates = [recovered_module]
         if isinstance(existing_alias, ModuleType):
-            candidate = existing_alias
-        elif isinstance(existing_canonical, ModuleType):
-            candidate = existing_canonical
-        else:
-            candidate = _module_from_globals(alias, globals_dict)
-
-        selected = candidate
-        other = existing_canonical if isinstance(existing_canonical, ModuleType) else None
-        if other is not None and other is not candidate:
-            selected = max((candidate, other), key=_module_quality)
+            candidates.append(existing_alias)
+        if isinstance(existing_canonical, ModuleType):
+            candidates.append(existing_canonical)
+        selected = max(candidates, key=_module_quality)
+        duplicate = len({id(item) for item in candidates}) > 1
 
         sys.modules[alias] = selected
         sys.modules[canonical] = selected
-        recovered[canonical] = f"alias={alias};thread={thread.name};marker={getattr(selected, '_MARKER', 'unknown')}"
+        recovered[canonical] = (
+            f"alias={alias};thread={thread.name};marker={getattr(selected, '_MARKER', 'unknown')};"
+            f"duplicate={str(duplicate).lower()}"
+        )
+        if duplicate:
+            os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1"
         logger.warning(
-            "UNREGISTERED_PATCH_MODULE_RECOVERED marker=%s canonical=%s alias=%s thread=%s selected_marker=%s",
+            "UNREGISTERED_PATCH_MODULE_RECOVERED marker=%s canonical=%s alias=%s thread=%s selected_marker=%s duplicate=%s",
             _MARKER,
             canonical,
             alias,
             thread.name,
             getattr(selected, "_MARKER", "unknown"),
+            str(duplicate).lower(),
         )
     return recovered
 
 
 def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
     details = recover_unregistered_patch_modules_from_threads()
-    ready = True
+    ready = not _truthy("NIJA_DUPLICATE_PATCH_MODULE_DETECTED")
     for alias, module in list(sys.modules.items()):
         if not alias.startswith("nija_") or not isinstance(module, ModuleType):
             continue
@@ -137,6 +136,7 @@ def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
         if isinstance(existing, ModuleType) and existing is not module:
             selected = max((existing, module), key=_module_quality)
             ready = False
+            os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1"
             logger.critical(
                 "DUPLICATE_PATCH_MODULE_CONVERGED marker=%s canonical=%s alias=%s selected_marker=%s",
                 _MARKER,
@@ -152,28 +152,31 @@ def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
     return ready, details
 
 
-def _wrapper_chain_status(func: Any) -> tuple[bool, bool, bool, int]:
+def _chain_has_attr(func: Any, attr: str) -> tuple[bool, bool, int]:
     current = func
     seen: set[int] = set()
-    legacy = current_v2 = cycle = False
+    found = False
     depth = 0
     while callable(current):
         ident = id(current)
         if ident in seen:
-            cycle = True
-            break
+            return found, True, depth
         seen.add(ident)
-        legacy = legacy or bool(getattr(current, _LEGACY_RISK_ATTR, False))
-        current_v2 = current_v2 or bool(getattr(current, _V2_RISK_ATTR, False))
+        found = found or bool(getattr(current, attr, False))
         nxt = getattr(current, "__wrapped__", None)
         if not callable(nxt):
-            break
+            return found, False, depth
         current = nxt
         depth += 1
         if depth >= 4096:
-            cycle = True
-            break
-    return current_v2, legacy, cycle, depth
+            return found, True, depth
+    return found, False, depth
+
+
+def _wrapper_chain_status(func: Any) -> tuple[bool, bool, bool, int]:
+    v2, cycle_v2, depth_v2 = _chain_has_attr(func, _V2_RISK_ATTR)
+    legacy, cycle_legacy, depth_legacy = _chain_has_attr(func, _LEGACY_RISK_ATTR)
+    return v2, legacy, cycle_v2 or cycle_legacy, max(depth_v2, depth_legacy)
 
 
 def normalize_runtime_limits() -> None:
@@ -181,7 +184,14 @@ def normalize_runtime_limits() -> None:
         cap = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "12") or 12))
     except Exception:
         cap = 12
-    os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] = str(min(max(cap, 2), 12))
+    cap = min(max(cap, 2), 12)
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] = str(cap)
+
+    try:
+        stale = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100") or 100))
+    except Exception:
+        stale = 100
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD"] = str(max(cap + 1, stale))
 
     try:
         timeout = float(os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120") or 120)
@@ -219,9 +229,16 @@ def audit() -> tuple[bool, dict[str, str]]:
     if isinstance(core, ModuleType):
         cls = getattr(core, "NijaCoreLoop", None)
         phase3 = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
-        capped = bool(getattr(phase3, "_nija_zero_streak_cap_e", False))
-        details["zero_signal_streak_guard"] = f"installed={capped}"
-        ready = ready and capped
+        capped, cap_cycle, cap_depth = _chain_has_attr(phase3, _ZERO_CAP_ATTR)
+        state_repair, state_cycle, state_depth = _chain_has_attr(phase3, _ZERO_STATE_ATTR)
+        cycle = cap_cycle or state_cycle
+        details["zero_signal_streak_chain"] = (
+            f"cap_guard={capped};state_repair={state_repair};cycle={cycle};"
+            f"depth={max(cap_depth, state_depth)}"
+        )
+        ready = ready and capped and state_repair and not cycle
+        if not state_repair or cycle:
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
 
     os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1" if ready else "0"
     return ready, details
@@ -257,10 +274,11 @@ def install() -> None:
             _STARTED = True
             threading.Thread(target=_watchdog, name="RuntimeModuleIdentityGuard", daemon=True).start()
         logger.critical(
-            "RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=%s ready=%s limits=streak:%s,stall:%s details=%s",
+            "RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=%s ready=%s limits=streak:%s,stale:%s,stall:%s details=%s",
             _MARKER,
             str(ready).lower(),
             os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP"),
+            os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD"),
             os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"),
             details,
         )
@@ -285,5 +303,6 @@ __all__ = [
     "canonicalize_loaded_patch_modules",
     "recover_unregistered_patch_modules_from_threads",
     "normalize_runtime_limits",
+    "_chain_has_attr",
     "_wrapper_chain_status",
 ]

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -1,10 +1,14 @@
 """Canonicalize startup patch modules before live trading imports begin.
 
-sitecustomize historically loaded files from ``bot/`` under private ``nija_*``
-aliases. Later runtime bootstraps imported the same files as ``bot.*``, executing
-them twice and creating independent monitors and wrapper registries. This caused
-alternating ExecutionPipeline wrappers, unbounded zero-signal streaks and duplicate
-recovery threads.
+Historically ``sitecustomize`` executed files from ``bot/`` under private
+``nija_*`` names without registering those module objects in ``sys.modules``.
+Later runtime bootstraps imported the same files as ``bot.*``, executing them a
+second time and creating independent monitor flags and wrapper registries.
+
+The active monitor thread retains the original module globals even when the
+module was not registered.  This guard reconstructs one module object from that
+thread target, binds both names to it, and prevents the canonical import from
+executing the source again.
 """
 from __future__ import annotations
 
@@ -18,12 +22,15 @@ from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.runtime_module_identity_convergence")
-_MARKER = "20260714-module-identity-v1"
+_MARKER = "20260714-module-identity-v2"
 _LOCK = threading.RLock()
 _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _LEGACY_RISK_ATTR = "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a"
 _V2_RISK_ATTR = "_nija_pre_dispatch_risk_sizing_v2"
+_REQUIRED_RISK_MARKER = "20260714-downstream-risk-v2"
+_RISK_ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
+_RISK_CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
 
 
 def _truthy(name: str) -> bool:
@@ -34,21 +41,29 @@ def _live() -> bool:
     return not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
 
 
+def _canonical_from_globals(globals_dict: dict[str, Any]) -> tuple[str, str]:
+    alias = str(globals_dict.get("__name__", "") or "").strip()
+    raw_path = str(globals_dict.get("__file__", "") or "").strip()
+    if not alias.startswith("nija_") or not raw_path:
+        return "", ""
+    path = Path(raw_path)
+    if path.suffix != ".py" or path.parent.name != "bot":
+        return "", ""
+    return alias, f"bot.{path.stem}"
+
+
 def _bot_canonical_name(module: ModuleType) -> str:
-    path = str(getattr(module, "__file__", "") or "")
-    if not path:
-        return ""
-    resolved = Path(path)
-    if resolved.suffix != ".py" or resolved.parent.name != "bot":
-        return ""
-    return f"bot.{resolved.stem}"
+    _alias, canonical = _canonical_from_globals(vars(module))
+    return canonical
 
 
 def _module_quality(module: ModuleType) -> tuple[int, int]:
     marker = str(getattr(module, "_MARKER", "") or "")
     score = 0
-    if "downstream-risk-v2" in marker:
-        score += 100
+    if marker == _REQUIRED_RISK_MARKER:
+        score += 1000
+    elif "downstream-risk-v2" in marker:
+        score += 500
     if callable(getattr(module, "install_import_hook", None)):
         score += 10
     if callable(getattr(module, "install", None)):
@@ -56,8 +71,60 @@ def _module_quality(module: ModuleType) -> tuple[int, int]:
     return score, len(vars(module))
 
 
+def _module_from_globals(alias: str, globals_dict: dict[str, Any]) -> ModuleType:
+    module = ModuleType(alias)
+    module.__dict__.update(globals_dict)
+    return module
+
+
+def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
+    """Recover sitecustomize modules from live Thread._target globals.
+
+    ``threading.Thread`` retains the target function while it is alive. Functions
+    retain the exact globals dictionary from the unregistered module execution,
+    so copying that dictionary into a ModuleType provides a stable import object
+    while all functions continue sharing their original mutable state.
+    """
+    recovered: dict[str, str] = {}
+    for thread in tuple(threading.enumerate()):
+        target = getattr(thread, "_target", None)
+        globals_dict = getattr(target, "__globals__", None)
+        if not isinstance(globals_dict, dict):
+            continue
+        alias, canonical = _canonical_from_globals(globals_dict)
+        if not alias or not canonical:
+            continue
+
+        existing_alias = sys.modules.get(alias)
+        existing_canonical = sys.modules.get(canonical)
+        if isinstance(existing_alias, ModuleType):
+            candidate = existing_alias
+        elif isinstance(existing_canonical, ModuleType):
+            candidate = existing_canonical
+        else:
+            candidate = _module_from_globals(alias, globals_dict)
+
+        selected = candidate
+        other = existing_canonical if isinstance(existing_canonical, ModuleType) else None
+        if other is not None and other is not candidate:
+            selected = max((candidate, other), key=_module_quality)
+
+        sys.modules[alias] = selected
+        sys.modules[canonical] = selected
+        recovered[canonical] = f"alias={alias};thread={thread.name};marker={getattr(selected, '_MARKER', 'unknown')}"
+        logger.warning(
+            "UNREGISTERED_PATCH_MODULE_RECOVERED marker=%s canonical=%s alias=%s thread=%s selected_marker=%s",
+            _MARKER,
+            canonical,
+            alias,
+            thread.name,
+            getattr(selected, "_MARKER", "unknown"),
+        )
+    return recovered
+
+
 def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
-    details: dict[str, str] = {}
+    details = recover_unregistered_patch_modules_from_threads()
     ready = True
     for alias, module in list(sys.modules.items()):
         if not alias.startswith("nija_") or not isinstance(module, ModuleType):
@@ -79,7 +146,9 @@ def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
             )
         sys.modules[canonical] = selected
         sys.modules[alias] = selected
-        details[canonical] = "same_object"
+        details[canonical] = (
+            f"same_object=true;marker={getattr(selected, '_MARKER', 'unknown')}"
+        )
     return ready, details
 
 
@@ -127,13 +196,12 @@ def audit() -> tuple[bool, dict[str, str]]:
     normalize_runtime_limits()
     ready = modules_ready
 
-    alias = sys.modules.get("nija_downstream_risk_governor_equity_repair_patch")
-    canonical = sys.modules.get("bot.downstream_risk_governor_equity_repair_patch")
-    if alias is not None or canonical is not None:
-        same = alias is canonical and isinstance(canonical, ModuleType)
-        marker = str(getattr(canonical, "_MARKER", "") or "") if same else "identity_mismatch"
-        details["downstream_risk_module"] = f"same={same};marker={marker or 'missing'}"
-        ready = ready and same and marker == "20260714-downstream-risk-v2"
+    alias = sys.modules.get(_RISK_ALIAS)
+    canonical = sys.modules.get(_RISK_CANONICAL)
+    same = alias is canonical and isinstance(canonical, ModuleType)
+    marker = str(getattr(canonical, "_MARKER", "") or "") if same else "identity_mismatch"
+    details["downstream_risk_module"] = f"same={same};marker={marker or 'missing'}"
+    ready = ready and same and marker == _REQUIRED_RISK_MARKER
 
     pipeline = sys.modules.get("bot.execution_pipeline") or sys.modules.get("execution_pipeline")
     if isinstance(pipeline, ModuleType):
@@ -144,7 +212,7 @@ def audit() -> tuple[bool, dict[str, str]]:
             f"v2={v2};legacy={legacy};cycle={cycle};depth={depth}"
         )
         ready = ready and v2 and not legacy and not cycle
-        if legacy or cycle:
+        if legacy or cycle or not v2:
             os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "0"
 
     core = sys.modules.get("bot.nija_core_loop") or sys.modules.get("nija_core_loop")
@@ -160,16 +228,20 @@ def audit() -> tuple[bool, dict[str, str]]:
 
 
 def _watchdog() -> None:
+    last_signature = ""
     while True:
         try:
             ready, details = audit()
-            logger.log(
-                logging.INFO if ready else logging.CRITICAL,
-                "RUNTIME_MODULE_IDENTITY_AUDIT marker=%s ready=%s details=%s",
-                _MARKER,
-                str(ready).lower(),
-                details,
-            )
+            signature = f"{ready}:{details}"
+            if signature != last_signature:
+                last_signature = signature
+                logger.log(
+                    logging.INFO if ready else logging.CRITICAL,
+                    "RUNTIME_MODULE_IDENTITY_AUDIT marker=%s ready=%s details=%s",
+                    _MARKER,
+                    str(ready).lower(),
+                    details,
+                )
         except Exception as exc:
             os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
             logger.critical("RUNTIME_MODULE_IDENTITY_AUDIT_FAILED marker=%s error=%s", _MARKER, exc)
@@ -211,6 +283,7 @@ __all__ = [
     "install_import_hook",
     "audit",
     "canonicalize_loaded_patch_modules",
+    "recover_unregistered_patch_modules_from_threads",
     "normalize_runtime_limits",
     "_wrapper_chain_status",
 ]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260714c"
+_MARKER = "20260714d"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -51,6 +51,7 @@ def _install_required(module_name: str) -> None:
 def _set_status(value: str) -> None:
     for name in (
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
+        "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
@@ -81,6 +82,9 @@ def install() -> bool:
             return True
         try:
             _install_required("prebot_writer_authority_fail_closed")
+            # Must precede every canonical bot import. It binds sitecustomize's
+            # nija_* modules to bot.* so source files cannot execute twice.
+            _install_required("runtime_module_identity_convergence_patch")
             _install_required("writer_generation_scope_repair_patch")
             _install_required("authority_heartbeat_generation_scope_patch")
             _install_required("final_worker_position_coinbase_repair_patch")
@@ -101,13 +105,21 @@ def install() -> bool:
             # Must be last: collapse every legacy scan/auth wrapper to one owner.
             _install_required("scan_owner_okx_auth_convergence_patch")
 
+            # Re-audit after every wrapper and core-loop module is installed.
+            identity = importlib.import_module("runtime_module_identity_convergence_patch")
+            audit = getattr(identity, "audit", None)
+            if callable(audit):
+                ready, details = audit()
+                if not ready:
+                    raise RuntimeError(f"runtime_module_identity_incomplete:{details}")
+
             _INSTALLED = True
             _set_status("1")
             commit = _deployment_commit()
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
-                "writer_authority=installed writer_generation_scope=installed "
-                "authority_heartbeat_generation_scope=installed "
+                "writer_authority=installed module_identity=installed "
+                "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
                 "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
                 "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
                 "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
@@ -124,6 +136,7 @@ def install() -> bool:
         except Exception as exc:
             _set_status("0")
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
+            os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
             message = f"{type(exc).__name__}:{exc}"
             live = _is_live_runtime()
             logger.critical(

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -52,6 +52,7 @@ def _set_status(value: str) -> None:
     for name in (
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
+        "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
@@ -90,6 +91,8 @@ def install() -> bool:
             _install_required("final_worker_position_coinbase_repair_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("runtime_convergence_hardening_patch")
+            # Arm before NijaCoreLoop imports so stale 999 state cannot enter Phase 3.
+            _install_required("bot.zero_signal_streak_state_repair_patch")
             _install_required("runtime_convergence_v2_patch")
             _install_required("runtime_auth_recursion_endpoint_repair_patch")
             _install_required("final_runtime_convergence_patch")
@@ -118,7 +121,7 @@ def install() -> bool:
             commit = _deployment_commit()
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
-                "writer_authority=installed module_identity=installed "
+                "writer_authority=installed module_identity=installed zero_signal_state_repair=armed "
                 "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
                 "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
                 "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
@@ -137,6 +140,7 @@ def install() -> bool:
             _set_status("0")
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
             os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
             message = f"{type(exc).__name__}:{exc}"
             live = _is_live_runtime()
             logger.critical(


### PR DESCRIPTION
## Runtime evidence

The July 14 Render process showed a live Phase 3 scan making progress while two legacy wrappers were reinstalled every few seconds:

```text
BROKER_INDEPENDENT_PIPELINE_PATCHED marker=20260711i
PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED marker=20260707a
```

It also showed:

```text
DEAD ZONE detected (streak=999 ≥ 2)
RUN_CYCLE_STALLED ... after 30s
```

The scan was not actually stalled: ADA-USD, ADA-USDT and ADA-USDC were being fetched and scored throughout the warning interval.

## Root causes

### The same patch source executed twice

`sitecustomize.py` executes patch files from `bot/` under private `nija_*` module names using `exec_module`, but those module objects are not registered in `sys.modules`. Later startup imports the same source files under canonical `bot.*` names.

That second execution creates independent module globals, monitor flags and wrapper registries. The monitor instances repeatedly wrap `ExecutionPipeline.execute`, causing the legacy `20260707a` marker to reappear even after the v9 source replacement.

### The dead-zone source state was never repaired

`NijaCoreLoop` passes `self._zero_signal_streak` into Phase 3, then increments the instance field after every no-entry cycle. A stale value of 999 therefore becomes 1000, 1001 and so on. Parameter-only clamping cannot recover this state.

### The stall watchdog ignored active scan progress

The watchdog fired after 30 seconds and was cancelled only when the full cycle returned. It therefore reported a stall while Phase 3 was actively waiting on valid OHLC requests and scoring symbols.

## Repairs

### Recover the original sitecustomize module

The earliest source bootstrap installs `runtime_module_identity_convergence_patch` immediately after writer-authority acquisition and before canonical `bot.*` runtime imports.

The guard inspects active patch-monitor thread targets. Each target retains the globals dictionary from the original unregistered sitecustomize module. The guard reconstructs one `ModuleType` from those globals and binds both names to the same object:

```text
nija_downstream_risk_governor_equity_repair_patch
bot.downstream_risk_governor_equity_repair_patch
```

Subsequent identity audits reuse that same object rather than rebuilding a proxy. The later canonical import returns the existing module instead of executing the source again.

### Reject legacy wrapper chains

The identity audit checks the complete `ExecutionPipeline.execute` wrapper chain and rejects live release readiness when:

- the v2 risk wrapper is absent,
- the legacy `20260707a` wrapper is present,
- the wrapper chain contains a cycle,
- private and canonical names do not reference the same module object,
- a true duplicate-module execution was detected,
- or the downstream module marker is not `20260714-downstream-risk-v2`.

### Repair the actual zero-signal state

A chain-aware Phase 3 state guard is armed before `NijaCoreLoop` imports.

- Clearly stale values at or above the configured stale threshold are reset to 0 before Phase 3.
- A value of 999 therefore enters Phase 3 as 0; if no order is placed, the production update advances it to 1 rather than 1000.
- Ordinary long streaks are bounded to the configured cap, no higher than 12, so progressive relaxation remains available without unbounded growth.
- The identity audit checks both the existing cap guard and the new state-repair guard anywhere in the Phase 3 wrapper chain, independent of wrapper order.
- Repeated watchdog audits remain idempotent and do not create a false duplicate latch.

### Remove false 30-second stall alarms

Startup enforces:

```text
NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S >= 120
```

This remains a warning-only watchdog. It does not bypass scan budgets, per-request timeouts, broker checks, writer authority or order controls.

### Strict v10 release contract

The manifest is bumped to `20260714-runtime-convergence-v10` and requires:

- canonical module identity guard installed and ready,
- v2 fail-closed risk sizing installed and attached,
- no legacy or cyclic risk wrapper chain,
- stale zero-signal state repair installed and attached,
- zero-signal cap no higher than 12,
- stale threshold greater than the cap,
- scan-appropriate stall warning threshold,
- all prior scan, readiness, Kraken equity, exit-only recovery and profit-realization guards.

## Expected Render proof

```text
UNREGISTERED_PATCH_MODULE_RECOVERED marker=20260714-module-identity-v2 canonical=bot.downstream_risk_governor_equity_repair_patch ... duplicate=false
RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=20260714-module-identity-v2 ready=true limits=streak:12,stale:100,stall:120.0
DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED marker=20260714-downstream-risk-v2
PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED ... chain_aware=true fail_closed=true exits_bypass=true
ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED marker=20260714-zero-signal-state-v1
ZERO_SIGNAL_STREAK_STATE_REPAIRED ... raw_state=999 repaired=0 reason=stale_sentinel_reset dead_zone_rearmed=true
NIJA_RUNTIME_RELEASE_MANIFEST release=20260714-runtime-convergence-v10 ... ready=true
```

The following recurring output must disappear:

```text
PRE_DISPATCH_RISK_SIZING_PIPELINE_PATCHED marker=20260707a
BROKER_INDEPENDENT_PIPELINE_PATCHED every two seconds
DEAD ZONE detected (streak=999 ...)
RUN_CYCLE_STALLED ... after 30s while SIGNAL_LOOP_PROGRESS continues
```

The existing `POSITION_COST_BASIS_RECONCILIATION_REQUIRED` warning remains intentional: NIJA must not calculate automated profit exits from an unverified adoption price.

## Regression coverage

- recovers an unregistered sitecustomize module from its active monitor thread,
- reuses the same recovered module across repeated audits,
- binds private and canonical module names to one object,
- selects v2 and fail-closes on true duplicate/legacy module identities,
- rejects legacy or cyclic execution wrapper chains,
- detects both Phase 3 guards anywhere in the wrapper chain,
- resets 999 to 0 before Phase 3,
- bounds ordinary long streaks and re-bounds the post-cycle increment,
- requires the streak repair in the release manifest,
- installs identity and streak guards before core runtime imports,
- rejects a 30-second cycle warning threshold.

## CI infrastructure status

The latest imports-smoke workflow terminated before repository checkout or test execution. GitHub returned `steps=None` and no job log URL, so the red workflow state contains no actionable code-level test failure.