### PR TITLE
Fail closed on Coinbase client gaps and OKX connect recursion

### DIFF
--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -1,17 +1,19 @@
-"""Repair auth-hook recursion and apply OKX fallback to live broker instances."""
+"""Repair auth-hook recursion and fail closed on uninitialized broker clients."""
 from __future__ import annotations
 
 import logging
 import os
 import sys
 import threading
+from functools import wraps
 from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.runtime_auth_endpoint_repair")
-_MARKER = "20260712c"
+_MARKER = "20260716-auth-endpoint-v2"
 _LOCK = threading.RLock()
 _PATCHED = False
+_LOCAL = threading.local()
 
 
 def _set_okx_endpoint(instance: Any, url: str) -> None:
@@ -24,30 +26,135 @@ def _set_okx_endpoint(instance: Any, url: str) -> None:
                 pass
 
 
+def _zero_coinbase_balance() -> dict[str, Any]:
+    return {
+        "usd": 0.0,
+        "usdc": 0.0,
+        "trading_balance": 0.0,
+        "usd_held": 0.0,
+        "usdc_held": 0.0,
+        "total_held": 0.0,
+        "total_funds": 0.0,
+        "crypto": {},
+        "consumer_usd": 0.0,
+        "consumer_usdc": 0.0,
+        "connected": False,
+        "reason": "coinbase_client_uninitialized",
+    }
+
+
+def _mark_coinbase_disconnected(instance: Any, reason: str) -> None:
+    for attr, value in (("connected", False), ("_is_available", False), ("_auth_failed", True)):
+        try:
+            setattr(instance, attr, value)
+        except Exception:
+            pass
+    os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+    os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+    os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"
+    os.environ["NIJA_COINBASE_FUNDING_STATUS"] = reason
+
+
+def _patch_coinbase_class(module: ModuleType) -> bool:
+    global _PATCHED
+    cls = getattr(module, "CoinbaseBroker", None)
+    if not isinstance(cls, type):
+        return False
+
+    changed = False
+    for method_name in ("_get_account_balance_detailed", "get_account_balance", "get_balance"):
+        original = getattr(cls, method_name, None)
+        if not callable(original) or getattr(original, "_nija_coinbase_client_guard_v2", False):
+            continue
+
+        @wraps(original)
+        def guarded(self: Any, *args: Any, __original: Callable[..., Any] = original,
+                    __method_name: str = method_name, **kwargs: Any) -> Any:
+            client = getattr(self, "client", None)
+            if client is None:
+                _mark_coinbase_disconnected(self, "client_uninitialized")
+                logger.error(
+                    "COINBASE_CLIENT_UNINITIALIZED_FAIL_CLOSED marker=%s method=%s action=zero_balance_no_api_call",
+                    _MARKER,
+                    __method_name,
+                )
+                return _zero_coinbase_balance()
+            return __original(self, *args, **kwargs)
+
+        guarded._nija_coinbase_client_guard_v2 = True  # type: ignore[attr-defined]
+        guarded.__wrapped__ = original  # type: ignore[attr-defined]
+        setattr(cls, method_name, guarded)
+        changed = True
+
+    if changed:
+        _PATCHED = True
+        logger.warning("COINBASE_CLIENT_FAIL_CLOSED_GUARD_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    return changed
+
+
 def _patch_okx_class(module: ModuleType) -> bool:
     global _PATCHED
     cls = getattr(module, "OKXBroker", None)
     if not isinstance(cls, type):
         return False
     original = getattr(cls, "connect", None)
-    if not callable(original) or getattr(original, "_nija_endpoint_instance_repair", False):
+    if not callable(original) or getattr(original, "_nija_endpoint_instance_repair_v2", False):
         return False
 
+    @wraps(original)
     def connect(self: Any, *args: Any, __original: Callable[..., Any] = original, **kwargs: Any) -> Any:
-        configured = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
-        if configured:
-            _set_okx_endpoint(self, configured)
-        result = __original(self, *args, **kwargs)
-        configured_after = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
-        if configured_after and configured_after != configured:
-            _set_okx_endpoint(self, configured_after)
-        return result
+        active = getattr(_LOCAL, "okx_connect_active", set())
+        identity = id(self)
+        if identity in active:
+            try:
+                self.connected = False
+            except Exception:
+                pass
+            os.environ["NIJA_OKX_CONNECTED"] = "0"
+            os.environ["NIJA_OKX_FUNDING_STATUS"] = "connect_recursion_blocked"
+            logger.error(
+                "OKX_CONNECT_REENTRY_BLOCKED marker=%s class=%s action=fail_closed",
+                _MARKER,
+                type(self).__name__,
+            )
+            return False
 
-    connect._nija_endpoint_instance_repair = True  # type: ignore[attr-defined]
+        active = set(active)
+        active.add(identity)
+        _LOCAL.okx_connect_active = active
+        try:
+            configured = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
+            if configured:
+                _set_okx_endpoint(self, configured)
+            result = __original(self, *args, **kwargs)
+            configured_after = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
+            if configured_after and configured_after != configured:
+                _set_okx_endpoint(self, configured_after)
+            return result
+        except RecursionError as exc:
+            try:
+                self.connected = False
+            except Exception:
+                pass
+            os.environ["NIJA_OKX_CONNECTED"] = "0"
+            os.environ["NIJA_OKX_FUNDING_STATUS"] = "connect_recursion_blocked"
+            logger.error(
+                "OKX_CONNECT_RECURSION_FAIL_CLOSED marker=%s class=%s error=%s",
+                _MARKER,
+                type(self).__name__,
+                str(exc)[:160],
+            )
+            return False
+        finally:
+            current = set(getattr(_LOCAL, "okx_connect_active", set()))
+            current.discard(identity)
+            _LOCAL.okx_connect_active = current
+
+    connect._nija_endpoint_instance_repair_v2 = True  # type: ignore[attr-defined]
     connect.__wrapped__ = original  # type: ignore[attr-defined]
     setattr(cls, "connect", connect)
     _PATCHED = True
-    logger.warning("OKX_INSTANCE_ENDPOINT_REPAIR_PATCHED marker=%s class=%s", _MARKER, cls.__name__)
+    logger.warning("OKX_INSTANCE_ENDPOINT_REPAIR_PATCHED marker=%s class=%s reentry_guard=true", _MARKER, cls.__name__)
     return True
 
 
@@ -71,10 +178,12 @@ def _disable_recursive_convergence_hook() -> None:
                 continue
             for method_name in ("connect", "verify_connection", "test_connection"):
                 original = getattr(cls, method_name, None)
-                if not callable(original) or getattr(original, "_nija_runtime_convergence_auth_safe", False):
+                if not callable(original) or getattr(original, "_nija_runtime_convergence_auth_safe_v2", False):
                     continue
 
-                def wrapped(self: Any, *args: Any, __original=original, __venue=venue, **kwargs: Any):
+                @wraps(original)
+                def wrapped(self: Any, *args: Any, __original: Callable[..., Any] = original,
+                            __venue: str = venue, **kwargs: Any) -> Any:
                     normalizer = getattr(auth, f"normalize_{__venue}_environment", None)
                     if callable(normalizer):
                         normalizer()
@@ -84,7 +193,7 @@ def _disable_recursive_convergence_hook() -> None:
                             _set_okx_endpoint(self, url)
                     return __original(self, *args, **kwargs)
 
-                wrapped._nija_runtime_convergence_auth_safe = True  # type: ignore[attr-defined]
+                wrapped._nija_runtime_convergence_auth_safe_v2 = True  # type: ignore[attr-defined]
                 wrapped.__wrapped__ = original  # type: ignore[attr-defined]
                 setattr(cls, method_name, wrapped)
                 patched = True
@@ -100,7 +209,9 @@ def install() -> None:
         for name in ("bot.broker_manager", "broker_manager"):
             module = sys.modules.get(name)
             if isinstance(module, ModuleType):
+                _patch_coinbase_class(module)
                 _patch_okx_class(module)
+        os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] = "1"
         logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED marker=%s patched=%s", _MARKER, _PATCHED)
 
 
