### PR TITLE
Recover runtime release after late Phase 3 replacement

### DIFF
--- a/.github/workflows/entrypoint-writer-authority-tests.yml
+++ b/.github/workflows/entrypoint-writer-authority-tests.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
-            if python -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest redis requests; then
+            if env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest redis requests; then
               exit 0
             fi
             if [ "$attempt" -lt 3 ]; then

--- a/.github/workflows/entrypoint-writer-authority-tests.yml
+++ b/.github/workflows/entrypoint-writer-authority-tests.yml
@@ -18,17 +18,21 @@ on:
       - 'prebot_writer_authority_bootstrap.py'
       - 'prebot_writer_authority_fail_closed.py'
       - 'source_runtime_guard_bootstrap.py'
+      - 'scan_wrapper_depth_convergence_patch.py'
       - 'three_venue_execution_readiness.py'
       - 'import_hook_recursion_shield_patch.py'
       - 'secondary_venue_activation_patch.py'
       - 'secondary_venue_strict_readiness_patch.py'
       - 'bot/activation_pending_commit_monitor_patch.py'
+      - 'bot/zero_signal_streak_state_repair_patch.py'
       - 'bot/writer_lock_release_guard.py'
       - 'bot/entrypoint_writer_authority.py'
       - 'bot/bot_main.py'
       - 'bot/tests/test_bot_package_defer_fix.py'
       - 'bot/tests/test_startup_handoff_all_fixes.py'
       - 'bot/tests/test_sitecustomize_defer_guard.py'
+      - 'bot/tests/test_scan_wrapper_depth_convergence_patch.py'
+      - 'bot/tests/test_zero_signal_streak_state_repair_patch.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -61,17 +65,21 @@ on:
       - 'prebot_writer_authority_bootstrap.py'
       - 'prebot_writer_authority_fail_closed.py'
       - 'source_runtime_guard_bootstrap.py'
+      - 'scan_wrapper_depth_convergence_patch.py'
       - 'three_venue_execution_readiness.py'
       - 'import_hook_recursion_shield_patch.py'
       - 'secondary_venue_activation_patch.py'
       - 'secondary_venue_strict_readiness_patch.py'
       - 'bot/activation_pending_commit_monitor_patch.py'
+      - 'bot/zero_signal_streak_state_repair_patch.py'
       - 'bot/writer_lock_release_guard.py'
       - 'bot/entrypoint_writer_authority.py'
       - 'bot/bot_main.py'
       - 'bot/tests/test_bot_package_defer_fix.py'
       - 'bot/tests/test_startup_handoff_all_fixes.py'
       - 'bot/tests/test_sitecustomize_defer_guard.py'
+      - 'bot/tests/test_scan_wrapper_depth_convergence_patch.py'
+      - 'bot/tests/test_zero_signal_streak_state_repair_patch.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -108,6 +116,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
 
       - name: Install focused test dependencies
         shell: bash
@@ -155,6 +166,8 @@ jobs:
             prebot_writer_authority_bootstrap.py \
             prebot_writer_authority_fail_closed.py \
             source_runtime_guard_bootstrap.py \
+            scan_wrapper_depth_convergence_patch.py \
+            bot/zero_signal_streak_state_repair_patch.py \
             three_venue_execution_readiness.py \
             import_hook_recursion_shield_patch.py \
             secondary_venue_activation_patch.py \
@@ -169,6 +182,10 @@ jobs:
         run: python -m pytest -q bot/tests/test_bot_package_defer_fix.py
       - name: Test sitecustomize runtime defer
         run: python -m pytest -q bot/tests/test_sitecustomize_defer_guard.py
+      - name: Test runtime release convergence repairs
+        run: |
+          python -m pytest -q bot/tests/test_scan_wrapper_depth_convergence_patch.py
+          python -m pytest -q bot/tests/test_zero_signal_streak_state_repair_patch.py
       - name: Test startup handoff ordering
         run: python -m pytest -q bot/tests/test_startup_handoff_all_fixes.py
       - name: Test three-venue readiness

--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -26,12 +26,15 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
+
       - name: Install focused smoke dependencies
         shell: bash
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
-            if python -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest==8.2.2 numpy==1.26.3; then
+            if env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest==8.2.2 numpy==1.26.3; then
               exit 0
             fi
             if [ "$attempt" -lt 3 ]; then

