### PR TITLE
Prevent sitecustomize from starting runtime during shell preflight

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -109,6 +109,7 @@ scripts/*
 !scripts/three_venue_config_check.py
 !scripts/render_entrypoint.sh
 !scripts/apply_startup_handoff_fix.py
+!scripts/install_sitecustomize_defer_guard.py
 check_*.py
 verify_*.py
 validate_*.py

--- a/.github/workflows/entrypoint-writer-authority-tests.yml
+++ b/.github/workflows/entrypoint-writer-authority-tests.yml
@@ -11,6 +11,7 @@ on:
       - 'apply_bot_package_defer_fix.py'
       - 'scripts/production_bootstrap.sh'
       - 'scripts/apply_startup_handoff_fix.py'
+      - 'scripts/install_sitecustomize_defer_guard.py'
       - 'scripts/three_venue_config_check.py'
       - 'render_liveness_server.py'
       - 'render_readiness_state_bridge.py'
@@ -27,6 +28,7 @@ on:
       - 'bot/bot_main.py'
       - 'bot/tests/test_bot_package_defer_fix.py'
       - 'bot/tests/test_startup_handoff_all_fixes.py'
+      - 'bot/tests/test_sitecustomize_defer_guard.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -52,6 +54,7 @@ on:
       - 'apply_bot_package_defer_fix.py'
       - 'scripts/production_bootstrap.sh'
       - 'scripts/apply_startup_handoff_fix.py'
+      - 'scripts/install_sitecustomize_defer_guard.py'
       - 'scripts/three_venue_config_check.py'
       - 'render_liveness_server.py'
       - 'render_readiness_state_bridge.py'
@@ -68,6 +71,7 @@ on:
       - 'bot/bot_main.py'
       - 'bot/tests/test_bot_package_defer_fix.py'
       - 'bot/tests/test_startup_handoff_all_fixes.py'
+      - 'bot/tests/test_sitecustomize_defer_guard.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -136,6 +140,7 @@ jobs:
           ! grep -A3 'HEALTHCHECK' Dockerfile | grep -Fq 'import requests'
           grep -Fq 'python3 -S - "$1"' scripts/production_bootstrap.sh
           grep -Fq 'python3 -S - "$@"' scripts/production_bootstrap.sh
+          grep -Fq 'install_sitecustomize_defer_guard.py' Dockerfile
           grep -Fq 'apply_bot_package_defer_fix.py' Dockerfile
           grep -Fq 'apply_startup_handoff_fix.py' Dockerfile
 
@@ -143,6 +148,7 @@ jobs:
         run: |
           python -m py_compile \
             apply_bot_package_defer_fix.py \
+            scripts/install_sitecustomize_defer_guard.py \
             scripts/apply_startup_handoff_fix.py \
             render_liveness_server.py \
             render_readiness_state_bridge.py \
@@ -161,6 +167,8 @@ jobs:
 
       - name: Test bot package runtime defer
         run: python -m pytest -q bot/tests/test_bot_package_defer_fix.py
+      - name: Test sitecustomize runtime defer
+        run: python -m pytest -q bot/tests/test_sitecustomize_defer_guard.py
       - name: Test startup handoff ordering
         run: python -m pytest -q bot/tests/test_startup_handoff_all_fixes.py
       - name: Test three-venue readiness

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY scripts/ scripts/
 COPY . .
-RUN python -S /app/apply_bot_package_defer_fix.py && \
+RUN python -S /app/scripts/install_sitecustomize_defer_guard.py && \
+    python -S /app/apply_bot_package_defer_fix.py && \
     python -S /app/scripts/apply_startup_handoff_fix.py && \
     bash -n /app/start.sh && \
     bash -n /app/scripts/production_bootstrap.sh
@@ -15,6 +16,7 @@ RUN python -m py_compile \
         /app/main.py \
         /app/bot.py \
         /app/apply_bot_package_defer_fix.py \
+        /app/scripts/install_sitecustomize_defer_guard.py \
         /app/render_liveness_server.py \
         /app/render_readiness_state_bridge.py \
         /app/prebot_writer_authority_bootstrap.py \

--- a/bot/tests/test_sitecustomize_defer_guard.py
+++ b/bot/tests/test_sitecustomize_defer_guard.py
@@ -37,7 +37,7 @@ def test_deferred_python_does_not_execute_real_sitecustomize(tmp_path: Path) -> 
 
     if os.name == "nt":
         python = venv / "Scripts" / "python.exe"
-        site_packages = next((venv / "Lib" / "site-packages",), None)
+        site_packages = venv / "Lib" / "site-packages"
     else:
         python = venv / "bin" / "python"
         site_packages = next((venv / "lib").glob("python*/site-packages"))
