### PR TITLE
Fix broker-local capital activation and alias drift

### DIFF
--- a/bot/runtime_guard_audit_patch.py
+++ b/bot/runtime_guard_audit_patch.py
@@ -8,7 +8,7 @@ import time
 from typing import Mapping
 
 logger = logging.getLogger("nija.runtime_guard_audit")
-_MARKER = "20260715-runtime-guard-audit-v2"
+_MARKER = "20260716-runtime-guard-audit-v3"
 _LOCK = threading.RLock()
 _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -18,6 +18,7 @@ _REQUIRED = (
     "NIJA_DAILY_GAIN_PROFIT_HARVEST_INSTALLED",
     "NIJA_KRAKEN_TPE_MIN_NOTIONAL_ALLOCATION_INSTALLED",
     "NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED",
+    "NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED",
 )
 
 
@@ -32,8 +33,9 @@ def _emit() -> bool:
     commit = next((str(os.environ.get(name, "") or "").strip() for name in ("RENDER_GIT_COMMIT", "GIT_COMMIT", "SOURCE_VERSION") if str(os.environ.get(name, "") or "").strip()), "unknown")
     logger.critical(
         "RUNTIME_GUARD_AUDIT marker=%s ready=%s commit=%s scan_hard_clamp=%s verified_cost_basis=%s "
-        "daily_gain_harvest=%s kraken_min_notional=%s okx_dual_wallet=%s okx_balance_observed=%s "
-        "okx_funding_status=%s okx_trading_spendable=%s okx_funding_spendable=%s missing=%s",
+        "daily_gain_harvest=%s kraken_min_notional=%s okx_dual_wallet=%s post_import_convergence=%s "
+        "authority_policy=%s authority_min_brokers=%s okx_balance_observed=%s okx_funding_status=%s "
+        "okx_trading_spendable=%s okx_funding_spendable=%s missing=%s",
         _MARKER,
         str(ready).lower(),
         commit,
@@ -42,6 +44,9 @@ def _emit() -> bool:
         os.environ.get(_REQUIRED[2], "0"),
         os.environ.get(_REQUIRED[3], "0"),
         os.environ.get(_REQUIRED[4], "0"),
+        os.environ.get(_REQUIRED[5], "0"),
+        os.environ.get("NIJA_RUNTIME_AUTHORITY_BROKER_POLICY", "unknown"),
+        os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "unknown"),
         os.environ.get("NIJA_OKX_BALANCE_OBSERVED", "0"),
         os.environ.get("NIJA_OKX_FUNDING_STATUS", "unobserved"),
         os.environ.get("NIJA_OKX_TRADING_SPENDABLE_QUOTE", "unknown"),

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -1,0 +1,155 @@
+"""Keep broker-local authority and canonical module identity stable after imports.
+
+Late startup imports can recreate the legacy downstream-risk module alias after the
+initial identity audit.  Runtime authority also historically defaulted to requiring
+two valid brokers, contradicting broker-local readiness where one healthy venue may
+trade independently.  This guard continuously restores the canonical alias and sets
+the authority broker threshold from the active readiness policy.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger("nija.runtime_post_import_convergence")
+_MARKER = "20260716-post-import-convergence-v1"
+_LOCK = threading.RLock()
+_STARTED = False
+
+_CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
+_ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
+
+
+def _policy() -> str:
+    explicit = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "") or "").strip().lower()
+    if explicit in {"broker_local", "global_all_required", "optional"}:
+        return explicit
+    strict = str(os.environ.get("NIJA_REQUIRE_SECONDARY_VENUES_READY", "") or "").strip().lower()
+    return "broker_local" if strict in {"1", "true", "yes", "on"} else "optional"
+
+
+def _required_broker_count() -> int:
+    return 2 if _policy() == "global_all_required" else 1
+
+
+def _apply_broker_threshold() -> int:
+    required = _required_broker_count()
+    current = str(os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "") or "").strip()
+    # Preserve an explicit stricter operator setting. Otherwise align the default
+    # with the broker-local contract.
+    if not current:
+        os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] = str(required)
+    else:
+        try:
+            configured = max(1, int(float(current)))
+        except Exception:
+            configured = required
+        if _policy() != "global_all_required" and configured == 2:
+            os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] = "1"
+        required = int(os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", required))
+    os.environ["NIJA_RUNTIME_AUTHORITY_BROKER_POLICY"] = _policy()
+    return required
+
+
+def _canonicalize_alias() -> bool:
+    canonical = sys.modules.get(_CANONICAL)
+    if not isinstance(canonical, ModuleType):
+        canonical = importlib.import_module(_CANONICAL)
+    changed = sys.modules.get(_ALIAS) is not canonical
+    sys.modules[_CANONICAL] = canonical
+    sys.modules[_ALIAS] = canonical
+    marker = str(getattr(canonical, "_MARKER", "") or "")
+    if marker != "20260714-downstream-risk-v2":
+        raise RuntimeError(f"downstream_risk_marker_mismatch:{marker or 'missing'}")
+    return changed
+
+
+def _patch_quiescence_audit() -> bool:
+    try:
+        module = importlib.import_module("runtime_convergence_quiescence_patch")
+    except Exception:
+        return False
+    current = getattr(module, "audit", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_post_import_alias_guard_v1", False):
+        return True
+    original = current
+
+    def audit(*args: Any, **kwargs: Any):
+        _canonicalize_alias()
+        _apply_broker_threshold()
+        return original(*args, **kwargs)
+
+    audit._nija_post_import_alias_guard_v1 = True  # type: ignore[attr-defined]
+    audit.__wrapped__ = original  # type: ignore[attr-defined]
+    module.audit = audit
+    return True
+
+
+def _iteration() -> bool:
+    changed = _canonicalize_alias()
+    required = _apply_broker_threshold()
+    patched = _patch_quiescence_audit()
+    os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
+    if changed:
+        logger.warning(
+            "DOWNSTREAM_RISK_ALIAS_DRIFT_REPAIRED marker=%s canonical=%s alias=%s same=true",
+            _MARKER,
+            _CANONICAL,
+            _ALIAS,
+        )
+    logger.debug(
+        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s",
+        _MARKER,
+        _policy(),
+        required,
+        str(patched).lower(),
+    )
+    return True
+
+
+def _watchdog() -> None:
+    while True:
+        try:
+            _iteration()
+        except Exception as exc:
+            logger.error("RUNTIME_POST_IMPORT_CONVERGENCE_ERROR marker=%s error=%s", _MARKER, exc)
+        time.sleep(max(1.0, float(os.environ.get("NIJA_POST_IMPORT_CONVERGENCE_INTERVAL_S", "5") or 5)))
+
+
+def install() -> bool:
+    global _STARTED
+    with _LOCK:
+        _iteration()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="RuntimePostImportConvergence",
+                daemon=True,
+            ).start()
+        logger.critical(
+            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true",
+            _MARKER,
+            _policy(),
+            _required_broker_count(),
+        )
+        return True
+
+
+__all__ = [
+    "install",
+    "_policy",
+    "_required_broker_count",
+    "_apply_broker_threshold",
+    "_canonicalize_alias",
+    "_patch_quiescence_audit",
+    "_iteration",
+]

--- a/bot/tests/test_runtime_post_import_convergence_patch.py
+++ b/bot/tests/test_runtime_post_import_convergence_patch.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType
+
+import bot.runtime_post_import_convergence_patch as patch
+
+
+def test_broker_local_policy_requires_one_broker(monkeypatch):
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.delenv("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", raising=False)
+    assert patch._required_broker_count() == 1
+    assert patch._apply_broker_threshold() == 1
+    assert os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] == "1"
+
+
+def test_global_all_required_policy_keeps_two_brokers(monkeypatch):
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "global_all_required")
+    monkeypatch.delenv("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", raising=False)
+    assert patch._required_broker_count() == 2
+    assert patch._apply_broker_threshold() == 2
+
+
+def test_legacy_default_two_is_lowered_for_broker_local(monkeypatch):
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS", "2")
+    assert patch._apply_broker_threshold() == 1
+    assert os.environ["NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"] == "1"
+
+
+def test_downstream_risk_alias_drift_is_repaired(monkeypatch):
+    canonical = ModuleType("bot.downstream_risk_governor_equity_repair_patch")
+    canonical._MARKER = "20260714-downstream-risk-v2"
+    drifted = ModuleType("nija_downstream_risk_governor_equity_repair_patch")
+    monkeypatch.setitem(sys.modules, patch._CANONICAL, canonical)
+    monkeypatch.setitem(sys.modules, patch._ALIAS, drifted)
+
+    assert patch._canonicalize_alias() is True
+    assert sys.modules[patch._ALIAS] is canonical
+    assert patch._canonicalize_alias() is False

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -10,7 +10,7 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger("nija.source_runtime_guard_bootstrap")
-_MARKER = "20260715l"
+_MARKER = "20260716m"
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -83,6 +83,7 @@ def _set_status(value: str) -> None:
         "NIJA_VENUE_READINESS_SOURCE_BOOTSTRAP",
         "NIJA_RUNTIME_MODULE_IDENTITY_GUARD_INSTALLED",
         "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_INSTALLED",
+        "NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED",
         "NIJA_SCAN_WRAPPER_DEPTH_GUARD_INSTALLED",
         "NIJA_SCAN_WRAPPER_HARD_CLAMP_INSTALLED",
         "NIJA_ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED",
@@ -156,6 +157,7 @@ def install() -> bool:
             _install_canonical_downstream_risk()
             _install_required("runtime_module_identity_convergence_patch")
             _install_required("runtime_convergence_quiescence_patch")
+            _install_required("bot.runtime_post_import_convergence_patch")
             _install_required("bot.runtime_guard_audit_patch")
 
             identity = importlib.import_module("runtime_module_identity_convergence_patch")
@@ -186,7 +188,8 @@ def install() -> bool:
             message = (
                 f"SOURCE_RUNTIME_GUARDS_READY marker={_MARKER} commit={_deployment_commit()} "
                 "writer_authority=installed module_identity=verified convergence_quiescence=verified "
-                "downstream_risk_identity=canonical scan_wrapper_depth=verified scan_wrapper_hard_clamp=installed "
+                "post_import_convergence=installed downstream_risk_identity=canonical "
+                "scan_wrapper_depth=verified scan_wrapper_hard_clamp=installed "
                 "zero_signal_state_repair=armed empty_position_sync=armed secondary_credential_quarantine=armed "
                 "writer_generation_scope=installed authority_heartbeat_generation_scope=installed "
                 "final_worker_position_coinbase_repair=installed broker_auth_recovery=installed "
@@ -209,6 +212,7 @@ def install() -> bool:
             for name in (
                 "NIJA_THREE_VENUE_EXECUTION_READY", "NIJA_RUNTIME_MODULE_IDENTITY_READY",
                 "NIJA_RUNTIME_CONVERGENCE_QUIESCENCE_READY", "NIJA_SCAN_WRAPPER_DEPTH_READY",
+                "NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED",
                 "NIJA_SCAN_WRAPPER_HARD_CLAMP_INSTALLED", "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
                 "NIJA_EMPTY_POSITION_SYNC_READY", "NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY",
                 "NIJA_COINBASE_FUNDING_READINESS_REPAIR_INSTALLED",


### PR DESCRIPTION
## Root cause

The runtime remained in `LIVE_PENDING_CONFIRMATION` because authority convergence defaulted to two valid brokers even under `secondary_venue_policy=broker_local`. Separately, late imports could recreate the legacy downstream-risk alias after the initial identity audit, causing quiescence to regress to `same=False`.

## Fix

- Align runtime-authority minimum broker count with readiness policy: one broker for `broker_local`/`optional`, two only for `global_all_required`.
- Preserve explicit stricter operator settings except the legacy default `2` under broker-local policy.
- Continuously restore `nija_downstream_risk_governor_equity_repair_patch` to the canonical `bot.` module object.
- Canonicalize the alias before every quiescence audit.
- Make the post-import convergence guard mandatory at startup and in the recurring runtime guard audit.
- Add regression coverage for broker-local/global policies and alias drift repair.

## Expected markers

- `RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=20260716-post-import-convergence-v1 policy=broker_local min_brokers=1 alias_same=true`
- `SOURCE_RUNTIME_GUARDS_READY marker=20260716m ... post_import_convergence=installed`
- `RUNTIME_GUARD_AUDIT marker=20260716-runtime-guard-audit-v3 ... authority_min_brokers=1`

## Safety

This does not fabricate capital or bypass broker authentication. Authority still requires hydrated, fresh, usable real capital, writer heartbeat, distributed writer authority, and a clear kill switch. It only permits one independently healthy broker to satisfy broker-local policy.