### PR TITLE
Recover runtime authority after broker bootstrap

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -10,9 +10,11 @@ on:
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - ".github/workflows/runtime-repair-regression.yml"
   push:
     branches: [main]
@@ -24,9 +26,11 @@ on:
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - ".github/workflows/runtime-repair-regression.yml"
 
 permissions:
@@ -35,17 +39,21 @@ permissions:
 jobs:
   focused-runtime-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PYTHONPATH: .
+      NIJA_DEFER_RUNTIME_SITE_HOOKS: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up production Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install pytest
-        run: python -m pip install --disable-pip-version-check pytest
+        run: python -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest==8.2.2
 
       - name: Compile repaired runtime modules
         run: |
@@ -54,6 +62,7 @@ jobs:
             bot/strategy_runtime_integrity_patch.py \
             bot/disconnected_coinbase_balance_guard_patch.py \
             bot/okx_patch_churn_guard_patch.py \
+            bot/live_active_dispatch_bridge_patch.py \
             bot/bot.py
 
       - name: Run focused regression suite
@@ -62,4 +71,5 @@ jobs:
             bot/tests/test_critical_runtime_repairs_v10.py \
             bot/tests/test_strategy_runtime_integrity_patch.py \
             bot/tests/test_disconnected_coinbase_balance_guard_patch.py \
-            bot/tests/test_okx_patch_churn_guard_patch.py
+            bot/tests/test_okx_patch_churn_guard_patch.py \
+            bot/tests/test_live_active_dispatch_bridge_recovery.py

--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -2,9 +2,18 @@
 
 This patch closes the gap where startup reaches live writer authority and the
 TradingStateMachine reaches LIVE_ACTIVE, but no TradingLoop thread is actually