--- a/bot/tests/test_scan_wrapper_depth_convergence_patch.py
+++ b/bot/tests/test_scan_wrapper_depth_convergence_patch.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from functools import wraps
 from types import ModuleType
 
 import scan_wrapper_depth_convergence_patch as patch
+
+
+def _set_origin(func, filename: str):
+    func.__code__ = func.__code__.replace(co_filename=filename)
+    return func
 
 
 def _broker_wrapper(base):
@@ -10,7 +16,7 @@ def _broker_wrapper(base):
         return base(self, *args, **kwargs)
     setattr(wrapper, patch._BROKER_ATTR, True)
     wrapper.__wrapped__ = base
-    return wrapper
+    return _set_origin(wrapper, f"/app/bot/{patch._BROKER_OWNER_FILE}")
 
 
 def _canonical_wrapper(base):
@@ -18,7 +24,7 @@ def _canonical_wrapper(base):
         return base(self, *args, **kwargs)
     setattr(wrapper, patch._CANONICAL_RELEASE_ATTR, "20260714a")
     wrapper.__wrapped__ = base
-    return wrapper
+    return _set_origin(wrapper, f"/app/{patch._CANONICAL_OWNER_FILE}")
 
 
 def test_inspect_chain_counts_single_broker_and_canonical_layers():
@@ -31,6 +37,8 @@ def test_inspect_chain_counts_single_broker_and_canonical_layers():
     assert status["depth"] == 2
     assert status["broker_layers"] == 1
     assert status["canonical_layers"] == 1
+    assert status["raw_broker_markers"] == 1
+    assert status["raw_canonical_markers"] == 1
     assert status["cycle"] is False
 
 
@@ -44,6 +52,27 @@ def test_inspect_chain_detects_duplicate_broker_layers():
     assert status["broker_layers"] == 2
 
 
+def test_inspect_chain_ignores_markers_copied_by_wraps():
+    def leaf(self, *args, **kwargs):
+        return "ok"
+
+    canonical = _canonical_wrapper(_broker_wrapper(leaf))
+
+    @wraps(canonical)
+    def outer(self, *args, **kwargs):
+        return canonical(self, *args, **kwargs)
+
+    outer.__wrapped__ = canonical
+    status = patch.inspect_chain(outer)
+
+    # wraps copied both ownership marker attributes onto outer, but outer's code
+    # was not defined by either owner module.
+    assert status["raw_broker_markers"] == 2
+    assert status["raw_canonical_markers"] == 2
+    assert status["broker_layers"] == 1
+    assert status["canonical_layers"] == 1
+
+
 def test_inspect_chain_follows_legacy_closure_original():
     def leaf(self, *args, **kwargs):
         return "ok"
@@ -54,6 +83,7 @@ def test_inspect_chain_follows_legacy_closure_original():
         return original(self, *args, **kwargs)
 
     setattr(legacy, patch._BROKER_ATTR, True)
+    _set_origin(legacy, f"/app/bot/{patch._BROKER_OWNER_FILE}")
     status = patch.inspect_chain(legacy)
 
     assert status["depth"] == 1
@@ -107,6 +137,7 @@ def test_guarded_installer_repairs_wrapped_link_on_new_layer():
             return previous(self, *args, **kwargs)
 
         setattr(broker, patch._BROKER_ATTR, True)
+        _set_origin(broker, f"/app/bot/{patch._BROKER_OWNER_FILE}")
         core_module.NijaCoreLoop.run_scan_phase = broker
         return True
 

--- a/bot/tests/test_scan_wrapper_depth_convergence_patch.py
+++ b/bot/tests/test_scan_wrapper_depth_convergence_patch.py
@@ -65,9 +65,10 @@ def test_inspect_chain_ignores_markers_copied_by_wraps():
     outer.__wrapped__ = canonical
     status = patch.inspect_chain(outer)
 
