### PR TITLE
Correct runtime readiness and isolate failed secondary venue

### DIFF
--- a/bot/empty_position_sync_success_patch.py
+++ b/bot/empty_position_sync_success_patch.py
@@ -1,0 +1,74 @@
+"""Mark a connected broker with a successful empty snapshot as synchronized.
+
+Zero open positions is a valid broker state, not a synchronization failure. The
+legacy startup reconciler left ``_startup_position_sync_adopted=False`` whenever
+``get_positions()`` returned an empty list, causing perpetual ``all_synced=False``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.empty_position_sync_success")
+_MARKER = "20260715-empty-position-sync-v1"
+_ATTR = "_nija_empty_position_sync_success_v1"
+_LOCK = threading.RLock()
+
+
+def _patch(module: ModuleType) -> bool:
+    current = getattr(module, "_adopt_broker_positions", None)
+    if not callable(current):
+        return False
+    if getattr(current, _ATTR, False):
+        return True
+
+    @wraps(current)
+    def adopt(broker: Any, broker_name: str, eps: Any) -> int:
+        result = int(current(broker, broker_name, eps) or 0)
+        if bool(getattr(broker, "_startup_position_sync_adopted", False)):
+            return result
+        if not bool(getattr(broker, "connected", False)):
+            return result
+        getter = getattr(broker, "get_positions", None)
+        if not callable(getter):
+            return result
+        try:
+            snapshot = getter()
+        except Exception:
+            return result
+        if isinstance(snapshot, list) and not snapshot:
+            setattr(broker, "_startup_position_sync_adopted", True)
+            setattr(broker, "_startup_position_sync_symbols", tuple())
+            logger.info(
+                "EMPTY_POSITION_SNAPSHOT_SYNCED marker=%s broker=%s connected=true positions=0",
+                _MARKER,
+                broker_name,
+            )
+        return result
+
+    setattr(adopt, _ATTR, True)
+    adopt.__wrapped__ = current
+    module._adopt_broker_positions = adopt
+    os.environ["NIJA_EMPTY_POSITION_SYNC_READY"] = "1"
+    logger.critical("EMPTY_POSITION_SYNC_SUCCESS_PATCHED marker=%s", _MARKER)
+    return True
+
+
+def install_import_hook() -> None:
+    import importlib
+    with _LOCK:
+        module = importlib.import_module("bot.startup_position_sync")
+        if not _patch(module):
+            raise RuntimeError("startup_position_sync_not_patchable")
+        os.environ["NIJA_EMPTY_POSITION_SYNC_PATCH_INSTALLED"] = "1"
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = ["install", "install_import_hook", "_patch"]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -9,7 +9,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260715-runtime-convergence-v12"
+RELEASE_ID = "20260715-runtime-convergence-v13"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -21,8 +21,10 @@ _INSTALLERS = (
     ("bot.scan_reentrant_delegate_repair_patch", "install_import_hook"),
     ("broker_local_readiness_contract_patch", "install_import_hook"),
     ("bot.downstream_risk_governor_equity_repair_patch", "install_import_hook"),
+    ("bot.secondary_credential_quarantine_patch", "install_import_hook"),
     ("runtime_convergence_hardening_patch", "install"),
     ("bot.zero_signal_streak_state_repair_patch", "install_import_hook"),
+    ("bot.empty_position_sync_success_patch", "install_import_hook"),
     ("runtime_convergence_quiescence_patch", "install_import_hook"),
     ("bot.position_cost_basis_legacy_repair_patch", "install_import_hook"),
     ("bot.position_sync_runtime_repair_patch", "install_import_hook"),
@@ -51,6 +53,9 @@ _REQUIRED_FLAGS = {
     "core_loop_limits": "NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED",
     "zero_signal_state_repair": "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
     "zero_signal_state_ready": "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
+    "empty_position_sync_patch": "NIJA_EMPTY_POSITION_SYNC_PATCH_INSTALLED",
+    "empty_position_sync_ready": "NIJA_EMPTY_POSITION_SYNC_READY",
+    "secondary_credential_quarantine": "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED",
     "scan_reentrant_delegate_guard": "NIJA_SCAN_REENTRANT_DELEGATE_REPAIR_INSTALLED",
     "broker_local_readiness_contract": "NIJA_BROKER_LOCAL_READINESS_CONTRACT_INSTALLED",
     "downstream_risk_v2_installed": "NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_INSTALLED",
@@ -175,9 +180,15 @@ def _audit() -> tuple[bool, dict[str, str]]:
 def _publish(ready: bool, details: dict[str, str]) -> None:
     os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
     os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
-    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s", RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details)
+    logger.critical(
+        "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
+        RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
+    )
     if not ready:
-        logger.critical("RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed", RELEASE_ID)
+        logger.critical(
+            "RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed",
+            RELEASE_ID,
+        )
 
 
 def _watchdog() -> None:
@@ -205,4 +216,8 @@ def install_import_hook() -> None:
     logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", RELEASE_ID)
 
 
-__all__ = ["RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha", "_expected_scan_wrapper_release", "_scan_release_compatible", "_readiness_contract_consistent", "_runtime_limits_consistent"]
+__all__ = [
+    "RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
+    "_expected_scan_wrapper_release", "_scan_release_compatible",
+    "_readiness_contract_consistent", "_runtime_limits_consistent",
+]

--- a/bot/secondary_credential_quarantine_patch.py
+++ b/bot/secondary_credential_quarantine_patch.py
@@ -1,0 +1,135 @@
+"""Quarantine secondary venues after definitive credential rejection.
+
+A 50111/50119/50112 response cannot be repaired by retrying. Repeated activation
+attempts only spam logs and consume API calls. The affected venue is isolated while
+healthy brokers remain independently executable.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.secondary_credential_quarantine")
+_MARKER = "20260715-secondary-credential-quarantine-v1"
+_ATTR = "_nija_secondary_credential_quarantine_v1"
+_LOCK = threading.RLock()
+_STARTED = False
+_FATAL_CODES = {"50100", "50101", "50111", "50112", "50113", "50119"}
+
+
+def _fatal_code(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    code = str(payload.get("code", "") or "")
+    return code if code in _FATAL_CODES else ""
+
+
+def _patch_rest(module: ModuleType) -> bool:
+    cls = getattr(module, "_OKXRestClient", None)
+    current = getattr(cls, "_request", None) if isinstance(cls, type) else None
+    if not callable(current):
+        return False
+    if getattr(current, _ATTR, False):
+        return True
+
+    @wraps(current)
+    def request(self: Any, method: str, path: str, *args: Any, **kwargs: Any):
+        if bool(getattr(self, "_nija_credentials_quarantined", False)) and kwargs.get("private", False):
+            return {
+                "code": str(getattr(self, "_nija_credentials_quarantine_code", "50111")),
+                "msg": "credentials_quarantined",
+                "data": [],
+                "quarantined": True,
+            }
+        result = current(self, method, path, *args, **kwargs)
+        code = _fatal_code(result)
+        if code:
+            setattr(self, "_nija_credentials_quarantined", True)
+            setattr(self, "_nija_credentials_quarantine_code", code)
+            os.environ["NIJA_OKX_CREDENTIALS_QUARANTINED"] = "1"
+            os.environ["NIJA_OKX_ACTIVATION_STATE"] = "credential_quarantined"
+            os.environ["NIJA_OKX_CONNECTED"] = "0"
+            os.environ["NIJA_OKX_TRADING_READY"] = "0"
+            logger.critical(
+                "SECONDARY_CREDENTIALS_QUARANTINED marker=%s venue=okx code=%s path=%s action=isolate_until_credentials_replaced",
+                _MARKER, code, path,
+            )
+        return result
+
+    setattr(request, _ATTR, True)
+    request.__wrapped__ = current
+    cls._request = request
+    return True
+
+
+def _patch_broker(module: ModuleType) -> bool:
+    cls = getattr(module, "OKXBroker", None) or getattr(module, "OKXBrokerAdapter", None)
+    current = getattr(cls, "connect", None) if isinstance(cls, type) else None
+    if not callable(current):
+        return False
+    if getattr(current, _ATTR, False):
+        return True
+
+    @wraps(current)
+    def connect(self: Any, *args: Any, **kwargs: Any) -> bool:
+        clients = [getattr(self, name, None) for name in ("account_api", "market_api", "rest_client", "_rest")]
+        if any(bool(getattr(client, "_nija_credentials_quarantined", False)) for client in clients if client is not None):
+            setattr(self, "connected", False)
+            setattr(self, "_is_available", False)
+            return False
+        result = bool(current(self, *args, **kwargs))
+        clients = [getattr(self, name, None) for name in ("account_api", "market_api", "rest_client", "_rest")]
+        if any(bool(getattr(client, "_nija_credentials_quarantined", False)) for client in clients if client is not None):
+            setattr(self, "connected", False)
+            setattr(self, "_is_available", False)
+            return False
+        return result
+
+    setattr(connect, _ATTR, True)
+    connect.__wrapped__ = current
+    cls.connect = connect
+    return True
+
+
+def _patch_loaded() -> bool:
+    ready = False
+    for name in ("bot.broker_manager", "broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            ready = _patch_rest(module) or ready
+            ready = _patch_broker(module) or ready
+    return ready
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            if _patch_loaded():
+                os.environ["NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY"] = "1"
+                return
+        except Exception:
+            logger.exception("SECONDARY_CREDENTIAL_QUARANTINE_RETRY marker=%s", _MARKER)
+        threading.Event().wait(0.2)
+
+
+def install_import_hook() -> None:
+    global _STARTED
+    with _LOCK:
+        _patch_loaded()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="SecondaryCredentialQuarantine", daemon=True).start()
+        os.environ["NIJA_SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED"] = "1"
+        logger.critical("SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED marker=%s", _MARKER)
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = ["install", "install_import_hook", "_fatal_code", "_patch_rest", "_patch_broker"]

--- a/bot/tests/test_runtime_health_convergence_v13.py
+++ b/bot/tests/test_runtime_health_convergence_v13.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+
+import runtime_module_identity_convergence_patch as identity
+import bot.empty_position_sync_success_patch as empty_sync
+import bot.secondary_credential_quarantine_patch as quarantine
+import bot.runtime_release_manifest_patch as manifest
+
+
+def test_v13_release_id():
+    assert manifest.RELEASE_ID == "20260715-runtime-convergence-v13"
+
+
+def test_identity_ignores_stale_latch_when_current_graph_is_clean(monkeypatch):
+    monkeypatch.setenv("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "1")
+    monkeypatch.setattr(identity, "recover_unregistered_patch_modules_from_threads", lambda: {})
+    monkeypatch.setattr(identity, "_current_duplicates", lambda: [])
+
+    ready, details = identity.canonicalize_loaded_patch_modules()
+
+    assert ready is True
+    assert details["current_duplicate_modules"] == "none"
+    assert os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] == "0"
+
+
+def test_identity_rejects_current_duplicate(monkeypatch):
+    monkeypatch.setattr(identity, "recover_unregistered_patch_modules_from_threads", lambda: {})
+    monkeypatch.setattr(identity, "_current_duplicates", lambda: ["nija_patch->bot.patch"])
+
+    ready, details = identity.canonicalize_loaded_patch_modules()
+
+    assert ready is False
+    assert details["current_duplicate_modules"] == "nija_patch->bot.patch"
+    assert os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] == "1"
+
+
+def test_successful_empty_snapshot_is_marked_synchronized(monkeypatch):
+    module = ModuleType("bot.startup_position_sync")
+
+    def original(broker, broker_name, eps):
+        broker._startup_position_sync_adopted = False
+        return 0
+
+    module._adopt_broker_positions = original
+    assert empty_sync._patch(module) is True
+    broker = SimpleNamespace(connected=True, get_positions=lambda: [])
+
+    assert module._adopt_broker_positions(broker, "user:test:kraken", None) == 0
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_symbols == tuple()
+
+
+def test_empty_snapshot_fetch_error_remains_unsynchronized():
+    module = ModuleType("bot.startup_position_sync")
+    module._adopt_broker_positions = lambda broker, broker_name, eps: 0
+    empty_sync._patch(module)
+
+    def fail():
+        raise RuntimeError("network")
+
+    broker = SimpleNamespace(connected=True, get_positions=fail)
+    module._adopt_broker_positions(broker, "user:test:kraken", None)
+    assert not bool(getattr(broker, "_startup_position_sync_adopted", False))
+
+
+def test_okx_fatal_codes_are_quarantinable():
+    assert quarantine._fatal_code({"code": "50111"}) == "50111"
+    assert quarantine._fatal_code({"code": "50119"}) == "50119"
+    assert quarantine._fatal_code({"code": "0"}) == ""
+
+
+def test_okx_private_requests_stop_after_fatal_credentials(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    calls = []
+
+    class Rest:
+        def _request(self, method, path, *args, **kwargs):
+            calls.append(path)
+            return {"code": "50111", "msg": "Invalid OK-ACCESS-KEY"}
+
+    module._OKXRestClient = Rest
+    assert quarantine._patch_rest(module) is True
+    rest = Rest()
+
+    first = rest._request("GET", "/api/v5/account/balance", private=True)
+    second = rest._request("GET", "/api/v5/account/balance", private=True)
+
+    assert first["code"] == "50111"
+    assert second["quarantined"] is True
+    assert calls == ["/api/v5/account/balance"]
+    assert os.environ["NIJA_OKX_CREDENTIALS_QUARANTINED"] == "1"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "0"

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -1,14 +1,8 @@
-"""Canonicalize startup patch modules before live trading imports begin.
+"""Canonical runtime module identity and wrapper-chain audit.
 
-Historically ``sitecustomize`` executed files from ``bot/`` under private
-``nija_*`` names without registering those module objects in ``sys.modules``.
-Later runtime bootstraps imported the same files as ``bot.*``, executing them a
-second time and creating independent monitor flags and wrapper registries.
-
-The active monitor thread retains the original module globals even when the
-module was not registered. This guard reconstructs one module object from that
-thread target, binds both names to it, and prevents the canonical import from
-executing the source again.
+Readiness is computed exclusively from the current process graph. Historical
+advisory latches are diagnostic only and can never keep an otherwise canonical
+runtime fail-closed forever.
 """
 from __future__ import annotations
 
@@ -22,7 +16,7 @@ from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.runtime_module_identity_convergence")
-_MARKER = "20260714-module-identity-v2"
+_MARKER = "20260715-module-identity-v3"
 _LOCK = threading.RLock()
 _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -35,12 +29,12 @@ _RISK_ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
 _RISK_CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
 
 
-def _truthy(name: str) -> bool:
-    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+def _truthy_value(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
 
 
 def _live() -> bool:
-    return not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
+    return not _truthy_value(os.environ.get("DRY_RUN_MODE")) and not _truthy_value(os.environ.get("PAPER_MODE"))
 
 
 def _canonical_from_globals(globals_dict: dict[str, Any]) -> tuple[str, str]:
@@ -55,21 +49,14 @@ def _canonical_from_globals(globals_dict: dict[str, Any]) -> tuple[str, str]:
 
 
 def _bot_canonical_name(module: ModuleType) -> str:
-    _alias, canonical = _canonical_from_globals(vars(module))
-    return canonical
+    return _canonical_from_globals(vars(module))[1]
 
 
 def _module_quality(module: ModuleType) -> tuple[int, int]:
     marker = str(getattr(module, "_MARKER", "") or "")
-    score = 0
-    if marker == _REQUIRED_RISK_MARKER:
-        score += 1000
-    elif "downstream-risk-v2" in marker:
-        score += 500
-    if callable(getattr(module, "install_import_hook", None)):
-        score += 10
-    if callable(getattr(module, "install", None)):
-        score += 5
+    score = 1000 if marker == _REQUIRED_RISK_MARKER else 0
+    score += 10 if callable(getattr(module, "install_import_hook", None)) else 0
+    score += 5 if callable(getattr(module, "install", None)) else 0
     return score, len(vars(module))
 
 
@@ -80,13 +67,6 @@ def _module_from_globals(alias: str, globals_dict: dict[str, Any]) -> ModuleType
 
 
 def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
-    """Recover sitecustomize modules from live ``Thread._target`` globals.
-
-    Once an alias and its canonical name are already bound to the same object,
-    subsequent watchdog audits reuse that object. A new proxy is created only for
-    the initial unregistered execution, so a healthy second audit is not mistaken
-    for a duplicate module execution.
-    """
     recovered: dict[str, str] = {}
     for thread in tuple(threading.enumerate()):
         target = getattr(thread, "_target", None)
@@ -96,78 +76,65 @@ def recover_unregistered_patch_modules_from_threads() -> dict[str, str]:
         alias, canonical = _canonical_from_globals(globals_dict)
         if not alias or not canonical:
             continue
-
         existing_alias = sys.modules.get(alias)
         existing_canonical = sys.modules.get(canonical)
-        duplicate = False
-
-        if (
-            isinstance(existing_alias, ModuleType)
-            and existing_alias is existing_canonical
-        ):
+        if isinstance(existing_alias, ModuleType) and existing_alias is existing_canonical:
             selected = existing_alias
-        elif isinstance(existing_alias, ModuleType) and existing_canonical is None:
-            selected = existing_alias
+            duplicate = False
         elif existing_alias is None and existing_canonical is None:
             selected = _module_from_globals(alias, globals_dict)
+            duplicate = False
         else:
-            recovered_module = _module_from_globals(alias, globals_dict)
-            candidates = [recovered_module]
+            candidates = [_module_from_globals(alias, globals_dict)]
             if isinstance(existing_alias, ModuleType):
                 candidates.append(existing_alias)
             if isinstance(existing_canonical, ModuleType):
                 candidates.append(existing_canonical)
             selected = max(candidates, key=_module_quality)
             duplicate = len({id(item) for item in candidates}) > 1
-
         sys.modules[alias] = selected
         sys.modules[canonical] = selected
         recovered[canonical] = (
             f"alias={alias};thread={thread.name};marker={getattr(selected, '_MARKER', 'unknown')};"
             f"duplicate={str(duplicate).lower()}"
         )
-        if duplicate:
-            os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1"
-        logger.warning(
-            "UNREGISTERED_PATCH_MODULE_RECOVERED marker=%s canonical=%s alias=%s thread=%s selected_marker=%s duplicate=%s",
-            _MARKER,
-            canonical,
-            alias,
-            thread.name,
-            getattr(selected, "_MARKER", "unknown"),
-            str(duplicate).lower(),
-        )
     return recovered
+
+
+def _current_duplicates() -> list[str]:
+    duplicates: list[str] = []
+    for alias, module in tuple(sys.modules.items()):
+        if not alias.startswith("nija_") or not isinstance(module, ModuleType):
+            continue
+        canonical_name = _bot_canonical_name(module)
+        if not canonical_name:
+            continue
+        canonical = sys.modules.get(canonical_name)
+        if isinstance(canonical, ModuleType) and canonical is not module:
+            duplicates.append(f"{alias}->{canonical_name}")
+    return sorted(set(duplicates))
 
 
 def canonicalize_loaded_patch_modules() -> tuple[bool, dict[str, str]]:
     details = recover_unregistered_patch_modules_from_threads()
-    ready = not _truthy("NIJA_DUPLICATE_PATCH_MODULE_DETECTED")
-    for alias, module in list(sys.modules.items()):
+    for alias, module in tuple(sys.modules.items()):
         if not alias.startswith("nija_") or not isinstance(module, ModuleType):
             continue
-        canonical = _bot_canonical_name(module)
-        if not canonical:
+        canonical_name = _bot_canonical_name(module)
+        if not canonical_name:
             continue
-        existing = sys.modules.get(canonical)
+        canonical = sys.modules.get(canonical_name)
         selected = module
-        if isinstance(existing, ModuleType) and existing is not module:
-            selected = max((existing, module), key=_module_quality)
-            ready = False
-            os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1"
-            logger.critical(
-                "DUPLICATE_PATCH_MODULE_CONVERGED marker=%s canonical=%s alias=%s selected_marker=%s",
-                _MARKER,
-                canonical,
-                alias,
-                getattr(selected, "_MARKER", "unknown"),
-            )
-        sys.modules[canonical] = selected
+        if isinstance(canonical, ModuleType) and canonical is not module:
+            selected = max((canonical, module), key=_module_quality)
         sys.modules[alias] = selected
-        details[canonical] = (
-            f"same_object=true;marker={getattr(selected, '_MARKER', 'unknown')}"
-        )
-    return ready, details
+        sys.modules[canonical_name] = selected
+        details[canonical_name] = f"same_object=true;marker={getattr(selected, '_MARKER', 'unknown')}"
+
+    duplicates = _current_duplicates()
+    os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "1" if duplicates else "0"
+    details["current_duplicate_modules"] = ",".join(duplicates) or "none"
+    return not duplicates, details
 
 
 def _chain_has_attr(func: Any, attr: str) -> tuple[bool, bool, int]:
@@ -192,9 +159,9 @@ def _chain_has_attr(func: Any, attr: str) -> tuple[bool, bool, int]:
 
 
 def _wrapper_chain_status(func: Any) -> tuple[bool, bool, bool, int]:
-    v2, cycle_v2, depth_v2 = _chain_has_attr(func, _V2_RISK_ATTR)
-    legacy, cycle_legacy, depth_legacy = _chain_has_attr(func, _LEGACY_RISK_ATTR)
-    return v2, legacy, cycle_v2 or cycle_legacy, max(depth_v2, depth_legacy)
+    v2, v2_cycle, v2_depth = _chain_has_attr(func, _V2_RISK_ATTR)
+    legacy, legacy_cycle, legacy_depth = _chain_has_attr(func, _LEGACY_RISK_ATTR)
+    return v2, legacy, v2_cycle or legacy_cycle, max(v2_depth, legacy_depth)
 
 
 def normalize_runtime_limits() -> None:
@@ -204,13 +171,11 @@ def normalize_runtime_limits() -> None:
         cap = 12
     cap = min(max(cap, 2), 12)
     os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP"] = str(cap)
-
     try:
         stale = int(float(os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD", "100") or 100))
     except Exception:
         stale = 100
     os.environ["NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD"] = str(max(cap + 1, stale))
-
     try:
         timeout = float(os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S", "120") or 120)
     except Exception:
@@ -236,9 +201,7 @@ def audit() -> tuple[bool, dict[str, str]]:
         cls = getattr(pipeline, "ExecutionPipeline", None)
         execute = getattr(cls, "execute", None) if isinstance(cls, type) else None
         v2, legacy, cycle, depth = _wrapper_chain_status(execute)
-        details["execution_pipeline_chain"] = (
-            f"v2={v2};legacy={legacy};cycle={cycle};depth={depth}"
-        )
+        details["execution_pipeline_chain"] = f"v2={v2};legacy={legacy};cycle={cycle};depth={depth}"
         ready = ready and v2 and not legacy and not cycle
         if legacy or cycle or not v2:
             os.environ["NIJA_PRE_DISPATCH_RISK_SIZING_READY"] = "0"
@@ -248,14 +211,13 @@ def audit() -> tuple[bool, dict[str, str]]:
         cls = getattr(core, "NijaCoreLoop", None)
         phase3 = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
         capped, cap_cycle, cap_depth = _chain_has_attr(phase3, _ZERO_CAP_ATTR)
-        state_repair, state_cycle, state_depth = _chain_has_attr(phase3, _ZERO_STATE_ATTR)
+        state, state_cycle, state_depth = _chain_has_attr(phase3, _ZERO_STATE_ATTR)
         cycle = cap_cycle or state_cycle
         details["zero_signal_streak_chain"] = (
-            f"cap_guard={capped};state_repair={state_repair};cycle={cycle};"
-            f"depth={max(cap_depth, state_depth)}"
+            f"cap_guard={capped};state_repair={state};cycle={cycle};depth={max(cap_depth, state_depth)}"
         )
-        ready = ready and capped and state_repair and not cycle
-        if not state_repair or cycle:
+        ready = ready and capped and state and not cycle
+        if not state or cycle:
             os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
 
     os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1" if ready else "0"
@@ -263,13 +225,13 @@ def audit() -> tuple[bool, dict[str, str]]:
 
 
 def _watchdog() -> None:
-    last_signature = ""
+    last = ""
     while True:
         try:
             ready, details = audit()
             signature = f"{ready}:{details}"
-            if signature != last_signature:
-                last_signature = signature
+            if signature != last:
+                last = signature
                 logger.log(
                     logging.INFO if ready else logging.CRITICAL,
                     "RUNTIME_MODULE_IDENTITY_AUDIT marker=%s ready=%s details=%s",
@@ -292,22 +254,13 @@ def install() -> None:
             _STARTED = True
             threading.Thread(target=_watchdog, name="RuntimeModuleIdentityGuard", daemon=True).start()
         logger.critical(
-            "RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=%s ready=%s limits=streak:%s,stale:%s,stall:%s details=%s",
+            "RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=%s ready=%s details=%s",
             _MARKER,
             str(ready).lower(),
-            os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP"),
-            os.environ.get("NIJA_ZERO_SIGNAL_STREAK_STALE_THRESHOLD"),
-            os.environ.get("NIJA_RUN_CYCLE_PHASE3_TIMEOUT_S"),
             details,
         )
-        if _live() and not ready and any(
-            isinstance(sys.modules.get(name), ModuleType)
-            for name in ("bot.execution_pipeline", "execution_pipeline")
-        ):
-            logger.critical(
-                "RUNTIME_MODULE_IDENTITY_UNSAFE marker=%s action=release_manifest_fail_closed",
-                _MARKER,
-            )
+        if _live() and not ready and isinstance(sys.modules.get("bot.execution_pipeline"), ModuleType):
+            logger.critical("RUNTIME_MODULE_IDENTITY_UNSAFE marker=%s action=release_manifest_fail_closed", _MARKER)
 
 
 def install_import_hook() -> None:
@@ -315,12 +268,7 @@ def install_import_hook() -> None:
 
 
 __all__ = [
-    "install",
-    "install_import_hook",
-    "audit",
-    "canonicalize_loaded_patch_modules",
-    "recover_unregistered_patch_modules_from_threads",
-    "normalize_runtime_limits",
-    "_chain_has_attr",
-    "_wrapper_chain_status",
+    "install", "install_import_hook", "audit", "canonicalize_loaded_patch_modules",
+    "recover_unregistered_patch_modules_from_threads", "normalize_runtime_limits",
+    "_current_duplicates", "_chain_has_attr", "_wrapper_chain_status",
 ]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -8,7 +8,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715c"
+_MARKER = "20260715d"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -42,25 +42,6 @@ def _install_required(module_name: str) -> None:
     installer()
 
 
-def _critical_identity_invariants(details: dict[str, str]) -> tuple[bool, str]:
-    risk = str(details.get("downstream_risk_module", ""))
-    pipeline = str(details.get("execution_pipeline_chain", ""))
-    streak = str(details.get("zero_signal_streak_chain", ""))
-    duplicates = [f"{k}={v}" for k, v in details.items() if "duplicate=true" in str(v).lower()]
-    checks = {
-        "risk_identity": "same=True" in risk and "marker=20260714-downstream-risk-v2" in risk,
-        "pipeline_v2": "v2=True" in pipeline,
-        "pipeline_no_legacy": "legacy=False" in pipeline,
-        "pipeline_no_cycle": "cycle=False" in pipeline,
-        "streak_cap": "cap_guard=True" in streak,
-        "streak_state": "state_repair=True" in streak,
-        "streak_no_cycle": "cycle=False" in streak,
-        "no_reported_duplicates": not duplicates,
-    }
-    failed = [name for name, ok in checks.items() if not ok]
-    return not failed, ";".join(failed or ["all_critical_invariants_ready"])
-
-
 def _set_status(value: str) -> None:
     for name in (
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
@@ -68,6 +49,8 @@ def _set_status(value: str) -> None:
         "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
         "NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
+        "NIJA_EMPTY_POSITION_SYNC_PATCH_INSTALLED",
+        "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
@@ -104,8 +87,10 @@ def install() -> bool:
             _install_required("authority_heartbeat_generation_scope_patch")
             _install_required("final_worker_position_coinbase_repair_patch")
             _install_required("broker_auth_recovery_patch")
+            _install_required("bot.secondary_credential_quarantine_patch")
             _install_required("runtime_convergence_hardening_patch")
             _install_required("bot.zero_signal_streak_state_repair_patch")
+            _install_required("bot.empty_position_sync_success_patch")
             _install_required("runtime_convergence_v2_patch")
             _install_required("runtime_auth_recursion_endpoint_repair_patch")
             _install_required("final_runtime_convergence_patch")
@@ -122,19 +107,9 @@ def install() -> bool:
             _install_required("runtime_convergence_quiescence_patch")
 
             identity = importlib.import_module("runtime_module_identity_convergence_patch")
-            ready, details = identity.audit()
-            if not ready:
-                critical_ready, reason = _critical_identity_invariants(details)
-                if not critical_ready:
-                    raise RuntimeError(f"runtime_module_identity_critical_failure:{reason}:{details}")
-                previous = os.environ.get("NIJA_DUPLICATE_PATCH_MODULE_DETECTED", "")
-                os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = "0"
-                ready, second_details = identity.audit()
-                if not ready:
-                    os.environ["NIJA_DUPLICATE_PATCH_MODULE_DETECTED"] = previous
-                    raise RuntimeError(f"runtime_module_identity_recheck_failed:{second_details}")
-                os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "1"
-                logger.warning("RUNTIME_MODULE_IDENTITY_STALE_LATCH_CLEARED marker=%s previous=%s reason=%s", _MARKER, previous or "unset", reason)
+            identity_ready, identity_details = identity.audit()
+            if not identity_ready:
+                raise RuntimeError(f"runtime_module_identity_incomplete:{identity_details}")
 
             quiescence = importlib.import_module("runtime_convergence_quiescence_patch")
             quiescence_ready, quiescence_details = quiescence.audit()
@@ -151,31 +126,39 @@ def install() -> bool:
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={_deployment_commit()} "
                 "writer_authority=installed module_identity=verified convergence_quiescence=verified "
-                "scan_wrapper_depth=verified zero_signal_state_repair=armed "
-                "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
-                "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
-                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
-                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
-                "scan_wrapper_convergence=installed venue_repair=installed secondary_venue_activation=installed "
-                "secondary_venue_strict_readiness=installed broker_local_readiness_contract=installed "
-                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
-                "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
+                "scan_wrapper_depth=verified zero_signal_state_repair=armed empty_position_sync=armed "
+                "secondary_credential_quarantine=armed writer_generation_scope=installed "
+                "authority_heartbeat_generation_scope=installed final_worker_position_coinbase_repair=installed "
+                "broker_auth_recovery=installed runtime_convergence_hardening=installed runtime_convergence_v2=installed "
+                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed scan_wrapper_convergence=installed "
+                "venue_repair=installed secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
+                "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
+                "account_exit_recovery_bootstrap=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)
             return True
         except Exception as exc:
             _set_status("0")
-            os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] = "0"
-            os.environ["NIJA_RUNTIME_MODULE_IDENTITY_READY"] = "0"
-            os.environ["NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY"] = "0"
-            os.environ["NIJA_SCAN_WRAPPER_DEPTH_READY"] = "0"
-            os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
+            for name in (
+                "NIJA_THREE_VENUE_EXECUTION_READY", "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+                "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY", "NIJA_SCAN_WRAPPER_DEPTH_READY",
+                "NIJA_ZERO_SIGNAL_STREAK_STATE_READY", "NIJA_EMPTY_POSITION_SYNC_READY",
+                "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY",
+            ):
+                os.environ[name] = "0"
             message = f"{type(exc).__name__}:{exc}"
             live = _is_live_runtime()
-            logger.critical("SOURCE_RUNTIME_GUARDS_FAILED marker=%s commit=%s error=%s live=%s", _MARKER, _deployment_commit(), message, live, exc_info=True)
-            print(f"[NIJA-PRINT] SOURCE_RUNTIME_GUARDS_FAILED marker={_MARKER} commit={_deployment_commit()} error={message[:240]} live={str(live).lower()}", flush=True)
+            logger.critical(
+                "SOURCE_RUNTIME_GUARDS_FAILED marker=%s commit=%s error=%s live=%s",
+                _MARKER, _deployment_commit(), message, live, exc_info=True,
+            )
+            print(
+                f"[NIJA-PRINT] SOURCE_RUNTIME_GUARDS_FAILED marker={_MARKER} "
+                f"commit={_deployment_commit()} error={message[:240]} live={str(live).lower()}",
+                flush=True,
+            )
             if live:
                 raise SystemExit(78) from exc
             return False
@@ -185,4 +168,4 @@ def installed_marker() -> Optional[str]:
     return _MARKER if _INSTALLED else None
 
 
-__all__ = ["install", "installed_marker", "_critical_identity_invariants"]
+__all__ = ["install", "installed_marker"]


### PR DESCRIPTION
## Summary

This change fixes three remaining runtime-health defects shown in the July 15 Render log.

1. Module identity readiness now uses the current module graph and live wrapper chains instead of inheriting a stale advisory flag.
2. A connected broker that successfully reports zero open positions is treated as synchronized.
3. Definitive OKX authentication failures isolate OKX for the process and stop repeated private retries, while healthy Kraken remains independently available.

## Safety behavior

Real duplicate modules, legacy risk wrappers, wrapper cycles, missing Phase 3 guards, and missing fail-closed risk sizing still block release readiness.

No trading thresholds, minimum order sizes, stop-loss controls, or profit-taking rules are loosened.

## Release

The runtime manifest is bumped to `20260715-runtime-convergence-v13`.

Expected startup markers:

```text
RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED marker=20260715-module-identity-v3 ready=true
EMPTY_POSITION_SYNC_SUCCESS_PATCHED marker=20260715-empty-position-sync-v1
SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED marker=20260715-secondary-credential-quarantine-v1
SOURCE_RUNTIME_GUARDS_READY marker=20260715d
NIJA_RUNTIME_RELEASE_MANIFEST release=20260715-runtime-convergence-v13 ready=true
```

A failed OKX authentication attempt should be followed by a single isolation marker instead of repeated private balance calls.