### PR TITLE
Fix false Coinbase low-balance startup state

### DIFF
--- a/bot/tests/test_coinbase_unobserved_readiness.py
+++ b/bot/tests/test_coinbase_unobserved_readiness.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import render_liveness_server as server
+import render_readiness_state_bridge as bridge
+
+
+def test_render_cold_start_does_not_report_synthetic_zero(monkeypatch, tmp_path):
+    monkeypatch.setenv("RENDER", "true")
+    monkeypatch.setenv("NIJA_RENDER_READINESS_STATE_FILE", str(tmp_path / "missing.json"))
+    monkeypatch.setenv("NIJA_REQUIRED_LIVE_VENUES", "coinbase,okx")
+
+    ready, details = server._readiness()
+
+    assert ready is False
+    assert details["readiness_source"] == "safe_render_startup"
+    assert details["coinbase_activation_state"] == "unobserved"
+    assert details["coinbase_balance_observed"] == "0"
+    assert details["coinbase_funding_status"] == "unobserved"
+    assert details["coinbase_spendable_quote"] == "unobserved"
+    assert details["degraded_live_venues"] == ""
+
+
+def test_bridge_preserves_real_observed_coinbase_balance(monkeypatch):
+    monkeypatch.setenv("NIJA_COINBASE_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_COINBASE_FUNDING_STATUS", "funded")
+    monkeypatch.setenv("NIJA_COINBASE_SPENDABLE_QUOTE", "27.124880759")
+
+    payload = bridge._payload()
+
+    assert payload["coinbase_balance_observed"] == "1"
+    assert payload["coinbase_funding_status"] == "funded"
+    assert payload["coinbase_spendable_quote"] == "27.124880759"
+
+
+def test_bridge_rejects_stale_zero_before_balance_probe(monkeypatch):
+    monkeypatch.setenv("NIJA_COINBASE_BALANCE_OBSERVED", "0")
+    monkeypatch.setenv("NIJA_COINBASE_FUNDING_STATUS", "observed_zero")
+    monkeypatch.setenv("NIJA_COINBASE_SPENDABLE_QUOTE", "0")
+
+    payload = bridge._payload()
+
+    assert payload["coinbase_balance_observed"] == "0"
+    assert payload["coinbase_funding_status"] == "unobserved"
+    assert payload["coinbase_spendable_quote"] == "unobserved"
+
+
+def test_observed_zero_remains_a_real_zero(monkeypatch):
+    monkeypatch.setenv("NIJA_COINBASE_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_COINBASE_FUNDING_STATUS", "observed_zero")
+    monkeypatch.setenv("NIJA_COINBASE_SPENDABLE_QUOTE", "0")
+
+    payload = bridge._payload()
+
+    assert payload["coinbase_balance_observed"] == "1"
+    assert payload["coinbase_funding_status"] == "observed_zero"
+    assert payload["coinbase_spendable_quote"] == "0"

--- a/render_liveness_server.py
+++ b/render_liveness_server.py
@@ -119,15 +119,23 @@ def _environment_snapshot() -> dict[str, Any]:
         "coinbase_trading_ready": os.environ.get(
             "NIJA_COINBASE_TRADING_READY", "0"
         ),
+        "coinbase_balance_observed": os.environ.get(
+            "NIJA_COINBASE_BALANCE_OBSERVED", "0"
+        ),
+        "coinbase_funding_status": os.environ.get(
+            "NIJA_COINBASE_FUNDING_STATUS", "unobserved"
+        ),
         "coinbase_spendable_quote": os.environ.get(
-            "NIJA_COINBASE_SPENDABLE_QUOTE", "0"
+            "NIJA_COINBASE_SPENDABLE_QUOTE", "unobserved"
         ),
         "okx_activation_state": os.environ.get(
             "NIJA_OKX_ACTIVATION_STATE", "unknown"
         ),
         "okx_connected": os.environ.get("NIJA_OKX_CONNECTED", "0"),
         "okx_trading_ready": os.environ.get("NIJA_OKX_TRADING_READY", "0"),
-        "okx_spendable_quote": os.environ.get("NIJA_OKX_SPENDABLE_QUOTE", "0"),
+        "okx_balance_observed": os.environ.get("NIJA_OKX_BALANCE_OBSERVED", "0"),
+        "okx_funding_status": os.environ.get("NIJA_OKX_FUNDING_STATUS", "unobserved"),
+        "okx_spendable_quote": os.environ.get("NIJA_OKX_SPENDABLE_QUOTE", "unobserved"),
         "commit": os.environ.get("GIT_COMMIT_SHORT", "unknown"),
     }
 
@@ -147,15 +155,19 @@ def _safe_render_startup_snapshot() -> dict[str, Any]:
         "required_venues": required,
         "required_venues_missing": required,
         "active_live_venues": "",
-        "degraded_live_venues": required,
-        "coinbase_activation_state": "unknown",
+        "degraded_live_venues": "",
+        "coinbase_activation_state": "unobserved",
         "coinbase_connected": "0",
         "coinbase_trading_ready": "0",
-        "coinbase_spendable_quote": "0",
-        "okx_activation_state": "unknown",
+        "coinbase_balance_observed": "0",
+        "coinbase_funding_status": "unobserved",
+        "coinbase_spendable_quote": "unobserved",
+        "okx_activation_state": "unobserved",
         "okx_connected": "0",
         "okx_trading_ready": "0",
-        "okx_spendable_quote": "0",
+        "okx_balance_observed": "0",
+        "okx_funding_status": "unobserved",
+        "okx_spendable_quote": "unobserved",
         "commit": os.environ.get("GIT_COMMIT_SHORT", "unknown"),
     }
 
