### PR TITLE
Include startup handoff patch in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -108,6 +108,7 @@ scripts/*
 !scripts/production_bootstrap.sh
 !scripts/three_venue_config_check.py
 !scripts/render_entrypoint.sh
+!scripts/apply_startup_handoff_fix.py
 check_*.py
 verify_*.py
 validate_*.py


### PR DESCRIPTION
## What changed
- Added `!scripts/apply_startup_handoff_fix.py` to `.dockerignore`.

## Root cause
The repository contained the startup handoff patch, but `.dockerignore` excluded all `scripts/*` files except a small allowlist. Docker therefore removed `scripts/apply_startup_handoff_fix.py` from the build context, causing the build to fail with `No such file or directory`.

## Result
The existing Dockerfile step can now execute the patch script and continue to shell syntax validation and image compilation.