### PR TITLE
Recognize OKX Funding and Trading wallet balances

### DIFF
--- a/bot/okx_funding_wallet_readiness_patch.py
+++ b/bot/okx_funding_wallet_readiness_patch.py
@@ -1,0 +1,250 @@
+"""Observe OKX Trading and Funding wallets without conflating them.
+
+OKX spot orders spend from the Trading account, while deposits can remain in the
+Funding account.  A zero Trading balance is therefore not proof that the OKX
+account is underfunded.  This patch publishes both wallet balances, returns only
+Trading equity to order-sizing code, and reports ``funded_needs_transfer`` when
+capital exists in Funding but is not yet spendable by the trading engine.
+
+No internal transfer is submitted automatically. Moving funds between OKX
+wallets remains an explicit account action.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.okx_funding_wallet_readiness")
+_MARKER = "20260715-okx-funding-wallet-v1"
+_LOCK = threading.RLock()
+_STARTED = False
+_PATCH_ATTR = "_nija_okx_funding_wallet_readiness_v1"
+_STABLES = {"USD", "USDT", "USDC"}
+
+
+def _float(value: Any) -> float:
+    try:
+        return max(0.0, float(value or 0.0))
+    except Exception:
+        return 0.0
+
+
+def _minimum_trade() -> float:
+    for name in ("OKX_MIN_ORDER_USD", "MIN_NOTIONAL_OVERRIDE", "MIN_TRADE_USD"):
+        value = _float(os.environ.get(name))
+        if value > 0:
+            return value
+    return 10.0
+
+
+def _stable_sum(rows: Any, *, funding: bool) -> tuple[float, float]:
+    """Return (spendable stable quote, total stable quote)."""
+    spendable = 0.0
+    total = 0.0
+    if not isinstance(rows, (list, tuple)):
+        return 0.0, 0.0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        ccy = str(row.get("ccy") or row.get("currency") or "").upper().strip()
+        if ccy not in _STABLES:
+            continue
+        if funding:
+            available = _float(row.get("availBal", row.get("available", row.get("bal", 0))))
+            balance = _float(row.get("bal", row.get("balance", available)))
+        else:
+            available = _float(row.get("availBal", row.get("cashBal", row.get("eqUsd", 0))))
+            balance = max(_float(row.get("cashBal")), _float(row.get("eqUsd")), available)
+        spendable += available
+        total += balance
+    return spendable, total
+
+
+def _trading_wallet(broker: Any) -> tuple[bool, float, float, str]:
+    api = getattr(broker, "account_api", None)
+    if api is None or not callable(getattr(api, "get_balance", None)):
+        return False, 0.0, 0.0, "account_api_unavailable"
+    try:
+        payload = api.get_balance()
+    except Exception as exc:
+        return False, 0.0, 0.0, f"{type(exc).__name__}:{exc}"
+    if not isinstance(payload, dict) or str(payload.get("code", "")) != "0":
+        return False, 0.0, 0.0, f"code={getattr(payload, 'get', lambda *_: 'invalid')('code', 'invalid')}"
+    data = payload.get("data") or []
+    root = data[0] if isinstance(data, list) and data and isinstance(data[0], dict) else {}
+    spendable, stable_total = _stable_sum(root.get("details") or [], funding=False)
+    total_equity = _float(root.get("totalEq")) or stable_total
+    return True, spendable, total_equity, "ok"
+
+
+def _funding_payload_from_client(client: Any) -> Any:
+    if client is None:
+        return None
+    for method_name in ("get_balances", "get_balance"):
+        method = getattr(client, method_name, None)
+        if callable(method) and method_name == "get_balances":
+            try:
+                return method(ccy="USD,USDT,USDC")
+            except TypeError:
+                try:
+                    return method()
+                except Exception:
+                    pass
+            except Exception:
+                pass
+    request = getattr(client, "_request", None)
+    if callable(request):
+        for kwargs in (
+            {"params": {"ccy": "USD,USDT,USDC"}},
+            {"params": None},
+            {},
+        ):
+            try:
+                return request("GET", "/api/v5/asset/balances", **kwargs)
+            except TypeError:
+                continue
+            except Exception:
+                break
+    return None
+
+
+def _funding_wallet(broker: Any) -> tuple[bool, float, float, str]:
+    clients: list[Any] = []
+    for name in ("asset_api", "funding_api", "rest_client", "_rest", "account_api"):
+        client = getattr(broker, name, None)
+        if client is not None and all(client is not seen for seen in clients):
+            clients.append(client)
+    last_reason = "funding_client_unavailable"
+    for client in clients:
+        try:
+            payload = _funding_payload_from_client(client)
+        except Exception as exc:
+            last_reason = f"{type(exc).__name__}:{exc}"
+            continue
+        if not isinstance(payload, dict):
+            continue
+        code = str(payload.get("code", ""))
+        if code != "0":
+            last_reason = f"code={code or 'missing'}"
+            continue
+        spendable, total = _stable_sum(payload.get("data") or [], funding=True)
+        return True, spendable, total, "ok"
+    return False, 0.0, 0.0, last_reason
+
+
+def _publish(broker: Any) -> None:
+    trading_ok, trading_spendable, trading_total, trading_reason = _trading_wallet(broker)
+    funding_ok, funding_spendable, funding_total, funding_reason = _funding_wallet(broker)
+    observed = trading_ok or funding_ok
+    minimum = _minimum_trade()
+    total_observed = trading_total + funding_total
+
+    if trading_ok and trading_spendable >= minimum:
+        status = "funded"
+        ready = True
+    elif funding_ok and funding_spendable >= minimum:
+        status = "funded_needs_transfer"
+        ready = False
+    elif observed:
+        status = "under_minimum"
+        ready = False
+    else:
+        status = "unobserved"
+        ready = False
+
+    values = {
+        "NIJA_OKX_BALANCE_OBSERVED": "1" if observed else "0",
+        "NIJA_OKX_FUNDING_STATUS": status,
+        "NIJA_OKX_TRADING_SPENDABLE_QUOTE": f"{trading_spendable:.8f}" if trading_ok else "unknown",
+        "NIJA_OKX_TRADING_TOTAL_QUOTE": f"{trading_total:.8f}" if trading_ok else "unknown",
+        "NIJA_OKX_FUNDING_SPENDABLE_QUOTE": f"{funding_spendable:.8f}" if funding_ok else "unknown",
+        "NIJA_OKX_FUNDING_TOTAL_QUOTE": f"{funding_total:.8f}" if funding_ok else "unknown",
+        "NIJA_OKX_TOTAL_OBSERVED_QUOTE": f"{total_observed:.8f}" if observed else "unknown",
+        "NIJA_OKX_TRADING_READY": "1" if ready else "0",
+        "NIJA_OKX_SPENDABLE_QUOTE": f"{trading_spendable:.8f}" if trading_ok else "unknown",
+    }
+    os.environ.update(values)
+    setattr(broker, "_okx_trading_spendable_quote", trading_spendable if trading_ok else None)
+    setattr(broker, "_okx_funding_spendable_quote", funding_spendable if funding_ok else None)
+    setattr(broker, "_okx_funding_status", status)
+
+    if observed:
+        logger.critical(
+            "OKX_DUAL_WALLET_BALANCE_OBSERVED marker=%s trading_spendable=$%.2f trading_total=$%.2f "
+            "funding_spendable=$%.2f funding_total=$%.2f total_observed=$%.2f status=%s minimum=$%.2f auto_transfer=false",
+            _MARKER, trading_spendable, trading_total, funding_spendable, funding_total,
+            total_observed, status, minimum,
+        )
+    else:
+        logger.warning(
+            "OKX_BALANCE_UNOBSERVED_NOT_UNDERFUNDED marker=%s trading_reason=%s funding_reason=%s",
+            _MARKER, trading_reason, funding_reason,
+        )
+
+
+def _patch_class(cls: type) -> bool:
+    current = getattr(cls, "get_account_balance", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return False
+
+    @wraps(current)
+    def get_account_balance(self: Any, *args: Any, **kwargs: Any) -> float:
+        result = current(self, *args, **kwargs)
+        try:
+            _publish(self)
+        except Exception:
+            logger.exception("OKX_DUAL_WALLET_PUBLISH_FAILED marker=%s", _MARKER)
+        # Only Trading-account equity is returned to sizing/execution code. Funding
+        # capital is visible but cannot be spent until explicitly transferred.
+        return float(result or 0.0)
+
+    setattr(get_account_balance, _PATCH_ATTR, True)
+    get_account_balance.__wrapped__ = current  # type: ignore[attr-defined]
+    setattr(cls, "get_account_balance", get_account_balance)
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for module_name in ("bot.broker_manager", "broker_manager", "bot.broker_integration"):
+        module = sys.modules.get(module_name)
+        if not isinstance(module, ModuleType):
+            continue
+        for class_name in ("OKXBroker", "OKXBrokerAdapter"):
+            cls = getattr(module, class_name, None)
+            if isinstance(cls, type):
+                changed = _patch_class(cls) or changed
+    return changed
+
+
+def _monitor() -> None:
+    deadline = time.monotonic() + max(120.0, float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600))
+    while time.monotonic() < deadline:
+        try:
+            _patch_loaded()
+        except Exception:
+            logger.exception("OKX_FUNDING_WALLET_MONITOR_ERROR marker=%s", _MARKER)
+        time.sleep(0.25)
+
+
+def install() -> bool:
+    global _STARTED
+    with _LOCK:
+        _patch_loaded()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_monitor, name="OKXFundingWalletReadiness", daemon=True).start()
+        os.environ["NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED"] = "1"
+        os.environ.setdefault("NIJA_OKX_BALANCE_OBSERVED", "0")
+        os.environ.setdefault("NIJA_OKX_FUNDING_STATUS", "unobserved")
+        logger.critical("OKX_FUNDING_WALLET_READINESS_INSTALLED marker=%s auto_transfer=false", _MARKER)
+        return True
+
+
+__all__ = ["install", "_stable_sum", "_trading_wallet", "_funding_wallet", "_publish"]

--- a/bot/runtime_guard_audit_patch.py
+++ b/bot/runtime_guard_audit_patch.py
@@ -8,7 +8,7 @@ import time
 from typing import Mapping
 
 logger = logging.getLogger("nija.runtime_guard_audit")
-_MARKER = "20260715-runtime-guard-audit-v1"
+_MARKER = "20260715-runtime-guard-audit-v2"
 _LOCK = threading.RLock()
 _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -17,6 +17,7 @@ _REQUIRED = (
     "NIJA_KRAKEN_VERIFIED_COST_BASIS_RECOVERY_INSTALLED",
     "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
     "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
+    "NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED",
 )
 
 
@@ -30,7 +31,9 @@ def _emit() -> bool:
     ready, missing = _ready()
     commit = next((str(os.environ.get(name, "") or "").strip() for name in ("RENDER_GIT_COMMIT", "GIT_COMMIT", "SOURCE_VERSION") if str(os.environ.get(name, "") or "").strip()), "unknown")
     logger.critical(
-        "RUNTIME_GUARD_AUDIT marker=%s ready=%s commit=%s scan_hard_clamp=%s verified_cost_basis=%s daily_gain_harvest=%s kraken_min_notional=%s missing=%s",
+        "RUNTIME_GUARD_AUDIT marker=%s ready=%s commit=%s scan_hard_clamp=%s verified_cost_basis=%s "
+        "daily_gain_harvest=%s kraken_min_notional=%s okx_dual_wallet=%s okx_balance_observed=%s "
+        "okx_funding_status=%s okx_trading_spendable=%s okx_funding_spendable=%s missing=%s",
         _MARKER,
         str(ready).lower(),
         commit,
@@ -38,6 +41,11 @@ def _emit() -> bool:
         os.environ.get(_REQUIRED[1], "0"),
         os.environ.get(_REQUIRED[2], "0"),
         os.environ.get(_REQUIRED[3], "0"),
+        os.environ.get(_REQUIRED[4], "0"),
+        os.environ.get("NIJA_OKX_BALANCE_OBSERVED", "0"),
+        os.environ.get("NIJA_OKX_FUNDING_STATUS", "unobserved"),
+        os.environ.get("NIJA_OKX_TRADING_SPENDABLE_QUOTE", "unknown"),
+        os.environ.get("NIJA_OKX_FUNDING_SPENDABLE_QUOTE", "unknown"),
         ",".join(missing) or "none",
     )
     if not ready and str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).upper() == "LIVE_ACTIVE":

--- a/bot/tests/test_okx_funding_wallet_readiness_patch.py
+++ b/bot/tests/test_okx_funding_wallet_readiness_patch.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+from bot.okx_funding_wallet_readiness_patch import _publish, _stable_sum
+
+
+class AccountAPI:
+    def __init__(self, spendable: float, total: float | None = None):
+        self.spendable = spendable
+        self.total = spendable if total is None else total
+
+    def get_balance(self):
+        return {
+            "code": "0",
+            "data": [{
+                "totalEq": str(self.total),
+                "details": [{"ccy": "USDT", "availBal": str(self.spendable), "cashBal": str(self.total)}],
+            }],
+        }
+
+
+class AssetAPI:
+    def __init__(self, spendable: float, total: float | None = None):
+        self.spendable = spendable
+        self.total = spendable if total is None else total
+
+    def get_balances(self, ccy=None):
+        return {
+            "code": "0",
+            "data": [{"ccy": "USDT", "availBal": str(self.spendable), "bal": str(self.total)}],
+        }
+
+
+def test_stable_sum_ignores_non_stable_assets():
+    spendable, total = _stable_sum([
+        {"ccy": "USDT", "availBal": "10", "bal": "11"},
+        {"ccy": "BTC", "availBal": "2", "bal": "2"},
+    ], funding=True)
+    assert spendable == 10.0
+    assert total == 11.0
+
+
+def test_funding_capital_is_visible_but_not_trading_ready(monkeypatch):
+    monkeypatch.setenv("OKX_MIN_ORDER_USD", "10")
+    broker = SimpleNamespace(account_api=AccountAPI(0), asset_api=AssetAPI(146.26))
+    _publish(broker)
+    assert os.environ["NIJA_OKX_BALANCE_OBSERVED"] == "1"
+    assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "funded_needs_transfer"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "0"
+    assert float(os.environ["NIJA_OKX_FUNDING_SPENDABLE_QUOTE"]) == 146.26
+    assert float(os.environ["NIJA_OKX_SPENDABLE_QUOTE"]) == 0.0
+
+
+def test_trading_wallet_capital_is_ready(monkeypatch):
+    monkeypatch.setenv("OKX_MIN_ORDER_USD", "10")
+    broker = SimpleNamespace(account_api=AccountAPI(25), asset_api=AssetAPI(121.26))
+    _publish(broker)
+    assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "funded"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "1"
+    assert float(os.environ["NIJA_OKX_SPENDABLE_QUOTE"]) == 25.0
+    assert float(os.environ["NIJA_OKX_TOTAL_OBSERVED_QUOTE"]) == 146.26
+
+
+def test_auth_failure_is_unobserved_not_underfunded(monkeypatch):
+    class Broken:
+        def get_balance(self):
+            raise RuntimeError("invalid key")
+
+        def _request(self, *args, **kwargs):
+            return {"code": "50111", "data": []}
+
+    broker = SimpleNamespace(account_api=Broken())
+    _publish(broker)
+    assert os.environ["NIJA_OKX_BALANCE_OBSERVED"] == "0"
+    assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "unobserved"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "0"
+    assert os.environ["NIJA_OKX_SPENDABLE_QUOTE"] == "unknown"

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -10,7 +10,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715k"
+_MARKER = "20260715l"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -45,13 +45,7 @@ def _install_required(module_name: str) -> None:
 
 
 def _install_canonical_downstream_risk() -> None:
-    """Install and publish one canonical downstream-risk module identity.
-
-    The identity audit historically expected both the canonical ``bot.`` name and
-    the legacy ``nija_`` alias to point at the same module. Import ordering could
-    leave only the canonical module registered when the first audit ran, causing a
-    false identity mismatch before the risk wrapper was installed.
-    """
+    """Install and publish one canonical downstream-risk module identity."""
     canonical_name = "bot.downstream_risk_governor_equity_repair_patch"
     alias_name = "nija_downstream_risk_governor_equity_repair_patch"
     module = importlib.import_module(canonical_name)
@@ -96,6 +90,7 @@ def _set_status(value: str) -> None:
         "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED",
         "NIJA_BROKER_AUTH_RECOVERY_INSTALLED",
         "NIJA_COINBASE_FUNDING_READINESS_REPAIR_INSTALLED",
+        "NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_HARDENING_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_V2_INSTALLED",
         "NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED",
@@ -135,6 +130,7 @@ def install() -> bool:
             _install_required("final_worker_position_coinbase_repair_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("bot.coinbase_funding_readiness_repair_patch")
+            _install_required("bot.okx_funding_wallet_readiness_patch")
             _install_required("bot.secondary_credential_quarantine_patch")
             _install_required("runtime_convergence_hardening_patch")
             _install_required("bot.zero_signal_streak_state_repair_patch")
@@ -157,8 +153,6 @@ def install() -> bool:
             _install_required("render_readiness_state_bridge")
             _install_required("scan_owner_okx_auth_convergence_patch")
 
-            # Identity and quiescence are final-state audits. Install every wrapper
-            # they inspect first, then canonicalize the downstream-risk alias.
             _install_canonical_downstream_risk()
             _install_required("runtime_module_identity_convergence_patch")
             _install_required("runtime_convergence_quiescence_patch")
@@ -196,14 +190,15 @@ def install() -> bool:
                 "zero_signal_state_repair=armed empty_position_sync=armed secondary_credential_quarantine=armed "
                 "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
                 "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
-                "coinbase_funding_readiness=installed runtime_convergence_hardening=installed "
-                "runtime_convergence_v2=installed runtime_auth_endpoint_repair=installed "
-                "final_runtime_convergence=installed scan_wrapper_convergence=installed venue_repair=installed "
-                "secondary_venue_activation=installed secondary_venue_strict_readiness=installed "
-                "broker_local_readiness_contract=installed account_exit_management_recovery=installed "
-                "account_exit_recovery_bootstrap=installed kraken_verified_cost_basis=installed "
-                "daily_gain_profit_harvest=installed kraken_tpe_min_notional_allocation=installed "
-                "runtime_guard_audit=installed three_venue_stage_verifier=installed render_readiness_bridge=installed "
+                "coinbase_funding_readiness=installed okx_funding_wallet_readiness=installed "
+                "runtime_convergence_hardening=installed runtime_convergence_v2=installed "
+                "runtime_auth_endpoint_repair=installed final_runtime_convergence=installed "
+                "scan_wrapper_convergence=installed venue_repair=installed secondary_venue_activation=installed "
+                "secondary_venue_strict_readiness=installed broker_local_readiness_contract=installed "
+                "account_exit_management_recovery=installed account_exit_recovery_bootstrap=installed "
+                "kraken_verified_cost_basis=installed daily_gain_profit_harvest=installed "
+                "kraken_tpe_min_notional_allocation=installed runtime_guard_audit=installed "
+                "three_venue_stage_verifier=installed render_readiness_bridge=installed "
                 "scan_owner_okx_auth_convergence=installed source=main_pre_bot"
             )
             logger.warning(message)
@@ -217,6 +212,7 @@ def install() -> bool:
                 "NIJA_SCAN_WRAPPER_HARD_CLAMP_INSTALLED", "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
                 "NIJA_EMPTY_POSITION_SYNC_READY", "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY",
                 "NIJA_COINBASE_FUNDING_READINESS_REPAIR_INSTALLED",
+                "NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED",
                 "NIJA_KRAKEN_VERIFIED_COST_BASIS_RECOVERY_INSTALLED",
                 "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
                 "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",


### PR DESCRIPTION
## Root cause
NIJA's OKX balance path only queried `/api/v5/account/balance`, which represents the Trading account. Deposited capital can remain in OKX's Funding account at `/api/v5/asset/balances`, so a funded account could be reported as zero or underfunded.

## Fix
- Observe both OKX Trading and Funding wallets.
- Publish trading spendable, trading total, funding spendable, funding total, and combined observed capital separately.
- Report `funded_needs_transfer` when funds exist in Funding but are not spendable by spot-order execution.
- Return only Trading-account equity to order sizing, preventing unavailable Funding capital from being used in an order.
- Never auto-transfer funds between OKX wallets.
- Distinguish authentication/unobserved state from actual underfunding.
- Make the dual-wallet observer mandatory at startup and in the recurring runtime guard audit.

## Expected markers
- `OKX_FUNDING_WALLET_READINESS_INSTALLED marker=20260715-okx-funding-wallet-v1`
- `OKX_DUAL_WALLET_BALANCE_OBSERVED ... total_observed=$146.26 status=funded_needs_transfer|funded`
- `SOURCE_RUNTIME_GUARDS_READY marker=20260715l ... okx_funding_wallet_readiness=installed`
- `RUNTIME_GUARD_AUDIT marker=20260715-runtime-guard-audit-v2 ... okx_dual_wallet=1`

## Safety
The patch does not move funds, bypass authentication, or size trades from the Funding wallet. If the $146.26 is in Funding, the user must explicitly transfer the intended amount to Trading in OKX before NIJA marks OKX trading-ready.