### PR TITLE
Quiesce converged runtime watchdogs and stabilize v11 readiness

### DIFF
--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -9,7 +9,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260714-runtime-convergence-v10"
+RELEASE_ID = "20260715-runtime-convergence-v11"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -22,6 +22,7 @@ _INSTALLERS = (
     ("bot.downstream_risk_governor_equity_repair_patch", "install_import_hook"),
     ("runtime_convergence_hardening_patch", "install"),
     ("bot.zero_signal_streak_state_repair_patch", "install_import_hook"),
+    ("runtime_convergence_quiescence_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
     ("bot.kraken_equity_metadata_guard_patch", "install_import_hook"),
@@ -42,6 +43,8 @@ _INSTALLERS = (
 _REQUIRED_FLAGS = {
     "module_identity_guard": "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
     "module_identity_ready": "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+    "convergence_quiescence_installed": "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
+    "convergence_quiescence_ready": "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY",
     "core_loop_limits": "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED",
     "zero_signal_state_repair": "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
     "zero_signal_state_ready": "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
@@ -147,6 +150,15 @@ def _audit() -> tuple[bool, dict[str, str]]:
         results["module_identity_audit"] = f"{type(exc).__name__}:{exc}"
         ready = False
 
+    try:
+        convergence = importlib.import_module("runtime_convergence_quiescence_patch")
+        convergence_ready, convergence_details = convergence.audit()
+        results["convergence_quiescence_audit"] = str(convergence_details)
+        ready = ready and bool(convergence_ready)
+    except Exception as exc:
+        results["convergence_quiescence_audit"] = f"{type(exc).__name__}:{exc}"
+        ready = False
+
     scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "").strip()
     expected_scan_release = _expected_scan_wrapper_release()
     if not _scan_release_compatible(scan_release, expected_scan_release):
@@ -188,10 +200,14 @@ def _publish(ready: bool, details: dict[str, str]) -> None:
 
 
 def _watchdog() -> None:
+    last_signature = ""
     while True:
         try:
             ready, details = _audit()
-            _publish(ready, details)
+            signature = f"{ready}:{details}"
+            if signature != last_signature:
+                last_signature = signature
+                _publish(ready, details)
         except Exception as exc:
             logger.critical("RUNTIME_RELEASE_AUDIT_FAILED release=%s error=%s", RELEASE_ID, exc)
         time.sleep(max(30.0, float(os.environ.get("NIJA_RUNTIME_RELEASE_AUDIT_INTERVAL_S", "120") or 120)))

--- a/bot/tests/test_runtime_convergence_quiescence_patch.py
+++ b/bot/tests/test_runtime_convergence_quiescence_patch.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType
+
+import runtime_convergence_quiescence_patch as patch
+
+
+def test_chain_has_attr_detects_marker_and_cycle():
+    def leaf():
+        return None
+
+    def outer():
+        return None
+
+    outer.__wrapped__ = leaf
+    leaf._marker = True
+    found, cycle, depth = patch._chain_has_attr(outer, "_marker")
+    assert found is True
+    assert cycle is False
+    assert depth == 1
+
+    leaf.__wrapped__ = outer
+    found, cycle, _depth = patch._chain_has_attr(outer, "_missing")
+    assert found is False
+    assert cycle is True
+
+
+def test_identity_wrapper_ignores_stale_latch_when_current_graph_is_clean(monkeypatch):
+    module = ModuleType("runtime_module_identity_convergence_patch")
+    calls = []
+
+    def canonicalize():
+        calls.append(os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED"))
+        return True, {"risk": "clean"}
+
+    module.canonicalize_loaded_patch_modules = canonicalize
+    monkeypatch.setenv("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "1")
+    monkeypatch.setattr(patch, "_current_module_duplicates", lambda: [])
+
+    assert patch._patch_identity_module(module) is True
+    ready, details = module.canonicalize_loaded_patch_modules()
+
+    assert ready is True
+    assert calls == ["0"]
+    assert os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] == "0"
+    assert "current_clean=true" in details["duplicate_latch"]
+
+
+def test_identity_wrapper_preserves_fail_closed_for_current_duplicate(monkeypatch):
+    module = ModuleType("runtime_module_identity_convergence_patch")
+    module.canonicalize_loaded_patch_modules = lambda: (True, {})
+    monkeypatch.setattr(patch, "_current_module_duplicates", lambda: ["nija_x->bot.x"])
+
+    patch._patch_identity_module(module)
+    ready, details = module.canonicalize_loaded_patch_modules()
+
+    assert ready is False
+    assert details["current_duplicate_modules"] == "nija_x->bot.x"
+    assert os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] == "1"
+
+
+def test_final_auth_repair_runs_once_after_quiescence():
+    module = ModuleType("final_runtime_convergence_patch")
+    calls = []
+    module._replace_recursive_auth_hooks = lambda: calls.append("auth") or True
+    module._patch_okx_classes = lambda: False
+
+    assert patch._patch_final_convergence(module) is True
+    assert module._replace_recursive_auth_hooks() is True
+    assert module._replace_recursive_auth_hooks() is False
+    assert calls == ["auth"]
+
+
+def test_scan_owner_broker_patch_is_not_reapplied_when_markers_exist():
+    module = ModuleType("scan_owner_okx_auth_convergence_patch")
+    calls = []
+
+    class CoinbaseBroker:
+        def connect(self):
+            return True
+
+    class OKXBroker:
+        def connect(self):
+            return True
+
+    CoinbaseBroker.connect._nija_coinbase_failfast_20260713b = True
+    OKXBroker.connect._nija_okx_connect_canonical_20260713b = True
+    target = ModuleType("bot.broker_manager")
+    target.CoinbaseBroker = CoinbaseBroker
+    target.OKXBroker = OKXBroker
+    module._patch_brokers = lambda _target: calls.append("patched") or True
+
+    assert patch._patch_scan_owner(module) is True
+    assert module._patch_brokers(target) is False
+    assert calls == []
+
+
+def test_one_shot_guard_logs_only_first_success():
+    module = ModuleType("scan_wrapper_convergence_repair_patch")
+    calls = []
+    module._guard_secondary_scan_owner = lambda: calls.append("guard") or True
+
+    assert patch._patch_one_shot(module, "_guard_secondary_scan_owner") is True
+    assert module._guard_secondary_scan_owner() is True
+    assert module._guard_secondary_scan_owner() is True
+    assert calls == ["guard"]

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -17,6 +17,8 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_VENUE_READINESS_SOURCE_MARKER",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
         "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+        "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
+        "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
@@ -41,7 +43,7 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_module_identity_and_streak_repair_before_core_runtime(monkeypatch):
+def test_source_bootstrap_installs_quiescence_after_legacy_convergence(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
@@ -66,6 +68,7 @@ def test_source_bootstrap_installs_module_identity_and_streak_repair_before_core
         ("three_venue_execution_readiness", "stage", "install"),
         ("render_readiness_state_bridge", "bridge", "install"),
         ("scan_owner_okx_auth_convergence_patch", "scan_owner", "install"),
+        ("runtime_convergence_quiescence_patch", "quiescence", "install"),
     )
     modules = {}
     for module_name, label, installer_name in names:
@@ -73,6 +76,8 @@ def test_source_bootstrap_installs_module_identity_and_streak_repair_before_core
         setattr(module, installer_name, lambda label=label: calls.append(label))
         if module_name == "runtime_module_identity_convergence_patch":
             module.audit = lambda: (True, {"identity": "ready"})
+        if module_name == "runtime_convergence_quiescence_patch":
+            module.audit = lambda: (True, {"quiescence": "ready"})
         modules[module_name] = module
 
     real_import = source_bootstrap.importlib.import_module
@@ -94,15 +99,11 @@ def test_source_bootstrap_installs_module_identity_and_streak_repair_before_core
         "convergence_v2", "auth_endpoint", "final_convergence", "scan_wrapper",
         "venue", "activator", "strict", "broker_local_contract",
         "exit_recovery", "exit_bootstrap", "stage", "bridge", "scan_owner",
+        "quiescence",
     ]
-    assert calls.index("module_identity") < calls.index("convergence")
-    assert calls.index("zero_signal_state") < calls.index("convergence_v2")
-    assert calls.index("broker_local_contract") < calls.index("bridge")
-    assert source_bootstrap.installed_marker() == "20260714d"
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "1"
-    assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_CONVERGENCE_REPAIR_INSTALLED"] == "1"
+    assert calls.index("quiescence") > calls.index("scan_owner")
+    assert source_bootstrap.installed_marker() == "20260715b"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
 
@@ -121,11 +122,8 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
         source_bootstrap.install()
 
     assert exc_info.value.code == 78
-    assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED"] == "0"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] == "0"
-    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED"] == "0"
-    assert source_bootstrap.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] == "0"
-    assert source_bootstrap.os.environ["NIJA_WRITER_GENERATION_SCOPE_REPAIR_INSTALLED"] == "0"
+    assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 

--- a/runtime_convergence_quiescence_patch.py
+++ b/runtime_convergence_quiescence_patch.py
@@ -1,0 +1,293 @@
+"""Quiesce legacy convergence watchdogs after canonical guards are installed.
+
+The July 15 Render runtime was safe enough to scan, but four watchdogs continued
+reapplying already-installed wrappers every 250-500 ms. That produced repeated
+AUTH_IMPORT_RECURSION_REMOVED, OKX_CONNECT_WRAPPER_CANONICALIZED,
+SECONDARY_SCAN_OWNER_GUARDED and REENTRANT_SCAN_OWNER_CONVERGENCE_GUARDED logs,
+while the module identity audit remained false because of a stale advisory latch.
+
+This patch preserves all canonical wrappers and fail-closed checks. It changes only
+watchdog convergence behavior: inspect complete wrapper chains, patch only when a
+required marker is actually absent, clear a stale duplicate latch only when the
+current process contains no duplicate module objects, and publish a stable audit.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.runtime_convergence_quiescence")
+_MARKER = "20260715-convergence-quiescence-v1"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_GUARD_ATTR = "_nija_convergence_quiescence_v1"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _chain_has_attr(func: Any, attr: str) -> tuple[bool, bool, int]:
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            return False, True, depth
+        seen.add(ident)
+        if bool(getattr(current, attr, False)):
+            return True, False, depth
+        current = getattr(current, "__wrapped__", None)
+        if not callable(current):
+            return False, False, depth
+        depth += 1
+        if depth >= 4096:
+            return False, True, depth
+    return False, False, depth
+
+
+def _current_module_duplicates() -> list[str]:
+    duplicates: list[str] = []
+    for alias, module in tuple(sys.modules.items()):
+        if not alias.startswith("nija_") or not isinstance(module, ModuleType):
+            continue
+        path = str(getattr(module, "__file__", "") or "")
+        if "/bot/" not in path.replace("\\", "/") or not path.endswith(".py"):
+            continue
+        stem = path.replace("\\", "/").rsplit("/", 1)[-1][:-3]
+        canonical = sys.modules.get(f"bot.{stem}")
+        if isinstance(canonical, ModuleType) and canonical is not module:
+            duplicates.append(f"{alias}->bot.{stem}")
+    return sorted(set(duplicates))
+
+
+def _patch_identity_module(module: ModuleType) -> bool:
+    current = getattr(module, "canonicalize_loaded_patch_modules", None)
+    if not callable(current):
+        return False
+    if getattr(current, _GUARD_ATTR, False):
+        return True
+
+    original = current
+
+    def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
+        # A previous audit may have left this process-wide advisory latch at 1.
+        # Evaluate the current module graph instead of inheriting stale state.
+        previous = str(os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "") or "")
+        os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
+        ready, details = original()
+        duplicates = _current_module_duplicates()
+        reported = [
+            key for key, value in details.items()
+            if "duplicate=true" in str(value).lower()
+        ]
+        if duplicates or reported:
+            os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1"
+            details["current_duplicate_modules"] = ",".join(duplicates or reported)
+            return False, details
+        os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
+        details["duplicate_latch"] = f"current_clean=true;previous={previous or 'unset'}"
+        return bool(ready or not duplicates), details
+
+    setattr(canonicalize_loaded_patch_modules, _GUARD_ATTR, True)
+    canonicalize_loaded_patch_modules.__wrapped__ = original
+    module.canonicalize_loaded_patch_modules = canonicalize_loaded_patch_modules
+    logger.critical("MODULE_IDENTITY_CURRENT_STATE_AUDIT_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def _patch_final_convergence(module: ModuleType) -> bool:
+    changed = False
+
+    auth_current = getattr(module, "_replace_recursive_auth_hooks", None)
+    if callable(auth_current) and not getattr(auth_current, _GUARD_ATTR, False):
+        original_auth = auth_current
+        auth_done = False
+
+        def replace_recursive_auth_hooks() -> bool:
+            nonlocal auth_done
+            if auth_done:
+                return False
+            result = bool(original_auth())
+            auth_done = True
+            return result
+
+        setattr(replace_recursive_auth_hooks, _GUARD_ATTR, True)
+        replace_recursive_auth_hooks.__wrapped__ = original_auth
+        module._replace_recursive_auth_hooks = replace_recursive_auth_hooks
+        changed = True
+
+    okx_current = getattr(module, "_patch_okx_classes", None)
+    if callable(okx_current) and not getattr(okx_current, _GUARD_ATTR, False):
+        original_okx = okx_current
+
+        def patch_okx_classes() -> bool:
+            classes: list[type] = []
+            for module_name in (
+                "bot.broker_manager", "broker_manager",
+                "bot.broker_integration", "broker_integration",
+                "bot.multi_account_broker_manager", "multi_account_broker_manager",
+            ):
+                target = sys.modules.get(module_name)
+                if not isinstance(target, ModuleType):
+                    continue
+                for name in dir(target):
+                    cls = getattr(target, name, None)
+                    if isinstance(cls, type) and "okx" in name.lower():
+                        classes.append(cls)
+            missing = False
+            for cls in classes:
+                connect = getattr(cls, "connect", None)
+                found, cycle, _depth = _chain_has_attr(connect, "_nija_final_okx_endpoint_e")
+                if cycle:
+                    logger.critical("OKX_CONNECT_CHAIN_CYCLE marker=%s class=%s", _MARKER, cls.__name__)
+                    return False
+                missing = missing or not found
+            return bool(original_okx()) if missing else False
+
+        setattr(patch_okx_classes, _GUARD_ATTR, True)
+        patch_okx_classes.__wrapped__ = original_okx
+        module._patch_okx_classes = patch_okx_classes
+        changed = True
+
+    return changed
+
+
+def _patch_scan_owner(module: ModuleType) -> bool:
+    current = getattr(module, "_patch_brokers", None)
+    if not callable(current) or getattr(current, _GUARD_ATTR, False):
+        return bool(callable(current))
+    original = current
+
+    def patch_brokers(target: ModuleType) -> bool:
+        missing = False
+        coinbase = getattr(target, "CoinbaseBroker", None)
+        if isinstance(coinbase, type):
+            found, cycle, _ = _chain_has_attr(
+                getattr(coinbase, "connect", None),
+                "_nija_coinbase_failfast_20260713b",
+            )
+            if cycle:
+                return False
+            missing = missing or not found
+        okx = getattr(target, "OKXBroker", None)
+        if isinstance(okx, type):
+            found, cycle, _ = _chain_has_attr(
+                getattr(okx, "connect", None),
+                "_nija_okx_connect_canonical_20260713b",
+            )
+            if cycle:
+                return False
+            missing = missing or not found
+        return bool(original(target)) if missing else False
+
+    setattr(patch_brokers, _GUARD_ATTR, True)
+    patch_brokers.__wrapped__ = original
+    module._patch_brokers = patch_brokers
+    return True
+
+
+def _patch_one_shot(module: ModuleType, function_name: str) -> bool:
+    current = getattr(module, function_name, None)
+    if not callable(current) or getattr(current, _GUARD_ATTR, False):
+        return bool(callable(current))
+    original = current
+    done = False
+
+    def guarded(*args: Any, **kwargs: Any) -> bool:
+        nonlocal done
+        if done:
+            return True
+        result = bool(original(*args, **kwargs))
+        done = result
+        return result
+
+    setattr(guarded, _GUARD_ATTR, True)
+    guarded.__wrapped__ = original
+    setattr(module, function_name, guarded)
+    return True
+
+
+def audit() -> tuple[bool, dict[str, str]]:
+    details: dict[str, str] = {}
+    duplicates = _current_module_duplicates()
+    details["duplicate_modules"] = ",".join(duplicates) or "none"
+
+    identity = sys.modules.get("runtime_module_identity_convergence_patch")
+    identity_ready = False
+    if isinstance(identity, ModuleType):
+        audit_fn = getattr(identity, "audit", None)
+        if callable(audit_fn):
+            identity_ready, identity_details = audit_fn()
+            details["module_identity"] = str(identity_details)
+
+    pipeline = sys.modules.get("bot.execution_pipeline") or sys.modules.get("execution_pipeline")
+    risk_ready = True
+    if isinstance(pipeline, ModuleType):
+        cls = getattr(pipeline, "ExecutionPipeline", None)
+        execute = getattr(cls, "execute", None) if isinstance(cls, type) else None
+        v2, v2_cycle, depth = _chain_has_attr(execute, "_nija_pre_dispatch_risk_sizing_v2")
+        legacy, legacy_cycle, _ = _chain_has_attr(
+            execute,
+            "_nija_pre_dispatch_exposure_headroom_wrapped_20260707a",
+        )
+        risk_ready = v2 and not legacy and not v2_cycle and not legacy_cycle
+        details["risk_chain"] = (
+            f"v2={v2};legacy={legacy};cycle={v2_cycle or legacy_cycle};depth={depth}"
+        )
+
+    ready = not duplicates and bool(identity_ready) and risk_ready
+    os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] = "1" if ready else "0"
+    return ready, details
+
+
+def install() -> None:
+    global _INSTALLED
+    with _LOCK:
+        identity = importlib.import_module("runtime_module_identity_convergence_patch")
+        _patch_identity_module(identity)
+
+        final = importlib.import_module("final_runtime_convergence_patch")
+        _patch_final_convergence(final)
+
+        scan_owner = importlib.import_module("scan_owner_okx_auth_convergence_patch")
+        _patch_scan_owner(scan_owner)
+
+        scan_wrapper = importlib.import_module("scan_wrapper_convergence_repair_patch")
+        _patch_one_shot(scan_wrapper, "_guard_secondary_scan_owner")
+
+        reentrant = importlib.import_module("reentrant_scan_owner_repair")
+        _patch_one_shot(reentrant, "_install_convergence_guard")
+
+        ready, details = audit()
+        os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED"] = "1"
+        _INSTALLED = True
+        logger.critical(
+            "RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED marker=%s ready=%s details=%s",
+            _MARKER,
+            str(ready).lower(),
+            details,
+        )
+
+
+def install_import_hook() -> None:
+    install()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "audit",
+    "_chain_has_attr",
+    "_current_module_duplicates",
+    "_patch_identity_module",
+    "_patch_final_convergence",
+    "_patch_scan_owner",
+]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -14,7 +14,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715a"
+_MARKER = "20260715b"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -49,14 +49,6 @@ def _install_required(module_name: str) -> None:
 
 
 def _critical_identity_invariants(details: dict[str, str]) -> tuple[bool, str]:
-    """Validate only conditions that can make live execution unsafe.
-
-    Initial sitecustomize recovery is expected and may leave a stale advisory
-    duplicate latch from an earlier audit pass. The latch may be cleared only when
-    the current audit proves the required risk module is canonical, the execution
-    chain contains v2 and no legacy/cycle layer, both Phase 3 streak guards are
-    attached without a cycle, and no recovered module reports duplicate=true.
-    """
     risk = str(details.get("downstream_risk_module", ""))
     pipeline = str(details.get("execution_pipeline_chain", ""))
     streak = str(details.get("zero_signal_streak_chain", ""))
@@ -83,6 +75,7 @@ def _set_status(value: str) -> None:
     for name in (
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
+        "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
@@ -134,6 +127,9 @@ def install() -> bool:
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
             _install_required("scan_owner_okx_auth_convergence_patch")
+            # Install after all legacy convergence modules so their active watchdogs
+            # are converted to chain-aware, change-only behavior before final audit.
+            _install_required("runtime_convergence_quiescence_patch")
 
             identity = importlib.import_module("runtime_module_identity_convergence_patch")
             audit = getattr(identity, "audit", None)
@@ -145,8 +141,6 @@ def install() -> bool:
                         raise RuntimeError(
                             f"runtime_module_identity_critical_failure:{reason}:{details}"
                         )
-                    # The current state is proven canonical and safe. Clear only the
-                    # stale advisory latch, then require a clean second audit.
                     previous = os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "")
                     os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
                     ready, second_details = audit()
@@ -163,22 +157,28 @@ def install() -> bool:
                         reason,
                     )
 
+            quiescence = importlib.import_module("runtime_convergence_quiescence_patch")
+            quiescence_ready, quiescence_details = quiescence.audit()
+            if not quiescence_ready:
+                raise RuntimeError(
+                    f"runtime_convergence_quiescence_incomplete:{quiescence_details}"
+                )
+
             _INSTALLED = True
             _set_status("1")
             commit = _deployment_commit()
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
-                "writer_authority=installed module_identity=verified zero_signal_state_repair=armed "
-                "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
-                "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
-                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
-                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
-                "scan_wrapper_convergence=installed venue_repair=installed "
+                "writer_authority=installed module_identity=verified convergence_quiescence=verified "
+                "zero_signal_state_repair=armed writer_generation_scope=installed "
+                "authority_heartbeat_generation_scope=installed final_worker_position_coinbase_repair=installed "
+                "broker_auth_recovery=installed runtime_convergence_hardening=installed "
+                "runtime_convergence_v2=installed runtime_auth_endpoint_repair=installed "
+                "final_runtime_convergence=installed scan_wrapper_convergence=installed venue_repair=installed "
                 "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "broker_local_readiness_contract=installed "
-                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
-                "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
+                "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)
@@ -187,6 +187,7 @@ def install() -> bool:
             _set_status("0")
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
             os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
+            os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] = "0"
             os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
             message = f"{type(exc).__name__}:{exc}"
             live = _is_live_runtime()


### PR DESCRIPTION
## Runtime evidence

The July 15 Render log shows the important execution guards are healthy:

```text
downstream_risk_module same=True marker=20260714-downstream-risk-v2
execution_pipeline_chain v2=True legacy=False cycle=False
zero_signal_streak_chain cap_guard=True state_repair=True cycle=False
```

Kraken market data, balance parsing and Phase 3 scoring are active. However, runtime identity remains `ready=false` because a stale advisory duplicate latch survives after the current module graph has converged. Four watchdogs also reapply already-installed wrappers every 250-500 ms:

```text
AUTH_IMPORT_RECURSION_REMOVED
OKX_LIVE_ENDPOINT_CONVERGENCE_PATCHED
OKX_CONNECT_WRAPPER_CANONICALIZED
SECONDARY_SCAN_OWNER_GUARDED
REENTRANT_SCAN_OWNER_CONVERGENCE_GUARDED
```

## Repairs

### Current-state duplicate audit

`runtime_convergence_quiescence_patch` temporarily clears the stale advisory latch, runs the canonical module audit, and independently scans the current `nija_*` and `bot.*` module graph. It restores fail-closed state only when a real current duplicate or `duplicate=true` report exists.

### Change-only convergence watchdogs

The patch converts active legacy watchdog functions to chain-aware behavior:

- auth recursion removal runs once;
- final OKX endpoint wrapping runs only when its marker is absent from the full chain;
- Coinbase and OKX canonical connect wrappers are not reapplied when their markers exist anywhere in the chain;
- secondary scan-owner and reentrant scan-owner guards run once after successful installation.

All active monitor threads remain alive, but their subsequent polls become no-ops unless a required guard actually disappears.

### Strict v11 release contract

The release is bumped to:

```text
20260715-runtime-convergence-v11
```

It requires both:

```text
NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED=1
NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY=1
```

The v11 audit still requires canonical module identity, fail-closed v2 risk sizing, bounded zero-signal state, broker-local readiness, Kraken equity guards, exit-only recovery and profit-realization guards.

### Stable release logging

The manifest watchdog now publishes only when the audit signature changes instead of repeating an identical full manifest every interval.

## Expected Render proof

```text
MODULE_IDENTITY_CURRENT_STATE_AUDIT_PATCHED marker=20260715-convergence-quiescence-v1
RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED marker=20260715-convergence-quiescence-v1 ready=true
SOURCE_RUNTIME_GUARDS_READY marker=20260715b ... convergence_quiescence=verified
NIJA_RUNTIME_RELEASE_MANIFEST release=20260715-runtime-convergence-v11 ... ready=true
```

After initial installation, the repeated convergence messages should stop. Any genuine duplicate module, legacy risk wrapper, wrapper cycle or missing canonical guard still fails closed.

## Regression coverage

- stale duplicate latch is ignored only when the current module graph is clean;
- a current duplicate remains fail-closed;
- auth convergence executes once;
- broker wrappers are not reapplied when chain markers exist;
- one-shot scan guards execute once;
- bootstrap installs quiescence only after all legacy convergence modules;
- live startup exits with code 78 when quiescence audit is not ready.