### PR TITLE
Finish runtime cleanup, writer authority, and execution observability

### DIFF
--- a/bot/final_runtime_cleanup_patch.py
+++ b/bot/final_runtime_cleanup_patch.py
@@ -1,0 +1,342 @@
+"""Final runtime cleanup for NIJA live execution.
+
+This guard is intentionally one-shot and thread-free. It:
+* prevents obsolete convergence watchdog threads from starting;
+* freezes canonical scan/Phase-3 wrapper chains after startup convergence;
+* hard-isolates OKX entries until connection and spendable balance are observed;
+* emits deterministic order-attempt, broker-ack, fill, and rejection telemetry.
+
+It never bypasses writer authority, risk controls, broker validation, minimum
+notional checks, or exit protections.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.final_runtime_cleanup")
+_MARKER = "20260717-final-runtime-cleanup-v1"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_ORIGINAL_IMPORT: Callable[..., Any] | None = None
+_ORIGINAL_THREAD_START: Callable[..., Any] | None = None
+
+_OBSOLETE_THREAD_NAMES = {
+    "ReentrantScanOwnerRepair",
+    "ScanReentrantDelegateRepair",
+    "ScanOwnerAuthConvergenceWatchdog",
+    "RuntimePostImportConvergence",
+    "runtime-authority-convergence-repair",
+}
+
+_PIPELINE_ATTR = "_nija_final_execution_telemetry_20260717"
+_OKX_GUARD_ATTR = "_nija_okx_unobserved_guard_20260717"
+
+
+def _truthy(name: str, default: str = "") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in {
+        "1", "true", "yes", "on", "enabled", "y",
+    }
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return default
+
+
+def _okx_ready() -> tuple[bool, str, float]:
+    connected = _truthy("NIJA_OKX_CONNECTED")
+    trading_ready = _truthy("NIJA_OKX_TRADING_READY")
+    activated = _truthy("NIJA_OKX_ACTIVATED")
+    observed = _truthy("NIJA_OKX_BALANCE_OBSERVED") or str(
+        os.environ.get("NIJA_OKX_FUNDING_STATUS", "") or ""
+    ).strip().lower() in {"observed", "ready", "funded"}
+    spendable = max(
+        0.0,
+        _safe_float(os.environ.get("NIJA_OKX_TRADING_SPENDABLE")),
+        _safe_float(os.environ.get("NIJA_OKX_SPENDABLE_QUOTE")),
+    )
+    minimum = max(0.01, _safe_float(os.environ.get("NIJA_OKX_MIN_ENTRY_USD"), 10.0))
+    ready = connected and trading_ready and activated and observed and spendable >= minimum
+    if not connected:
+        reason = "not_connected"
+    elif not trading_ready:
+        reason = "trading_not_ready"
+    elif not activated:
+        reason = "not_activated"
+    elif not observed:
+        reason = "balance_unobserved"
+    elif spendable < minimum:
+        reason = f"insufficient_spendable:{spendable:.2f}<{minimum:.2f}"
+    else:
+        reason = "ready"
+    os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "0" if ready else "1"
+    os.environ["NIJA_OKX_ENTRY_ISOLATION_REASON"] = reason
+    return ready, reason, spendable
+
+
+def _thread_name(thread: threading.Thread) -> str:
+    try:
+        return str(getattr(thread, "name", "") or "")
+    except Exception:
+        return ""
+
+
+def _install_thread_quiescence() -> None:
+    global _ORIGINAL_THREAD_START
+    if getattr(threading.Thread.start, "_nija_final_runtime_cleanup", False):
+        return
+    _ORIGINAL_THREAD_START = threading.Thread.start
+
+    def guarded_start(self: threading.Thread, *args: Any, **kwargs: Any) -> Any:
+        name = _thread_name(self)
+        if name in _OBSOLETE_THREAD_NAMES:
+            logger.critical(
+                "LEGACY_RUNTIME_WATCHDOG_SUPPRESSED marker=%s thread=%s action=not_started",
+                _MARKER,
+                name,
+            )
+            return None
+        return _ORIGINAL_THREAD_START(self, *args, **kwargs)  # type: ignore[misc]
+
+    guarded_start._nija_final_runtime_cleanup = True  # type: ignore[attr-defined]
+    guarded_start.__wrapped__ = _ORIGINAL_THREAD_START  # type: ignore[attr-defined]
+    threading.Thread.start = guarded_start  # type: ignore[assignment]
+
+
+def _request_broker_name(request: Any, pipeline: Any = None) -> str:
+    for owner in (request, pipeline):
+        if owner is None:
+            continue
+        for attr in (
+            "preferred_broker", "execution_broker", "broker", "broker_client",
+            "broker_name", "venue", "exchange",
+        ):
+            try:
+                value = getattr(owner, attr, None)
+            except Exception:
+                continue
+            if value is None:
+                continue
+            raw = getattr(value, "value", value)
+            text = f"{raw} {type(value).__name__}".lower().replace("_", "").replace("-", "")
+            if "okx" in text:
+                return "okx"
+            if "kraken" in text:
+                return "kraken"
+            if "coinbase" in text:
+                return "coinbase"
+    return "unknown"
+
+
+def _is_entry(request: Any) -> bool:
+    if bool(getattr(request, "reduce_only", False)):
+        return False
+    intent = str(getattr(request, "intent_type", "entry") or "entry").strip().lower()
+    effect = str(getattr(request, "position_effect", "") or "").strip().lower()
+    return intent not in {"exit", "close", "reduce", "liquidate", "liquidation"} and effect not in {
+        "exit", "close", "reduce",
+    }
+
+
+def _result_field(result: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        try:
+            value = getattr(result, name, None)
+        except Exception:
+            value = None
+        if value is not None:
+            return value
+        if isinstance(result, dict) and name in result:
+            return result[name]
+    return default
+
+
+def _make_denial(module: ModuleType, request: Any, reason: str, started: float) -> Any:
+    result_cls = getattr(module, "PipelineResult", None)
+    if callable(result_cls):
+        return result_cls(
+            success=False,
+            symbol=str(getattr(request, "symbol", "") or ""),
+            side=str(getattr(request, "side", "") or ""),
+            size_usd=float(getattr(request, "size_usd", 0.0) or 0.0),
+            error=reason,
+            latency_ms=(time.monotonic() - started) * 1000.0,
+        )
+    raise RuntimeError(reason)
+
+
+def _patch_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    current = getattr(cls, "execute", None) if isinstance(cls, type) else None
+    if not callable(current) or getattr(current, _PIPELINE_ATTR, False):
+        return bool(callable(current) and getattr(current, _PIPELINE_ATTR, False))
+    original = current
+
+    def execute(self: Any, request: Any, *args: Any, **kwargs: Any) -> Any:
+        started = time.monotonic()
+        broker = _request_broker_name(request, self)
+        symbol = str(getattr(request, "symbol", "") or "")
+        side = str(getattr(request, "side", "") or "")
+        size = _safe_float(getattr(request, "size_usd", 0.0))
+        intent = str(getattr(request, "intent_id", "") or getattr(request, "request_id", "") or "unknown")
+        logger.critical(
+            "ORDER_ATTEMPT marker=%s intent=%s broker=%s symbol=%s side=%s size_usd=%.8f",
+            _MARKER, intent, broker, symbol, side, size,
+        )
+
+        if broker == "okx" and _is_entry(request):
+            ready, reason, spendable = _okx_ready()
+            if not ready:
+                error = f"okx_entry_isolated:{reason}"
+                logger.critical(
+                    "ORDER_REJECTED marker=%s intent=%s broker=okx symbol=%s reason=%s spendable=%.8f",
+                    _MARKER, intent, symbol, error, spendable,
+                )
+                return _make_denial(module, request, error, started)
+
+        try:
+            result = original(self, request, *args, **kwargs)
+        except Exception as exc:
+            logger.critical(
+                "ORDER_REJECTED marker=%s intent=%s broker=%s symbol=%s reason=exception:%s",
+                _MARKER, intent, broker, symbol, type(exc).__name__,
+            )
+            raise
+
+        success = bool(_result_field(result, "success", "ok", default=False))
+        order_id = str(_result_field(result, "order_id", "broker_order_id", "id", default="") or "")
+        fill_price = _safe_float(_result_field(result, "fill_price", "average_price", "avg_price", default=0.0))
+        filled_qty = _safe_float(_result_field(result, "filled_quantity", "filled_qty", "quantity", default=0.0))
+        status = str(_result_field(result, "status", "state", default="") or "").strip().lower()
+        error = str(_result_field(result, "error", "reason", "message", default="") or "")
+
+        acknowledged = bool(order_id) or status in {
+            "accepted", "acknowledged", "submitted", "open", "pending", "filled", "partially_filled",
+        }
+        filled = success and (
+            fill_price > 0.0 or filled_qty > 0.0 or status in {"filled", "partially_filled", "closed"}
+        )
+        if acknowledged:
+            logger.critical(
+                "BROKER_ACK marker=%s intent=%s broker=%s symbol=%s order_id=%s status=%s",
+                _MARKER, intent, broker, symbol, order_id or "unknown", status or "acknowledged",
+            )
+        if filled:
+            logger.critical(
+                "ORDER_FILLED marker=%s intent=%s broker=%s symbol=%s order_id=%s fill_price=%.12f filled_qty=%.12f",
+                _MARKER, intent, broker, symbol, order_id or "unknown", fill_price, filled_qty,
+            )
+        elif not success:
+            logger.critical(
+                "ORDER_REJECTED marker=%s intent=%s broker=%s symbol=%s reason=%s status=%s",
+                _MARKER, intent, broker, symbol, error or "unspecified", status or "rejected",
+            )
+        elif not acknowledged:
+            logger.warning(
+                "ORDER_RESULT_UNACKNOWLEDGED marker=%s intent=%s broker=%s symbol=%s result_type=%s",
+                _MARKER, intent, broker, symbol, type(result).__name__,
+            )
+        return result
+
+    setattr(execute, _PIPELINE_ATTR, True)
+    setattr(execute, _OKX_GUARD_ATTR, True)
+    setattr(execute, "__wrapped__", original)
+    setattr(cls, "execute", execute)
+    logger.critical("FINAL_EXECUTION_TELEMETRY_PATCHED marker=%s module=%s", _MARKER, module.__name__)
+    return True
+
+
+def _freeze_scan_installers() -> None:
+    """Mark canonical owners so legacy watchdog patchers exit without rewrapping."""
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        cls = getattr(module, "NijaCoreLoop", None) if isinstance(module, ModuleType) else None
+        if not isinstance(cls, type):
+            continue
+        for method_name in ("run_scan_phase", "_phase3_scan_and_enter"):
+            method = getattr(cls, method_name, None)
+            if not callable(method):
+                continue
+            for attr in (
+                "_nija_scan_wrapper_release",
+                "_nija_scan_wrapper_canonical_h",
+                "_nija_scan_wrapper_canonical_v2",
+                "_nija_scan_identity_lock_v2",
+                "_nija_final_result_contract_e",
+                "_nija_account_scan_serialized_e",
+                "_nija_zero_streak_cap_e",
+                "_nija_final_runtime_frozen_20260717",
+            ):
+                try:
+                    setattr(method, attr, True)
+                except Exception:
+                    pass
+
+
+def _patch_loaded() -> None:
+    _freeze_scan_installers()
+    for name in ("bot.execution_pipeline", "execution_pipeline"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _patch_execution_pipeline(module)
+    _okx_ready()
+
+
+def install_import_hook() -> None:
+    global _INSTALLED, _ORIGINAL_IMPORT
+    with _LOCK:
+        if _INSTALLED:
+            _patch_loaded()
+            return
+        _install_thread_quiescence()
+        os.environ["NIJA_LEGACY_RUNTIME_WATCHDOGS_DISABLED"] = "1"
+        os.environ.setdefault("NIJA_MAX_SCAN_WRAPPER_DEPTH", "64")
+        _patch_loaded()
+        if not getattr(builtins, "_NIJA_FINAL_RUNTIME_CLEANUP_IMPORT_HOOK", False):
+            _ORIGINAL_IMPORT = builtins.__import__
+
+            def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
+                if name.endswith((
+                    "nija_core_loop",
+                    "execution_pipeline",
+                    "scan_owner_okx_auth_convergence_patch",
+                    "reentrant_scan_owner_repair",
+                    "runtime_post_import_convergence_patch",
+                    "runtime_authority_convergence_repair_patch",
+                )):
+                    try:
+                        _patch_loaded()
+                    except Exception:
+                        logger.exception("FINAL_RUNTIME_CLEANUP_IMPORT_REPAIR_FAILED marker=%s module=%s", _MARKER, name)
+                return module
+
+            builtins.__import__ = guarded_import
+            setattr(builtins, "_NIJA_FINAL_RUNTIME_CLEANUP_IMPORT_HOOK", True)
+        _INSTALLED = True
+        logger.critical(
+            "FINAL_RUNTIME_CLEANUP_INSTALLED marker=%s watchdogs=disabled okx_fail_closed=true execution_telemetry=true background_thread=false",
+            _MARKER,
+        )
+
+
+def install() -> None:
+    install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_okx_ready",
+    "_patch_execution_pipeline",
+    "_patch_loaded",
+]

--- a/bot/runtime_patch_quiescence_guard_patch.py
+++ b/bot/runtime_patch_quiescence_guard_patch.py
@@ -1,31 +1,26 @@
-"""Quiesce legacy runtime patch watchdogs once canonical owners are installed.
+"""One-shot compatibility guard for NIJA runtime patch convergence.
 
-Several older watchdogs inspect only the outermost callable marker. When another
-legitimate wrapper sits above their marker they repeatedly wrap the same method,
-causing scan-chain growth, noisy logs, and occasional false readiness failures.
-This guard makes those checks chain-aware and delegates scan ownership to the
-20260714a canonical scan wrapper.
+The former implementation started another watchdog and import wrapper to control
+older watchdogs. That reduced churn but still left mutation threads alive. This
+module now delegates to ``final_runtime_cleanup_patch`` and exposes the legacy
+helper API without starting a thread of its own.
 """
 from __future__ import annotations
 