@@ -52,24 +52,46 @@ def test_deferred_python_does_not_execute_real_sitecustomize(tmp_path: Path) -> 
     )
     module.install(site_packages=site_packages, app_root=str(app_root))
 
+    # Use -S and explicitly process only the test venv's site-packages. This
+    # avoids Ubuntu's distribution-level /usr/lib/.../sitecustomize.py from
+    # changing which module wins the normal-mode import in CI.
     env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
     env["NIJA_DEFER_RUNTIME_SITE_HOOKS"] = "1"
+    deferred_code = (
+        "import site,sys; "
+        f"site.addsitedir({str(site_packages)!r}); "
+        "mod=sys.modules.get('sitecustomize'); "
+        "print('stub=' + ('1' if mod is not None and not getattr(mod, '__file__', None) else '0'))"
+    )
     result = subprocess.run(
-        [python, "-c", "import sitecustomize; print(sitecustomize.__name__)"],
+        [python, "-S", "-c", deferred_code],
         env=env,
+        cwd=tmp_path,
         check=True,
         capture_output=True,
         text=True,
     )
-    assert result.stdout.strip() == "sitecustomize"
+    assert result.stdout.strip() == "stub=1"
     assert not marker.exists()
 
+    # With the defer flag absent, processing the same .pth file must not insert
+    # the stub. The real application sitecustomize remains importable and runs.
     env.pop("NIJA_DEFER_RUNTIME_SITE_HOOKS", None)