-started. It does not relax order admission, does not set operator override flags,
-and does not create a second strategy. It only dispatches an already-published
-TradingStrategy after strict live writer authority is present.
+started. It does not relax order admission, set operator overrides, or create a
+second strategy. It starts an already-published TradingStrategy only after the
+canonical distributed writer lease, runtime execution authority, and LIVE_ACTIVE
+state are all present.
+
+The bridge also repairs a deferred-startup deadlock observed in production:
+``activation_pending_commit_monitor_patch`` historically waited only for
+``multi_account_broker_manager`` even when the active runtime loaded
+``bot.broker_manager``/``bot.broker_integration``. Once a canonical broker
+surface is loaded, this module invokes the existing idempotent startup-repair
+installer. Those installers remain fail-closed and retain their own authority,
+capital, kill-switch, nonce, and execution checks.
 """
 
 from __future__ import annotations
@@ -23,6 +32,14 @@ _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _STARTED = False
 _START_LOCK = threading.Lock()
 _THREAD_NAMES = {"TradingLoop", "nija-trading-loop"}
+_BROKER_MODULE_NAMES = (
+    "bot.multi_account_broker_manager",
+    "multi_account_broker_manager",
+    "bot.broker_manager",
+    "broker_manager",
+    "bot.broker_integration",
+    "broker_integration",
+)
 
 
 def _truthy(name: str, default: bool = False) -> bool:
@@ -33,21 +50,49 @@ def _truthy(name: str, default: bool = False) -> bool:
 
 
 def _live_mode() -> bool:
-    return _truthy("LIVE_CAPITAL_VERIFIED", False) and not _truthy("DRY_RUN_MODE", False) and not _truthy("PAPER_MODE", False)
+    return (
+        _truthy("LIVE_CAPITAL_VERIFIED", False)
+        and not _truthy("DRY_RUN_MODE", False)
+        and not _truthy("PAPER_MODE", False)
+    )
+
+
+def _writer_authority_snapshot() -> dict[str, Any]:
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip()
+    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")).strip()
+    lease_flag = _truthy("NIJA_WRITER_LEASE_ACQUIRED", False)
+    lease = bool(lease_flag or token)
+    runtime_auth = _truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY", False)
+    heartbeat_active = _truthy("NIJA_WRITER_HEARTBEAT_ACTIVE", False)
+    return {
+        "token": token,
+        "token_present": bool(token),
+        "generation": generation,
+        "generation_present": bool(generation),
+        "lease_flag": lease_flag,
+        "lease": lease,
+        "runtime_auth": runtime_auth,
+        "heartbeat_active": heartbeat_active,
+        "ready": bool(token and generation and lease),
+    }
 
 
 def _has_writer_authority() -> bool:
-    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip()
-    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")).strip()
-    lease = _truthy("NIJA_WRITER_LEASE_ACQUIRED", False) or bool(token)
-    runtime_auth = _truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY", False)
-    return bool(token and generation and lease and runtime_auth)
+    """Return distributed writer-lease readiness, excluding runtime state."""
+
+    return bool(_writer_authority_snapshot()["ready"])
+
+
+def _runtime_execution_authority() -> bool:
+    return bool(_writer_authority_snapshot()["runtime_auth"])
 
 
 def _loop_thread_running() -> bool:
     for thread in threading.enumerate():
         try:
-            if thread.is_alive() and (thread.name in _THREAD_NAMES or "TradingLoop" in thread.name):
+            if thread.is_alive() and (
+                thread.name in _THREAD_NAMES or "TradingLoop" in thread.name
+            ):
                 return True
         except Exception:
             continue
@@ -70,8 +115,132 @@ def _state_machine_live_active() -> bool:
             if state_value == "LIVE_ACTIVE":
                 return True
         except Exception as exc:
-            logger.debug("LIVE_ACTIVE probe skipped module=%s err=%s", module_name, exc)
-    return str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip() == "LIVE_ACTIVE"
+            logger.debug(
+                "LIVE_ACTIVE probe skipped module=%s err=%s", module_name, exc
+            )
+    return (
+        str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip()
+        == "LIVE_ACTIVE"
+    )
+
+
+def _broker_bootstrap_loaded() -> tuple[bool, str]:
+    """Observe canonical broker modules without importing them ahead of startup."""
+
+    for name in _BROKER_MODULE_NAMES:
+        module = sys.modules.get(name)
+        if module is None:
+            continue
+        if name.endswith("broker_manager"):
+            return True, name
+        for attr in (
+            "BrokerManager",
+            "MultiAccountBrokerManager",
+            "KrakenBroker",
+            "CoinbaseBroker",
+            "OKXBroker",
+            "KrakenBrokerAdapter",
+            "CoinbaseBrokerAdapter",
+            "OKXBrokerAdapter",
+        ):
+            if hasattr(module, attr):
+                return True, f"{name}.{attr}"
+    return False, "not_loaded"
+
+
+def _ensure_deferred_startup_repairs() -> tuple[bool, str]:
+    """Install the existing deferred repair set after any canonical broker loads."""
+
+    broker_loaded, broker_source = _broker_bootstrap_loaded()
+    if not broker_loaded:
+        return False, "broker_bootstrap_not_loaded"
+
+    module = None
+    for module_name in (
+        "bot.activation_pending_commit_monitor_patch",
+        "activation_pending_commit_monitor_patch",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            break
+        except Exception:
+            continue
+    if module is None:
+        return False, "activation_pending_monitor_unavailable"
+
+    ready_event = getattr(module, "_STARTUP_REPAIRS_READY", None)
+    if ready_event is not None and bool(getattr(ready_event, "is_set", lambda: False)()):
+        return True, "already_ready"
+
+    installer = getattr(module, "_install_startup_execution_repairs", None)
+    if not callable(installer):
+        return False, "startup_repair_installer_unavailable"
+
+    try:
+        complete = bool(installer())
+    except Exception as exc:
+        logger.warning(
+            "LIVE_ACTIVE_DISPATCH_BRIDGE_STARTUP_REPAIRS_FAILED "
+            "broker_source=%s err=%s",
+            broker_source,
+            exc,
+            exc_info=True,
+        )
+        return False, f"installer_error:{type(exc).__name__}:{exc}"
+
+    logger.warning(
+        "LIVE_ACTIVE_DISPATCH_BRIDGE_STARTUP_REPAIRS_TRIGGERED "
+        "broker_source=%s complete=%s",
+        broker_source,
+        complete,
+    )
+    return complete, "installed" if complete else "incomplete"
+
+
+def _attempt_runtime_convergence(source: str) -> tuple[bool, str]:
+    """Invoke the normal convergence repair; never force state or authority."""
+
+    if not _has_writer_authority():
+        return False, "writer_authority_missing"
+
+    module = None
+    for module_name in (
+        "bot.runtime_authority_convergence_repair_patch",
+        "runtime_authority_convergence_repair_patch",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            break
+        except Exception:
+            continue
+    if module is None:
+        return False, "runtime_convergence_module_unavailable"
+
+    installer = getattr(module, "install_import_hook", None)
+    if callable(installer):
+        try:
+            installer()
+        except Exception as exc:
+            return False, f"runtime_convergence_install_failed:{exc}"
+
+    converge = getattr(module, "converge_runtime_authority", None)
+    if not callable(converge):
+        return False, "runtime_convergence_callable_unavailable"
+
+    try:
+        changed = bool(converge(source))
+    except Exception as exc:
+        logger.warning(
+            "LIVE_ACTIVE_DISPATCH_BRIDGE_RUNTIME_CONVERGENCE_FAILED "
+            "source=%s err=%s",
+            source,
+            exc,
+            exc_info=True,
+        )
+        return False, f"runtime_convergence_error:{type(exc).__name__}:{exc}"
+
+    ready = _runtime_execution_authority() and _state_machine_live_active()
+    return ready, "ready" if ready else ("changed" if changed else "waiting")
 
 
 def _dispatch_allowed() -> Tuple[bool, str]:
@@ -79,6 +248,8 @@ def _dispatch_allowed() -> Tuple[bool, str]:
         return False, "not_live_mode"
     if not _has_writer_authority():
         return False, "writer_authority_missing"
+    if not _runtime_execution_authority():
+        return False, "runtime_execution_authority_missing"
     if not _state_machine_live_active():
         return False, "state_not_live_active"
     if _loop_thread_running():
@@ -110,7 +281,11 @@ def _strategy_class() -> Optional[type]:
             if isinstance(cls, type):
                 return cls
         except Exception as exc:
-            logger.debug("TradingStrategy class probe skipped module=%s err=%s", module_name, exc)
+            logger.debug(
+                "TradingStrategy class probe skipped module=%s err=%s",
+                module_name,
+                exc,
+            )
     return None
 
 
@@ -173,7 +348,10 @@ def _set_start_gate() -> None:
             ready = getattr(module, "TRADING_ENGINE_READY", None)
             if ready is not None and callable(getattr(ready, "set", None)):
                 ready.set()
-                logger.warning("LIVE_ACTIVE_DISPATCH_BRIDGE_START_GATE_SET module=%s", module_name)
+                logger.warning(
+                    "LIVE_ACTIVE_DISPATCH_BRIDGE_START_GATE_SET module=%s",
+                    module_name,
+                )
                 return
         except Exception as exc:
             logger.debug("start gate set skipped module=%s err=%s", module_name, exc)
@@ -187,7 +365,9 @@ def _start_trading_loop(strategy: Any, source: str) -> bool:
         return True
     with _START_LOCK:
         if _loop_thread_running():
-            logger.warning("LIVE_ACTIVE_DISPATCH_BRIDGE_ALREADY_RUNNING source=%s", source)
+            logger.warning(
+                "LIVE_ACTIVE_DISPATCH_BRIDGE_ALREADY_RUNNING source=%s", source
+            )
             return True
         try:
             module = importlib.import_module("bot.nija_core_loop")
@@ -195,18 +375,24 @@ def _start_trading_loop(strategy: Any, source: str) -> bool:
             module = importlib.import_module("nija_core_loop")
         starter = getattr(module, "start_trading_engine", None)
         if not callable(starter):
-            logger.error("LIVE_ACTIVE_DISPATCH_BRIDGE_START_FAILED reason=start_trading_engine_unavailable")
+            logger.error(
+                "LIVE_ACTIVE_DISPATCH_BRIDGE_START_FAILED "
+                "reason=start_trading_engine_unavailable"
+            )
             return False
         _set_start_gate()
         logger.critical(
-            "LIVE_ACTIVE_DISPATCH_BRIDGE_STARTING strategy_source=%s strategy_type=%s token_prefix=%s generation=%s",
+            "LIVE_ACTIVE_DISPATCH_BRIDGE_STARTING strategy_source=%s "
+            "strategy_type=%s token_prefix=%s generation=%s",
             source,
             type(strategy).__name__,
             str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", ""))[:8],
             os.environ.get("NIJA_WRITER_LEASE_GENERATION", ""),
         )
         thread = starter(strategy)
-        alive = bool(thread is not None and getattr(thread, "is_alive", lambda: False)())
+        alive = bool(
+            thread is not None and getattr(thread, "is_alive", lambda: False)()
+        )
         logger.critical(
             "LIVE_ACTIVE_DISPATCH_BRIDGE_STARTED_THREAD name=%s alive=%s ident=%s",
             getattr(thread, "name", "none"),
@@ -217,39 +403,88 @@ def _start_trading_loop(strategy: Any, source: str) -> bool:
 
 
 def _monitor() -> None:
-    interval = max(1.0, float(os.environ.get("NIJA_LIVE_DISPATCH_BRIDGE_INTERVAL_S", "3") or 3.0))
-    warn_every = max(5.0, float(os.environ.get("NIJA_LIVE_DISPATCH_BRIDGE_LOG_INTERVAL_S", "15") or 15.0))
+    interval = max(
+        1.0,
+        float(os.environ.get("NIJA_LIVE_DISPATCH_BRIDGE_INTERVAL_S", "3") or 3.0),
+    )
+    warn_every = max(
+        5.0,
+        float(
+            os.environ.get("NIJA_LIVE_DISPATCH_BRIDGE_LOG_INTERVAL_S", "15")
+            or 15.0
+        ),
+    )
     last_log = 0.0
     logger.warning("LIVE_ACTIVE_DISPATCH_BRIDGE_STARTED interval_s=%.1f", interval)
+
     while True:
         try:
+            repairs_ready, repair_detail = _ensure_deferred_startup_repairs()
+
+            if _has_writer_authority() and (
+                not _runtime_execution_authority()
+                or not _state_machine_live_active()
+            ):
+                convergence_ready, convergence_detail = _attempt_runtime_convergence(
+                    "live_active_dispatch_bridge"
+                )
+            else:
+                convergence_ready = bool(
+                    _runtime_execution_authority() and _state_machine_live_active()
+                )
+                convergence_detail = "not_needed" if convergence_ready else "waiting"
+
             allowed, reason = _dispatch_allowed()
             now = time.time()
             if not allowed:
                 if reason == "trading_loop_already_running":
                     return
                 if now - last_log >= warn_every:
+                    writer = _writer_authority_snapshot()
+                    broker_loaded, broker_source = _broker_bootstrap_loaded()
                     logger.warning(
-                        "LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=%s live=%s writer_authority=%s live_active=%s threads=%s",
+                        "LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=%s live=%s "
+                        "writer_authority=%s token=%s generation=%s lease=%s "
+                        "heartbeat=%s runtime_auth=%s live_active=%s "
+                        "broker_loaded=%s broker_source=%s repairs_ready=%s "
+                        "repair_detail=%s convergence_ready=%s "
+                        "convergence_detail=%s threads=%s",
                         reason,
                         _live_mode(),
-                        _has_writer_authority(),
+                        writer["ready"],
+                        writer["token_present"],
+                        writer["generation"] or "missing",
+                        writer["lease"],
+                        writer["heartbeat_active"],
+                        writer["runtime_auth"],
                         _state_machine_live_active(),
+                        broker_loaded,
+                        broker_source,
+                        repairs_ready,
+                        repair_detail,
+                        convergence_ready,
+                        convergence_detail,
                         [t.name for t in threading.enumerate() if t.is_alive()],
                     )
                     last_log = now
                 time.sleep(interval)
                 continue
+
             strategy, source = _find_strategy()
             if strategy is None:
                 if now - last_log >= warn_every:
                     logger.critical(
-                        "LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=no_strategy live_active=True writer_authority=True modules=%s",
-                        sorted(str(getattr(m, "__name__", "")) for m in _module_candidates()),
+                        "LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=no_strategy "
+                        "live_active=True writer_authority=True modules=%s",
+                        sorted(
+                            str(getattr(m, "__name__", ""))
+                            for m in _module_candidates()
+                        ),
                     )
                     last_log = now
                 time.sleep(interval)
                 continue
+
             if _start_trading_loop(strategy, source):
                 return
             time.sleep(interval)
@@ -263,6 +498,23 @@ def install_import_hook() -> None:
     if _STARTED:
         return
     _STARTED = True
-    thread = threading.Thread(target=_monitor, name="live-active-dispatch-bridge", daemon=True)
+    thread = threading.Thread(
+        target=_monitor,
+        name="live-active-dispatch-bridge",
+        daemon=True,
+    )
     thread.start()
-    logger.warning("LIVE_ACTIVE_DISPATCH_BRIDGE_INSTALL_COMPLETE thread_alive=%s", thread.is_alive())
+    logger.warning(
+        "LIVE_ACTIVE_DISPATCH_BRIDGE_INSTALL_COMPLETE thread_alive=%s",
+        thread.is_alive(),
+    )
+
+
+__all__ = [
+    "install_import_hook",
+    "_broker_bootstrap_loaded",
+    "_ensure_deferred_startup_repairs",
+    "_attempt_runtime_convergence",
+    "_dispatch_allowed",
+    "_writer_authority_snapshot",
+]

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "bot" / "live_active_dispatch_bridge_patch.py"
+    spec = importlib.util.spec_from_file_location(
+        "nija_test_live_active_dispatch_bridge_recovery", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_broker_bootstrap_accepts_active_broker_manager_alias(monkeypatch) -> None:
+    module = _load_module()
+    for name in module._BROKER_MODULE_NAMES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    broker_manager = ModuleType("bot.broker_manager")
+    broker_manager.OKXBroker = type("OKXBroker", (), {})
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", broker_manager)
+
+    loaded, source = module._broker_bootstrap_loaded()
+
+    assert loaded is True
+    assert source == "bot.broker_manager"
+
+
+def test_deferred_repairs_install_after_broker_manager_load(monkeypatch) -> None:
+    module = _load_module()
+    for name in module._BROKER_MODULE_NAMES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    broker_manager = ModuleType("bot.broker_manager")
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", broker_manager)
+
+    ready_event = threading.Event()
+    activation = ModuleType("bot.activation_pending_commit_monitor_patch")
+    activation._STARTUP_REPAIRS_READY = ready_event
+    calls: list[str] = []
+
+    def install() -> bool:
+        calls.append("install")
+        ready_event.set()
+        return True
+
+    activation._install_startup_execution_repairs = install
+    monkeypatch.setitem(
+        sys.modules, "bot.activation_pending_commit_monitor_patch", activation
+    )
+
+    ready, detail = module._ensure_deferred_startup_repairs()
+
+    assert ready is True
+    assert detail == "installed"
+    assert calls == ["install"]
+
+
+def test_writer_authority_is_separate_from_runtime_authority(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "123")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+    monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
+    monkeypatch.setattr(module, "_state_machine_live_active", lambda: False)
+
+    snapshot = module._writer_authority_snapshot()
+    allowed, reason = module._dispatch_allowed()
+
+    assert snapshot["ready"] is True
+    assert snapshot["runtime_auth"] is False
+    assert allowed is False
+    assert reason == "runtime_execution_authority_missing"
+
+
+def test_runtime_convergence_uses_existing_fail_closed_repair(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "123")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    convergence = ModuleType("bot.runtime_authority_convergence_repair_patch")
+    calls: list[str] = []
+
+    def install_import_hook() -> None:
+        calls.append("install")
+
+    def converge(source: str) -> bool:
+        calls.append(source)
+        monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+        monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+        return True
+
+    convergence.install_import_hook = install_import_hook
+    convergence.converge_runtime_authority = converge
+    monkeypatch.setitem(
+        sys.modules, "bot.runtime_authority_convergence_repair_patch", convergence
+    )
+    monkeypatch.setattr(
+        module,
+        "_state_machine_live_active",
+        lambda: module._truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY")
+        and module.os.environ.get("NIJA_RUNTIME_TRADING_STATE") == "LIVE_ACTIVE",
+    )
+
+    ready, detail = module._attempt_runtime_convergence("test")
+
+    assert ready is True
+    assert detail == "ready"
+    assert calls == ["install", "test"]


### PR DESCRIPTION
## Root cause

The deployed process acquired the Redis writer lease and kept the `entrypoint-writer-lock-heartbeat` thread alive, but the live dispatch bridge continued reporting `writer_authority_missing` and `live_active=False`.

The deferred startup-repair worker only recognized `multi_account_broker_manager`. The active deployment loaded `bot.broker_manager` and `bot.broker_integration`, so the worker never installed the remaining startup repairs, including `runtime_authority_convergence_repair_patch`. As a result, the writer lease existed while runtime execution authority and `LIVE_ACTIVE` were never published.

## Changes

- Recognize all canonical broker bootstrap surfaces: `multi_account_broker_manager`, `broker_manager`, and `broker_integration`, including `bot.*` aliases.
- Trigger the existing idempotent deferred startup-repair installer once a canonical broker surface is loaded.
- Invoke the existing fail-closed runtime-authority convergence path when the distributed writer lease is present but runtime authority or `LIVE_ACTIVE` is missing.
- Separate writer-lease readiness from runtime execution authority in diagnostics.
- Add detailed recovery telemetry without bypassing Redis fencing, capital readiness, kill switches, nonce authority, or order admission.
- Add focused regression tests and run them on production Python 3.11.

## Expected deployment proof

The next deployment should show:

- `LIVE_ACTIVE_DISPATCH_BRIDGE_STARTUP_REPAIRS_TRIGGERED ...`
- `RUNTIME_AUTHORITY_CONVERGENCE_MONITOR_STARTED ...`
- `RUNTIME_AUTHORITY_CONVERGENCE_REPAIRED ...` when all normal gates are ready
- `LIVE_ACTIVE_DISPATCH_BRIDGE_STARTING ...`
- `LIVE_ACTIVE_DISPATCH_BRIDGE_STARTED_THREAD ... alive=True`

If a normal safety prerequisite is still missing, the enhanced waiting log will identify the exact lease, heartbeat, runtime-authority, state, broker, repair, and convergence status.