### PR TITLE
Converge OKX order wrappers and pretrade risk

### DIFF
--- a/.github/workflows/entrypoint-writer-authority-tests.yml
+++ b/.github/workflows/entrypoint-writer-authority-tests.yml
@@ -25,6 +25,8 @@ on:
       - 'secondary_venue_strict_readiness_patch.py'
       - 'bot/activation_pending_commit_monitor_patch.py'
       - 'bot/zero_signal_streak_state_repair_patch.py'
+      - 'bot/okx_order_wrapper_stability_patch.py'
+      - 'bot/downstream_risk_governor_equity_repair_patch.py'
       - 'bot/writer_lock_release_guard.py'
       - 'bot/entrypoint_writer_authority.py'
       - 'bot/bot_main.py'
@@ -33,6 +35,7 @@ on:
       - 'bot/tests/test_sitecustomize_defer_guard.py'
       - 'bot/tests/test_scan_wrapper_depth_convergence_patch.py'
       - 'bot/tests/test_zero_signal_streak_state_repair_patch.py'
+      - 'bot/tests/test_okx_order_wrapper_stability_v2.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -72,6 +75,8 @@ on:
       - 'secondary_venue_strict_readiness_patch.py'
       - 'bot/activation_pending_commit_monitor_patch.py'
       - 'bot/zero_signal_streak_state_repair_patch.py'
+      - 'bot/okx_order_wrapper_stability_patch.py'
+      - 'bot/downstream_risk_governor_equity_repair_patch.py'
       - 'bot/writer_lock_release_guard.py'
       - 'bot/entrypoint_writer_authority.py'
       - 'bot/bot_main.py'
@@ -80,6 +85,7 @@ on:
       - 'bot/tests/test_sitecustomize_defer_guard.py'
       - 'bot/tests/test_scan_wrapper_depth_convergence_patch.py'
       - 'bot/tests/test_zero_signal_streak_state_repair_patch.py'
+      - 'bot/tests/test_okx_order_wrapper_stability_v2.py'
       - 'bot/tests/test_three_venue_execution_readiness.py'
       - 'bot/tests/test_import_hook_chain_compactor.py'
       - 'bot/tests/test_activation_pending_startup_order.py'
@@ -168,6 +174,8 @@ jobs:
             source_runtime_guard_bootstrap.py \
             scan_wrapper_depth_convergence_patch.py \
             bot/zero_signal_streak_state_repair_patch.py \
+            bot/okx_order_wrapper_stability_patch.py \
+            bot/downstream_risk_governor_equity_repair_patch.py \
             three_venue_execution_readiness.py \
             import_hook_recursion_shield_patch.py \
             secondary_venue_activation_patch.py \
@@ -186,6 +194,7 @@ jobs:
         run: |
           python -m pytest -q bot/tests/test_scan_wrapper_depth_convergence_patch.py
           python -m pytest -q bot/tests/test_zero_signal_streak_state_repair_patch.py
+          python -m pytest -q bot/tests/test_okx_order_wrapper_stability_v2.py
       - name: Test startup handoff ordering
         run: python -m pytest -q bot/tests/test_startup_handoff_all_fixes.py
       - name: Test three-venue readiness

--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -10,14 +10,18 @@ on:
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/okx_order_wrapper_stability_patch.py"
+      - "bot/downstream_risk_governor_equity_repair_patch.py"
       - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/runtime_patch_churn_safety_patch.py"
       - "bot/generation_sync_timing_patch.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_okx_order_wrapper_stability_v2.py"
       - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
+      - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
   push:
     branches: [main]
@@ -29,14 +33,18 @@ on:
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
+      - "bot/okx_order_wrapper_stability_patch.py"
+      - "bot/downstream_risk_governor_equity_repair_patch.py"
       - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/runtime_patch_churn_safety_patch.py"
       - "bot/generation_sync_timing_patch.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
+      - "bot/tests/test_okx_order_wrapper_stability_v2.py"
       - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
+      - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
 
 permissions:
@@ -58,8 +66,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
+
       - name: Install pytest
-        run: python -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest==8.2.2
+        run: env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --retries 5 --timeout 30 pytest==8.2.2
 
       - name: Compile repaired runtime modules
         run: |
@@ -68,6 +79,8 @@ jobs:
             bot/strategy_runtime_integrity_patch.py \
             bot/disconnected_coinbase_balance_guard_patch.py \
             bot/okx_patch_churn_guard_patch.py \
+            bot/okx_order_wrapper_stability_patch.py \
+            bot/downstream_risk_governor_equity_repair_patch.py \
             bot/live_active_dispatch_bridge_patch.py \
             bot/runtime_patch_churn_safety_patch.py \
             bot/generation_sync_timing_patch.py \
@@ -80,5 +93,6 @@ jobs:
             bot/tests/test_strategy_runtime_integrity_patch.py \
             bot/tests/test_disconnected_coinbase_balance_guard_patch.py \
             bot/tests/test_okx_patch_churn_guard_patch.py \
+            bot/tests/test_okx_order_wrapper_stability_v2.py \
             bot/tests/test_live_active_dispatch_bridge_recovery.py \
             bot/tests/test_runtime_patch_churn_safety_patch.py

--- a/.github/workflows/zero-trust-ci.yml
+++ b/.github/workflows/zero-trust-ci.yml
@@ -214,7 +214,13 @@ jobs:
         run: |
           set -euo pipefail
           env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --upgrade pip
-          env -u PYTHONPATH python -P -m pip install pytest==8.2.2 pytest-cov pytest-timeout
+          env -u PYTHONPATH python -P -m pip install \
+            pytest==8.2.2 \
+            pytest-cov \
+            pytest-timeout \
+            numpy==1.26.3 \
+            redis \
+            requests
 
       - name: Apply production package defer guard
         run: python -S apply_bot_package_defer_fix.py

--- a/.github/workflows/zero-trust-ci.yml
+++ b/.github/workflows/zero-trust-ci.yml
@@ -6,253 +6,244 @@ on:
   pull_request:
     branches: [ main ]
 
-# Strict permissions (least privilege)
 permissions:
   contents: read
 
 jobs:
-  # Ephemeral runner setup
   setup-runner:
     name: Setup Isolated Runner
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # For OIDC authentication
-
+      id-token: write
     outputs:
       runner-id: ${{ steps.runner.outputs.id }}
-
     steps:
-    - name: Generate Runner Token
-      id: runner
-      run: |
-        RUNNER_ID=$(uuidgen)
-        echo "id=${RUNNER_ID}" >> $GITHUB_OUTPUT
-        echo "::notice::Created ephemeral runner: ${RUNNER_ID}"
+      - name: Generate Runner Token
+        id: runner
+        run: |
+          RUNNER_ID=$(uuidgen)
+          echo "id=${RUNNER_ID}" >> $GITHUB_OUTPUT
+          echo "::notice::Created ephemeral runner: ${RUNNER_ID}"
 
-  # Isolated build job
   build:
     name: Build with Zero-Trust Isolation
     runs-on: ubuntu-latest
     needs: setup-runner
-
-    # Strict permissions
     permissions:
       contents: read
       packages: write
       id-token: write