-    subprocess.run(
-        [python, "-c", "import sitecustomize"],
+    normal_code = (
+        "import importlib,site,sys; "
+        f"site.addsitedir({str(site_packages)!r}); "
+        "print('stub_before=' + ('1' if 'sitecustomize' in sys.modules else '0')); "
+        f"sys.path.insert(0, {str(app_root)!r}); "
+        "importlib.import_module('sitecustomize')"
+    )
+    result = subprocess.run(
+        [python, "-S", "-c", normal_code],
         env=env,
+        cwd=tmp_path,
         check=True,
         capture_output=True,
         text=True,
     )
+    assert result.stdout.strip() == "stub_before=0"
     assert marker.read_text(encoding="utf-8") == "ran"

--- a/bot/tests/test_sitecustomize_defer_guard.py
+++ b/bot/tests/test_sitecustomize_defer_guard.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = ROOT / "scripts" / "install_sitecustomize_defer_guard.py"
+
+
+def _load_installer():
+    spec = importlib.util.spec_from_file_location(
+        "install_sitecustomize_defer_guard", INSTALLER
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_guard_content_is_silent_and_flag_scoped() -> None:
+    module = _load_installer()
+    content = module.guard_content("/app")
+    assert content.startswith("/app\nimport os,sys,types;")
+    assert "NIJA_DEFER_RUNTIME_SITE_HOOKS" in content
+    assert 'sys.modules.setdefault("sitecustomize"' in content
+    assert "print(" not in content
+
+
+def test_deferred_python_does_not_execute_real_sitecustomize(tmp_path: Path) -> None:
+    module = _load_installer()
+    venv = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+
+    if os.name == "nt":
+        python = venv / "Scripts" / "python.exe"
+        site_packages = next((venv / "Lib" / "site-packages",), None)
+    else:
+        python = venv / "bin" / "python"
+        site_packages = next((venv / "lib").glob("python*/site-packages"))
+
+    app_root = tmp_path / "app"
+    app_root.mkdir()
+    marker = tmp_path / "sitecustomize-ran.txt"
+    (app_root / "sitecustomize.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('ran', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    module.install(site_packages=site_packages, app_root=str(app_root))
+
+    env = os.environ.copy()
+    env["NIJA_DEFER_RUNTIME_SITE_HOOKS"] = "1"
+    result = subprocess.run(
+        [python, "-c", "import sitecustomize; print(sitecustomize.__name__)"],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == "sitecustomize"
+    assert not marker.exists()
+
+    env.pop("NIJA_DEFER_RUNTIME_SITE_HOOKS", None)
+    subprocess.run(
+        [python, "-c", "import sitecustomize"],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert marker.read_text(encoding="utf-8") == "ran"

--- a/scripts/install_sitecustomize_defer_guard.py
+++ b/scripts/install_sitecustomize_defer_guard.py
@@ -1,0 +1,57 @@
+"""Install a Python startup guard for NIJA's deferred shell preflight.
+
+Python processes normally import ``sitecustomize`` after processing ``.pth``
+files. NIJA's shell preflight intentionally sets
+``NIJA_DEFER_RUNTIME_SITE_HOOKS=1`` so harmless validation commands cannot start
+writer, broker, activation, or execution monitors before ``main.py``. The
+existing .pth and ``bot.__init__`` guards did not stop Python's automatic
+``sitecustomize`` import.
+
+This installer creates an early .pth file that places a no-op ``sitecustomize``
+module in ``sys.modules`` only for deferred preflight processes. The canonical
+``main.py`` process starts after the flag is removed and therefore imports the
+real ``sitecustomize.py`` normally.
+"""
+
+from __future__ import annotations
+
+import site
+from pathlib import Path
+
+FILENAME = "0000_nija_sitecustomize_defer_guard.pth"
+DEFER_FLAG = "NIJA_DEFER_RUNTIME_SITE_HOOKS"
+
+
+def guard_content(app_root: str = "/app") -> str:
+    root = str(app_root or "/app").rstrip("/") or "/app"
+    code = (
+        'import os,sys,types; '
+        f'os.environ.get("{DEFER_FLAG}", "0") == "1" and '
+        'sys.modules.setdefault("sitecustomize", types.ModuleType("sitecustomize"))'
+    )
+    return f"{root}\n{code}\n"
+
+
+def install(site_packages: Path | None = None, app_root: str = "/app") -> Path:
+    if site_packages is None:
+        candidates = site.getsitepackages()
+        if not candidates:
+            raise RuntimeError("Python site-packages directory not found")
+        site_packages = Path(candidates[0])
+    site_packages = Path(site_packages)
+    site_packages.mkdir(parents=True, exist_ok=True)
+    target = site_packages / FILENAME
+    target.write_text(guard_content(app_root), encoding="utf-8")
+    return target
+
+
+def main() -> None:
+    target = install()
+    print(
+        "NIJA_SITECUSTOMIZE_DEFER_GUARD_INSTALLED "
+        f"path={target} flag={DEFER_FLAG}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Root cause

The new Render deployment reached `STARTUP_HANDOFF_PREFLIGHT_BEGIN` but did not reach `STARTUP_HANDOFF_REDIS_VALIDATION_COMPLETE` or `STARTUP_HANDOFF_RUNTIME_BEGIN`. A Python preflight process then started `activation_pending_commit_monitor`, proving runtime hooks were still activating before `main.py`.

The existing defer protections covered Docker `.pth` hook bodies and `bot/__init__.py`, but Python automatically imports `sitecustomize.py` after processing `.pth` files. NIJA's `sitecustomize.py` unconditionally installs activation, dispatch, risk, execution, and broker patches, so a harmless `$PY` validation command could start the runtime stack and stall the shell handoff.

## Fix

- Install an early `0000_nija_sitecustomize_defer_guard.pth` file in the production image.
- When `NIJA_DEFER_RUNTIME_SITE_HOOKS=1`, the guard places a no-op `sitecustomize` module in the current preflight process only.
- When `start.sh` removes the defer flag before `main.py`, Python imports the real `sitecustomize.py` and the full runtime stack normally.
- Add an integration test using an isolated virtual environment to prove the real `sitecustomize` is skipped only during deferred preflight and executes normally afterward.
- Wire the installer and test into NIJA Deployment Safety and production compilation.

## Safety

This does not bypass Redis, writer fencing, broker authentication, capital hydration, kill switches, risk controls, order admission, or exit protections. It only prevents those runtime systems from being started by non-runtime validation interpreters before the canonical `main.py` process.

## Expected deployment sequence

```text
STARTUP_HANDOFF_PREFLIGHT_BEGIN runtime_site_hooks=deferred
STARTUP_HANDOFF_REDIS_VALIDATION_COMPLETE
STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=main.py runtime_site_hooks=enabled
```

The activation-pending monitor should not emit before `STARTUP_HANDOFF_RUNTIME_BEGIN`.