-import builtins
 import logging
 import sys
-import threading
-import time
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 logger = logging.getLogger("nija.runtime_patch_quiescence")
-_MARKER = "20260716-runtime-patch-quiescence-v1"
-_LOCK = threading.RLock()
-_ORIGINAL_IMPORT: Callable[..., Any] | None = None
-_STARTED = False
+_MARKER = "20260717-runtime-patch-quiescence-v2"
+_INSTALLED = False
 
 _CANONICAL_SCAN_MARKERS = (
     "_nija_scan_wrapper_release",
     "_nija_scan_wrapper_canonical_h",
     "_nija_scan_wrapper_canonical_v2",
+    "_nija_final_runtime_frozen_20260717",
 )
 
 
@@ -66,6 +61,7 @@ def _mark_scan_compatibility(func: Any) -> None:
         "_nija_final_result_contract_e",
         "_nija_account_scan_serialized_e",
         "_nija_final_result_contract",
+        "_nija_final_runtime_frozen_20260717",
     ):
         try:
             setattr(func, attr, True)
@@ -78,7 +74,6 @@ def _guard_core_patcher(module: ModuleType, attr_name: str) -> bool:
     guard_attr = f"_nija_quiescence_guard_{attr_name}"
     if not callable(patcher) or getattr(patcher, guard_attr, False):
         return False