-    # wraps copied both ownership marker attributes onto outer, but outer's code
-    # was not defined by either owner module.
-    assert status["raw_broker_markers"] == 2
+    # wraps copies the direct wrapped function's marker dictionary. The outer
+    # function therefore repeats the canonical marker, while the deeper broker
+    # marker remains present only on the broker wrapper that actually owns it.
+    assert status["raw_broker_markers"] == 1
     assert status["raw_canonical_markers"] == 2
     assert status["broker_layers"] == 1
     assert status["canonical_layers"] == 1

--- a/bot/tests/test_source_runtime_guard_bootstrap.py
+++ b/bot/tests/test_source_runtime_guard_bootstrap.py
@@ -88,6 +88,7 @@ def test_source_bootstrap_installs_current_guard_chain_in_order(monkeypatch):
     _reset_source_bootstrap(monkeypatch)
     calls: list[str] = []
     modules, expected = _fake_runtime_modules(calls)
+    expected.insert(expected.index("downstream_risk"), "zero_signal_state")
 
     real_import = source_bootstrap.importlib.import_module
     monkeypatch.setattr(
@@ -103,6 +104,7 @@ def test_source_bootstrap_installs_current_guard_chain_in_order(monkeypatch):
     assert source_bootstrap.install() is True
     assert source_bootstrap.install() is True
     assert calls == expected
+    assert calls.count("zero_signal_state") == 2
     assert calls.index("scan_depth") < calls.index("convergence")
     assert calls.index("scan_delegate") < calls.index("scan_clamp")
     assert calls.index("scan_owner") < calls.index("downstream_risk")

--- a/bot/tests/test_zero_signal_streak_state_repair_patch.py
+++ b/bot/tests/test_zero_signal_streak_state_repair_patch.py
@@ -21,7 +21,6 @@ def _module(observed):
             zero_signal_streak=0,
         ):
             observed.append((self._zero_signal_streak, zero_signal_streak))
-            # Mirror the production post-scan no-entry update source behavior.
             self._zero_signal_streak += 1
             return 0, 0, 1, {}
 
@@ -89,3 +88,41 @@ def test_install_is_chain_aware(monkeypatch):
     first = module.NijaCoreLoop._phase3_scan_and_enter
     assert patch._install_on_core_loop(module) is True
     assert module.NijaCoreLoop._phase3_scan_and_enter is first
+
+
+def test_try_loaded_reattaches_after_late_phase3_replacement(monkeypatch):
+    observed = []
+    module = _module(observed)
+    monkeypatch.setitem(patch.sys.modules, "bot.nija_core_loop", module)
+    monkeypatch.delitem(patch.sys.modules, "nija_core_loop", raising=False)
+
+    assert patch._try_loaded() is True
+    first = module.NijaCoreLoop._phase3_scan_and_enter
+    found, cycle, _ = patch._chain_contains(first)
+    assert found is True
+    assert cycle is False
+
+    def late_replacement(
+        self,
+        broker,
+        snapshot,
+        symbols,
+        available_slots,
+        zero_signal_streak=0,
+    ):
+        observed.append((self._zero_signal_streak, zero_signal_streak))
+        return 0, 0, 0, {}
+
+    module.NijaCoreLoop._phase3_scan_and_enter = late_replacement
+    found, cycle, _ = patch._chain_contains(module.NijaCoreLoop._phase3_scan_and_enter)
+    assert found is False
+    assert cycle is False
+
+    assert patch._try_loaded() is True
+    repaired = module.NijaCoreLoop._phase3_scan_and_enter
+    found, cycle, _ = patch._chain_contains(repaired)
+    assert repaired is not late_replacement
+    assert found is True
+    assert cycle is False
+    assert repaired.__wrapped__ is late_replacement
+    assert patch.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] == "1"

--- a/bot/zero_signal_streak_state_repair_patch.py
+++ b/bot/zero_signal_streak_state_repair_patch.py
@@ -4,6 +4,11 @@ The core loop passes ``self._zero_signal_streak`` into Phase 3 and increments th
 instance field after every no-entry cycle. A stale sentinel such as 999 therefore
 becomes 1000, 1001, ... forever. Parameter-only clamping does not repair the source
 state and leaves dead-zone bypass permanently active.
