### PR TITLE
Lift approved Kraken allocations to executable minimum

### DIFF
--- a/bot/kraken_tpe_min_notional_allocation_patch.py
+++ b/bot/kraken_tpe_min_notional_allocation_patch.py
@@ -1,0 +1,151 @@
+"""Align approved Kraken TPE allocations with the executable broker minimum.
+
+TradePermissionEngine historically defaulted approved trades to five percent of
+account balance.  For small Kraken accounts this produced an EXECUTE decision
+with a non-executable allocation (for example $11.71 against a $23.10 minimum),
+forcing Phase 3 into its deliberately disabled fallback-entry path.
+
+This patch changes only the approved allocation.  It never turns a blocked trade
+into an executable trade and never bypasses downstream risk, writer authority,
+position caps, broker validation, or exchange minimum checks.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from functools import wraps
+from typing import Any
+
+logger = logging.getLogger("nija.kraken_tpe_min_notional_allocation")
+_MARKER = "20260715-kraken-tpe-min-notional-v1"
+_PATCH_ATTR = "_nija_kraken_tpe_min_notional_v1"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+        return default if parsed != parsed else parsed
+    except Exception:
+        return default
+
+
+def _truthy(name: str, default: str = "true") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _is_kraken(value: Any) -> bool:
+    return "kraken" in str(value or "").strip().lower()
+
+
+def _entry_side(value: Any) -> bool:
+    return str(value or "long").strip().lower() in {"buy", "long", "enter_long", "open_long"}
+
+
+def _target_notional() -> float:
+    values = (
+        os.environ.get("NIJA_KRAKEN_TARGET_ORDER_USD"),
+        os.environ.get("KRAKEN_TARGET_ORDER_USD"),
+        os.environ.get("MIN_TRADE_USD"),
+        os.environ.get("MIN_NOTIONAL_OVERRIDE"),
+        os.environ.get("KRAKEN_MIN_NOTIONAL_USD"),
+        os.environ.get("NIJA_KRAKEN_MIN_NOTIONAL_USD"),
+    )
+    return max(23.10, *(_f(value, 0.0) for value in values))
+
+
+def _max_position_pct() -> float:
+    values = (
+        os.environ.get("NIJA_MAX_POSITION_SIZE_PCT"),
+        os.environ.get("MAX_POSITION_PCT"),
+        os.environ.get("MAX_POSITION_SIZE_PCT"),
+    )
+    parsed = [value for value in (_f(raw, 0.0) for raw in values) if value > 0.0]
+    pct = min(parsed) if parsed else 0.50
+    if pct > 1.0:
+        pct /= 100.0
+    return max(0.01, min(pct, 0.50))
+
+
+def _lift_allowed(balance: float, target: float) -> tuple[bool, float]:
+    cap = max(0.0, balance) * _max_position_pct()
+    return balance >= target and target <= cap + 1e-9, cap
+
+
+def patch_trade_permission_engine(module: Any) -> bool:
+    cls = getattr(module, "TradePermissionEngine", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "evaluate", None)
+    if not callable(original) or getattr(original, _PATCH_ATTR, False):
+        return bool(getattr(original, _PATCH_ATTR, False))
+
+    @wraps(original)
+    def evaluate(self: Any, *args: Any, **kwargs: Any):
+        decision = original(self, *args, **kwargs)
+        if not _truthy("NIJA_KRAKEN_TPE_MIN_NOTIONAL_LIFT_ENABLED", "true"):
+            return decision
+
+        broker = kwargs.get("broker", getattr(decision, "broker", ""))
+        side = kwargs.get("side", getattr(decision, "side", "long"))
+        final = str(getattr(decision, "final_decision", "") or "").upper()
+        risk_allowed = bool(getattr(decision, "risk_allowed", final == "EXECUTE"))
+        balance = _f(kwargs.get("balance", getattr(decision, "capital_balance", 0.0)), 0.0)
+        allocated = _f(getattr(decision, "capital_allocated", 0.0), 0.0)
+        target = _target_notional()
+
+        if final != "EXECUTE" or not risk_allowed or not _is_kraken(broker) or not _entry_side(side):
+            return decision
+        if allocated + 1e-9 >= target:
+            return decision
+
+        allowed, risk_cap = _lift_allowed(balance, target)
+        if not allowed:
+            logger.warning(
+                "KRAKEN_TPE_MIN_NOTIONAL_LIFT_BLOCKED marker=%s symbol=%s balance=$%.2f allocated=$%.2f target=$%.2f risk_cap=$%.2f",
+                _MARKER,
+                getattr(decision, "symbol", kwargs.get("symbol", "UNKNOWN")),
+                balance,
+                allocated,
+                target,
+                risk_cap,
+            )
+            return decision
+
+        decision.capital_allocated = target
+        try:
+            decision.risk_allowed = True
+        except Exception:
+            pass
+        logger.critical(
+            "KRAKEN_TPE_MIN_NOTIONAL_LIFT_APPLIED marker=%s symbol=%s balance=$%.2f old_allocation=$%.2f final_allocation=$%.2f risk_cap=$%.2f downstream_risk_recheck=true",
+            _MARKER,
+            getattr(decision, "symbol", kwargs.get("symbol", "UNKNOWN")),
+            balance,
+            allocated,
+            target,
+            risk_cap,
+        )
+        return decision
+
+    setattr(evaluate, _PATCH_ATTR, True)
+    setattr(evaluate, "__wrapped__", original)
+    cls.evaluate = evaluate
+    logger.warning("KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_PATCHED marker=%s target=$%.2f", _MARKER, _target_notional())
+    return True
+
+
+def install() -> bool:
+    try:
+        from bot import trade_permission_engine as module
+    except Exception:
+        import trade_permission_engine as module  # type: ignore
+    os.environ.setdefault("NIJA_KRAKEN_TPE_MIN_NOTIONAL_LIFT_ENABLED", "true")
+    result = patch_trade_permission_engine(module)
+    os.environ["NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED"] = "1" if result else "0"
+    return result
+
+
+install()
+
+__all__ = ["install", "patch_trade_permission_engine", "_target_notional", "_max_position_pct"]

--- a/bot/tests/test_kraken_tpe_min_notional_allocation_patch.py
+++ b/bot/tests/test_kraken_tpe_min_notional_allocation_patch.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from bot.kraken_tpe_min_notional_allocation_patch import patch_trade_permission_engine
+
+
+def _module(decision):
+    module = ModuleType("bot.trade_permission_engine")
+
+    class TradePermissionEngine:
+        def evaluate(self, *args, **kwargs):
+            return decision
+
+    module.TradePermissionEngine = TradePermissionEngine
+    return module
+
+
+def _decision(**updates):
+    values = dict(
+        symbol="ADA-USDT",
+        side="long",
+        broker="kraken",
+        final_decision="EXECUTE",
+        risk_allowed=True,
+        capital_balance=234.30,
+        capital_allocated=11.71485976101703,
+    )
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def test_approved_kraken_allocation_is_lifted_to_executable_floor():
+    decision = _decision()
+    module = _module(decision)
+    assert patch_trade_permission_engine(module)
+    with patch.dict(os.environ, {
+        "NIJA_KRAKEN_TARGET_ORDER_USD": "23.10",
+        "NIJA_MAX_POSITION_SIZE_PCT": "0.50",
+    }, clear=False):
+        result = module.TradePermissionEngine().evaluate(
+            symbol="ADA-USDT", side="long", broker="kraken", balance=234.30
+        )
+    assert result.capital_allocated == 23.10
+    assert result.final_decision == "EXECUTE"
+
+
+def test_blocked_decision_is_never_converted_to_execute():
+    decision = _decision(final_decision="BLOCKED", risk_allowed=False, capital_allocated=0.0)
+    module = _module(decision)
+    assert patch_trade_permission_engine(module)
+    result = module.TradePermissionEngine().evaluate(
+        symbol="ADA-USDT", side="long", broker="kraken", balance=234.30
+    )
+    assert result.final_decision == "BLOCKED"
+    assert result.capital_allocated == 0.0
+
+
+def test_lift_fails_closed_when_target_exceeds_account_risk_cap():
+    decision = _decision(capital_balance=104.94, capital_allocated=5.25)
+    module = _module(decision)
+    assert patch_trade_permission_engine(module)
+    with patch.dict(os.environ, {
+        "NIJA_KRAKEN_TARGET_ORDER_USD": "23.10",
+        "NIJA_MAX_POSITION_SIZE_PCT": "0.20",
+        "MAX_POSITION_PCT": "0.20",
+    }, clear=False):
+        result = module.TradePermissionEngine().evaluate(
+            symbol="ADA-USDT", side="long", broker="kraken", balance=104.94
+        )
+    assert result.capital_allocated == 5.25
+
+
+def test_non_kraken_and_exit_sides_are_unchanged():
+    for broker, side in (("coinbase", "long"), ("kraken", "sell")):
+        decision = _decision(broker=broker, side=side)
+        module = _module(decision)
+        assert patch_trade_permission_engine(module)
+        result = module.TradePermissionEngine().evaluate(
+            symbol="ADA-USDT", side=side, broker=broker, balance=234.30
+        )
+        assert result.capital_allocated == 11.71485976101703

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -8,7 +8,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715e"
+_MARKER = "20260715f"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -67,6 +67,7 @@ def _set_status(value: str) -> None:
         "NIJA_ACCOUNT_EXIT_MANAGEMENT_RECOVERY_INSTALLED",
         "NIJA_ACCOUNT_EXIT_RECOVERY_BOOTSTRAP_INSTALLED",
         "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
+        "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
         "NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED",
         "NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED",
         "NIJA_RENDER_READINESS_BRIDGE_INSTALLED",
@@ -103,6 +104,7 @@ def install() -> bool:
             _install_required("account_exit_management_recovery_patch")
             _install_required("account_exit_recovery_bootstrap_patch")
             _install_required("bot.daily_gain_profit_harvest_patch")
+            _install_required("bot.kraken_tpe_min_notional_allocation_patch")
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
             _install_required("scan_owner_okx_auth_convergence_patch")
@@ -136,8 +138,8 @@ def install() -> bool:
                 "venue_repair=installed secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
                 "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
                 "account_exit_recovery_bootstrap=installed daily_gain_profit_harvest=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
-                "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
+                "kraken_tpe_min_notional_allocation=installed three_venue_stage_verifier=installed "
+                "render_readiness_bridge=installed scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
             print(f"[NIJA-PRINT] {message}", flush=True)
@@ -149,6 +151,7 @@ def install() -> bool:
                 "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY", "NIJA_SCAN_WRAPPER_DEPTH_READY",
                 "NIJA_ZERO_SIGNAL_STREAK_STATE_READY", "NIJA_EMPTY_POSITION_SYNC_READY",
                 "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY", "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
+                "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
             ):
                 os.environ[name] = "0"
             message = f"{type(exc).__name__}:{exc}"


### PR DESCRIPTION
## Runtime evidence

The July 15 log shows TPE approved ADA-USDT with `final_decision=EXECUTE`, `risk_allowed=True`, and `$11.7149` allocated, but Kraken required `$23.10`. Phase 3 therefore resolved `decision=SKIP` and fell into the intentionally disabled live fallback-entry path.

## Root cause

`TradePermissionEngine.evaluate()` defaults an approved trade to five percent of balance when signal metadata has no explicit order size. For the $234.30 account, that equals $11.71—below Kraken’s normalized live minimum.

## Fix

- Wraps the authoritative TPE evaluation result.
- Applies only to approved, risk-allowed Kraken long/buy entries.
- Raises allocations below the configured Kraken target to at least $23.10.
- Requires the target to remain within the account’s configured maximum-position percentage and available balance.
- Does not convert blocked decisions into executable trades.
- Leaves Coinbase, exits/sells, signal gates, fallback-entry prohibition, writer authority, position caps, downstream risk, ECEL, and exchange validation unchanged.
- Makes the guard mandatory in fail-closed live startup.

## Exact log result for the supplied account

`balance=$234.30`, `risk_cap=50%=$117.15`, `old_allocation=$11.71`, `target=$23.10` → allocation lift permitted, then downstream risk rechecks the $23.10 order.

## Expected deployment markers

- `KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_PATCHED marker=20260715-kraken-tpe-min-notional-v1 target=$23.10`
- `SOURCE_RUNTIME_GUARDS_READY marker=20260715f ... kraken_tpe_min_notional_allocation=installed`
- For an eligible trade: `KRAKEN_TPE_MIN_NOTIONAL_LIFT_APPLIED ... final_allocation=$23.10 downstream_risk_recheck=true`

## Regression coverage

- approved Kraken allocation is raised to the executable floor;
- blocked decisions stay blocked;
- lift fails closed when target exceeds account risk cap;
- Coinbase and sell/exit sides remain unchanged.