-
     original = patcher
 
     def guarded(target: ModuleType, *args: Any, **kwargs: Any) -> bool:
@@ -101,26 +96,12 @@ def _guard_final_okx_patcher(module: ModuleType) -> bool:
     original = patcher
 
     def guarded() -> bool:
-        missing = False
-        for module_name in (
-            "bot.broker_manager", "broker_manager",
-            "bot.broker_integration", "broker_integration",
-            "bot.multi_account_broker_manager", "multi_account_broker_manager",
-        ):
-            target = sys.modules.get(module_name)
-            if not isinstance(target, ModuleType):
-                continue
-            for class_name in dir(target):
-                cls = getattr(target, class_name, None)
-                if not isinstance(cls, type) or "okx" not in class_name.lower():
-                    continue
-                connect = getattr(cls, "connect", None)
-                if callable(connect) and not _chain_has(connect, "_nija_final_okx_endpoint_e"):
-                    missing = True
-                    break
-            if missing:
-                break
-        return bool(original()) if missing else False
+        try:
+            from bot.final_runtime_cleanup_patch import _okx_ready
+        except ImportError:
+            from final_runtime_cleanup_patch import _okx_ready  # type: ignore[import]
+        ready, _reason, _spendable = _okx_ready()
+        return bool(original()) if ready else False
 
     guarded._nija_quiescence_okx_guard = True  # type: ignore[attr-defined]
     guarded.__wrapped__ = original  # type: ignore[attr-defined]
@@ -130,80 +111,40 @@ def _guard_final_okx_patcher(module: ModuleType) -> bool:
 
 def _patch_loaded() -> bool:
     changed = False
-    with _LOCK:
-        canonical = sys.modules.get("scan_wrapper_convergence_repair_patch")
-        if not isinstance(canonical, ModuleType):
-            canonical = sys.modules.get("nija.scan_wrapper_convergence_repair_patch")
-        if isinstance(canonical, ModuleType):
-            patch_loaded = getattr(canonical, "_patch_loaded", None)
-            if callable(patch_loaded):
-                try:
-                    patch_loaded()
-                except Exception:
-                    logger.debug("Canonical scan collapse deferred", exc_info=True)
-
-        for name in ("runtime_convergence_v2_patch", "nija.runtime_convergence_v2_patch"):
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
-                changed = _guard_core_patcher(module, "_patch_core_loop") or changed
-
-        for name in ("final_runtime_convergence_patch", "nija.final_runtime_convergence_patch"):
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
-                changed = _guard_core_patcher(module, "_patch_core_loop") or changed
-                changed = _guard_final_okx_patcher(module) or changed
-
-        for name in ("bot.nija_core_loop", "nija_core_loop"):
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
-                method = _core_method(module)
-                if callable(method) and _has_canonical_scan_owner(method):
-                    _mark_scan_compatibility(method)
+    for name in ("runtime_convergence_v2_patch", "nija.runtime_convergence_v2_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _guard_core_patcher(module, "_patch_core_loop") or changed
+    for name in ("final_runtime_convergence_patch", "nija.final_runtime_convergence_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _guard_core_patcher(module, "_patch_core_loop") or changed
+            changed = _guard_final_okx_patcher(module) or changed
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            method = _core_method(module)
+            if callable(method) and _has_canonical_scan_owner(method):
+                _mark_scan_compatibility(method)
+    try:
+        from bot.final_runtime_cleanup_patch import _patch_loaded as final_patch_loaded
+    except ImportError:
+        from final_runtime_cleanup_patch import _patch_loaded as final_patch_loaded  # type: ignore[import]
+    final_patch_loaded()
     return changed
 
 
-def _watchdog() -> None:
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            _patch_loaded()
-        except Exception:
-            logger.debug("Runtime patch quiescence retry", exc_info=True)
-        time.sleep(0.5)
-
-
 def install_import_hook() -> None:
-    global _ORIGINAL_IMPORT, _STARTED
+    global _INSTALLED
+    try:
+        from bot.final_runtime_cleanup_patch import install_import_hook as install_final
+    except ImportError:
+        from final_runtime_cleanup_patch import install_import_hook as install_final  # type: ignore[import]
+    install_final()
     _patch_loaded()
-    if not getattr(builtins, "_NIJA_RUNTIME_PATCH_QUIESCENCE_IMPORT_HOOK", False):
-        _ORIGINAL_IMPORT = builtins.__import__
-
-        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
-            module = _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)  # type: ignore[misc]
-            if name.endswith((
-                "runtime_convergence_v2_patch",
-                "final_runtime_convergence_patch",
-                "scan_wrapper_convergence_repair_patch",
-                "nija_core_loop",
-            )):
-                try:
-                    _patch_loaded()
-                except Exception:
-                    logger.debug("Import-time quiescence deferred", exc_info=True)
-            return module
-
-        builtins.__import__ = guarded_import
-        setattr(builtins, "_NIJA_RUNTIME_PATCH_QUIESCENCE_IMPORT_HOOK", True)
-
-    if not _STARTED:
-        _STARTED = True
-        threading.Thread(
-            target=_watchdog,
-            name="RuntimePatchQuiescenceGuard",
-            daemon=True,
-        ).start()
+    _INSTALLED = True
     logger.critical(
-        "RUNTIME_PATCH_QUIESCENCE_GUARD_INSTALLED marker=%s canonical_scan_owner=true chain_aware=true",
+        "RUNTIME_PATCH_QUIESCENCE_GUARD_INSTALLED marker=%s canonical_scan_owner=true legacy_watchdogs=disabled background_thread=false",
         _MARKER,
     )
 
@@ -212,4 +153,16 @@ def install() -> None:
     install_import_hook()
 
 
-__all__ = ["install", "install_import_hook", "_patch_loaded", "_chain_has"]
+def installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "installed",
+    "_patch_loaded",
+    "_chain_has",
+    "_guard_core_patcher",
+    "_guard_final_okx_patcher",
+]

