### PR TITLE
Bound scan wrapper depth and stop broker wrapper reinstallation

### DIFF
--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -9,13 +9,14 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260715-runtime-convergence-v11"
+RELEASE_ID = "20260715-runtime-convergence-v12"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 _INSTALLERS = (
     ("runtime_module_identity_convergence_patch", "install_import_hook"),
+    ("scan_wrapper_depth_convergence_patch", "install_import_hook"),
     ("scan_wrapper_convergence_repair_patch", "install"),
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("broker_local_readiness_contract_patch", "install_import_hook"),
@@ -45,6 +46,8 @@ _REQUIRED_FLAGS = {
     "module_identity_ready": "NIJA_RUNTIME_MODULE_IDENTITY_READY",
     "convergence_quiescence_installed": "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
     "convergence_quiescence_ready": "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY",
+    "scan_wrapper_depth_guard": "NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED",
+    "scan_wrapper_depth_ready": "NIJA_SCAN_WRAPPER_DEPTH_READY",
     "core_loop_limits": "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED",
     "zero_signal_state_repair": "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
     "zero_signal_state_ready": "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
@@ -65,10 +68,7 @@ def _truthy(value: str | None) -> bool:
 
 
 def _deployment_sha() -> str:
-    for name in (
-        "RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "SOURCE_VERSION",
-        "RENDER_GIT_COMMIT", "HEROKU_SLUG_COMMIT",
-    ):
+    for name in ("RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "SOURCE_VERSION", "RENDER_GIT_COMMIT", "HEROKU_SLUG_COMMIT"):
         value = str(os.environ.get(name, "") or "").strip()
         if value:
             return value
@@ -103,9 +103,7 @@ def _readiness_contract_consistent() -> tuple[bool, str]:
     policy = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "") or "").strip().lower()
     missing = str(os.environ.get("NIJA_REQUIRED_VENUES_MISSING", "") or "").strip().strip(",")
     required_ready = _truthy(os.environ.get("NIJA_REQUIRED_VENUES_READY"))
-    global_ready = _truthy(
-        os.environ.get("NIJA_GLOBAL_TRADING_READY", os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0"))
-    )
+    global_ready = _truthy(os.environ.get("NIJA_GLOBAL_TRADING_READY", os.environ.get("NIJA_MULTI_BROKER_TRADING_READY", "0")))
     active = str(os.environ.get("NIJA_ACTIVE_LIVE_VENUES", "") or "").strip().strip(",")
     if policy not in {"broker_local", "global_all_required", "optional"}:
         return False, f"invalid_policy:{policy or 'missing'}"
@@ -113,10 +111,7 @@ def _readiness_contract_consistent() -> tuple[bool, str]:
         return False, f"contradiction:missing={missing};required_ready=1"
     if global_ready and not active:
         return False, "contradiction:global_ready=1;active_live_venues=missing"
-    return True, (
-        f"policy={policy};required_ready={int(required_ready)};missing={missing or 'none'};"
-        f"global_ready={int(global_ready)};active={active or 'none'}"
-    )
+    return True, f"policy={policy};required_ready={int(required_ready)};missing={missing or 'none'};global_ready={int(global_ready)};active={active or 'none'}"
 
 
 def _runtime_limits_consistent() -> tuple[bool, str]:
@@ -127,10 +122,7 @@ def _runtime_limits_consistent() -> tuple[bool, str]:
     except Exception as exc:
         return False, f"parse_error:{exc}"
     ok = 2 <= streak <= 12 and stale > streak and stall >= 120.0
-    return ok, (
-        f"zero_signal_streak_cap={streak};stale_threshold={stale};"
-        f"run_cycle_stall_warn_s={stall:.1f}"
-    )
+    return ok, f"zero_signal_streak_cap={streak};stale_threshold={stale};run_cycle_stall_warn_s={stall:.1f}"
 
 
 def _audit() -> tuple[bool, dict[str, str]]:
@@ -141,23 +133,19 @@ def _audit() -> tuple[bool, dict[str, str]]:
         results[module_name] = reason
         ready = ready and ok
 
-    try:
-        identity = importlib.import_module("runtime_module_identity_convergence_patch")
-        identity_ready, identity_details = identity.audit()
-        results["module_identity_audit"] = str(identity_details)
-        ready = ready and bool(identity_ready)
-    except Exception as exc:
-        results["module_identity_audit"] = f"{type(exc).__name__}:{exc}"
-        ready = False
-
-    try:
-        convergence = importlib.import_module("runtime_convergence_quiescence_patch")
-        convergence_ready, convergence_details = convergence.audit()
-        results["convergence_quiescence_audit"] = str(convergence_details)
-        ready = ready and bool(convergence_ready)
-    except Exception as exc:
-        results["convergence_quiescence_audit"] = f"{type(exc).__name__}:{exc}"
-        ready = False
+    for module_name, key in (
+        ("runtime_module_identity_convergence_patch", "module_identity_audit"),
+        ("runtime_convergence_quiescence_patch", "convergence_quiescence_audit"),
+        ("scan_wrapper_depth_convergence_patch", "scan_wrapper_depth_audit"),
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            module_ready, module_details = module.audit()
+            results[key] = str(module_details)
+            ready = ready and bool(module_ready)
+        except Exception as exc:
+            results[key] = f"{type(exc).__name__}:{exc}"
+            ready = False
 
     scan_release = str(os.environ.get("NIJA_SCAN_WRAPPER_RELEASE", "") or "").strip()
     expected_scan_release = _expected_scan_wrapper_release()
@@ -178,7 +166,6 @@ def _audit() -> tuple[bool, dict[str, str]]:
     limits_ok, limits_reason = _runtime_limits_consistent()
     results["core_loop_runtime_limits"] = limits_reason
     ready = ready and limits_ok
-
     contract_ok, contract_reason = _readiness_contract_consistent()
     results["readiness_contract"] = contract_reason
     ready = ready and contract_ok
@@ -188,15 +175,9 @@ def _audit() -> tuple[bool, dict[str, str]]:
 def _publish(ready: bool, details: dict[str, str]) -> None:
     os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
     os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
-    logger.critical(
-        "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
-        RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
-    )
+    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s", RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details)
     if not ready:
-        logger.critical(
-            "RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed",
-            RELEASE_ID,
-        )
+        logger.critical("RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed", RELEASE_ID)
 
 
 def _watchdog() -> None:
@@ -224,8 +205,4 @@ def install_import_hook() -> None:
     logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", RELEASE_ID)
 
 
-__all__ = [
-    "RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
-    "_expected_scan_wrapper_release", "_scan_release_compatible",
-    "_readiness_contract_consistent", "_runtime_limits_consistent",
-]
+__all__ = ["RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha", "_expected_scan_wrapper_release", "_scan_release_compatible", "_readiness_contract_consistent", "_runtime_limits_consistent"]

--- a/bot/tests/test_scan_wrapper_depth_convergence_patch.py
+++ b/bot/tests/test_scan_wrapper_depth_convergence_patch.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import scan_wrapper_depth_convergence_patch as patch
+
+
+def _broker_wrapper(base):
+    def wrapper(self, *args, **kwargs):
+        return base(self, *args, **kwargs)
+    setattr(wrapper, patch._BROKER_ATTR, True)
+    wrapper.__wrapped__ = base
+    return wrapper
+
+
+def _canonical_wrapper(base):
+    def wrapper(self, *args, **kwargs):
+        return base(self, *args, **kwargs)
+    setattr(wrapper, patch._CANONICAL_RELEASE_ATTR, "20260714a")
+    wrapper.__wrapped__ = base
+    return wrapper
+
+
+def test_inspect_chain_counts_single_broker_and_canonical_layers():
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    chain = _canonical_wrapper(_broker_wrapper(leaf))
+    status = patch.inspect_chain(chain)
+
+    assert status["depth"] == 2
+    assert status["broker_layers"] == 1
+    assert status["canonical_layers"] == 1
+    assert status["cycle"] is False
+
+
+def test_inspect_chain_detects_duplicate_broker_layers():
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    chain = _canonical_wrapper(_broker_wrapper(_broker_wrapper(leaf)))
+    status = patch.inspect_chain(chain)
+
+    assert status["broker_layers"] == 2
+
+
+def test_inspect_chain_follows_legacy_closure_original():
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    original = leaf
+
+    def legacy(self, *args, **kwargs):
+        return original(self, *args, **kwargs)
+
+    setattr(legacy, patch._BROKER_ATTR, True)
+    status = patch.inspect_chain(legacy)
+
+    assert status["depth"] == 1
+    assert status["broker_layers"] == 1
+    assert status["tail"].endswith("leaf")
+
+
+def test_guarded_installer_does_not_rewrap_when_marker_is_below_outer_owner(monkeypatch):
+    calls = []
+
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    broker = _broker_wrapper(leaf)
+    outer = _canonical_wrapper(broker)
+
+    core = ModuleType("bot.nija_core_loop")
+    core.NijaCoreLoop = type("NijaCoreLoop", (), {"run_scan_phase": outer})
+
+    module = ModuleType("bot.broker_independent_live_execution_patch")
+
+    def legacy_patch(core_module):
+        calls.append(core_module)
+        previous = core_module.NijaCoreLoop.run_scan_phase
+        core_module.NijaCoreLoop.run_scan_phase = _broker_wrapper(previous)
+        return True
+
+    module._patch_core_loop_module = legacy_patch
+    module._PATCHED = False
+
+    assert patch._guard_broker_module(module) is True
+    assert module._patch_core_loop_module(core) is True
+    assert calls == []
+    assert module._PATCHED is True
+    assert core.NijaCoreLoop.run_scan_phase is outer
+
+
+def test_guarded_installer_repairs_wrapped_link_on_new_layer():
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    core = ModuleType("bot.nija_core_loop")
+    core.NijaCoreLoop = type("NijaCoreLoop", (), {"run_scan_phase": leaf})
+
+    module = ModuleType("bot.broker_independent_live_execution_patch")
+
+    def legacy_patch(core_module):
+        previous = core_module.NijaCoreLoop.run_scan_phase
+
+        def broker(self, *args, **kwargs):
+            return previous(self, *args, **kwargs)
+
+        setattr(broker, patch._BROKER_ATTR, True)
+        core_module.NijaCoreLoop.run_scan_phase = broker
+        return True
+
+    module._patch_core_loop_module = legacy_patch
+    module._PATCHED = False
+
+    patch._guard_broker_module(module)
+    assert module._patch_core_loop_module(core) is True
+    installed = core.NijaCoreLoop.run_scan_phase
+    assert installed.__wrapped__ is leaf
+    assert patch.inspect_chain(installed)["broker_layers"] == 1
+
+
+def test_audit_rejects_oversized_or_duplicate_chain(monkeypatch):
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    chain = _canonical_wrapper(_broker_wrapper(_broker_wrapper(leaf)))
+    core = ModuleType("bot.nija_core_loop")
+    core.NijaCoreLoop = type("NijaCoreLoop", (), {"run_scan_phase": chain})
+    monkeypatch.setitem(patch.sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(patch.sys.modules, "nija_core_loop", raising=False)
+    monkeypatch.setattr(patch, "_patch_loaded_broker_modules", lambda: True)
+
+    ready, details = patch.audit()
+
+    assert ready is False
+    assert "broker_layers=2" in details["scan_chain"]
+    assert patch.os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] == "0"

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -19,6 +19,8 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         "NIJA_RUNTIME_MODULE_IDENTITY_READY",
         "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY",
+        "NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED",
+        "NIJA_SCAN_WRAPPER_DEPTH_READY",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
@@ -43,12 +45,13 @@ def _reset_source_bootstrap(monkeypatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_source_bootstrap_installs_quiescence_after_legacy_convergence(monkeypatch):
+def test_source_bootstrap_installs_scan_depth_before_legacy_convergence(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     names = (
         ("prebot_writer_authority_fail_closed", "writer", "install"),
         ("runtime_module_identity_convergence_patch", "module_identity", "install"),
+        ("scan_wrapper_depth_convergence_patch", "scan_depth", "install"),
         ("writer_generation_scope_repair_patch", "generation_scope", "install"),
         ("authority_heartbeat_generation_scope_patch", "heartbeat_scope", "install"),
         ("final_worker_position_coinbase_repair_patch", "worker_position", "install"),
@@ -78,14 +81,12 @@ def test_source_bootstrap_installs_quiescence_after_legacy_convergence(monkeypat
             module.audit = lambda: (True, {"identity": "ready"})
         if module_name == "runtime_convergence_quiescence_patch":
             module.audit = lambda: (True, {"quiescence": "ready"})
+        if module_name == "scan_wrapper_depth_convergence_patch":
+            module.audit = lambda: (True, {"scan_chain": "depth=2"})
         modules[module_name] = module
 
     real_import = source_bootstrap.importlib.import_module
-    monkeypatch.setattr(
-        source_bootstrap.importlib,
-        "import_module",
-        lambda name: modules.get(name) or real_import(name),
-    )
+    monkeypatch.setattr(source_bootstrap.importlib, "import_module", lambda name: modules.get(name) or real_import(name))
     monkeypatch.setenv("RENDER_GIT_COMMIT", "abc123")
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("DRY_RUN_MODE", "false")
@@ -94,15 +95,16 @@ def test_source_bootstrap_installs_quiescence_after_legacy_convergence(monkeypat
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == [
-        "writer", "module_identity", "generation_scope", "heartbeat_scope",
-        "worker_position", "auth", "convergence", "zero_signal_state",
-        "convergence_v2", "auth_endpoint", "final_convergence", "scan_wrapper",
-        "venue", "activator", "strict", "broker_local_contract",
-        "exit_recovery", "exit_bootstrap", "stage", "bridge", "scan_owner",
-        "quiescence",
+        "writer", "module_identity", "scan_depth", "generation_scope", "heartbeat_scope",
+        "worker_position", "auth", "convergence", "zero_signal_state", "convergence_v2",
+        "auth_endpoint", "final_convergence", "scan_wrapper", "venue", "activator", "strict",
+        "broker_local_contract", "exit_recovery", "exit_bootstrap", "stage", "bridge",
+        "scan_owner", "quiescence",
     ]
+    assert calls.index("scan_depth") < calls.index("convergence")
     assert calls.index("quiescence") > calls.index("scan_owner")
-    assert source_bootstrap.installed_marker() == "20260715b"
+    assert source_bootstrap.installed_marker() == "20260715c"
+    assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED"] == "1"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "1"
 
@@ -112,11 +114,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("DRY_RUN_MODE", "false")
     monkeypatch.setenv("PAPER_MODE", "false")
-    monkeypatch.setattr(
-        source_bootstrap.importlib,
-        "import_module",
-        lambda _name: (_ for _ in ()).throw(ImportError("repair missing")),
-    )
+    monkeypatch.setattr(source_bootstrap.importlib, "import_module", lambda _name: (_ for _ in ()).throw(ImportError("repair missing")))
 
     with pytest.raises(SystemExit) as exc_info:
         source_bootstrap.install()
@@ -124,6 +122,7 @@ def test_source_bootstrap_live_failure_raises_system_exit(monkeypatch):
     assert exc_info.value.code == 78
     assert source_bootstrap.os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] == "0"
     assert source_bootstrap.os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] == "0"
+    assert source_bootstrap.os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] == "0"
     assert source_bootstrap.os.environ["NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED"] == "0"
 
 
@@ -139,11 +138,7 @@ def test_global_startup_guards_install_source_repair_before_other_guards(monkeyp
     fake_source = ModuleType("source_runtime_guard_bootstrap")
     fake_source.install = lambda: order.append("source") or True
     real_import = module.importlib.import_module
-    monkeypatch.setattr(
-        module.importlib,
-        "import_module",
-        lambda name: fake_source if name == "source_runtime_guard_bootstrap" else real_import(name),
-    )
+    monkeypatch.setattr(module.importlib, "import_module", lambda name: fake_source if name == "source_runtime_guard_bootstrap" else real_import(name))
     monkeypatch.setattr(module, "_set_defaults", lambda: order.append("defaults"))
     monkeypatch.setattr(module, "_install_kraken_patch_log_dedupe", lambda: order.append("dedupe"))
     monkeypatch.setattr(module, "_install_module", lambda module_name, marker: order.append(module_name) or True)

--- a/scan_wrapper_depth_convergence_patch.py
+++ b/scan_wrapper_depth_convergence_patch.py
@@ -1,0 +1,261 @@
+"""Prevent unbounded ``NijaCoreLoop.run_scan_phase`` wrapper growth.
+
+The broker-independent live execution patch historically checked only the
+outermost method for its marker and did not expose ``__wrapped__``. Once the
+canonical scan owner became outermost, the broker monitor installed another
+broker wrapper. The two layers alternated until runtime recovery reported more
+than one thousand wrappers.
+
+This guard makes that installer chain-aware, repairs the next installed wrapper
+to expose its base, and audits the live scan chain. A release is unsafe when the
+chain cycles, exceeds the configured depth, or contains duplicate canonical or
+broker-independent owners.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.scan_wrapper_depth_convergence")
+_MARKER = "20260715-scan-depth-v1"
+_GUARD_ATTR = "_nija_scan_depth_guard_v1"
+_BROKER_ATTR = "_nija_broker_independent_live_execution_v20260705a"
+_CANONICAL_RELEASE_ATTR = "_nija_scan_wrapper_release"
+_LOCK = threading.RLock()
+_STARTED = False
+_LAST_SIGNATURE = ""
+
+_CLOSURE_NAMES = (
+    "original",
+    "original_run_scan_phase",
+    "original_scan_phase",
+    "original_method",
+    "wrapped",
+    "base",
+)
+
+
+def _closure_link(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    try:
+        code = getattr(func, "__code__", None)
+        closure = tuple(getattr(func, "__closure__", ()) or ())
+        freevars = tuple(getattr(code, "co_freevars", ()) or ())
+        values = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+    except Exception:
+        return None
+    for name in _CLOSURE_NAMES:
+        candidate = values.get(name)
+        if callable(candidate) and candidate is not func:
+            return candidate
+    return None
+
+
+def _next_link(func: Callable[..., Any]) -> Callable[..., Any] | None:
+    wrapped = getattr(func, "__wrapped__", None)
+    if callable(wrapped) and wrapped is not func:
+        return wrapped
+    return _closure_link(func)
+
+
+def inspect_chain(func: Any, *, limit: int = 4096) -> dict[str, Any]:
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    broker_layers = 0
+    canonical_layers = 0
+    cycle = False
+    names: list[str] = []
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            cycle = True
+            break
+        seen.add(ident)
+        names.append(getattr(current, "__qualname__", getattr(current, "__name__", type(current).__name__)))
+        broker_layers += int(bool(getattr(current, _BROKER_ATTR, False)))
+        canonical_layers += int(bool(getattr(current, _CANONICAL_RELEASE_ATTR, "")))
+        nxt = _next_link(current)
+        if not callable(nxt):
+            break
+        current = nxt
+        depth += 1
+        if depth >= limit:
+            cycle = True
+            break
+    return {
+        "depth": depth,
+        "broker_layers": broker_layers,
+        "canonical_layers": canonical_layers,
+        "cycle": cycle,
+        "head": names[0] if names else "missing",
+        "tail": names[-1] if names else "missing",
+    }
+
+
+def _chain_has_broker_layer(func: Any) -> bool:
+    return bool(inspect_chain(func).get("broker_layers"))
+
+
+def _repair_new_broker_wrapper(cls: type, previous: Callable[..., Any]) -> None:
+    current = getattr(cls, "run_scan_phase", None)
+    if not callable(current) or current is previous:
+        return
+    if getattr(current, _BROKER_ATTR, False) and not callable(getattr(current, "__wrapped__", None)):
+        try:
+            setattr(current, "__wrapped__", previous)
+        except Exception:
+            logger.exception("BROKER_SCAN_WRAPPER_LINK_REPAIR_FAILED marker=%s", _MARKER)
+
+
+def _guard_broker_module(module: ModuleType) -> bool:
+    patch_core = getattr(module, "_patch_core_loop_module", None)
+    if not callable(patch_core):
+        return False
+    if getattr(patch_core, _GUARD_ATTR, False):
+        os.environ["NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED"] = "1"
+        return True
+
+    @wraps(patch_core)
+    def guarded_patch_core(core_module: ModuleType) -> bool:
+        cls = getattr(core_module, "NijaCoreLoop", None)
+        current = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+        if callable(current) and _chain_has_broker_layer(current):
+            # Keep the module's own state coherent so its monitor exits.
+            try:
+                setattr(module, "_PATCHED", True)
+            except Exception:
+                pass
+            return True
+        previous = current
+        result = bool(patch_core(core_module))
+        if result and isinstance(cls, type) and callable(previous):
+            _repair_new_broker_wrapper(cls, previous)
+        return result
+
+    setattr(guarded_patch_core, _GUARD_ATTR, True)
+    setattr(guarded_patch_core, "__wrapped__", patch_core)
+    module._patch_core_loop_module = guarded_patch_core
+    os.environ["NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED"] = "1"
+    logger.critical(
+        "BROKER_SCAN_INSTALLER_CHAIN_GUARDED marker=%s module=%s chain_aware=true",
+        _MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded_broker_modules() -> bool:
+    patched = False
+    for name in (
+        "bot.broker_independent_live_execution_patch",
+        "broker_independent_live_execution_patch",
+        "nija_broker_independent_live_execution_patch",
+    ):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        if isinstance(module, ModuleType):
+            patched = _guard_broker_module(module) or patched
+    return patched
+
+
+def _core_method() -> Any:
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            cls = getattr(module, "NijaCoreLoop", None)
+            method = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+            if callable(method):
+                return method
+    return None
+
+
+def audit() -> tuple[bool, dict[str, str]]:
+    _patch_loaded_broker_modules()
+    method = _core_method()
+    if method is None:
+        os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] = "0"
+        return False, {"scan_chain": "core_loop_not_loaded"}
+
+    status = inspect_chain(method)
+    try:
+        max_depth = max(4, min(64, int(float(os.environ.get("NIJA_MAX_SCAN_WRAPPER_DEPTH", "24") or 24))))
+    except Exception:
+        max_depth = 24
+    ready = (
+        not bool(status["cycle"])
+        and int(status["depth"]) <= max_depth
+        and int(status["broker_layers"]) <= 1
+        and int(status["canonical_layers"]) <= 1
+    )
+    os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] = "1" if ready else "0"
+    os.environ["NIJA_SCAN_WRAPPER_DEPTH"] = str(status["depth"])
+    details = {
+        "scan_chain": (
+            f"depth={status['depth']};max={max_depth};broker_layers={status['broker_layers']};"
+            f"canonical_layers={status['canonical_layers']};cycle={status['cycle']};"
+            f"head={status['head']};tail={status['tail']}"
+        )
+    }
+    return ready, details
+
+
+def _watchdog() -> None:
+    global _LAST_SIGNATURE
+    while True:
+        try:
+            ready, details = audit()
+            signature = f"{ready}:{details}"
+            if signature != _LAST_SIGNATURE:
+                _LAST_SIGNATURE = signature
+                logger.log(
+                    logging.INFO if ready else logging.CRITICAL,
+                    "SCAN_WRAPPER_DEPTH_AUDIT marker=%s ready=%s details=%s",
+                    _MARKER,
+                    str(ready).lower(),
+                    details,
+                )
+        except Exception as exc:
+            os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] = "0"
+            logger.critical("SCAN_WRAPPER_DEPTH_AUDIT_FAILED marker=%s error=%s", _MARKER, exc)
+        time.sleep(max(1.0, float(os.environ.get("NIJA_SCAN_WRAPPER_DEPTH_AUDIT_S", "5") or 5)))
+
+
+def install() -> None:
+    global _STARTED
+    with _LOCK:
+        _patch_loaded_broker_modules()
+        os.environ["NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED"] = "1"
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="ScanWrapperDepthGuard", daemon=True).start()
+        logger.critical(
+            "SCAN_WRAPPER_DEPTH_GUARD_INSTALLED marker=%s max_depth=%s",
+            _MARKER,
+            os.environ.get("NIJA_MAX_SCAN_WRAPPER_DEPTH", "24"),
+        )
+
+
+def install_import_hook() -> None:
+    install()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "audit",
+    "inspect_chain",
+    "_guard_broker_module",
+    "_chain_has_broker_layer",
+]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -1,10 +1,4 @@
-"""Earliest source-level runtime guard bootstrap for NIJA.
-
-This module is loaded before the first ``bot.*`` import. It acquires canonical
-writer lineage and installs mandatory authentication, broker-isolation, account
-recovery, worker-deduplication and readiness guards. Live-capital startup fails
-closed if a required guard cannot be installed.
-"""
+"""Earliest source-level runtime guard bootstrap for NIJA."""
 from __future__ import annotations
 
 import importlib
@@ -14,7 +8,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715b"
+_MARKER = "20260715c"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -52,11 +46,7 @@ def _critical_identity_invariants(details: dict[str, str]) -> tuple[bool, str]:
     risk = str(details.get("downstream_risk_module", ""))
     pipeline = str(details.get("execution_pipeline_chain", ""))
     streak = str(details.get("zero_signal_streak_chain", ""))
-    duplicate_values = [
-        f"{key}={value}"
-        for key, value in details.items()
-        if "duplicate=true" in str(value).lower()
-    ]
+    duplicates = [f"{k}={v}" for k, v in details.items() if "duplicate=true" in str(v).lower()]
     checks = {
         "risk_identity": "same=True" in risk and "marker=20260714-downstream-risk-v2" in risk,
         "pipeline_v2": "v2=True" in pipeline,
@@ -65,7 +55,7 @@ def _critical_identity_invariants(details: dict[str, str]) -> tuple[bool, str]:
         "streak_cap": "cap_guard=True" in streak,
         "streak_state": "state_repair=True" in streak,
         "streak_no_cycle": "cycle=False" in streak,
-        "no_reported_duplicates": not duplicate_values,
+        "no_reported_duplicates": not duplicates,
     }
     failed = [name for name, ok in checks.items() if not ok]
     return not failed, ";".join(failed or ["all_critical_invariants_ready"])
@@ -76,6 +66,7 @@ def _set_status(value: str) -> None:
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
+        "NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
@@ -108,6 +99,7 @@ def install() -> bool:
         try:
             _install_required("prebot_writer_authority_fail_closed")
             _install_required("runtime_module_identity_convergence_patch")
+            _install_required("scan_wrapper_depth_convergence_patch")
             _install_required("writer_generation_scope_repair_patch")
             _install_required("authority_heartbeat_generation_scope_patch")
             _install_required("final_worker_position_coinbase_repair_patch")
@@ -127,58 +119,48 @@ def install() -> bool:
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
             _install_required("scan_owner_okx_auth_convergence_patch")
-            # Install after all legacy convergence modules so their active watchdogs
-            # are converted to chain-aware, change-only behavior before final audit.
             _install_required("runtime_convergence_quiescence_patch")
 
             identity = importlib.import_module("runtime_module_identity_convergence_patch")
-            audit = getattr(identity, "audit", None)
-            if callable(audit):
-                ready, details = audit()
+            ready, details = identity.audit()
+            if not ready:
+                critical_ready, reason = _critical_identity_invariants(details)
+                if not critical_ready:
+                    raise RuntimeError(f"runtime_module_identity_critical_failure:{reason}:{details}")
+                previous = os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "")
+                os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
+                ready, second_details = identity.audit()
                 if not ready:
-                    critical_ready, reason = _critical_identity_invariants(details)
-                    if not critical_ready:
-                        raise RuntimeError(
-                            f"runtime_module_identity_critical_failure:{reason}:{details}"
-                        )
-                    previous = os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "")
-                    os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
-                    ready, second_details = audit()
-                    if not ready:
-                        os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = previous
-                        raise RuntimeError(
-                            f"runtime_module_identity_recheck_failed:{second_details}"
-                        )
-                    os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1"
-                    logger.warning(
-                        "RUNTIME_MODULE_IDENTITY_STALE_LATCH_CLEARED marker=%s previous=%s reason=%s",
-                        _MARKER,
-                        previous or "unset",
-                        reason,
-                    )
+                    os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = previous
+                    raise RuntimeError(f"runtime_module_identity_recheck_failed:{second_details}")
+                os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1"
+                logger.warning("RUNTIME_MODULE_IDENTITY_STALE_LATCH_CLEARED marker=%s previous=%s reason=%s", _MARKER, previous or "unset", reason)
 
             quiescence = importlib.import_module("runtime_convergence_quiescence_patch")
             quiescence_ready, quiescence_details = quiescence.audit()
             if not quiescence_ready:
-                raise RuntimeError(
-                    f"runtime_convergence_quiescence_incomplete:{quiescence_details}"
-                )
+                raise RuntimeError(f"runtime_convergence_quiescence_incomplete:{quiescence_details}")
+
+            scan_depth = importlib.import_module("scan_wrapper_depth_convergence_patch")
+            scan_ready, scan_details = scan_depth.audit()
+            if not scan_ready:
+                raise RuntimeError(f"scan_wrapper_depth_incomplete:{scan_details}")
 
             _INSTALLED = True
             _set_status("1")
-            commit = _deployment_commit()
             message = (
-                f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={commit} "
+                f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={_deployment_commit()} "
                 "writer_authority=installed module_identity=verified convergence_quiescence=verified "
-                "zero_signal_state_repair=armed writer_generation_scope=installed "
-                "authority_heartbeat_generation_scope=installed final_worker_position_coinbase_repair=installed "
-                "broker_auth_recovery=installed runtime_convergence_hardening=installed "
-                "runtime_convergence_v2=installed runtime_auth_endpoint_repair=installed "
-                "final_runtime_convergence=installed scan_wrapper_convergence=installed venue_repair=installed "
-                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
-                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
-                "render_readiness_bridge=installed scan_owner_okx_auth_convergence=installed source=main_pre_bot"
+                "scan_wrapper_depth=verified zero_signal_state_repair=armed "
+                "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
+                "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
+                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
+                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
+                "scan_wrapper_convergence=installed venue_repair=installed secondary_venue_activation=installed "
+                "secondary_venue_strict_readiness=installed broker_local_readiness_contract=installed "
+                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
+                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
+                "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)
@@ -188,18 +170,12 @@ def install() -> bool:
             os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
             os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
             os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] = "0"
+            os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] = "0"
             os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
             message = f"{type(exc).__name__}:{exc}"
             live = _is_live_runtime()
-            logger.critical(
-                "SOURCE_RUNTIME_GUARDS_FAILED marker=%s commit=%s error=%s live=%s",
-                _MARKER, _deployment_commit(), message, live, exc_info=True,
-            )
-            print(
-                f"[NIJA-PRINT] SOURCE_RUNTIME_GUARDS_FAILED marker={_MARKER} "
-                f"commit={_deployment_commit()} error={message[:240]} live={str(live).lower()}",
-                flush=True,
-            )
+            logger.critical("SOURCE_RUNTIME_GUARDS_FAILED marker=%s commit=%s error=%s live=%s", _MARKER, _deployment_commit(), message, live, exc_info=True)
+            print(f"[NIJA-PRINT] SOURCE_RUNTIME_GUARDS_FAILED marker={_MARKER} commit={_deployment_commit()} error={message[:240]} live={str(live).lower()}", flush=True)
             if live:
                 raise SystemExit(78) from exc
             return False


### PR DESCRIPTION
## Runtime evidence

The July 15 Render log showed a live Kraken user scan recovering an alternating scan-wrapper chain with 1,383 removed layers:

```text
SCAN_REENTRANT_CAPTURED_OWNER_UNWRAPPED ... removed_layers=1383
SCAN_REENTRANT_WRAPPER_RECOVERED ... removed_layers=1383
```

The same runtime remained active and continued scanning 100 symbols, but a chain of that size creates recursion, CPU, latency, duplicate-scan and dispatch-integrity risk.

## Root cause

`bot.broker_independent_live_execution_patch._patch_core_loop_module` checked only the outermost `NijaCoreLoop.run_scan_phase` function for its marker and did not expose `__wrapped__`.

Once the canonical scan owner became the outermost wrapper, the broker-independent monitor could no longer see its existing layer and installed another one. The canonical owner and broker-independent layers then alternated indefinitely.

## Repairs

### Chain-aware broker scan installer

A new early guard patches the broker-independent installer itself:

- traverses explicit `__wrapped__` links and narrowly named legacy closure-held originals,
- detects an existing broker-independent layer anywhere in the chain,
- marks the broker patch complete so its monitor exits,
- prevents another wrapper from being installed,
- and repairs `__wrapped__` on a newly installed legacy broker layer.

### Strict scan-chain audit

The live `run_scan_phase` chain is audited continuously. Runtime release readiness fails closed when:

- the chain cycles,
- depth exceeds the configured maximum (default 24, hard ceiling 64),
- more than one broker-independent layer exists,
- or more than one canonical scan owner exists.

The audit publishes:

```text
NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED=1
NIJA_SCAN_WRAPPER_DEPTH_READY=1
NIJA_SCAN_WRAPPER_DEPTH=<bounded depth>
```

### Earliest bootstrap installation

The depth guard installs immediately after module-identity convergence and before legacy convergence modules can import or reapply scan wrappers. A final bootstrap audit runs after every legacy guard and watchdog is installed.

### v12 release contract

The release manifest is bumped to `20260715-runtime-convergence-v12` and requires both the depth guard and a healthy live scan-chain audit in addition to all prior v11 safety, Kraken exit and profit-realization controls.

## Expected Render proof

```text
BROKER_SCAN_INSTALLER_CHAIN_GUARDED marker=20260715-scan-depth-v1 chain_aware=true
SCAN_WRAPPER_DEPTH_GUARD_INSTALLED marker=20260715-scan-depth-v1 max_depth=24
SCAN_WRAPPER_DEPTH_AUDIT marker=20260715-scan-depth-v1 ready=true details={'scan_chain': 'depth=...;broker_layers=1;canonical_layers=1;cycle=False;...'}
SOURCE_RUNTIME_GUARDS_READY marker=20260715c ... scan_wrapper_depth=verified
NIJA_RUNTIME_RELEASE_MANIFEST release=20260715-runtime-convergence-v12 ... ready=true
```

The following must not recur:

```text
removed_layers=1383
broker_layers>1
canonical_layers>1
SCAN_WRAPPER_DEPTH_AUDIT ... ready=false
```

## Regression coverage

- counts canonical and broker-independent layers through explicit chains,
- follows the legacy closure-held `original` link,
- prevents reinstallation when the broker marker is below an outer canonical owner,
- repairs missing `__wrapped__` on a newly installed broker layer,
- rejects duplicate broker layers,
- verifies bootstrap installation and fail-closed state propagation.

This does not relax signal filters, broker readiness, writer authority, position limits, entry sizing, stop loss, verified cost basis, exchange minimums or profit-realization requirements.