-
-    # Network isolation
     env:
-      # Disable network access to internal services
       NO_PROXY: ""
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-
+      PYTHONPATH: .
+      NIJA_DEFER_RUNTIME_SITE_HOOKS: "1"
     steps:
-    - name: Harden Runner (Network Egress Control)
-      uses: step-security/harden-runner@v2
-      with:
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
-          github.com:443
-          objects.githubusercontent.com:443
-          registry.npmjs.org:443
-          pypi.org:443
-          files.pythonhosted.org:443
+      - name: Harden Runner (Network Egress Control)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false  # Don't persist credentials
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-    - name: Set up Python (Isolated)
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
+      - name: Set up Python (Isolated)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    # Verify dependencies before install
-    - name: Verify Dependencies Hash
-      run: |
-        sha256sum requirements.txt > requirements.txt.sha256
-        echo "Dependency hash: $(cat requirements.txt.sha256)"
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
 
-    - name: Install Dependencies (Isolated)
-      run: |
-        python -m pip install --upgrade pip
-        # Install in isolated environment
-        pip install --no-cache-dir --require-hashes -r requirements.txt || \
-        pip install --no-cache-dir -r requirements.txt
+      - name: Verify Dependencies Hash
+        run: |
+          sha256sum requirements.txt > requirements.txt.sha256
+          echo "Dependency hash: $(cat requirements.txt.sha256)"
 
-    # Build in isolated environment
-    - name: Build Application (Sandboxed)
-      run: |
-        # Run build in restricted environment
-        python -c "import sys; print(f'Python: {sys.version}')"
-        python -m compileall bot/
-      env:
-        PYTHONDONTWRITEBYTECODE: 1
+      - name: Install Dependencies (Isolated)
+        run: |
+          set -euo pipefail
+          env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --upgrade pip
+          env -u PYTHONPATH python -P -m pip install --no-cache-dir --require-hashes -r requirements.txt || \
+            env -u PYTHONPATH python -P -m pip install --no-cache-dir -r requirements.txt
 
-    # Generate the integrity manifest for both push and pull_request events.
-    # The verification job always consumes this file, so conditionally skipping
-    # signing on PRs made every pull-request run fail before security scanning.
-    - name: Sign Build Artifacts
-      run: |
-        set -euo pipefail
-        find bot/ -name "*.pyc" -type f -print0 \
-          | sort -z \
-          | xargs -0 -r sha256sum > build-artifacts.sha256
-        test -s build-artifacts.sha256
-        echo "::notice::Build artifacts signed"
+      - name: Apply production package defer guard
+        run: python -S apply_bot_package_defer_fix.py
 
-    - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v4.4.3
-      with:
-        name: build-artifacts-${{ github.sha }}
-        path: |
-          bot/
-          build-artifacts.sha256
-        retention-days: 7
+      - name: Build Application (Sandboxed)
+        run: |
+          python -S -c "import sys; print(f'Python: {sys.version}')"
+          python -S -m compileall -q bot/
+        env:
+          PYTHONDONTWRITEBYTECODE: 0
 
-  # Isolated security scan
+      - name: Sign Build Artifacts
+        run: |
+          set -euo pipefail
+          find bot/ -name "*.pyc" -type f -print0 \
+            | sort -z \
+            | xargs -0 -r sha256sum > build-artifacts.sha256
+          test -s build-artifacts.sha256
+          echo "::notice::Build artifacts signed"
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: build-artifacts-${{ github.sha }}
+          path: |
+            bot/
+            build-artifacts.sha256
+          retention-days: 7
+
   security-scan:
     name: Security Scan (Isolated)
     runs-on: ubuntu-latest
     needs: build
-
     permissions:
       contents: read
       security-events: write
       id-token: write
-
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@v2
-      with:
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
-          github.com:443
-          objects.githubusercontent.com:443
-          ghcr.io:443
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            ghcr.io:443
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-    - name: Download Build Artifacts
-      uses: actions/download-artifact@v4.1.3
-      with:
-        name: build-artifacts-${{ github.sha }}
-        path: build/
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: build-artifacts-${{ github.sha }}
+          path: build/
 
-    # Verify artifact signatures
-    - name: Verify Artifact Signatures
-      run: |
-        set -euo pipefail
-        cd build
-        test -s build-artifacts.sha256
-        sha256sum -c build-artifacts.sha256
-        echo "::notice::Artifact signatures verified"
+      - name: Verify Artifact Signatures
+        run: |
+          set -euo pipefail
+          cd build
+          test -s build-artifacts.sha256
+          sha256sum -c build-artifacts.sha256
+          echo "::notice::Artifact signatures verified"
 
-    - name: Run Security Scan in Sandbox
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'table'
-        severity: 'CRITICAL,HIGH'
-        exit-code: '0'
+      - name: Run Security Scan in Sandbox
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
 
-  # Isolated test execution
   test:
-    name: Test (Isolated Environment)
+    name: Test (Isolated Environment) (${{ matrix.test-group }})
     runs-on: ubuntu-latest
     needs: build
-    # Integration tests can require broker/network services that are deliberately
-    # unavailable under zero-trust egress blocking. Keep their result visible,
-    # but do not let that expected environmental limitation block checksPass.
-    continue-on-error: ${{ matrix.allow-failure }}
-
     permissions:
       contents: read
       id-token: write
-
-    # Test matrix for isolation
+    env:
+      PYTHONPATH: .
+      NIJA_DEFER_RUNTIME_SITE_HOOKS: "1"
     strategy:
       fail-fast: false
       matrix:
         include:
           - test-group: unit
-            allow-failure: false
+            test-paths: >-
+              bot/tests/test_okx_order_wrapper_stability_v2.py
+              bot/tests/test_scan_wrapper_depth_convergence_patch.py
+              bot/tests/test_zero_signal_streak_state_repair_patch.py
+              bot/tests/test_runtime_patch_churn_safety_patch.py
+              bot/tests/test_entrypoint_writer_authority.py
           - test-group: integration
-            allow-failure: true
-
+            test-paths: >-
+              tests/imports_smoke_test.py
+              bot/tests/test_source_runtime_guard_bootstrap.py
+              bot/tests/test_render_prebot_writer_handoff.py
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@v2
-      with:
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
-          github.com:443
-          objects.githubusercontent.com:443
-          pypi.org:443
-          files.pythonhosted.org:443
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    - name: Download Build Artifacts
-      uses: actions/download-artifact@v4.1.3
-      with:
-        name: build-artifacts-${{ github.sha }}
-        path: build/
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
 
-    - name: Install Test Dependencies (Isolated)
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov pytest-timeout
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: build-artifacts-${{ github.sha }}
+          path: build/
 
-    # Run tests in isolated environment
-    - name: Run ${{ matrix.test-group }} Tests (Sandboxed)
-      run: |
-        # Run tests with timeout and resource limits
-        timeout 600 pytest -v \
-          --timeout=60 \
-          --cov=bot \
-          --cov-report=xml \
-          -k "${{ matrix.test-group }}"
-      env:
-        # Disable network for unit tests
-        PYTEST_DISABLE_NETWORK: ${{ matrix.test-group == 'unit' && 'true' || 'false' }}
+      - name: Install Test Dependencies (Isolated)
+        run: |
+          set -euo pipefail
+          env -u PYTHONPATH python -P -m pip install --disable-pip-version-check --upgrade pip
+          env -u PYTHONPATH python -P -m pip install pytest==8.2.2 pytest-cov pytest-timeout
 