--- a/bot/secondary_credential_quarantine_patch.py
+++ b/bot/secondary_credential_quarantine_patch.py
@@ -1,8 +1,9 @@
 """Quarantine secondary venues after definitive credential rejection.
 
-A 50111/50119/50112 response cannot be repaired by retrying. Repeated activation
-attempts only spam logs and consume API calls. The affected venue is isolated while
-healthy brokers remain independently executable.
+Fatal OKX credential responses are process-global facts, not per-client state.
+Once observed, all private requests and connection attempts are blocked until a
+new deployment starts with replacement credentials. Healthy brokers continue
+independently.
 """
 from __future__ import annotations
 
@@ -15,11 +16,17 @@ from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.secondary_credential_quarantine")
-_MARKER = "20260715-secondary-credential-quarantine-v1"
-_ATTR = "_nija_secondary_credential_quarantine_v1"
+_MARKER = "20260717-secondary-credential-quarantine-v2"
+_ATTR = "_nija_secondary_credential_quarantine_v2"
 _LOCK = threading.RLock()
 _STARTED = False
+_LOGGED = False
 _FATAL_CODES = {"50100", "50101", "50111", "50112", "50113", "50119"}
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
 
 
 def _fatal_code(payload: Any) -> str:
@@ -27,6 +34,41 @@ def _fatal_code(payload: Any) -> str:
         return ""
     code = str(payload.get("code", "") or "")
     return code if code in _FATAL_CODES else ""
+
+
+def _is_quarantined() -> bool:
+    return _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED")
+
+
+def _publish_quarantine(code: str, path: str) -> None:
+    global _LOGGED
+    os.environ["NIJA_OKX_CREDENTIALS_QUARANTINED"] = "1"
+    os.environ["NIJA_OKX_CREDENTIAL_QUARANTINE_CODE"] = str(code or "50111")
+    os.environ["NIJA_OKX_ACTIVATION_STATE"] = "credential_quarantined"
+    os.environ["NIJA_OKX_CONNECTED"] = "0"
+    os.environ["NIJA_OKX_TRADING_READY"] = "0"
+    os.environ["NIJA_OKX_BALANCE_OBSERVED"] = "0"
+    os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "1"
+    os.environ["OKX_DISABLE_ENDPOINT_FALLBACK"] = "true"
+    os.environ["NIJA_OKX_RECONNECT_DISABLED"] = "1"
+    if not _LOGGED:
+        _LOGGED = True
+        logger.critical(
+            "SECONDARY_CREDENTIALS_QUARANTINED marker=%s venue=okx code=%s path=%s "
+            "action=isolate_until_credentials_replaced retries_disabled=true endpoint_fallback_disabled=true",
+            _MARKER,
+            code,
+            path,
+        )
+
+
+def _quarantined_payload() -> dict[str, Any]:
+    return {
+        "code": os.environ.get("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "50111"),
+        "msg": "credentials_quarantined",
+        "data": [],
+        "quarantined": True,
+    }
 
 
 def _patch_rest(module: ModuleType) -> bool:
@@ -39,32 +81,36 @@ def _patch_rest(module: ModuleType) -> bool:
 
     @wraps(current)
     def request(self: Any, method: str, path: str, *args: Any, **kwargs: Any):
-        if bool(getattr(self, "_nija_credentials_quarantined", False)) and kwargs.get("private", False):
-            return {
-                "code": str(getattr(self, "_nija_credentials_quarantine_code", "50111")),
-                "msg": "credentials_quarantined",
-                "data": [],
-                "quarantined": True,
-            }
+        private = bool(kwargs.get("private", False))
+        if private and (_is_quarantined() or bool(getattr(self, "_nija_credentials_quarantined", False))):
+            setattr(self, "_nija_credentials_quarantined", True)
+            return _quarantined_payload()
         result = current(self, method, path, *args, **kwargs)
         code = _fatal_code(result)
         if code:
             setattr(self, "_nija_credentials_quarantined", True)
             setattr(self, "_nija_credentials_quarantine_code", code)
-            os.environ["NIJA_OKX_CREDENTIALS_QUARANTINED"] = "1"
-            os.environ["NIJA_OKX_ACTIVATION_STATE"] = "credential_quarantined"
-            os.environ["NIJA_OKX_CONNECTED"] = "0"
-            os.environ["NIJA_OKX_TRADING_READY"] = "0"
-            logger.critical(
-                "SECONDARY_CREDENTIALS_QUARANTINED marker=%s venue=okx code=%s path=%s action=isolate_until_credentials_replaced",
-                _MARKER, code, path,
-            )
+            _publish_quarantine(code, path)
         return result
 
     setattr(request, _ATTR, True)
     request.__wrapped__ = current
     cls._request = request
     return True
+
+
+def _disable_broker(self: Any) -> None:
+    for attr, value in (
+        ("connected", False),
+        ("_is_available", False),
+        ("trading_ready", False),
+        ("_auth_failed", True),
+        ("_nija_credentials_quarantined", True),
+    ):
+        try:
+            setattr(self, attr, value)
+        except Exception:
+            pass
 
 
 def _patch_broker(module: ModuleType) -> bool:
@@ -77,16 +123,25 @@ def _patch_broker(module: ModuleType) -> bool:
 
     @wraps(current)
     def connect(self: Any, *args: Any, **kwargs: Any) -> bool:
+        if _is_quarantined():
+            _disable_broker(self)
+            return False
         clients = [getattr(self, name, None) for name in ("account_api", "market_api", "rest_client", "_rest")]
         if any(bool(getattr(client, "_nija_credentials_quarantined", False)) for client in clients if client is not None):
-            setattr(self, "connected", False)
-            setattr(self, "_is_available", False)
+            _publish_quarantine(
+                str(next((getattr(client, "_nija_credentials_quarantine_code", "50111") for client in clients if client is not None), "50111")),
+                "connect_precheck",
+            )
+            _disable_broker(self)
             return False
         result = bool(current(self, *args, **kwargs))
+        if _is_quarantined():
+            _disable_broker(self)
+            return False
         clients = [getattr(self, name, None) for name in ("account_api", "market_api", "rest_client", "_rest")]
         if any(bool(getattr(client, "_nija_credentials_quarantined", False)) for client in clients if client is not None):
-            setattr(self, "connected", False)
-            setattr(self, "_is_available", False)
+            _publish_quarantine("50111", "connect_postcheck")
+            _disable_broker(self)
             return False
         return result
 
@@ -107,7 +162,7 @@ def _patch_loaded() -> bool:
 
 
 def _watchdog() -> None:
-    while True:
+    for _ in range(300):
         try:
             if _patch_loaded():
                 os.environ["NIJA_SECONDARY_CREDENTIAL_QUARANTINE_READY"] = "1"
@@ -125,11 +180,19 @@ def install_import_hook() -> None:
             _STARTED = True
             threading.Thread(target=_watchdog, name="SecondaryCredentialQuarantine", daemon=True).start()
         os.environ["NIJA_SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED"] = "1"
-        logger.critical("SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED marker=%s", _MARKER)
+        logger.critical("SECONDARY_CREDENTIAL_QUARANTINE_INSTALLED marker=%s process_global=true", _MARKER)
 
 
 def install() -> None:
     install_import_hook()
 
 
-__all__ = ["install", "install_import_hook", "_fatal_code", "_patch_rest", "_patch_broker"]
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_fatal_code",
+    "_patch_rest",
+    "_patch_broker",
+    "_is_quarantined",
+    "_publish_quarantine",
+]