@@ -108,4 +219,11 @@ def installed() -> bool:
     return _PATCHED
 
 
-__all__ = ["install", "installed", "_set_okx_endpoint"]
+__all__ = [
+    "install",
+    "installed",
+    "_set_okx_endpoint",
+    "_zero_coinbase_balance",
+    "_patch_coinbase_class",
+    "_patch_okx_class",
+]

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from types import ModuleType
+
+import runtime_auth_recursion_endpoint_repair_patch as repair
+
+
+def test_coinbase_balance_fails_closed_when_client_is_missing(monkeypatch):
+    class CoinbaseBroker:
+        def __init__(self):
+            self.client = None
+            self.connected = True
+
+        def _get_account_balance_detailed(self, verbose=False):
+            raise AssertionError("uninitialized client must not reach original balance method")
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+
+    assert repair._patch_coinbase_class(module) is True
+    broker = CoinbaseBroker()
+    payload = broker._get_account_balance_detailed()
+
+    assert payload["total_funds"] == 0.0
+    assert payload["trading_balance"] == 0.0
+    assert payload["connected"] is False
+    assert broker.connected is False
+    assert os.environ["NIJA_COINBASE_CONNECTED"] == "0"
+    assert os.environ["NIJA_COINBASE_FUNDING_STATUS"] == "client_uninitialized"
+
+
+def test_okx_recursive_connect_is_blocked(monkeypatch):
+    class OKXBroker:
+        def __init__(self):
+            self.connected = True
+
+        def connect(self):
+            return self.connect()
+
+    module = ModuleType("bot.broker_manager")
+    module.OKXBroker = OKXBroker
+
+    assert repair._patch_okx_class(module) is True
+    broker = OKXBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert os.environ["NIJA_OKX_CONNECTED"] == "0"
+    assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "connect_recursion_blocked"
+
+
+def test_okx_endpoint_is_applied_without_recursion(monkeypatch):
+    monkeypatch.setenv("OKX_BASE_URL", "https://us.okx.com")
+
+    class OKXBroker:
+        def __init__(self):
+            self.connected = False
+            self.base_url = ""
+
+        def connect(self):
+            self.connected = True
+            return True
+
+    module = ModuleType("bot.broker_manager")
+    module.OKXBroker = OKXBroker
+
+    assert repair._patch_okx_class(module) is True
+    broker = OKXBroker()
+
+    assert broker.connect() is True
+    assert broker.connected is True
+    assert broker.base_url == "https://us.okx.com"


### PR DESCRIPTION
## What changed

- Added a fail-closed Coinbase balance guard so an uninitialized `self.client` never reaches `get_accounts()`.
- Publishes disconnected, unobserved, zero-spendable Coinbase readiness state when the client is unavailable.
- Added per-instance OKX connection re-entry protection and explicit `RecursionError` containment.
- Preserves OKX endpoint application while preventing recursive wrapper chains from crashing startup.
- Added regression tests covering Coinbase missing-client behavior, OKX recursion containment, and endpoint propagation.

## Root cause

Coinbase balance fallback dereferenced `self.client.get_accounts` even when client construction had failed. OKX had multiple runtime wrappers around `connect()`, allowing the wrapped method to re-enter itself until Python raised `RecursionError`.

## Validation

The branch is two commits ahead of `main` and changes only the auth endpoint repair module plus focused regression tests. Runtime verification still requires Render to deploy the merged commit and show broker-local readiness/fill telemetry.