@@ -227,11 +239,15 @@ def _readiness() -> tuple[bool, dict[str, object]]:
         ),
         "coinbase_connected": snapshot.get("coinbase_connected", "0"),
         "coinbase_trading_ready": snapshot.get("coinbase_trading_ready", "0"),
-        "coinbase_spendable_quote": snapshot.get("coinbase_spendable_quote", "0"),
+        "coinbase_balance_observed": snapshot.get("coinbase_balance_observed", "0"),
+        "coinbase_funding_status": snapshot.get("coinbase_funding_status", "unobserved"),
+        "coinbase_spendable_quote": snapshot.get("coinbase_spendable_quote", "unobserved"),
         "okx_activation_state": snapshot.get("okx_activation_state", "unknown"),
         "okx_connected": snapshot.get("okx_connected", "0"),
         "okx_trading_ready": snapshot.get("okx_trading_ready", "0"),
-        "okx_spendable_quote": snapshot.get("okx_spendable_quote", "0"),
+        "okx_balance_observed": snapshot.get("okx_balance_observed", "0"),
+        "okx_funding_status": snapshot.get("okx_funding_status", "unobserved"),
+        "okx_spendable_quote": snapshot.get("okx_spendable_quote", "unobserved"),
         "readiness_source": source,
         "shared_state_status": shared_status,
         "shared_state_age_seconds": round(age, 3) if age is not None else None,

--- a/render_readiness_state_bridge.py
+++ b/render_readiness_state_bridge.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("nija.render_readiness_bridge")
-_MARKER = "20260714c"
+_MARKER = "20260717a"
 _LOCK = threading.RLock()
 _INSTALLED = False
 _THREAD: threading.Thread | None = None
@@ -63,9 +63,29 @@ def _global_ready() -> str:
     return "1" if active else "0"
 
 
+def _observed_balance_fields(prefix: str) -> tuple[str, str, str]:
+    observed = "1" if _truthy(os.environ.get(f"NIJA_{prefix}_BALANCE_OBSERVED", "0")) else "0"
+    funding_status = str(
+        os.environ.get(f"NIJA_{prefix}_FUNDING_STATUS", "unobserved") or "unobserved"
+    ).strip().lower()
+    spendable = str(os.environ.get(f"NIJA_{prefix}_SPENDABLE_QUOTE", "") or "").strip()
+    if observed != "1":
+        # Do not publish a synthetic zero before the broker has authenticated and
+        # completed a real balance probe. Zero is a valid observed balance and must
+        # remain distinguishable from an unknown startup state.
+        spendable = "unobserved"
+        if funding_status in {"", "unknown", "observed_zero", "funded"}:
+            funding_status = "unobserved"
+    elif not spendable:
+        spendable = "0"
+    return observed, funding_status, spendable
+
+
 def _payload() -> dict[str, Any]:
     missing = _required_missing()
     global_ready = _global_ready()
+    cb_observed, cb_funding, cb_spendable = _observed_balance_fields("COINBASE")
+    okx_observed, okx_funding, okx_spendable = _observed_balance_fields("OKX")
     return {
         "timestamp": time.time(),
         "pid": os.getpid(),
@@ -91,15 +111,17 @@ def _payload() -> dict[str, Any]:
         "coinbase_trading_ready": os.environ.get(
             "NIJA_COINBASE_TRADING_READY", "0"
         ),
-        "coinbase_spendable_quote": os.environ.get(
-            "NIJA_COINBASE_SPENDABLE_QUOTE", "0"
-        ),
+        "coinbase_balance_observed": cb_observed,
+        "coinbase_funding_status": cb_funding,
+        "coinbase_spendable_quote": cb_spendable,
         "okx_activation_state": os.environ.get(
             "NIJA_OKX_ACTIVATION_STATE", "unknown"
         ),
         "okx_connected": os.environ.get("NIJA_OKX_CONNECTED", "0"),
         "okx_trading_ready": os.environ.get("NIJA_OKX_TRADING_READY", "0"),
-        "okx_spendable_quote": os.environ.get("NIJA_OKX_SPENDABLE_QUOTE", "0"),
+        "okx_balance_observed": okx_observed,
+        "okx_funding_status": okx_funding,
+        "okx_spendable_quote": okx_spendable,
         "commit": os.environ.get(
             "GIT_COMMIT_SHORT",
             os.environ.get("RENDER_GIT_COMMIT", "unknown")[:12],
@@ -176,4 +198,4 @@ def install() -> None:
         )
 
 
-__all__ = ["install", "publish_once", "_payload"]
+__all__ = ["install", "publish_once", "_payload", "_observed_balance_fields"]


### PR DESCRIPTION
## Root cause

Render starts the liveness server before the trading process publishes `/tmp/nija_render_readiness.json`. During that window, `safe_render_startup` substituted `coinbase_spendable_quote="0"`, which made an unobserved Coinbase account look like a confirmed zero/low balance.

## Fix

- represent pre-probe Coinbase and OKX balances as `unobserved`, not `0`
- publish explicit `balance_observed` and `funding_status` fields
- preserve a genuine broker-reported zero when a completed balance probe confirms it
- stop listing an unprobed secondary venue as degraded solely because startup state is missing
- retain fail-closed `/readyz` behavior until writer authority and a live venue are confirmed

## Validation

Added four regression tests covering cold startup, a real funded Coinbase balance, stale synthetic zero suppression, and a genuine observed zero.

This changes readiness diagnostics only. It does not bypass Coinbase authentication, broker-local cash validation, order minimums, or execution safeguards.