--- a/bot/tests/test_final_runtime_cleanup_patch.py
+++ b/bot/tests/test_final_runtime_cleanup_patch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
+import sys
 import threading
 from dataclasses import dataclass
 from types import ModuleType, SimpleNamespace
@@ -150,4 +151,36 @@ def test_unobserved_okx_entry_is_rejected_before_original_execute(monkeypatch):
     result = ExecutionPipeline().execute(request)
     assert result.success is False
     assert result.error.startswith("okx_entry_isolated:")
+    assert calls == []
+
+
+def test_prebot_runtime_is_bridged_across_both_import_aliases(monkeypatch):
+    bridge = importlib.import_module("prebot_writer_authority_fail_closed")
+    runtime = object()
+    canonical = ModuleType("bot.entrypoint_writer_authority")
+    duplicate = ModuleType("entrypoint_writer_authority")
+
+    monkeypatch.setitem(sys.modules, "bot.entrypoint_writer_authority", canonical)
+    monkeypatch.setitem(sys.modules, "entrypoint_writer_authority", duplicate)
+    monkeypatch.delenv("NIJA_WRITER_AUTHORITY_SINGLETON_BRIDGED", raising=False)
+
+    bridge._bridge_canonical_runtime(runtime)
+
+    assert sys.modules["bot.entrypoint_writer_authority"] is canonical
+    assert sys.modules["entrypoint_writer_authority"] is canonical
+    assert canonical.get_entrypoint_writer_authority() is runtime
+    assert canonical._SINGLETON is runtime
+    assert os.environ["NIJA_WRITER_AUTHORITY_SINGLETON_BRIDGED"] == "1"
+
+
+def test_reentrant_repair_does_not_start_background_thread(monkeypatch):
+    repair = importlib.import_module("reentrant_scan_owner_repair")
+    calls: list[str] = []
+
+    monkeypatch.setattr(repair, "_INSTALLED", False)
+    monkeypatch.setattr(repair, "_repair_loaded", lambda: True)
+    monkeypatch.setattr(threading.Thread, "start", lambda self: calls.append(self.name))
+
+    repair.install()
+
     assert calls == []

--- a/bot/tests/test_final_runtime_cleanup_patch.py
+++ b/bot/tests/test_final_runtime_cleanup_patch.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+
+
+cleanup = importlib.import_module("bot.final_runtime_cleanup_patch")
+
+
+def test_obsolete_runtime_watchdog_thread_is_suppressed(monkeypatch):
+    calls: list[str] = []
+
+    def fake_start(self, *args, **kwargs):
+        calls.append(self.name)
+        return "started"
+
+    monkeypatch.setattr(threading.Thread, "start", fake_start)
+    cleanup._ORIGINAL_THREAD_START = None
+    cleanup._install_thread_quiescence()
+
+    blocked = threading.Thread(target=lambda: None, name="ScanOwnerAuthConvergenceWatchdog")
+    allowed = threading.Thread(target=lambda: None, name="authority-heartbeat-monitor")
+
+    assert blocked.start() is None
+    assert allowed.start() == "started"
+    assert calls == ["authority-heartbeat-monitor"]
+
+
+def test_okx_isolated_until_balance_is_observed(monkeypatch):
+    for key in (
+        "NIJA_OKX_CONNECTED",
+        "NIJA_OKX_TRADING_READY",
+        "NIJA_OKX_ACTIVATED",
+        "NIJA_OKX_BALANCE_OBSERVED",
+        "NIJA_OKX_TRADING_SPENDABLE",
+        "NIJA_OKX_SPENDABLE_QUOTE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    ready, reason, spendable = cleanup._okx_ready()
+    assert ready is False
+    assert reason == "not_connected"
+    assert spendable == 0.0
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "1"
+
+    monkeypatch.setenv("NIJA_OKX_CONNECTED", "1")
+    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATED", "1")
+    monkeypatch.setenv("NIJA_OKX_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_OKX_TRADING_SPENDABLE", "25")
+
+    ready, reason, spendable = cleanup._okx_ready()
+    assert ready is True
+    assert reason == "ready"
+    assert spendable == 25.0
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "0"
+
+
+def test_execution_pipeline_emits_attempt_ack_and_fill(monkeypatch, caplog):
+    module = ModuleType("bot.execution_pipeline")
+
+    @dataclass
+    class PipelineResult:
+        success: bool
+        symbol: str
+        side: str
+        size_usd: float
+        error: str = ""
+        latency_ms: float = 0.0
+        order_id: str = ""
+        status: str = ""
+        fill_price: float = 0.0
+        filled_quantity: float = 0.0
+
+    class ExecutionPipeline:
+        def execute(self, request):
+            return PipelineResult(
+                success=True,
+                symbol=request.symbol,
+                side=request.side,
+                size_usd=request.size_usd,
+                order_id="abc123",
+                status="filled",
+                fill_price=12.5,
+                filled_quantity=2.0,
+            )
+
+    module.PipelineResult = PipelineResult
+    module.ExecutionPipeline = ExecutionPipeline
+    assert cleanup._patch_execution_pipeline(module) is True
+
+    request = SimpleNamespace(
+        symbol="SOL-USD",
+        side="buy",
+        size_usd=25.0,
+        preferred_broker="kraken",
+        intent_type="entry",
+        intent_id="intent-1",
+        reduce_only=False,
+    )
+
+    with caplog.at_level(logging.CRITICAL):
+        result = ExecutionPipeline().execute(request)
+
+    assert result.success is True
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "ORDER_ATTEMPT" in text
+    assert "BROKER_ACK" in text
+    assert "ORDER_FILLED" in text
+
+
+def test_unobserved_okx_entry_is_rejected_before_original_execute(monkeypatch):
+    module = ModuleType("bot.execution_pipeline")
+    calls = []
+
+    @dataclass
+    class PipelineResult:
+        success: bool
+        symbol: str
+        side: str
+        size_usd: float
+        error: str = ""
+        latency_ms: float = 0.0
+
+    class ExecutionPipeline:
+        def execute(self, request):
+            calls.append(request)
+            return PipelineResult(True, request.symbol, request.side, request.size_usd)
+
+    module.PipelineResult = PipelineResult
+    module.ExecutionPipeline = ExecutionPipeline
+    monkeypatch.setenv("NIJA_OKX_CONNECTED", "0")
+    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "0")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATED", "0")
+    monkeypatch.setenv("NIJA_OKX_BALANCE_OBSERVED", "0")
+    assert cleanup._patch_execution_pipeline(module) is True
+
+    request = SimpleNamespace(
+        symbol="SOL-USDT",
+        side="buy",
+        size_usd=10.0,
+        preferred_broker="okx",
+        intent_type="entry",
+        reduce_only=False,
+    )
+    result = ExecutionPipeline().execute(request)
+    assert result.success is False
+    assert result.error.startswith("okx_entry_isolated:")
+    assert calls == []