+
+Phase 3 is intentionally wrapped by several late runtime repairs. Those repairs
+can replace ``_phase3_scan_and_enter`` after this module first attaches. The
+monitor therefore remains active for the process lifetime and reattaches this
+required state repair whenever a later replacement removes it.
 """
 from __future__ import annotations
 
@@ -134,7 +139,7 @@ def _install_on_core_loop(module: ModuleType) -> bool:
     cls._phase3_scan_and_enter = phase3
     os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "1"
     logger.critical(
-        "ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED marker=%s module=%s cap_env=%s stale_threshold_env=%s",
+        "ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED marker=%s module=%s cap_env=%s stale_threshold_env=%s persistent=true",
         _MARKER,
         module.__name__,
         os.environ.get("NIJA_ZERO_SIGNAL_STREAK_CAP", "12"),
@@ -145,33 +150,50 @@ def _install_on_core_loop(module: ModuleType) -> bool:
 
 def _try_loaded() -> bool:
     patched = False
+    seen: set[int] = set()
     for name in ("bot.nija_core_loop", "nija_core_loop"):
         module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
             patched = _install_on_core_loop(module) or patched
     return patched
 
 
+def _monitor_interval() -> float:
+    try:
+        return max(
+            0.25,
+            float(os.environ.get("NIJA_ZERO_SIGNAL_STATE_MONITOR_S", "1.0") or 1.0),
+        )
+    except Exception:
+        return 1.0
+
+
 def _watchdog() -> None:
-    deadline = time.monotonic() + max(
-        60.0,
-        float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600),
-    )
-    while time.monotonic() < deadline:
+    last_ready: bool | None = None
+    while True:
         try:
-            if _try_loaded():
-                return
+            ready = _try_loaded()
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "1" if ready else "0"
+            if ready != last_ready:
+                logger.log(
+                    logging.INFO if ready else logging.WARNING,
+                    "ZERO_SIGNAL_STREAK_STATE_MONITOR marker=%s ready=%s persistent=true",
+                    _MARKER,
+                    str(ready).lower(),
+                )
+                last_ready = ready
         except Exception:
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
             logger.exception("ZERO_SIGNAL_STREAK_STATE_REPAIR_RETRY marker=%s", _MARKER)
-        time.sleep(0.10)
-    os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "0"
-    logger.critical("ZERO_SIGNAL_STREAK_STATE_REPAIR_EXPIRED marker=%s", _MARKER)
+        time.sleep(_monitor_interval())
 
 
 def install_import_hook() -> None:
     global _STARTED
     with _LOCK:
-        _try_loaded()
+        ready = _try_loaded()
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] = "1" if ready else "0"
         if not _STARTED:
             _STARTED = True
             threading.Thread(
@@ -192,4 +214,6 @@ __all__ = [
     "_install_on_core_loop",
     "_repair_value",
     "_chain_contains",
+    "_try_loaded",
+    "_monitor_interval",
 ]

--- a/scan_wrapper_depth_convergence_patch.py
+++ b/scan_wrapper_depth_convergence_patch.py
@@ -10,17 +10,23 @@ This guard makes that installer chain-aware, repairs the next installed wrapper
 to expose its base, and audits the live scan chain. A release is unsafe when the
 chain cycles, exceeds the configured depth, or contains duplicate canonical or
 broker-independent owners.
+
+``functools.wraps`` copies the wrapped function's ``__dict__``. A later wrapper
+can therefore carry NIJA ownership marker attributes even though its code was
+defined by a different patch. Ownership counts use the function code filename,
+while raw marker counts remain diagnostic. This distinguishes real duplicate
+owners from copied metadata.
 """
 from __future__ import annotations
 
 import importlib
-import inspect
 import logging
 import os
 import sys
 import threading
 import time
 from functools import wraps
+from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable
 
@@ -29,6 +35,8 @@ _MARKER = "20260715-scan-depth-v1"
 _GUARD_ATTR = "_nija_scan_depth_guard_v1"
 _BROKER_ATTR = "_nija_broker_independent_live_execution_v20260705a"
 _CANONICAL_RELEASE_ATTR = "_nija_scan_wrapper_release"
+_BROKER_OWNER_FILE = "broker_independent_live_execution_patch.py"
+_CANONICAL_OWNER_FILE = "scan_wrapper_convergence_repair_patch.py"
 _LOCK = threading.RLock()
 _STARTED = False
 _LAST_SIGNATURE = ""
