### PR TITLE
Fix import-smoke post-job cache failure

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: pip
 
       - name: Install focused smoke dependencies
         shell: bash


### PR DESCRIPTION
## Fix

- Remove the nonessential `setup-python` pip cache from the import-smoke workflow.
- Keep the focused `pytest + numpy` dependency set, runtime-hook defer flag, production package transformation, and fail-closed import test.

## Root cause

The import tests completed successfully, but the workflow was marked failed afterward by the setup-python cache post step. The cache does not affect correctness and is unnecessary for this small focused dependency set.

## Expected result

The import-smoke job should complete successfully after all import tests pass, with no failing post-job cache cleanup.