--- a/bot/tests/test_secondary_credential_quarantine_v2.py
+++ b/bot/tests/test_secondary_credential_quarantine_v2.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib
+import os
+from types import ModuleType
+
+
+quarantine = importlib.import_module("bot.secondary_credential_quarantine_patch")
+
+
+def test_fatal_okx_code_sets_process_global_quarantine(monkeypatch):
+    for key in (
+        "NIJA_OKX_CREDENTIALS_QUARANTINED",
+        "NIJA_OKX_CREDENTIAL_QUARANTINE_CODE",
+        "NIJA_OKX_CONNECTED",
+        "NIJA_OKX_TRADING_READY",
+        "NIJA_OKX_BALANCE_OBSERVED",
+        "NIJA_OKX_ENTRY_ISOLATED",
+        "OKX_DISABLE_ENDPOINT_FALLBACK",
+        "NIJA_OKX_RECONNECT_DISABLED",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(quarantine, "_LOGGED", False)
+
+    quarantine._publish_quarantine("50111", "/api/v5/account/balance")
+
+    assert quarantine._is_quarantined() is True
+    assert os.environ["NIJA_OKX_CONNECTED"] == "0"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "0"
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "1"
+    assert os.environ["OKX_DISABLE_ENDPOINT_FALLBACK"] == "true"
+    assert os.environ["NIJA_OKX_RECONNECT_DISABLED"] == "1"
+
+
+def test_new_okx_broker_instance_does_not_retry_after_global_quarantine(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    calls: list[str] = []
+
+    class OKXBroker:
+        connected = True
+        _is_available = True
+
+        def connect(self):
+            calls.append("connect")
+            return True
+
+    module.OKXBroker = OKXBroker
+    monkeypatch.setenv("NIJA_OKX_CREDENTIALS_QUARANTINED", "1")
+    monkeypatch.setenv("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "50111")
+
+    assert quarantine._patch_broker(module) is True
+    broker = OKXBroker()
+    assert broker.connect() is False
+    assert calls == []
+    assert broker.connected is False
+    assert broker._is_available is False
+
+
+def test_private_okx_request_is_short_circuited_after_global_quarantine(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    calls: list[str] = []
+
+    class _OKXRestClient:
+        def _request(self, method, path, *args, **kwargs):
+            calls.append(path)
+            return {"code": "0", "data": []}
+
+    module._OKXRestClient = _OKXRestClient
+    monkeypatch.setenv("NIJA_OKX_CREDENTIALS_QUARANTINED", "1")
+    monkeypatch.setenv("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "50111")
+
+    assert quarantine._patch_rest(module) is True
+    result = _OKXRestClient()._request("GET", "/api/v5/account/balance", private=True)
+    assert result["quarantined"] is True
+    assert result["code"] == "50111"
+    assert calls == []

--- a/bot/tests/test_secondary_credential_quarantine_v2.py
+++ b/bot/tests/test_secondary_credential_quarantine_v2.py
@@ -6,6 +6,7 @@ from types import ModuleType
 
 
 quarantine = importlib.import_module("bot.secondary_credential_quarantine_patch")
+auth = importlib.import_module("broker_auth_recovery_patch")
 
 
 def test_fatal_okx_code_sets_process_global_quarantine(monkeypatch):
@@ -74,3 +75,12 @@ def test_private_okx_request_is_short_circuited_after_global_quarantine(monkeypa
     assert result["quarantined"] is True
     assert result["code"] == "50111"
     assert calls == []
+
+
+def test_auth_recovery_does_not_flip_endpoint_after_quarantine(monkeypatch):
+    monkeypatch.setenv("NIJA_OKX_CREDENTIALS_QUARANTINED", "1")
+    monkeypatch.setenv("OKX_BASE_URL", "https://us.okx.com")
+
+    assert auth._okx_quarantined() is True
+    assert auth._alternate_okx_url("https://us.okx.com") == ""
+    assert auth.normalize_okx_environment() is False

--- a/broker_auth_recovery_patch.py
+++ b/broker_auth_recovery_patch.py
@@ -1,14 +1,9 @@
 """Recover valid Coinbase/OKX credentials from deployment formatting and region drift.
 
-This guard does not create credentials or bypass authentication.  It only:
-* extracts Coinbase CDP key material from common JSON/escaped/base64 deployment forms;
-* preserves complete PEM framing and normalizes escaped newlines;
-* accepts documented environment aliases without exposing secret contents; and
-* retries OKX authentication once against the alternate US/global production host
-  when the configured host rejects an otherwise complete credential tuple.
-
-A broker is considered connected only when its original connect() implementation
-successfully completes the authenticated account/balance probe.
+This guard normalizes credential formatting and retries OKX once against the
+alternate production host. A definitive OKX credential rejection is process-wide:
+after quarantine, no reconnect or endpoint fallback is attempted until restart
+with replacement credentials.
 """
 from __future__ import annotations
 
@@ -24,10 +19,11 @@ from types import ModuleType
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger("nija.broker_auth_recovery")
-_MARKER = "20260711n"
+_MARKER = "20260717-okx-quarantine-aware-auth-v2"
 _LOCK = threading.RLock()
 _ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
 _PATCHED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 
 def _clean(value: Any) -> str:
@@ -36,6 +32,14 @@ def _clean(value: Any) -> str:
         if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
             text = text[1:-1].strip()
     return text
+
+
+def _truthy(name: str) -> bool:
+    return _clean(os.environ.get(name)).lower() in _TRUE
+
+
+def _okx_quarantined() -> bool:
+    return _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED") or _truthy("NIJA_OKX_RECONNECT_DISABLED")
 
 
 def _json_value(text: str, keys: tuple[str, ...]) -> str:
@@ -75,7 +79,6 @@ def _normalize_pem(value: str) -> str:
     text = text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n").strip()
     text = _decode_possible_base64(text)
     text = text.replace("\\n", "\n").strip()
-
     match = re.search(
         r"-----BEGIN (?P<label>(?:EC )?PRIVATE KEY)-----\s*(?P<body>.*?)\s*-----END (?P=label)-----",
         text,
@@ -114,8 +117,7 @@ def normalize_coinbase_environment() -> bool:
     )
     if raw_key:
         extracted_key = _json_value(raw_key, ("name", "apiKeyName", "api_key_name", "apiKey", "api_key"))
-        normalized_key = extracted_key or raw_key
-        os.environ["COINBASE_API_KEY"] = normalized_key.strip()
+        os.environ["COINBASE_API_KEY"] = (extracted_key or raw_key).strip()
     if raw_secret:
         normalized_secret = _normalize_pem(raw_secret)
         os.environ["COINBASE_API_SECRET"] = normalized_secret
@@ -160,27 +162,44 @@ def normalize_okx_environment() -> bool:
     elif region in {"us", "usa", "united_states"}:
         explicit = "https://us.okx.com"
     if not explicit:
-        explicit = "https://us.okx.com" if _clean(os.environ.get("OKX_US_REGION")).lower() in {"1", "true", "yes", "on"} else "https://www.okx.com"
+        explicit = "https://us.okx.com" if _truthy("OKX_US_REGION") else "https://www.okx.com"
     os.environ["OKX_BASE_URL"] = explicit
     complete = all(_clean(os.environ.get(k)) for k in ("OKX_API_KEY", "OKX_API_SECRET", "OKX_PASSPHRASE"))
     logger.warning(
-        "OKX_AUTH_NORMALIZED marker=%s credentials_complete=%s base_url=%s region_hint=%s simulated=%s",
+        "OKX_AUTH_NORMALIZED marker=%s credentials_complete=%s base_url=%s region_hint=%s simulated=%s quarantined=%s",
         _MARKER,
         complete,
         explicit,
         region or "unset",
         _clean(os.environ.get("OKX_SIMULATED_TRADING") or "false").lower(),
+        _okx_quarantined(),
     )
-    return complete
+    return complete and not _okx_quarantined()
 
 
 def _alternate_okx_url(url: str) -> str:
+    if _okx_quarantined():
+        return ""
     normalized = _clean(url).rstrip("/")
     if normalized == "https://us.okx.com":
         return "https://www.okx.com"
     if normalized in {"https://www.okx.com", "https://openapi.okx.com"}:
         return "https://us.okx.com"
     return ""
+
+
+def _disable_okx_instance(instance: Any) -> None:
+    for attr, value in (
+        ("connected", False),
+        ("_is_available", False),
+        ("trading_ready", False),
+        ("_auth_failed", True),
+        ("_nija_credentials_quarantined", True),
+    ):
+        try:
+            setattr(instance, attr, value)
+        except Exception:
+            pass
 
 
 def _patch_module(module: ModuleType) -> bool:
@@ -204,19 +223,33 @@ def _patch_module(module: ModuleType) -> bool:
         original_okx = getattr(okx_cls, "connect", None)
         if callable(original_okx) and not getattr(original_okx, "_nija_auth_recovery_20260711n", False):
             def okx_connect(self: Any, *args: Any, __original: Callable[..., Any] = original_okx, **kwargs: Any) -> Any:
-                normalize_okx_environment()
+                if _okx_quarantined():
+                    _disable_okx_instance(self)
+                    logger.warning(
+                        "OKX_AUTH_RETRY_SUPPRESSED marker=%s reason=credentials_quarantined",
+                        _MARKER,
+                    )
+                    return False
+                if not normalize_okx_environment():
+                    _disable_okx_instance(self)
+                    return False
                 primary = _clean(os.environ.get("OKX_BASE_URL")).rstrip("/")
                 result = __original(self, *args, **kwargs)
-                if result:
+                if result or _okx_quarantined():
+                    if _okx_quarantined():
+                        _disable_okx_instance(self)
+                        return False
                     return result
-                if _clean(os.environ.get("OKX_DISABLE_ENDPOINT_FALLBACK")).lower() in {"1", "true", "yes", "on"}:
+                if _truthy("OKX_DISABLE_ENDPOINT_FALLBACK"):
                     return result
                 alternate = _alternate_okx_url(primary)
                 if not alternate:
                     return result
                 logger.warning(
                     "OKX_AUTH_ENDPOINT_FALLBACK marker=%s primary=%s alternate=%s reason=primary_auth_failed",
-                    _MARKER, primary, alternate,
+                    _MARKER,
+                    primary,
+                    alternate,
                 )
                 os.environ["OKX_BASE_URL"] = alternate
                 for attr, value in (("connected", False), ("client", None), ("_auth_failed", False), ("_is_available", True)):
@@ -225,6 +258,9 @@ def _patch_module(module: ModuleType) -> bool:
                     except Exception:
                         pass
                 second = __original(self, *args, **kwargs)
+                if _okx_quarantined():
+                    _disable_okx_instance(self)
+                    return False
                 if second:
                     logger.warning("OKX_AUTH_ENDPOINT_RECOVERED marker=%s base_url=%s", _MARKER, alternate)
                     return second
@@ -257,24 +293,21 @@ def install() -> None:
         if _ORIGINAL_IMPORT is not None:
             return
         _ORIGINAL_IMPORT = importlib.import_module
+
         def wrapped(name: str, package: str | None = None):
-            module = _ORIGINAL_IMPORT(name, package)  # type: ignore[misc]
+            module = _ORIGINAL_IMPORT(name, package)
             if name in {"bot.broker_manager", "broker_manager"}:
-                _patch_module(module)
+                _try_loaded()
             return module
+
         importlib.import_module = wrapped  # type: ignore[assignment]
-        logger.warning("BROKER_AUTH_RECOVERY_INSTALL_REQUESTED marker=%s", _MARKER)
-
-
-def installed() -> bool:
-    return _PATCHED
+        logger.warning("BROKER_AUTH_RECOVERY_IMPORT_HOOK_INSTALLED marker=%s", _MARKER)
 
 
 __all__ = [
     "install",
-    "installed",
     "normalize_coinbase_environment",
     "normalize_okx_environment",
-    "_normalize_pem",
     "_alternate_okx_url",
+    "_okx_quarantined",
 ]

--- a/prebot_writer_authority_fail_closed.py
+++ b/prebot_writer_authority_fail_closed.py
@@ -9,14 +9,17 @@ acquires the exact same canonical writer authority before any ``bot.*`` import.
 
 from __future__ import annotations
 
+import builtins
 import logging
 import os
+import sys
+from types import ModuleType
 from typing import Any
 
 import prebot_writer_authority_bootstrap as bootstrap
 
 logger = logging.getLogger("nija.prebot_writer_authority_fail_closed")
-_MARKER = "20260710ab"
+_MARKER = "20260717a"
 _DEFER_MARKER = "20260711a"
 
 
@@ -25,6 +28,39 @@ def _publish_fail_closed_state() -> None:
     os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
     os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
     os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "0"
+
+
+def _bridge_canonical_runtime(runtime: Any) -> None:
+    """Force every authority import alias to reuse the pre-bot singleton.
+
+    A second copy of ``entrypoint_writer_authority`` previously created a new
+    singleton and waited forever on the Redis lease already held by this process.
+    The bridge is process-local and never adopts another process's lock.
+    """
+    if runtime is None:
+        return
+    canonical = sys.modules.get("bot.entrypoint_writer_authority")
+    alias = sys.modules.get("entrypoint_writer_authority")
+    module = canonical if isinstance(canonical, ModuleType) else alias
+    if not isinstance(module, ModuleType):
+        raise RuntimeError("canonical writer authority module missing after prebot acquisition")
+
+    def get_existing_runtime() -> Any:
+        return runtime
+
+    module._SINGLETON = runtime
+    module.get_entrypoint_writer_authority = get_existing_runtime
+    sys.modules["bot.entrypoint_writer_authority"] = module
+    sys.modules["entrypoint_writer_authority"] = module
+    setattr(builtins, "_NIJA_PREBOT_WRITER_AUTHORITY_RUNTIME", runtime)
+    setattr(builtins, "_NIJA_ENTRYPOINT_WRITER_AUTHORITY_MODULE", module)
+    os.environ["NIJA_WRITER_AUTHORITY_SINGLETON_BRIDGED"] = "1"
+    logger.critical(
+        "PREBOT_WRITER_SINGLETON_BRIDGED marker=%s runtime_id=%s module_id=%s aliases_same=true",
+        _MARKER,
+        id(runtime),
+        id(module),
+    )
 
 
 def install(*, defer_if_render: bool = False) -> Any:
@@ -58,13 +94,12 @@ def install(*, defer_if_render: bool = False) -> Any:
     try:
         runtime = bootstrap.install()
         if runtime is not None:
+            _bridge_canonical_runtime(runtime)
             os.environ["NIJA_PREBOT_WRITER_AUTHORITY_DEFERRED"] = "0"
             import venue_readiness_execution_repair_patch as venue_repair
 
             venue_repair.install()
-            logger.warning(
-                "PREBOT_VENUE_READINESS_REPAIR_READY marker=20260710ae"
-            )
+            logger.warning("PREBOT_VENUE_READINESS_REPAIR_READY marker=20260710ae")
         return runtime
     except BaseException as exc:
         # Python's site module reports and swallows exceptions raised by a .pth
@@ -90,4 +125,4 @@ def install(*, defer_if_render: bool = False) -> Any:
         os._exit(78)
 
 
-__all__ = ["install"]
+__all__ = ["install", "_bridge_canonical_runtime"]

--- a/reentrant_scan_owner_repair.py
+++ b/reentrant_scan_owner_repair.py
@@ -1,30 +1,28 @@
-"""Disable the scan-owner wrapper that suppresses legitimate live scans.
+"""Disable the obsolete scan-owner wrapper without a background watchdog.
 
-The convergence wrapper can misclassify NIJA's normal same-thread scan delegation
-as recursion and return an empty blocked result before any symbol is scored. This
-repair removes only that wrapper, preserves its underlying scan pipeline, and
-permanently guards the convergence patch from reinstalling it.
+The repair is applied once during startup. Canonical scan ownership is now
+managed by the reviewed convergence owner, so a permanent mutation thread is
+both unnecessary and unsafe.
 """
 from __future__ import annotations
 
+import builtins
 import logging
 import sys
 import threading
-import time
 from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.reentrant_scan_owner_repair")
-_MARKER = "20260713e"
+_MARKER = "20260717a"
 _PATCH_ATTR = "_nija_scan_owner_result_reuse_20260713b"
 _REPAIR_ATTR = "_nija_reentrant_scan_owner_repair_20260713c"
 _GUARD_ATTR = "_nija_reentrant_scan_owner_guard_20260713e"
-_STARTED = False
+_INSTALLED = False
 _LOCK = threading.RLock()
 
 
 def _wrapper_chain_has_attr(func: Callable[..., Any], attr: str) -> bool:
-    """Return True when any callable in ``func.__wrapped__`` chain has ``attr``."""
     current: Any = func
     seen: set[int] = set()
     for _ in range(128):
@@ -61,19 +59,9 @@ def _repair_module(module: ModuleType) -> bool:
     if not callable(current):
         return False
 
-    # A legitimate outer wrapper (for example venue readiness) may sit above the
-    # repaired canonical method. Promote the repair marker to that outer wrapper
-    # instead of treating it as an unprotected method. This prevents the
-    # convergence watchdog from reinstalling its owner wrapper every few seconds.
     if _wrapper_chain_has_attr(current, _REPAIR_ATTR):
         if not getattr(current, _REPAIR_ATTR, False):
             setattr(current, _REPAIR_ATTR, True)
-            logger.info(
-                "REENTRANT_SCAN_OWNER_REPAIR_MARKER_PROPAGATED marker=%s module=%s wrapper=%s",
-                _MARKER,
-                getattr(module, "__name__", "unknown"),
-                getattr(current, "__qualname__", "unknown"),
-            )
         return True
 
     if not getattr(current, _PATCH_ATTR, False):
@@ -96,7 +84,6 @@ def _repair_module(module: ModuleType) -> bool:
 
 
 def _install_convergence_guard() -> bool:
-    """Make the convergence watchdog respect repaired canonical scan methods."""
     try:
         import scan_owner_okx_auth_convergence_patch as convergence
     except Exception as exc:
@@ -118,15 +105,10 @@ def _install_convergence_guard() -> bool:
     def guarded_patch_core(module: ModuleType) -> bool:
         cls = getattr(module, "NijaCoreLoop", None)
         method = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
-
-        # Inspect the full wrapper chain. Venue-readiness and other legitimate
-        # wrappers may be above the repaired canonical method. Checking only the
-        # outer function caused the patch/remove loop seen in live logs.
         if callable(method) and _wrapper_chain_has_attr(method, _REPAIR_ATTR):
             if not getattr(method, _REPAIR_ATTR, False):
                 setattr(method, _REPAIR_ATTR, True)
             return True
-
         result = original_patch_core(module)
         _repair_module(module)
         return result
@@ -147,24 +129,18 @@ def _repair_loaded() -> bool:
     return changed
 
 
-def _watchdog() -> None:
-    while True:
-        try:
-            _repair_loaded()
-        except Exception as exc:
-            logger.warning("REENTRANT_SCAN_OWNER_REPAIR_RETRY marker=%s error=%s", _MARKER, exc)
-        time.sleep(0.5)
-
-
 def install() -> None:
-    global _STARTED
+    global _INSTALLED
     with _LOCK:
-        _repair_loaded()
-        if _STARTED:
+        if _INSTALLED:
             return
-        _STARTED = True
-        threading.Thread(target=_watchdog, name="ReentrantScanOwnerRepair", daemon=True).start()
-        logger.warning("REENTRANT_SCAN_OWNER_REPAIR_INSTALLED marker=%s", _MARKER)
+        _repair_loaded()
+        _INSTALLED = True
+        setattr(builtins, "_NIJA_REENTRANT_SCAN_OWNER_REPAIR_ONE_SHOT", True)
+        logger.warning(
+            "REENTRANT_SCAN_OWNER_REPAIR_INSTALLED marker=%s mode=one_shot thread_started=false",
+            _MARKER,
+        )
 
 
 install()


### PR DESCRIPTION
## What changed

- Replaces the watchdog-based quiescence layer with a one-shot, thread-free compatibility guard.
- Suppresses obsolete convergence threads before they start.
- Converts `ReentrantScanOwnerRepair` to one-shot mode with no background thread.
- Bridges the pre-bot Redis writer authority across both `bot.entrypoint_writer_authority` and `entrypoint_writer_authority` aliases so later startup code reuses the already-acquired in-process singleton instead of deadlocking on its own lease.
- Freezes canonical scan and Phase 3 ownership markers so legacy patchers stop growing wrapper chains.
- Keeps the existing verified wrapper-depth ceiling instead of stripping active risk controls.
- Hard-isolates OKX entry orders until connection, activation, observed balance, and minimum spendable quote are all verified.
- Adds deterministic `ORDER_ATTEMPT`, `BROKER_ACK`, `ORDER_FILLED`, `ORDER_REJECTED`, and `ORDER_RESULT_UNACKNOWLEDGED` telemetry.
- Adds regression tests for watchdog suppression, one-shot reentrant repair, writer-singleton alias bridging, OKX fail-closed behavior, and order lifecycle telemetry.

## Root cause confirmed from Render logs

The preview process acquired the Redis writer lease during the pre-bot bootstrap, then a second module instance created another writer-authority singleton in the same process and waited indefinitely on the lease held by itself. The holder metadata showed the same Render preview service and PID. The new singleton bridge eliminates that self-deadlock without allowing adoption of another process's lease.

## Safety

This does not bypass writer authority, risk controls, exchange validation, minimum-notional rules, liquidity checks, or exit protections. Existing Phase 3 safety wrappers are preserved and frozen rather than indiscriminately removed.

## Validation

Focused regression tests are included under `bot/tests/test_final_runtime_cleanup_patch.py`. The branch must be refreshed against current `main` and CI must pass before merge.