@@ -65,12 +73,29 @@ def _next_link(func: Callable[..., Any]) -> Callable[..., Any] | None:
     return _closure_link(func)
 
 
+def _code_filename(func: Any) -> str:
+    try:
+        code = getattr(func, "__code__", None)
+        return str(getattr(code, "co_filename", "") or "").replace("\\", "/")
+    except Exception:
+        return ""
+
+
+def _owns_marker(func: Any, attr: str, owner_file: str) -> bool:
+    if not bool(getattr(func, attr, False)):
+        return False
+    filename = _code_filename(func)
+    return bool(filename and Path(filename).name == owner_file)
+
+
 def inspect_chain(func: Any, *, limit: int = 4096) -> dict[str, Any]:
     current = func
     seen: set[int] = set()
     depth = 0
     broker_layers = 0
     canonical_layers = 0
+    raw_broker_markers = 0
+    raw_canonical_markers = 0
     cycle = False
     names: list[str] = []
     while callable(current):
@@ -80,8 +105,12 @@ def inspect_chain(func: Any, *, limit: int = 4096) -> dict[str, Any]:
             break
         seen.add(ident)
         names.append(getattr(current, "__qualname__", getattr(current, "__name__", type(current).__name__)))
-        broker_layers += int(bool(getattr(current, _BROKER_ATTR, False)))
-        canonical_layers += int(bool(getattr(current, _CANONICAL_RELEASE_ATTR, "")))
+        raw_broker_markers += int(bool(getattr(current, _BROKER_ATTR, False)))
+        raw_canonical_markers += int(bool(getattr(current, _CANONICAL_RELEASE_ATTR, "")))
+        broker_layers += int(_owns_marker(current, _BROKER_ATTR, _BROKER_OWNER_FILE))
+        canonical_layers += int(
+            _owns_marker(current, _CANONICAL_RELEASE_ATTR, _CANONICAL_OWNER_FILE)
+        )
         nxt = _next_link(current)
         if not callable(nxt):
             break
@@ -94,6 +123,8 @@ def inspect_chain(func: Any, *, limit: int = 4096) -> dict[str, Any]:
         "depth": depth,
         "broker_layers": broker_layers,
         "canonical_layers": canonical_layers,
+        "raw_broker_markers": raw_broker_markers,
+        "raw_canonical_markers": raw_canonical_markers,
         "cycle": cycle,
         "head": names[0] if names else "missing",
         "tail": names[-1] if names else "missing",
@@ -128,7 +159,6 @@ def _guard_broker_module(module: ModuleType) -> bool:
         cls = getattr(core_module, "NijaCoreLoop", None)
         current = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
         if callable(current) and _chain_has_broker_layer(current):
-            # Keep the module's own state coherent so its monitor exits.
             try:
                 setattr(module, "_PATCHED", True)
             except Exception:
@@ -204,7 +234,8 @@ def audit() -> tuple[bool, dict[str, str]]:
     details = {
         "scan_chain": (
             f"depth={status['depth']};max={max_depth};broker_layers={status['broker_layers']};"
-            f"canonical_layers={status['canonical_layers']};cycle={status['cycle']};"
+            f"canonical_layers={status['canonical_layers']};raw_broker_markers={status['raw_broker_markers']};"
+            f"raw_canonical_markers={status['raw_canonical_markers']};cycle={status['cycle']};"
             f"head={status['head']};tail={status['tail']}"
         )
     }
@@ -241,7 +272,7 @@ def install() -> None:
             _STARTED = True
             threading.Thread(target=_watchdog, name="ScanWrapperDepthGuard", daemon=True).start()
         logger.critical(
-            "SCAN_WRAPPER_DEPTH_GUARD_INSTALLED marker=%s max_depth=%s",
+            "SCAN_WRAPPER_DEPTH_GUARD_INSTALLED marker=%s max_depth=%s ownership=code_origin",
             _MARKER,
             os.environ.get("NIJA_MAX_SCAN_WRAPPER_DEPTH", "24"),
         )
@@ -258,4 +289,6 @@ __all__ = [
     "inspect_chain",
     "_guard_broker_module",
     "_chain_has_broker_layer",
+    "_code_filename",
+    "_owns_marker",
 ]

