### PR TITLE
Audit and fail closed on missing production guards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ RUN python -m py_compile \
         /app/bot/activation_pending_commit_monitor_patch.py \
         /app/bot/writer_lock_release_guard.py \
         /app/bot/global_runtime_startup_guards.py \
+        /app/bot/scan_wrapper_hard_clamp_patch.py \
+        /app/bot/kraken_verified_cost_basis_recovery_patch.py \
+        /app/bot/daily_gain_profit_harvest_patch.py \
+        /app/bot/kraken_tpe_min_notional_allocation_patch.py \
+        /app/bot/runtime_guard_audit_patch.py \
         /app/import_hook_recursion_shield_patch.py \
         /app/disconnected_broker_execution_guard_patch.py \
         /app/scripts/three_venue_config_check.py

--- a/bot/runtime_guard_audit_patch.py
+++ b/bot/runtime_guard_audit_patch.py
@@ -1,0 +1,70 @@
+"""Continuously prove that NIJA's mandatory live guards remain active."""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Mapping
+
+logger = logging.getLogger("nija.runtime_guard_audit")
+_MARKER = "20260715-runtime-guard-audit-v1"
+_LOCK = threading.RLock()
+_STARTED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_REQUIRED = (
+    "NIJA_SCAN_WRAPPER_HARD_CLAMP_INSTALLED",
+    "NIJA_KRAKEN_VERIFIED_COST_BASIS_RECOVERY_INSTALLED",
+    "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
+    "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
+)
+
+
+def _ready(env: Mapping[str, str] | None = None) -> tuple[bool, list[str]]:
+    source = os.environ if env is None else env
+    missing = [name for name in _REQUIRED if str(source.get(name, "") or "").strip().lower() not in _TRUE]
+    return not missing, missing
+
+
+def _emit() -> bool:
+    ready, missing = _ready()
+    commit = next((str(os.environ.get(name, "") or "").strip() for name in ("RENDER_GIT_COMMIT", "GIT_COMMIT", "SOURCE_VERSION") if str(os.environ.get(name, "") or "").strip()), "unknown")
+    logger.critical(
+        "RUNTIME_GUARD_AUDIT marker=%s ready=%s commit=%s scan_hard_clamp=%s verified_cost_basis=%s daily_gain_harvest=%s kraken_min_notional=%s missing=%s",
+        _MARKER,
+        str(ready).lower(),
+        commit,
+        os.environ.get(_REQUIRED[0], "0"),
+        os.environ.get(_REQUIRED[1], "0"),
+        os.environ.get(_REQUIRED[2], "0"),
+        os.environ.get(_REQUIRED[3], "0"),
+        ",".join(missing) or "none",
+    )
+    if not ready and str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).upper() == "LIVE_ACTIVE":
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+        logger.critical("RUNTIME_GUARD_AUDIT_FAIL_CLOSED marker=%s missing=%s", _MARKER, ",".join(missing))
+    return ready
+
+
+def _watchdog() -> None:
+    interval = max(15.0, float(os.environ.get("NIJA_RUNTIME_GUARD_AUDIT_INTERVAL_S", "60") or 60))
+    while True:
+        _emit()
+        time.sleep(interval)
+
+
+def install() -> bool:
+    global _STARTED
+    with _LOCK:
+        if not _emit():
+            raise RuntimeError("mandatory_runtime_guards_not_ready")
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="RuntimeGuardAudit", daemon=True).start()
+        os.environ["NIJA_RUNTIME_GUARD_AUDIT_INSTALLED"] = "1"
+        logger.critical("RUNTIME_GUARD_AUDIT_INSTALLED marker=%s interval_s=%s", _MARKER, os.environ.get("NIJA_RUNTIME_GUARD_AUDIT_INTERVAL_S", "60"))
+        return True
+
+
+__all__ = ["install", "_ready", "_emit"]

--- a/bot/tests/test_runtime_guard_audit_patch.py
+++ b/bot/tests/test_runtime_guard_audit_patch.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import bot.runtime_guard_audit_patch as audit
+
+
+def test_ready_when_all_mandatory_guards_are_true():
+    env = {name: "1" for name in audit._REQUIRED}
+    ready, missing = audit._ready(env)
+    assert ready is True
+    assert missing == []
+
+
+def test_missing_guard_is_reported():
+    env = {name: "1" for name in audit._REQUIRED}
+    env[audit._REQUIRED[1]] = "0"
+    ready, missing = audit._ready(env)
+    assert ready is False
+    assert missing == [audit._REQUIRED[1]]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -8,7 +8,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715g"
+_MARKER = "20260715h"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -70,6 +70,7 @@ def _set_status(value: str) -> None:
         "NIJA_KRAKEN_VERIFIED_COST_BASIS_RECOVERY_INSTALLED",
         "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
         "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
+        "NIJA_RUNTIME_GUARD_AUDIT_INSTALLED",
         "NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED",
         "NIJA_SOURCE_WRITER_AUTHORITY_INSTALLED",
         "NIJA_RENDER_READINESS_BRIDGE_INSTALLED",
@@ -129,8 +130,9 @@ def install() -> bool:
             if not scan_ready:
                 raise RuntimeError(f"scan_wrapper_depth_incomplete:{scan_details}")
 
-            _INSTALLED = True
             _set_status("1")
+            _install_required("bot.runtime_guard_audit_patch")
+            _INSTALLED = True
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={_deployment_commit()} "
                 "writer_authority=installed module_identity=verified convergence_quiescence=verified "
@@ -143,7 +145,7 @@ def install() -> bool:
                 "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
                 "account_exit_recovery_bootstrap=installed kraken_verified_cost_basis=installed "
                 "daily_gain_profit_harvest=installed kraken_tpe_min_notional_allocation=installed "
-                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
+                "runtime_guard_audit=installed three_venue_stage_verifier=installed render_readiness_bridge=installed "
                 "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
@@ -159,6 +161,7 @@ def install() -> bool:
                 "NIJA_KRAKEN_VERIFIED_COST_BASIS_RECOVERY_INSTALLED",
                 "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
                 "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
+                "NIJA_RUNTIME_GUARD_AUDIT_INSTALLED",
             ):
                 os.environ[name] = "0"
             message = f"{type(exc).__name__}:{exc}"


### PR DESCRIPTION
## What changed
- Adds a recurring runtime audit for the four mandatory production guards: scan-wrapper hard clamp, verified Kraken cost basis, daily-gain harvest, and Kraken executable-minimum sizing.
- Removes execution authority and turns runtime state OFF if any required guard disappears while live.
- Emits one clear `RUNTIME_GUARD_AUDIT` line every 60 seconds with deployment commit and guard state.
- Makes the audit mandatory in `source_runtime_guard_bootstrap` after all guards finish installing.
- Compiles every new mandatory guard module during the Docker image build.

## Why
Recent log excerpts were mid-cycle and did not include startup markers, making it impossible to distinguish an old deployment from a healthy current deployment. This change makes guard state continuously visible and fail-closed.

## Safety
The dedicated Kraken exit-recovery supervisor remains exit-only. Normal account traders continue handling entries independently, avoiding duplicate scans and duplicate orders.

## Expected markers
- `SOURCE_RUNTIME_GUARDS_READY marker=20260715h ... runtime_guard_audit=installed`
- `RUNTIME_GUARD_AUDIT_INSTALLED marker=20260715-runtime-guard-audit-v1`
- `RUNTIME_GUARD_AUDIT ... ready=true ... missing=none`
