### PR TITLE
Fix scan hard-clamp crash on stable wrapper stack

### DIFF
--- a/bot/scan_wrapper_hard_clamp_patch.py
+++ b/bot/scan_wrapper_hard_clamp_patch.py
@@ -11,11 +11,14 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.scan_wrapper_hard_clamp")
-_MARKER = "20260715-scan-hard-clamp-v1"
+_MARKER = "20260716-scan-hard-clamp-v2"
 _LOCK = threading.RLock()
 _INSTALLED = False
 _WATCHDOG = False
-_MAX_DEPTH = 24
+# NIJA's fully converged safety stack currently settles around 32 linked wrappers.
+# Keep a strict ceiling above that stable baseline while still collapsing runaway
+# chains such as the 94/1383-layer production failures.
+_MAX_DEPTH = 64
 _WRAP_ATTR = "_nija_broker_independent_live_execution_v20260705a"
 
 
@@ -58,10 +61,29 @@ def _chain_has(func: Callable[..., Any], attr: str) -> bool:
     return any(bool(getattr(item, attr, False)) for item in chain)
 
 
+def _normalise_depth_ceiling() -> int:
+    """Publish one ceiling shared by the clamp and depth audit.
+
+    Older releases defaulted to 24, below the current stable safety stack. Treat
+    that legacy value as a default and migrate it to 64. Values above 64 are
+    reduced to the hard safety ceiling.
+    """
+    raw = str(os.environ.get("NIJA_MAX_SCAN_WRAPPER_DEPTH", "") or "").strip()
+    try:
+        configured = int(float(raw)) if raw else _MAX_DEPTH
+    except Exception:
+        configured = _MAX_DEPTH
+    if configured <= 24:
+        configured = _MAX_DEPTH
+    configured = max(32, min(_MAX_DEPTH, configured))
+    os.environ["NIJA_MAX_SCAN_WRAPPER_DEPTH"] = str(configured)
+    return configured
+
+
 def _guard_broker_installer(module: ModuleType) -> bool:
     current = getattr(module, "_patch_core_loop_module", None)
-    if not callable(current) or getattr(current, "_nija_chain_aware_hard_clamp_v1", False):
-        return bool(getattr(current, "_nija_chain_aware_hard_clamp_v1", False))
+    if not callable(current) or getattr(current, "_nija_chain_aware_hard_clamp_v2", False):
+        return bool(getattr(current, "_nija_chain_aware_hard_clamp_v2", False))
 
     def patch_core_loop_module(core_module: ModuleType) -> bool:
         cls = getattr(core_module, "NijaCoreLoop", None)
@@ -75,7 +97,7 @@ def _guard_broker_installer(module: ModuleType) -> bool:
             after.__wrapped__ = before  # type: ignore[attr-defined]
         return result
 
-    patch_core_loop_module._nija_chain_aware_hard_clamp_v1 = True  # type: ignore[attr-defined]
+    patch_core_loop_module._nija_chain_aware_hard_clamp_v2 = True  # type: ignore[attr-defined]
     patch_core_loop_module.__wrapped__ = current  # type: ignore[attr-defined]
     module._patch_core_loop_module = patch_core_loop_module
     logger.critical("BROKER_SCAN_INSTALLER_HARD_GUARDED marker=%s", _MARKER)
@@ -87,8 +109,9 @@ def _collapse_core(core_module: ModuleType) -> bool:
     current = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
     if not callable(current):
         return False
+    ceiling = _normalise_depth_ceiling()
     chain, cycle = _walk(current)
-    if not cycle and len(chain) <= _MAX_DEPTH:
+    if not cycle and len(chain) <= ceiling:
         return False
     deepest = chain[-1] if chain else current
     setattr(cls, "run_scan_phase", deepest)
@@ -102,17 +125,26 @@ def _collapse_core(core_module: ModuleType) -> bool:
     convergence._patch_core_loop(core_module)
     final = getattr(cls, "run_scan_phase")
     final_chain, final_cycle = _walk(final)
-    ready = not final_cycle and len(final_chain) <= _MAX_DEPTH
+    ready = not final_cycle and len(final_chain) <= ceiling
     logger.critical(
-        "SCAN_WRAPPER_HARD_CLAMP_APPLIED marker=%s old_depth=%d old_cycle=%s new_depth=%d new_cycle=%s ready=%s",
-        _MARKER, len(chain), str(cycle).lower(), len(final_chain), str(final_cycle).lower(), str(ready).lower(),
+        "SCAN_WRAPPER_HARD_CLAMP_APPLIED marker=%s old_depth=%d old_cycle=%s new_depth=%d new_cycle=%s ceiling=%d ready=%s",
+        _MARKER,
+        len(chain),
+        str(cycle).lower(),
+        len(final_chain),
+        str(final_cycle).lower(),
+        ceiling,
+        str(ready).lower(),
     )
     if not ready:
-        raise RuntimeError(f"scan_wrapper_hard_clamp_failed:depth={len(final_chain)} cycle={final_cycle}")
+        raise RuntimeError(
+            f"scan_wrapper_hard_clamp_failed:depth={len(final_chain)} ceiling={ceiling} cycle={final_cycle}"
+        )
     return True
 
 
 def _apply() -> bool:
+    _normalise_depth_ceiling()
     broker_patch = importlib.import_module("bot.broker_independent_live_execution_patch")
     changed = _guard_broker_installer(broker_patch)
     for name in ("bot.nija_core_loop", "nija_core_loop"):
@@ -134,14 +166,26 @@ def _watchdog() -> None:
 def install() -> bool:
     global _INSTALLED, _WATCHDOG
     with _LOCK:
+        ceiling = _normalise_depth_ceiling()
         _apply()
         if not _WATCHDOG:
             _WATCHDOG = True
             threading.Thread(target=_watchdog, name="ScanWrapperHardClamp", daemon=True).start()
         _INSTALLED = True
         os.environ["NIJA_SCAN_WRAPPER_HARD_CLAMP_INSTALLED"] = "1"
-        logger.critical("SCAN_WRAPPER_HARD_CLAMP_INSTALLED marker=%s max_depth=%d", _MARKER, _MAX_DEPTH)
+        logger.critical(
+            "SCAN_WRAPPER_HARD_CLAMP_INSTALLED marker=%s max_depth=%d",
+            _MARKER,
+            ceiling,
+        )
         return True
 
 
-__all__ = ["install", "_walk", "_chain_has", "_guard_broker_installer", "_collapse_core"]
+__all__ = [
+    "install",
+    "_walk",
+    "_chain_has",
+    "_normalise_depth_ceiling",
+    "_guard_broker_installer",
+    "_collapse_core",
+]

--- a/bot/tests/test_scan_wrapper_hard_clamp_ceiling.py
+++ b/bot/tests/test_scan_wrapper_hard_clamp_ceiling.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from types import ModuleType
+
+from bot import scan_wrapper_hard_clamp_patch as clamp
+
+
+def _chain(depth: int):
+    def base(self=None):
+        return None
+
+    current = base
+    for index in range(depth - 1):
+        previous = current
+
+        def wrapper(self=None, _previous=previous):
+            return _previous(self)
+
+        wrapper.__wrapped__ = previous
+        wrapper.__name__ = f"wrapper_{index}"
+        current = wrapper
+    return current
+
+
+def test_legacy_24_depth_default_migrates_to_64(monkeypatch):
+    monkeypatch.setenv("NIJA_MAX_SCAN_WRAPPER_DEPTH", "24")
+    assert clamp._normalise_depth_ceiling() == 64
+    assert os.environ["NIJA_MAX_SCAN_WRAPPER_DEPTH"] == "64"
+
+
+def test_stable_32_layer_chain_is_accepted(monkeypatch):
+    monkeypatch.setenv("NIJA_MAX_SCAN_WRAPPER_DEPTH", "64")
+    module = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        run_scan_phase = _chain(32)
+
+    module.NijaCoreLoop = NijaCoreLoop
+    assert clamp._collapse_core(module) is False
+    chain, cycle = clamp._walk(module.NijaCoreLoop.run_scan_phase)
+    assert len(chain) == 32
+    assert cycle is False
+
+
+def test_64_remains_hard_maximum(monkeypatch):
+    monkeypatch.setenv("NIJA_MAX_SCAN_WRAPPER_DEPTH", "200")
+    assert clamp._normalise_depth_ceiling() == 64


### PR DESCRIPTION
## Root cause

The live process grew to 94 scan wrappers. The hard clamp successfully rebuilt the chain to 32 acyclic layers, but then crashed because its fixed ceiling was 24. NIJA's current fully converged safety stack legitimately settles near 32 linked wrappers.

## Fix

- Raise the hard safety ceiling from 24 to 64.
- Migrate the legacy `NIJA_MAX_SCAN_WRAPPER_DEPTH=24` default to 64.
- Cap any configured value above 64 back to 64.
- Keep automatic collapse for chains above 64 or containing a cycle.
- Publish the same ceiling for the scan-depth audit.
- Add regression coverage for the 32-layer stable stack and ceiling normalization.

## Safety

This does not ignore runaway growth. The 94-layer production chain still collapses, cycles still fail closed, and 64 remains an enforced maximum.