--- a/source_runtime_guard_bootstrap.py
+++ b/source_runtime_guard_bootstrap.py
@@ -130,8 +130,6 @@ def install() -> bool:
             _install_required("authority_heartbeat_generation_scope_patch")
             _install_required("final_worker_position_coinbase_repair_patch")
 
-            # Select and validate the OKX regional host before any auth normalizer,
-            # private client, balance probe, quarantine decision, or market load.
             _install_required("bot.okx_regional_endpoint_isolation_patch")
             _install_required("broker_auth_recovery_patch")
             _install_required("bot.coinbase_funding_readiness_repair_patch")
@@ -146,9 +144,6 @@ def install() -> bool:
             _install_required("final_runtime_convergence_patch")
             _install_required("scan_wrapper_convergence_repair_patch")
 
-            # Repair captured legacy delegates immediately after the canonical scan
-            # owner exists and before hard-clamp/watchdog modules can preserve a
-            # stale wrapper chain.
             _install_required("bot.scan_reentrant_delegate_repair_patch")
             _install_required("bot.scan_wrapper_hard_clamp_patch")
 
@@ -166,6 +161,11 @@ def install() -> bool:
             _install_required("three_venue_execution_readiness")
             _install_required("render_readiness_state_bridge")
             _install_required("scan_owner_okx_auth_convergence_patch")
+
+            # Late Phase 3 installers above may replace the method after the first
+            # zero-signal installation. Re-run it synchronously before identity and
+            # release audits; its process-lifetime monitor handles later changes.
+            _install_required("bot.zero_signal_streak_state_repair_patch")
 
             _install_canonical_downstream_risk()
             _install_required("runtime_module_identity_convergence_patch")


### PR DESCRIPTION
## Root cause

The July 23 Render runtime reached broker/bootstrap code but remained fail-closed in `LIVE_PENDING_CONFIRMATION` with `NIJA_RUNTIME_EXECUTION_AUTHORITY=0`.

The runtime module identity audit showed one decisive failure:

```text
zero_signal_streak_chain: cap_guard=True;state_repair=False;cycle=False
```

`zero_signal_streak_state_repair_patch` stopped its monitor after the first successful attachment. Later Phase 3 patches replaced `_phase3_scan_and_enter`, removing the required state-repair wrapper. The release manifest then stayed unsafe, runtime authority was never published, and the trade loop remained at zero cycles.

The scan-depth audit also reported `canonical_layers=14` and `broker_layers=3`. Most of those were copied marker attributes: `functools.wraps` copies the wrapped function's `__dict__`, so later wrappers appeared to own earlier markers even though their code came from different modules.

## Fix

- Keep the zero-signal state-repair monitor active for the process lifetime.
- Reattach the state repair whenever a late Phase 3 replacement removes it.
- Re-run the zero-signal installer synchronously after late scan/Phase 3 installers and immediately before runtime identity audits.
- Count scan wrapper ownership using each function's actual code filename.
- Preserve raw marker counts for diagnostics while using real owner counts for readiness.
- Add regression tests for late Phase 3 replacement and copied marker metadata.

## Safety

This does not bypass Redis writer fencing, runtime release checks, risk sizing, broker readiness, exchange minimums, kill switches, cost-basis verification, position limits, exits, take-profit, or stop-loss protection. It restores required safety wrappers and makes ownership telemetry accurate.

## Expected deployment proof

```text
ZERO_SIGNAL_STREAK_STATE_REPAIR_INSTALLED ... persistent=true
ZERO_SIGNAL_STREAK_STATE_MONITOR ... ready=true
RUNTIME_MODULE_IDENTITY_AUDIT ... ready=true ... state_repair=True
SCAN_WRAPPER_DEPTH_AUDIT ... ready=true ... broker_layers<=1 canonical_layers<=1
NIJA_RUNTIME_RELEASE_MANIFEST ... ready=true
RUNTIME_RELEASE_CONVERGENCE_RECOVERED
RUNTIME_AUTHORITY_CONVERGENCE_REPAIRED
NIJA_RUNTIME_TRADING_STATE=LIVE_ACTIVE
NIJA_RUNTIME_EXECUTION_AUTHORITY=1
```

Normal scan cycles may then begin; entries still require market signals and all ordinary risk/order gates.