-  # Cleanup ephemeral resources
+      - name: Apply production package defer guard
+        run: python -S apply_bot_package_defer_fix.py
+
+      - name: Run ${{ matrix.test-group }} Tests (Sandboxed)
+        env:
+          TEST_PATHS: ${{ matrix.test-paths }}
+          PYTEST_DISABLE_NETWORK: ${{ matrix.test-group == 'unit' && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          timeout 600 python -m pytest -q \
+            --timeout=60 \
+            --cov=bot \
+            --cov-report=xml \
+            $TEST_PATHS
+
   cleanup:
     name: Cleanup Isolated Resources
     runs-on: ubuntu-latest
     needs: [build, security-scan, test]
     if: always()
-
     permissions:
       contents: read
-
     steps:
-    - name: Cleanup Artifacts
-      uses: geekyeggo/delete-artifact@v2
-      with:
-        name: build-artifacts-${{ github.sha }}
-        failOnError: false
+      - name: Cleanup Artifacts
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: build-artifacts-${{ github.sha }}
+          failOnError: false
 
-    - name: Cleanup Complete
-      run: |
-        echo "::notice::Ephemeral resources cleaned up"
+      - name: Cleanup Complete
+        run: echo "::notice::Ephemeral resources cleaned up"

--- a/.github/workflows/zero-trust-ci.yml
+++ b/.github/workflows/zero-trust-ci.yml
@@ -154,7 +154,7 @@ jobs:
           exit-code: '0'
 
   test:
-    name: Test (Isolated Environment) (${{ matrix.test-group }})
+    name: Test (Isolated Environment) (${{ matrix.test_group }})
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -167,15 +167,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test-group: unit
-            test-paths: >-
+          - test_group: unit
+            test_paths: >-
               bot/tests/test_okx_order_wrapper_stability_v2.py
               bot/tests/test_scan_wrapper_depth_convergence_patch.py
               bot/tests/test_zero_signal_streak_state_repair_patch.py
               bot/tests/test_runtime_patch_churn_safety_patch.py
               bot/tests/test_entrypoint_writer_authority.py
-          - test-group: integration
-            test-paths: >-
+          - test_group: integration
+            test_paths: >-
               tests/imports_smoke_test.py
               bot/tests/test_source_runtime_guard_bootstrap.py
               bot/tests/test_render_prebot_writer_handoff.py
@@ -225,10 +225,10 @@ jobs:
       - name: Apply production package defer guard
         run: python -S apply_bot_package_defer_fix.py
 
-      - name: Run ${{ matrix.test-group }} Tests (Sandboxed)
+      - name: Run ${{ matrix.test_group }} Tests (Sandboxed)
         env:
-          TEST_PATHS: ${{ matrix.test-paths }}
-          PYTEST_DISABLE_NETWORK: ${{ matrix.test-group == 'unit' && 'true' || 'false' }}
+          TEST_PATHS: ${{ matrix.test_paths }}
+          PYTEST_DISABLE_NETWORK: ${{ matrix.test_group == 'unit' && 'true' || 'false' }}
         run: |
           set -euo pipefail
           timeout 600 python -m pytest -q \

--- a/.github/workflows/zero-trust-ci.yml
+++ b/.github/workflows/zero-trust-ci.yml
@@ -153,6 +153,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           exit-code: '0'
 
+  # Underscore keys keep matrix expressions unambiguous to GitHub's parser.
   test:
     name: Test (Isolated Environment) (${{ matrix.test_group }})
     runs-on: ubuntu-latest

--- a/bot/okx_order_wrapper_stability_patch.py
+++ b/bot/okx_order_wrapper_stability_patch.py
@@ -263,8 +263,10 @@ def _ensure_okx_wrappers() -> tuple[bool, dict[str, str]]:
     for cls in instid_classes:
         roles[id(cls)] = (cls, True, False)
     for cls in final_classes:
-        previous = roles.get(id(cls))
-        roles[id(cls)] = (cls, bool(previous and previous[1]), True)
+        # Any broker/adapter surface that owns final-submit validation must also
+        # retain instId normalization.  Only low-level REST-only classes are
+        # permitted to require instId without the final-submit layer.
+        roles[id(cls)] = (cls, True, True)
 
     details: dict[str, str] = {}
     ready = bool(roles)
@@ -352,8 +354,9 @@ def _monitor_interval() -> float:
 def _monitor() -> None:
     while True:
         try:
-            ready, details = _apply()
-            _publish_state(ready, details)
+            with _LOCK:
+                ready, details = _apply()
+                _publish_state(ready, details)
         except Exception as exc:
             os.environ["NIJA_RUNTIME_ERROR_CLEANUP_V1_READY"] = "0"
             logger.warning(
@@ -363,6 +366,8 @@ def _monitor() -> None:
                 f"{type(exc).__name__}:{exc}",
                 exc_info=True,
             )
+        # Keep the sleep outside the convergence lock so explicit installer calls
+        # are never delayed by the monitor interval.
         time.sleep(_monitor_interval())
 
 

--- a/bot/okx_order_wrapper_stability_patch.py
+++ b/bot/okx_order_wrapper_stability_patch.py
@@ -1,113 +1,373 @@
-"""Freeze canonical OKX order wrappers after their first successful install.
+"""Converge OKX order wrappers and downstream pre-trade risk deterministically.
 
-Legacy import/monitor hooks can alternately replace the same methods, causing the
-final-submit and instId patches to wrap each other repeatedly. This module installs
-both once, marks the class surfaces as stable, and replaces their patch entrypoints
-with class-marker-aware delegates. Broker authentication and order validation remain
-unchanged.
+Two legacy OKX patches protect different parts of the same order path:
+
+* ``okx_final_order_submission_bridge_patch`` validates the final call shape.
+* ``okx_order_instid_payload_repair_patch`` normalizes and validates ``instId``.
+
+Both patches historically inspected only the outer function.  The final bridge also
+unwrapped one layer before replacing a method, so the two import hooks could remove
+and reinstall each other indefinitely.  This module makes both installers
+chain-aware, preserves both layers, binds canonical/legacy module aliases to one
+object, and heals late method replacement without log flooding.
+
+The same convergence pass imports and patches ``PreTradeRiskEngine`` explicitly.
+The downstream risk monitor previously waited only for an incidental import, which
+left its required ``pretrade`` state false for the full monitor lifetime.
 """
 from __future__ import annotations
 
 import importlib
 import logging
 import os
+import sys
 import threading
+import time
 from functools import wraps
+from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.okx_order_wrapper_stability")
-_MARKER = "20260718-okx-wrapper-stability-v1"
-_CLASS_MARKER = "_nija_okx_order_wrapper_chain_stable_v1"
+_MARKER = "20260723-okx-wrapper-stability-v2"
+_CLEANUP_MARKER = "20260723-runtime-error-cleanup-v1"
 _LOCK = threading.RLock()
 _INSTALLED = False
+_MONITOR_STARTED = False
+_LAST_STATE = ""
+
+_INSTID_CANONICAL = "bot.okx_order_instid_payload_repair_patch"
+_INSTID_ALIAS = "okx_order_instid_payload_repair_patch"
+_FINAL_CANONICAL = "bot.okx_final_order_submission_bridge_patch"
+_FINAL_ALIAS = "okx_final_order_submission_bridge_patch"
+_RISK_CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
+_RISK_ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
+_PRETRADE_CANONICAL = "bot.pre_trade_risk_engine"
+_PRETRADE_ALIAS = "pre_trade_risk_engine"
+
+_INSTID_ATTR = "_nija_okx_order_instid_payload_repair_order_v20260705f"
+_FINAL_ATTR = "_nija_okx_final_order_submission_bridge_order_v20260709d"
+_GUARD_ATTR = "_nija_okx_wrapper_stability_guard_v2"
+_CLASS_MARKER = "_nija_okx_order_wrapper_chain_stable_v2"
+_ORDER_METHODS = ("place_market_order", "execute_order", "place_order")
+_TARGET_MODULES = {
+    "bot.broker_manager",
+    "broker_manager",
+    "bot.broker_integration",
+    "broker_integration",
+    "bot.multi_account_broker_manager",
+    "multi_account_broker_manager",
+    "bot.multi_broker_execution_router",
+    "multi_broker_execution_router",
+}
 
 
-def _candidate_classes(module: Any) -> list[type]:
-    fn = getattr(module, "_candidate_order_classes", None)
-    if callable(fn):
-        found: list[type] = []
-        for target_name in ("bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"):
-            try:
-                target = importlib.import_module(target_name)
-            except Exception:
-                continue
-            try:
-                for cls in fn(target):
-                    if isinstance(cls, type) and cls not in found:
-                        found.append(cls)
-            except Exception:
-                continue
-        return found
-    return []
+def _deployment_sha() -> str:
+    for name in (
+        "RENDER_GIT_COMMIT",
+        "GIT_COMMIT_SHA",
+        "GIT_COMMIT",
+        "SOURCE_VERSION",
+        "RAILWAY_GIT_COMMIT_SHA",
+    ):
+        value = str(os.environ.get(name, "") or "").strip()
+        if value:
+            return value
+    return "unknown"
 
 
-def _freeze_module(module: Any) -> bool:
-    original_wrap = getattr(module, "_wrap_order_class", None)
-    if not callable(original_wrap) or getattr(original_wrap, "_nija_okx_stability_guard", False):
-        return False
+def _chain_has_attr(func: Any, attr: str, *, max_depth: int = 256) -> tuple[bool, bool, int]:
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    while callable(current):
+        identity = id(current)
+        if identity in seen:
+            return False, True, depth
+        seen.add(identity)
+        if bool(getattr(current, attr, False)):
+            return True, False, depth
+        current = getattr(current, "__wrapped__", None)
+        if not callable(current):
+            return False, False, depth
+        depth += 1
+        if depth >= max_depth:
+            return False, True, depth
+    return False, False, depth
 
-    @wraps(original_wrap)
-    def stable_wrap(cls: type, module_name: str) -> bool:
-        if bool(getattr(cls, _CLASS_MARKER, False)):
+
+def _bind_alias(canonical_name: str, alias_name: str) -> ModuleType:
+    module = importlib.import_module(canonical_name)
+    sys.modules[canonical_name] = module
+    sys.modules[alias_name] = module
+    return module
+
+
+def _narrow_interesting(name: str) -> bool:
+    return str(name or "").strip() in _TARGET_MODULES
+
+
+def _propagate_chain_marker(func: Any, marker: str) -> bool:
+    found, cycle, _depth = _chain_has_attr(func, marker)
+    if cycle or not found or not callable(func):
+        return found and not cycle
+    if not bool(getattr(func, marker, False)):
+        try:
+            setattr(func, marker, True)
+        except Exception:
             return False
-        changed = bool(original_wrap(cls, module_name))
-        # Mark only after the module has had an opportunity to install its wrappers.
-        if changed or any(
-            bool(getattr(getattr(cls, name, None), attr, False))
-            for name in ("place_market_order", "execute_order", "place_order")
-            for attr in (
-                "_nija_okx_final_order_submission_bridge_order_v20260709d",
-                "_nija_okx_order_instid_payload_repair_order_v20260705f",
-            )
-        ):
-            setattr(cls, _CLASS_MARKER, True)
-        return changed
-
-    stable_wrap._nija_okx_stability_guard = True
-    stable_wrap.__wrapped__ = original_wrap
-    module._wrap_order_class = stable_wrap
     return True
 
 
-def _install_once() -> bool:
-    modules = []
-    for name in (
-        "bot.okx_order_instid_payload_repair_patch",
-        "bot.okx_final_order_submission_bridge_patch",
-    ):
-        modules.append(importlib.import_module(name))
+def _guard_patch_module(module: ModuleType, marker: str) -> bool:
+    current = getattr(module, "_wrap_order_class", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _GUARD_ATTR, False)):
+        module._interesting_module = _narrow_interesting
+        return True
 
-    # First allow both canonical modules to install their current wrappers.
-    for module in modules:
-        installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
-        if callable(installer):
-            installer()
+    original = current
 
-    # Then freeze future watchdog/import-hook passes at the class level.
-    changed = False
-    for module in modules:
-        changed = _freeze_module(module) or changed
-        for cls in _candidate_classes(module):
-            setattr(cls, _CLASS_MARKER, True)
+    @wraps(original)
+    def stable_wrap(okx_cls: type, module_name: str) -> bool:
+        # Propagate markers already present below a later outer wrapper so legacy
+        # top-level checks cannot reinstall or discard an existing safety layer.
+        for method_name in _ORDER_METHODS:
+            method = getattr(okx_cls, method_name, None)
+            if callable(method):
+                _propagate_chain_marker(method, marker)
+        changed = bool(original(okx_cls, module_name))
+        for method_name in _ORDER_METHODS:
+            method = getattr(okx_cls, method_name, None)
+            if callable(method):
+                _propagate_chain_marker(method, marker)
+        return changed
 
-    os.environ["NIJA_OKX_ORDER_WRAPPER_STABILITY_INSTALLED"] = "1"
-    logger.critical(
-        "OKX_ORDER_WRAPPER_CHAIN_STABLE marker=%s modules=%s class_marker=%s",
-        _MARKER,
-        ",".join(getattr(module, "__name__", "unknown") for module in modules),
-        _CLASS_MARKER,
+    setattr(stable_wrap, _GUARD_ATTR, True)
+    setattr(stable_wrap, "__wrapped__", original)
+    module._wrap_order_class = stable_wrap
+    module._interesting_module = _narrow_interesting
+    return True
+
+
+def _load_patch_modules() -> tuple[ModuleType, ModuleType]:
+    instid = _bind_alias(_INSTID_CANONICAL, _INSTID_ALIAS)
+    final = _bind_alias(_FINAL_CANONICAL, _FINAL_ALIAS)
+    if not _guard_patch_module(final, _FINAL_ATTR):
+        raise RuntimeError("final_okx_order_wrapper_guard_unavailable")
+    if not _guard_patch_module(instid, _INSTID_ATTR):
+        raise RuntimeError("instid_okx_order_wrapper_guard_unavailable")
+    return instid, final
+
+
+def _loaded_target_modules() -> list[ModuleType]:
+    modules: list[ModuleType] = []
+    seen: set[int] = set()
+    for name in _TARGET_MODULES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            modules.append(module)
+    return modules
+
+
+def _candidate_classes(module: ModuleType, targets: list[ModuleType]) -> list[type]:
+    finder = getattr(module, "_candidate_order_classes", None)
+    if not callable(finder):
+        return []
+    classes: list[type] = []
+    seen: set[int] = set()
+    for target in targets:
+        try:
+            candidates = finder(target)
+        except Exception:
+            logger.debug("OKX candidate scan failed module=%s", target.__name__, exc_info=True)
+            continue
+        for cls in candidates:
+            if isinstance(cls, type) and id(cls) not in seen:
+                seen.add(id(cls))
+                classes.append(cls)
+    return classes
+
+
+def _class_state(cls: type) -> tuple[bool, dict[str, str]]:
+    details: dict[str, str] = {}
+    ready = True
+    observed = False
+    for method_name in _ORDER_METHODS:
+        method = getattr(cls, method_name, None)
+        if not callable(method):
+            continue
+        observed = True
+        instid, instid_cycle, instid_depth = _chain_has_attr(method, _INSTID_ATTR)
+        final, final_cycle, final_depth = _chain_has_attr(method, _FINAL_ATTR)
+        cycle = instid_cycle or final_cycle
+        method_ready = instid and final and not cycle
+        details[method_name] = (
+            f"instid={instid};final={final};cycle={cycle};"
+            f"depth={max(instid_depth, final_depth)}"
+        )
+        ready = ready and method_ready
+        if method_ready:
+            _propagate_chain_marker(method, _INSTID_ATTR)
+            _propagate_chain_marker(method, _FINAL_ATTR)
+    if observed and ready:
+        setattr(cls, _CLASS_MARKER, True)
+    return observed and ready, details
+
+
+def _install_patch_module(module: ModuleType) -> None:
+    installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer):
+        raise RuntimeError(f"{module.__name__}_installer_missing")
+    installer()
+
+
+def _ensure_okx_wrappers() -> tuple[bool, dict[str, str]]:
+    instid, final = _load_patch_modules()
+
+    # Install final-call validation first, then put instId normalization around it.
+    # The chain-aware guards keep both layers present on subsequent import-hook runs.
+    _install_patch_module(final)
+    _install_patch_module(instid)
+
+    targets = _loaded_target_modules()
+    for target in targets:
+        patch_final = getattr(final, "_patch_module", None)
+        patch_instid = getattr(instid, "_patch_module", None)
+        if callable(patch_final):
+            patch_final(target)
+        if callable(patch_instid):
+            patch_instid(target)
+
+    classes: list[type] = []
+    seen: set[int] = set()
+    for module in (final, instid):
+        for cls in _candidate_classes(module, targets):
+            if id(cls) not in seen:
+                seen.add(id(cls))
+                classes.append(cls)
+
+    details: dict[str, str] = {}
+    ready = bool(classes)
+    for cls in classes:
+        class_ready, class_details = _class_state(cls)
+        ready = ready and class_ready
+        label = f"{getattr(cls, '__module__', '')}.{getattr(cls, '__name__', '')}"
+        details[label] = str(class_details)
+    if not classes:
+        details["classes"] = "not_loaded"
+    os.environ["NIJA_OKX_ORDER_WRAPPER_STABILITY_READY"] = "1" if ready else "0"
+    return ready, details
+
+
+def _ensure_pretrade_risk() -> tuple[bool, str]:
+    pretrade = _bind_alias(_PRETRADE_CANONICAL, _PRETRADE_ALIAS)
+    risk = _bind_alias(_RISK_CANONICAL, _RISK_ALIAS)
+    installer = getattr(risk, "_install_on_pre_trade_risk_engine", None)
+    if not callable(installer):
+        return False, "pretrade_installer_missing"
+    ready = bool(installer(pretrade))
+    full_install = getattr(risk, "install_import_hook", None) or getattr(risk, "install", None)
+    if callable(full_install):
+        full_install()
+    state = getattr(risk, "_STATE", {})
+    ready = ready and bool(state.get("pretrade", False))
+    os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = (
+        "1" if all(bool(state.get(key, False)) for key in ("downstream", "pipeline", "pretrade", "taxonomy")) else "0"
     )
-    return changed or True
+    return ready, str(state)
+
+
+def _apply() -> tuple[bool, dict[str, str]]:
+    okx_ready, okx_details = _ensure_okx_wrappers()
+    pretrade_ready, pretrade_details = _ensure_pretrade_risk()
+    ready = okx_ready and pretrade_ready
+    os.environ["NIJA_OKX_ORDER_WRAPPER_STABILITY_INSTALLED"] = "1"
+    os.environ["NIJA_RUNTIME_ERROR_CLEANUP_V1_INSTALLED"] = "1"
+    os.environ["NIJA_RUNTIME_ERROR_CLEANUP_V1_READY"] = "1" if ready else "0"
+    return ready, {
+        "okx": str(okx_details),
+        "pretrade": pretrade_details,
+        "deployment_sha": _deployment_sha(),
+    }
+
+
+def _publish_state(ready: bool, details: dict[str, str]) -> None:
+    global _LAST_STATE
+    signature = f"{ready}:{details}"
+    if signature == _LAST_STATE:
+        return
+    previous = _LAST_STATE
+    _LAST_STATE = signature
+    logger.log(
+        logging.CRITICAL if ready else logging.WARNING,
+        "RUNTIME_ERROR_CLEANUP_STATE marker=%s cleanup=%s ready=%s details=%s",
+        _MARKER,
+        _CLEANUP_MARKER,
+        str(ready).lower(),
+        details,
+    )
+    if ready and (not previous or not previous.startswith("True:")):
+        logger.critical(
+            "RUNTIME_ERROR_CLEANUP_READY marker=%s cleanup=%s commit=%s okx_wrapper_chain=stable pretrade_risk=ready",
+            _MARKER,
+            _CLEANUP_MARKER,
+            _deployment_sha(),
+        )
+
+
+def _monitor_interval() -> float:
+    try:
+        return max(0.5, float(os.environ.get("NIJA_RUNTIME_ERROR_CLEANUP_MONITOR_S", "2.0") or 2.0))
+    except Exception:
+        return 2.0
+
+
+def _monitor() -> None:
+    while True:
+        try:
+            ready, details = _apply()
+            _publish_state(ready, details)
+        except Exception as exc:
+            os.environ["NIJA_RUNTIME_ERROR_CLEANUP_V1_READY"] = "0"
+            logger.warning(
+                "RUNTIME_ERROR_CLEANUP_RETRY marker=%s cleanup=%s error=%s",
+                _MARKER,
+                _CLEANUP_MARKER,
+                f"{type(exc).__name__}:{exc}",
+                exc_info=True,
+            )
+        time.sleep(_monitor_interval())
 
 
 def install() -> bool:
-    global _INSTALLED
+    global _INSTALLED, _MONITOR_STARTED
     with _LOCK:
-        if _INSTALLED:
-            return True
-        result = _install_once()
+        ready, details = _apply()
+        _publish_state(ready, details)
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_monitor,
+                name="RuntimeErrorCleanupV1",
+                daemon=True,
+            ).start()
         _INSTALLED = True
-        return result
+        return ready
 
 
-__all__ = ["install", "_freeze_module"]
+def installed_marker() -> str | None:
+    return _MARKER if _INSTALLED else None
+
+
+__all__ = [
+    "install",
+    "installed_marker",
+    "_chain_has_attr",
+    "_guard_patch_module",
+    "_ensure_okx_wrappers",
+    "_ensure_pretrade_risk",
+    "_class_state",
+    "_narrow_interesting",
+]

--- a/bot/okx_order_wrapper_stability_patch.py
+++ b/bot/okx_order_wrapper_stability_patch.py
@@ -192,7 +192,12 @@ def _candidate_classes(module: ModuleType, targets: list[ModuleType]) -> list[ty
     return classes
 
 
-def _class_state(cls: type) -> tuple[bool, dict[str, str]]:
+def _class_state(
+    cls: type,
+    *,
+    require_instid: bool = True,
+    require_final: bool = True,
+) -> tuple[bool, dict[str, str]]:
     details: dict[str, str] = {}
     ready = True
     observed = False
@@ -204,15 +209,22 @@ def _class_state(cls: type) -> tuple[bool, dict[str, str]]:
         instid, instid_cycle, instid_depth = _chain_has_attr(method, _INSTID_ATTR)
         final, final_cycle, final_depth = _chain_has_attr(method, _FINAL_ATTR)
         cycle = instid_cycle or final_cycle
-        method_ready = instid and final and not cycle
+        method_ready = (
+            (instid or not require_instid)
+            and (final or not require_final)
+            and not cycle
+        )
         details[method_name] = (
             f"instid={instid};final={final};cycle={cycle};"
+            f"require_instid={require_instid};require_final={require_final};"
             f"depth={max(instid_depth, final_depth)}"
         )
         ready = ready and method_ready
         if method_ready:
-            _propagate_chain_marker(method, _INSTID_ATTR)
-            _propagate_chain_marker(method, _FINAL_ATTR)
+            if require_instid:
+                _propagate_chain_marker(method, _INSTID_ATTR)
+            if require_final:
+                _propagate_chain_marker(method, _FINAL_ATTR)
     if observed and ready:
         setattr(cls, _CLASS_MARKER, True)
     return observed and ready, details
@@ -245,22 +257,27 @@ def _ensure_okx_wrappers() -> tuple[bool, dict[str, str]]:
         if callable(patch_instid):
             patch_instid(target)
 
-    classes: list[type] = []
-    seen: set[int] = set()
-    for module in (final, instid):
-        for cls in _candidate_classes(module, targets):
-            if id(cls) not in seen:
-                seen.add(id(cls))
-                classes.append(cls)
+    final_classes = _candidate_classes(final, targets)
+    instid_classes = _candidate_classes(instid, targets)
+    roles: dict[int, tuple[type, bool, bool]] = {}
+    for cls in instid_classes:
+        roles[id(cls)] = (cls, True, False)
+    for cls in final_classes:
+        previous = roles.get(id(cls))
+        roles[id(cls)] = (cls, bool(previous and previous[1]), True)
 
     details: dict[str, str] = {}
-    ready = bool(classes)
-    for cls in classes:
-        class_ready, class_details = _class_state(cls)
+    ready = bool(roles)
+    for cls, require_instid, require_final in roles.values():
+        class_ready, class_details = _class_state(
+            cls,
+            require_instid=require_instid,
+            require_final=require_final,
+        )
         ready = ready and class_ready
         label = f"{getattr(cls, '__module__', '')}.{getattr(cls, '__name__', '')}"
         details[label] = str(class_details)
-    if not classes:
+    if not roles:
         details["classes"] = "not_loaded"
     os.environ["NIJA_OKX_ORDER_WRAPPER_STABILITY_READY"] = "1" if ready else "0"
     return ready, details

--- a/bot/okx_order_wrapper_stability_patch.py
+++ b/bot/okx_order_wrapper_stability_patch.py
@@ -25,7 +25,7 @@ import threading
 import time
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 logger = logging.getLogger("nija.okx_order_wrapper_stability")
 _MARKER = "20260723-okx-wrapper-stability-v2"
@@ -33,6 +33,8 @@ _CLEANUP_MARKER = "20260723-runtime-error-cleanup-v1"
 _LOCK = threading.RLock()
 _INSTALLED = False
 _MONITOR_STARTED = False
+_PATCH_INSTALLERS_READY = False
+_RISK_INSTALLER_READY = False
 _LAST_STATE = ""
 
 _INSTID_CANONICAL = "bot.okx_order_instid_payload_repair_patch"
@@ -224,12 +226,15 @@ def _install_patch_module(module: ModuleType) -> None:
 
 
 def _ensure_okx_wrappers() -> tuple[bool, dict[str, str]]:
+    global _PATCH_INSTALLERS_READY
     instid, final = _load_patch_modules()
 
-    # Install final-call validation first, then put instId normalization around it.
-    # The chain-aware guards keep both layers present on subsequent import-hook runs.
-    _install_patch_module(final)
-    _install_patch_module(instid)
+    # Import hooks are activated once. Healing passes patch loaded class surfaces
+    # directly, which avoids repeated INSTALL_COMPLETE log messages.
+    if not _PATCH_INSTALLERS_READY:
+        _install_patch_module(final)
+        _install_patch_module(instid)
+        _PATCH_INSTALLERS_READY = True
 
     targets = _loaded_target_modules()
     for target in targets:
@@ -262,15 +267,18 @@ def _ensure_okx_wrappers() -> tuple[bool, dict[str, str]]:
 
 
 def _ensure_pretrade_risk() -> tuple[bool, str]:
+    global _RISK_INSTALLER_READY
     pretrade = _bind_alias(_PRETRADE_CANONICAL, _PRETRADE_ALIAS)
     risk = _bind_alias(_RISK_CANONICAL, _RISK_ALIAS)
     installer = getattr(risk, "_install_on_pre_trade_risk_engine", None)
     if not callable(installer):
         return False, "pretrade_installer_missing"
     ready = bool(installer(pretrade))
-    full_install = getattr(risk, "install_import_hook", None) or getattr(risk, "install", None)
-    if callable(full_install):
-        full_install()
+    if not _RISK_INSTALLER_READY:
+        full_install = getattr(risk, "install_import_hook", None) or getattr(risk, "install", None)
+        if callable(full_install):
+            full_install()
+        _RISK_INSTALLER_READY = True
     state = getattr(risk, "_STATE", {})
     ready = ready and bool(state.get("pretrade", False))
     os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] = (

--- a/bot/tests/test_okx_order_wrapper_stability_v2.py
+++ b/bot/tests/test_okx_order_wrapper_stability_v2.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import bot.okx_order_wrapper_stability_patch as stability
+
+
+def _fake_patch_modules():
+    instid = ModuleType(stability._INSTID_CANONICAL)
+    final = ModuleType(stability._FINAL_CANONICAL)
+    instid._ORDER_WRAP_ATTR = stability._INSTID_ATTR
+    final._ORDER_WRAP_ATTR = stability._FINAL_ATTR
+    install_calls = {"instid": 0, "final": 0}
+
+    def candidate_classes(module):
+        cls = getattr(module, "OKXBroker", None)
+        return [cls] if isinstance(cls, type) else []
+
+    instid._candidate_order_classes = candidate_classes
+    final._candidate_order_classes = candidate_classes
+
+    def final_wrap(cls, _module_name):
+        changed = False
+        for method_name in stability._ORDER_METHODS:
+            current = getattr(cls, method_name, None)
+            if not callable(current) or getattr(current, stability._FINAL_ATTR, False):
+                continue
+            # Mirror the legacy defect: one wrapper layer was discarded.
+            base = getattr(current, "__wrapped__", current)
+
+            def final_order(self, *args, __base=base, **kwargs):
+                return __base(self, *args, **kwargs)
+
+            setattr(final_order, stability._FINAL_ATTR, True)
+            final_order.__wrapped__ = base
+            setattr(cls, method_name, final_order)
+            changed = True
+        return changed
+
+    def instid_wrap(cls, _module_name):
+        changed = False
+        for method_name in stability._ORDER_METHODS:
+            current = getattr(cls, method_name, None)
+            if not callable(current) or getattr(current, stability._INSTID_ATTR, False):
+                continue
+
+            def instid_order(self, symbol, side, quantity, *args, __current=current, **kwargs):
+                normalized = str(symbol).upper().replace("/", "-")
+                if normalized.endswith("-USD"):
+                    normalized = normalized[:-4] + "-USDT"
+                return __current(self, normalized, side, quantity, *args, **kwargs)
+
+            setattr(instid_order, stability._INSTID_ATTR, True)
+            instid_order.__wrapped__ = current
+            setattr(cls, method_name, instid_order)
+            changed = True
+        return changed
+
+    instid._wrap_order_class = instid_wrap
+    final._wrap_order_class = final_wrap
+
+    def patch_module_factory(module):
+        def patch_module(target):
+            changed = False
+            for cls in candidate_classes(target):
+                changed = bool(module._wrap_order_class(cls, target.__name__)) or changed
+            return changed
+
+        return patch_module
+
+    instid._patch_module = patch_module_factory(instid)
+    final._patch_module = patch_module_factory(final)
+    instid.install_import_hook = lambda: install_calls.__setitem__("instid", install_calls["instid"] + 1)
+    final.install_import_hook = lambda: install_calls.__setitem__("final", install_calls["final"] + 1)
+    return instid, final, install_calls
+
+
+def _prepare_okx_runtime(monkeypatch):
+    calls = []
+
+    class OKXBroker:
+        def place_market_order(self, symbol, side, quantity, *args, **kwargs):
+            calls.append((symbol, side, quantity))
+            return {"status": "ok", "symbol": symbol}
+
+    target = ModuleType("bot.broker_manager")
+    target.OKXBroker = OKXBroker
+    instid, final, install_calls = _fake_patch_modules()
+    mapping = {
+        stability._INSTID_CANONICAL: instid,
+        stability._FINAL_CANONICAL: final,
+    }
+    real_import = stability.importlib.import_module
+    monkeypatch.setattr(
+        stability.importlib,
+        "import_module",
+        lambda name: mapping.get(name) or real_import(name),
+    )
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", target)
+    monkeypatch.setitem(sys.modules, "broker_manager", target)
+    monkeypatch.setattr(stability, "_PATCH_INSTALLERS_READY", False)
+    return target, calls, install_calls
+
+
+def test_two_okx_safety_layers_are_preserved_and_idempotent(monkeypatch):
+    target, calls, install_calls = _prepare_okx_runtime(monkeypatch)
+
+    ready, details = stability._ensure_okx_wrappers()
+    assert ready is True
+    first = target.OKXBroker.place_market_order
+    instid, instid_cycle, _ = stability._chain_has_attr(first, stability._INSTID_ATTR)
+    final, final_cycle, _ = stability._chain_has_attr(first, stability._FINAL_ATTR)
+    assert instid is True and final is True
+    assert instid_cycle is False and final_cycle is False
+    assert "instid=True" in str(details)
+    assert "final=True" in str(details)
+
+    result = target.OKXBroker().place_market_order("BTC/USD", "buy", 10)
+    assert result["status"] == "ok"
+    assert calls == [("BTC-USDT", "buy", 10)]
+
+    ready, _ = stability._ensure_okx_wrappers()
+    assert ready is True
+    assert target.OKXBroker.place_market_order is first
+    assert install_calls == {"instid": 1, "final": 1}
+    assert sys.modules[stability._INSTID_ALIAS] is sys.modules[stability._INSTID_CANONICAL]
+    assert sys.modules[stability._FINAL_ALIAS] is sys.modules[stability._FINAL_CANONICAL]
+
+
+def test_late_okx_method_replacement_is_healed_without_chain_growth(monkeypatch):
+    target, calls, _install_calls = _prepare_okx_runtime(monkeypatch)
+    ready, _ = stability._ensure_okx_wrappers()
+    assert ready is True
+
+    def late_replacement(self, symbol, side, quantity, *args, **kwargs):
+        calls.append(("late", symbol, side, quantity))
+        return {"status": "late"}
+
+    target.OKXBroker.place_market_order = late_replacement
+    ready, _ = stability._ensure_okx_wrappers()
+    assert ready is True
+    repaired = target.OKXBroker.place_market_order
+    instid, instid_cycle, instid_depth = stability._chain_has_attr(repaired, stability._INSTID_ATTR)
+    final, final_cycle, final_depth = stability._chain_has_attr(repaired, stability._FINAL_ATTR)
+    assert instid is True and final is True
+    assert instid_cycle is False and final_cycle is False
+    assert max(instid_depth, final_depth) <= 2
+
+    target.OKXBroker().place_market_order("ETH/USD", "sell", 5)
+    assert calls[-1] == ("late", "ETH-USDT", "sell", 5)
+
+    same = target.OKXBroker.place_market_order
+    ready, _ = stability._ensure_okx_wrappers()
+    assert ready is True
+    assert target.OKXBroker.place_market_order is same
+
+
+def test_pretrade_risk_is_imported_patched_and_alias_bound_once(monkeypatch):
+    pretrade = ModuleType(stability._PRETRADE_CANONICAL)
+    pretrade.PreTradeRiskEngine = type("PreTradeRiskEngine", (), {"assess": lambda self, **kwargs: None})
+    pretrade.PreTradeRiskDecision = type("PreTradeRiskDecision", (), {})
+
+    risk = ModuleType(stability._RISK_CANONICAL)
+    risk._STATE = {"downstream": True, "pipeline": True, "pretrade": False, "taxonomy": True}
+    install_calls = []
+
+    def patch_pretrade(module):
+        assert module is pretrade
+        risk._STATE["pretrade"] = True
+        return True
+
+    risk._install_on_pre_trade_risk_engine = patch_pretrade
+    risk.install_import_hook = lambda: install_calls.append("install")
+    mapping = {
+        stability._PRETRADE_CANONICAL: pretrade,
+        stability._RISK_CANONICAL: risk,
+    }
+    real_import = stability.importlib.import_module
+    monkeypatch.setattr(
+        stability.importlib,
+        "import_module",
+        lambda name: mapping.get(name) or real_import(name),
+    )
+    monkeypatch.setattr(stability, "_RISK_INSTALLER_READY", False)
+
+    ready, details = stability._ensure_pretrade_risk()
+    assert ready is True
+    assert "'pretrade': True" in details
+    ready, _ = stability._ensure_pretrade_risk()
+    assert ready is True
+    assert install_calls == ["install"]
+    assert sys.modules[stability._PRETRADE_ALIAS] is pretrade
+    assert sys.modules[stability._RISK_ALIAS] is risk
+    assert stability.os.environ["NIJA_DOWNSTREAM_RISK_GOVERNOR_V2_READY"] == "1"
+
+
+def test_import_hook_scope_is_exact_not_all_broker_or_okx_modules():
+    assert stability._narrow_interesting("bot.broker_manager") is True
+    assert stability._narrow_interesting("broker_integration") is True
+    assert stability._narrow_interesting("some_unrelated_broker_module") is False
+    assert stability._narrow_interesting("random_okx_helper") is False

--- a/bot/tests/test_okx_order_wrapper_stability_v2.py
+++ b/bot/tests/test_okx_order_wrapper_stability_v2.py
@@ -156,6 +156,30 @@ def test_late_okx_method_replacement_is_healed_without_chain_growth(monkeypatch)
     assert target.OKXBroker.place_market_order is same
 
 
+def test_rest_client_role_requires_instid_but_not_final_submit():
+    class OKXRestClient:
+        def place_order(self, symbol, side, quantity):
+            return symbol, side, quantity
+
+    method = OKXRestClient.place_order
+    setattr(method, stability._INSTID_ATTR, True)
+
+    ready, details = stability._class_state(
+        OKXRestClient,
+        require_instid=True,
+        require_final=False,
+    )
+    assert ready is True
+    assert "require_final=False" in details["place_order"]
+
+    missing_final, _ = stability._class_state(
+        OKXRestClient,
+        require_instid=True,
+        require_final=True,
+    )
+    assert missing_final is False
+
+
 def test_pretrade_risk_is_imported_patched_and_alias_bound_once(monkeypatch):
     pretrade = ModuleType(stability._PRETRADE_CANONICAL)
     pretrade.PreTradeRiskEngine = type("PreTradeRiskEngine", (), {"assess": lambda self, **kwargs: None})

--- a/bot/tests/test_okx_order_wrapper_stability_v2.py
+++ b/bot/tests/test_okx_order_wrapper_stability_v2.py
@@ -91,6 +91,13 @@ def _prepare_okx_runtime(monkeypatch):
         stability._INSTID_CANONICAL: instid,
         stability._FINAL_CANONICAL: final,
     }
+    for name in (
+        stability._INSTID_CANONICAL,
+        stability._INSTID_ALIAS,
+        stability._FINAL_CANONICAL,
+        stability._FINAL_ALIAS,
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
     real_import = stability.importlib.import_module
     monkeypatch.setattr(
         stability.importlib,
@@ -200,6 +207,13 @@ def test_pretrade_risk_is_imported_patched_and_alias_bound_once(monkeypatch):
         stability._PRETRADE_CANONICAL: pretrade,
         stability._RISK_CANONICAL: risk,
     }
+    for name in (
+        stability._PRETRADE_CANONICAL,
+        stability._PRETRADE_ALIAS,
+        stability._RISK_CANONICAL,
+        stability._RISK_ALIAS,
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
     real_import = stability.importlib.import_module
     monkeypatch.setattr(
         stability.importlib,


### PR DESCRIPTION
## Runtime evidence

The July 23 Render process remained fail-closed with:

- `zero_signal_streak_chain ... state_repair=False`
- scan ownership reported as `broker_layers=4;canonical_layers=14`
- `LIVE_PENDING_CONFIRMATION`, execution authority `0`, and scan cycles `0`
- downstream risk state permanently missing `pretrade`
- repeated `OKX_ORDER_SYMBOL_METHOD_PATCHED` and `OKX_FINAL_ORDER_METHOD_PATCHED` messages

The first two release-manifest defects were repaired in merged PR #2218, but the supplied process was still running the old audit format. This PR adds an unambiguous deployment marker and closes the remaining runtime defects.

## Root causes

1. The downstream risk patch only inspected modules already present in `sys.modules`. It never imported `bot.pre_trade_risk_engine`, so its required `pretrade` state could remain false until the monitor expired.
2. The two OKX order patches inspected only the outer wrapper. The final submission bridge also unwrapped one layer before replacing the method, allowing the final-call and instId patches to remove and reinstall each other.
3. The existing Zero-Trust workflow selected tests with `pytest -k unit` / `pytest -k integration`, which did not define real test groups and caused both test jobs to fail.

## Changes

- Replace the OKX wrapper stability layer with a persistent, chain-aware two-layer owner.
- Preserve both final-call validation and instId normalization across repeated imports and late method replacement.
- Bind canonical and legacy OKX/risk module aliases to the same module objects.
- Narrow OKX import rescans to exact broker/router modules.
- Import and patch `PreTradeRiskEngine` deterministically.
- Keep healing continuous but installer activation one-time to prevent log flooding.
- Publish `RUNTIME_ERROR_CLEANUP_READY ... commit=<sha>` as deployment proof.
- Add focused tests for idempotence, late replacement, alias identity, instrument normalization, and pre-trade convergence.
- Make Runtime Repair Regression, NIJA Deployment Safety, and Zero-Trust CI install the startup defer guard before pip.
- Replace Zero-Trust substring selection with explicit blocking unit and integration test paths.

## Safety

This does not bypass Redis writer fencing, runtime release checks, broker authentication, regional endpoint selection, capital hydration, kill switches, exposure limits, exchange minimums, cost-basis verification, position limits, exits, take-profit, or stop-loss protection.

## Expected deployment proof

```text
RUNTIME_ERROR_CLEANUP_READY marker=20260723-okx-wrapper-stability-v2 cleanup=20260723-runtime-error-cleanup-v1 commit=<latest-main-sha> okx_wrapper_chain=stable pretrade_risk=ready
ZERO_SIGNAL_STREAK_STATE_MONITOR ... ready=true
RUNTIME_MODULE_IDENTITY_AUDIT ... ready=true ... state_repair=True
SCAN_WRAPPER_DEPTH_AUDIT ... ready=true ... raw_broker_markers=... raw_canonical_markers=...
NIJA_RUNTIME_RELEASE_MANIFEST ... ready=true
RUNTIME_AUTHORITY_CONVERGENCE_REPAIRED
```

Only after normal broker/capital/risk gates pass should the runtime publish `LIVE_ACTIVE` and execution authority `1`.