### PR TITLE
make canonical broker initialization entrypoint-enforced

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -106,11 +106,11 @@ except Exception as exc:
     logger.warning("OKX_FINAL_ORDER_SUBMISSION_BRIDGE_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
 try:
-    from bot.canonical_broker_bootstrap_handoff_patch import install_import_hook as _install_canonical_broker_handoff
-    _install_canonical_broker_handoff()
-    logger.warning("CANONICAL_BROKER_BOOTSTRAP_HANDOFF_INSTALL_REQUESTED source=bot_entrypoint")
+    from bot.canonical_broker_main_entry_guard_v20 import install_import_hook as _install_canonical_broker_main_guard
+    _install_canonical_broker_main_guard()
+    logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
 except Exception as exc:
-    logger.warning("CANONICAL_BROKER_BOOTSTRAP_HANDOFF_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+    logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
 from bot.bot_main import main
 

--- a/bot/canonical_broker_main_entry_guard_v20.py
+++ b/bot/canonical_broker_main_entry_guard_v20.py
@@ -1,0 +1,374 @@
+"""Direct canonical broker-manager guard for the active bot_main entrypoint.
+
+This guard repairs a startup ordering failure where the legacy v18 handoff wrapper
+can be lost or can encounter an InitRegistry key owned by a different manager
+instance. It runs only after SelfHealingStartup reports a connected broker, repairs
+the canonical manager's capital-FSM latch when necessary, and requires a fresh
+positive CapitalAuthority snapshot before returning success in live mode.
+
+It never grants writer authority, forces LIVE_ACTIVE, fabricates balances, creates
+orders, or bypasses normal risk/state-machine gates.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.canonical_broker_main_guard")
+_MARKER = "20260723-canonical-broker-main-guard-v20"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_INSTALLED = False
+_STARTUP_WRAP_ATTR = "_nija_canonical_broker_main_guard_startup_v20"
+_MAIN_WRAP_ATTR = "_nija_canonical_broker_main_guard_main_v20"
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _canonical_manager() -> Any:
+    module = importlib.import_module("bot.multi_account_broker_manager")
+    manager = getattr(module, "multi_account_broker_manager", None)
+    if manager is None:
+        getter = getattr(module, "get_broker_manager", None)
+        manager = getter() if callable(getter) else None
+    if manager is None:
+        raise RuntimeError("canonical MultiAccountBrokerManager singleton unavailable")
+    return manager
+
+
+def _authority_snapshot(manager: Any) -> dict[str, Any]:
+    module = importlib.import_module("bot.capital_authority")
+    getter = getattr(module, "get_capital_authority", None)
+    authority = getter() if callable(getter) else None
+    if authority is None:
+        return {
+            "hydrated": False,
+            "capital": 0.0,
+            "stale": True,
+            "valid_brokers": int(getattr(manager, "_capital_last_valid_brokers", 0) or 0),
+        }
+
+    try:
+        capital = float(authority.get_real_capital() or 0.0)
+    except Exception:
+        capital = float(getattr(authority, "total_capital", 0.0) or 0.0)
+    try:
+        stale = bool(authority.is_stale())
+    except Exception:
+        stale = True
+
+    hydrated_raw = getattr(authority, "is_hydrated", False)
+    try:
+        hydrated = bool(hydrated_raw() if callable(hydrated_raw) else hydrated_raw)
+    except Exception:
+        hydrated = False
+
+    valid = int(getattr(manager, "_capital_last_valid_brokers", 0) or 0)
+    if valid <= 0:
+        for attr in ("valid_brokers", "broker_count", "_valid_broker_count"):
+            try:
+                candidate = int(getattr(authority, attr, 0) or 0)
+            except Exception:
+                candidate = 0
+            if candidate > 0:
+                valid = candidate
+                break
+
+    return {
+        "hydrated": hydrated,
+        "capital": capital,
+        "stale": stale,
+        "valid_brokers": valid,
+    }
+
+
+def _manager_contract(manager: Any) -> tuple[bool, str]:
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        return False, "fsm_not_initialized"
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    if callable(has_sources) and not bool(has_sources()):
+        return False, "no_registered_platform_source"
+
+    attempted = getattr(manager, "has_attempted_connections", None)
+    if callable(attempted) and not bool(attempted()):
+        return False, "broker_registration_not_finalized"
+
+    return True, "manager_ready"
+
+
+def _repair_capital_fsm_latch(manager: Any, cause: BaseException | None = None) -> bool:
+    """Repair only the canonical manager's missing capital-FSM wiring.
+
+    InitRegistry is process-global. If a duplicate or early manager consumed the
+    MABM_CAPITAL_FSM key, the canonical manager can remain unwired forever.
+    _init_capital_fsm is idempotent, so calling it on the canonical singleton is
+    a narrow repair that does not reset the registry or create another manager.
+    """
+
+    if bool(getattr(manager, "_fsm_initialized", False)):
+        return True
+
+    repair = getattr(manager, "_init_capital_fsm", None)
+    if not callable(repair):
+        return False
+
+    logger.critical(
+        "CANONICAL_BROKER_FSM_LATCH_REPAIR_BEGIN marker=%s cause=%s",
+        _MARKER,
+        f"{type(cause).__name__}:{cause}" if cause is not None else "missing_fsm_after_initialize",
+    )
+    repair()
+    repaired = bool(getattr(manager, "_fsm_initialized", False))
+    logger.critical(
+        "CANONICAL_BROKER_FSM_LATCH_REPAIR_RESULT marker=%s repaired=%s",
+        _MARKER,
+        repaired,
+    )
+    return repaired
+
+
+def _initialize_manager(manager: Any) -> None:
+    initialize = getattr(manager, "initialize", None)
+    if not callable(initialize):
+        raise RuntimeError("MultiAccountBrokerManager.initialize is unavailable")
+
+    if bool(getattr(manager, "_fsm_initialized", False)):
+        return
+
+    try:
+        initialize()
+    except Exception as first_exc:
+        if not _repair_capital_fsm_latch(manager, first_exc):
+            raise
+        logger.warning(
+            "CANONICAL_BROKER_MANAGER_INITIALIZE_RETRY marker=%s first_error=%s",
+            _MARKER,
+            f"{type(first_exc).__name__}:{first_exc}",
+        )
+        initialize()
+
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        if not _repair_capital_fsm_latch(manager):
+            raise RuntimeError("canonical broker manager contract failed: fsm_not_initialized")
+
+
+def _refresh_capital(manager: Any) -> None:
+    refresh = getattr(manager, "refresh_capital_authority", None)
+    if not callable(refresh):
+        return
+    try:
+        refresh(trigger="bot_main_direct_canonical_handoff")
+    except TypeError:
+        refresh("bot_main_direct_canonical_handoff")
+
+
+def _initialize_canonical_runtime(
+    broker: Any,
+    broker_name: str,
+) -> tuple[bool, Any, str]:
+    manager = _canonical_manager()
+
+    logger.critical(
+        "CANONICAL_BROKER_MAIN_GUARD_INITIALIZING marker=%s broker=%s thread=%s",
+        _MARKER,
+        broker_name or type(broker).__name__,
+        threading.current_thread().name,
+    )
+    _initialize_manager(manager)
+
+    manager_ok, manager_reason = _manager_contract(manager)
+    if not manager_ok:
+        raise RuntimeError(f"canonical broker manager contract failed: {manager_reason}")
+
+    timeout_s = max(
+        1.0,
+        float(os.environ.get("NIJA_CANONICAL_BROKER_BOOTSTRAP_TIMEOUT_S", "60") or 60),
+    )
+    poll_s = max(
+        0.1,
+        float(os.environ.get("NIJA_CANONICAL_BROKER_BOOTSTRAP_POLL_S", "1") or 1),
+    )
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, Any] = {}
+
+    while True:
+        last = _authority_snapshot(manager)
+        live_mode = (
+            _truthy("LIVE_CAPITAL_VERIFIED")
+            and not _truthy("DRY_RUN_MODE")
+            and not _truthy("PAPER_MODE")
+        )
+        ready = bool(last["hydrated"]) and not bool(last["stale"])
+        if live_mode:
+            ready = (
+                ready
+                and float(last["capital"]) > 0.0
+                and int(last["valid_brokers"]) >= 1
+            )
+
+        if ready:
+            os.environ["NIJA_CANONICAL_BROKER_BOOTSTRAP_READY"] = "1"
+            os.environ["NIJA_CANONICAL_BROKER_BOOTSTRAP_MARKER"] = _MARKER
+            os.environ["NIJA_CANONICAL_BROKER_MAIN_GUARD_READY"] = "1"
+            logger.critical(
+                "CANONICAL_BROKER_MAIN_GUARD_READY marker=%s broker=%s hydrated=%s "
+                "capital=%.8f stale=%s valid_brokers=%s fsm_initialized=true",
+                _MARKER,
+                broker_name or type(broker).__name__,
+                last["hydrated"],
+                float(last["capital"]),
+                last["stale"],
+                last["valid_brokers"],
+            )
+            return True, broker, broker_name
+
+        if time.monotonic() >= deadline:
+            break
+
+        try:
+            _refresh_capital(manager)
+        except Exception as exc:
+            logger.warning(
+                "CANONICAL_BROKER_MAIN_GUARD_REFRESH_WAITING marker=%s err=%s state=%s",
+                _MARKER,
+                exc,
+                last,
+            )
+        time.sleep(poll_s)
+
+    os.environ["NIJA_CANONICAL_BROKER_BOOTSTRAP_READY"] = "0"
+    os.environ["NIJA_CANONICAL_BROKER_MAIN_GUARD_READY"] = "0"
+    raise RuntimeError(
+        "canonical broker capital hydration timed out "
+        f"after {timeout_s:.1f}s state={last}"
+    )
+
+
+def _unwrap_legacy_startup(current: Callable[..., Any]) -> Callable[..., Any]:
+    """Return the original startup function beneath legacy wrapper layers."""
+
+    seen: set[int] = set()
+    base = current
+    while callable(getattr(base, "__wrapped__", None)) and id(base) not in seen:
+        seen.add(id(base))
+        candidate = getattr(base, "__wrapped__")
+        if not callable(candidate):
+            break
+        base = candidate
+    return base
+
+
+def _patch_startup(module: ModuleType) -> bool:
+    current = getattr(module, "_run_self_healing_startup", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _STARTUP_WRAP_ATTR, False)):
+        return True
+
+    base = _unwrap_legacy_startup(current)
+
+    @wraps(base)
+    def guarded_startup(*args: Any, **kwargs: Any):
+        ok, broker, broker_name = base(*args, **kwargs)
+        if not ok:
+            return ok, broker, broker_name
+        try:
+            return _initialize_canonical_runtime(broker, broker_name)
+        except Exception as exc:
+            os.environ["NIJA_CANONICAL_BROKER_BOOTSTRAP_READY"] = "0"
+            os.environ["NIJA_CANONICAL_BROKER_MAIN_GUARD_READY"] = "0"
+            logger.critical(
+                "CANONICAL_BROKER_MAIN_GUARD_FAILED marker=%s broker=%s err=%s "
+                "trading_remains_fail_closed=true",
+                _MARKER,
+                broker_name or type(broker).__name__,
+                exc,
+                exc_info=True,
+            )
+            return False, None, ""
+
+    setattr(guarded_startup, _STARTUP_WRAP_ATTR, True)
+    setattr(guarded_startup, "__wrapped__", base)
+    setattr(module, "_run_self_healing_startup", guarded_startup)
+    logger.critical(
+        "CANONICAL_BROKER_MAIN_GUARD_STARTUP_PATCHED marker=%s module=%s "
+        "legacy_layers_unwrapped=%s",
+        _MARKER,
+        module.__name__,
+        base is not current,
+    )
+    return True
+
+
+def _patch_main(module: ModuleType) -> bool:
+    current = getattr(module, "main", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _MAIN_WRAP_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def guarded_main(*args: Any, **kwargs: Any):
+        if not _patch_startup(module):
+            logger.critical(
+                "CANONICAL_BROKER_MAIN_GUARD_REPATCH_FAILED marker=%s "
+                "trading_remains_fail_closed=true",
+                _MARKER,
+            )
+            return 1
+        return current(*args, **kwargs)
+
+    setattr(guarded_main, _MAIN_WRAP_ATTR, True)
+    setattr(guarded_main, "__wrapped__", current)
+    setattr(module, "main", guarded_main)
+    logger.critical(
+        "CANONICAL_BROKER_MAIN_GUARD_MAIN_PATCHED marker=%s module=%s",
+        _MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        module = importlib.import_module("bot.bot_main")
+        startup_patched = _patch_startup(module)
+        main_patched = _patch_main(module)
+        _INSTALLED = bool(startup_patched and main_patched)
+        os.environ["NIJA_CANONICAL_BROKER_MAIN_GUARD_INSTALLED"] = (
+            "1" if _INSTALLED else "0"
+        )
+        logger.critical(
+            "CANONICAL_BROKER_MAIN_GUARD_INSTALLED marker=%s startup_patched=%s "
+            "main_patched=%s",
+            _MARKER,
+            startup_patched,
+            main_patched,
+        )
+        return _INSTALLED
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_initialize_canonical_runtime",
+    "_initialize_manager",
+    "_repair_capital_fsm_latch",
+    "_unwrap_legacy_startup",
+    "_patch_startup",
+    "_patch_main",
+]

--- a/bot/tests/test_canonical_broker_main_entry_guard_v20.py
+++ b/bot/tests/test_canonical_broker_main_entry_guard_v20.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import types
+
+import bot.canonical_broker_main_entry_guard_v20 as guard
+
+
+class LatchBlockedManager:
+    def __init__(self):
+        self._fsm_initialized = False
+        self.initialize_calls = 0
+        self.repair_calls = 0
+
+    def initialize(self):
+        self.initialize_calls += 1
+        if not self._fsm_initialized:
+            raise RuntimeError("BrokerManager not initialized")
+
+    def _init_capital_fsm(self):
+        self.repair_calls += 1
+        self._fsm_initialized = True
+
+
+def test_initialize_manager_repairs_stale_fsm_latch_and_retries():
+    manager = LatchBlockedManager()
+
+    guard._initialize_manager(manager)
+
+    assert manager._fsm_initialized is True
+    assert manager.repair_calls == 1
+    assert manager.initialize_calls == 2
+
+
+def test_unwrap_legacy_startup_returns_original_function():
+    def original():
+        return True, object(), "kraken"
+
+    def wrapper():
+        return original()
+
+    wrapper.__wrapped__ = original
+
+    assert guard._unwrap_legacy_startup(wrapper) is original
+
+
+def test_main_guard_repatches_startup_immediately_before_execution(monkeypatch):
+    module = types.ModuleType("bot.bot_main")
+    broker = object()
+
+    def original_startup():
+        return True, broker, "kraken"
+
+    module._run_self_healing_startup = original_startup
+    module.main = lambda: module._run_self_healing_startup()
+
+    monkeypatch.setattr(
+        guard,
+        "_initialize_canonical_runtime",
+        lambda connected_broker, name: (True, connected_broker, name),
+    )
+
+    assert guard._patch_startup(module)
+    assert guard._patch_main(module)
+
+    # Simulate a later import hook replacing the startup wrapper. The guarded
+    # main function must restore the canonical handoff before bot_main executes.
+    module._run_self_healing_startup = original_startup
+
+    assert module.main() == (True, broker, "kraken")
+    assert getattr(
+        module._run_self_healing_startup,
+        guard._STARTUP_WRAP_ATTR,
+        False,
+    ) is True


### PR DESCRIPTION
## Root cause

Fresh Render logs still exhausted startup with `broker_manager_not_initialized`, `hydrated=False`, `$0.00` capital, and zero brokers. The v18 canonical handoff file existed, but the critical initialization still depended on a wrapper around `_run_self_healing_startup`. Later import-hook churn or a stale process-wide `InitRegistry` key could leave the canonical `MultiAccountBrokerManager` unwired.

## Fix

- Replace the v18 entrypoint installer with a v20 main-entry guard.
- Wrap `bot_main.main` itself and re-apply the startup handoff immediately before execution.
- Unwrap older `__wrapped__` startup layers so the new guard owns the single canonical handoff.
- Call `MultiAccountBrokerManager.initialize()` only after SelfHealingStartup returns a connected broker.
- If a stale `MABM_CAPITAL_FSM` registry latch left the canonical manager unwired, repair only that manager through its idempotent `_init_capital_fsm()` method, then retry normal initialization.
- Require registered sources, finalized connection attempts, a fresh hydrated CapitalAuthority snapshot, positive live capital, and at least one valid broker before returning success.
- Add explicit v20 startup, latch-repair, readiness, and fail-closed markers.
- Add focused tests for latch repair, legacy-wrapper unwrapping, and main-time re-patching.

## Safety

This change does not grant writer authority, force `LIVE_ACTIVE`, fabricate balances, create a second broker manager, submit probe orders, bypass nonce protection, loosen risk limits, or bypass exchange admission. Failure still returns startup failure and keeps trading blocked.

## Expected runtime proof

- `CANONICAL_BROKER_MAIN_GUARD_INSTALLED`
- `CANONICAL_BROKER_MAIN_GUARD_STARTUP_PATCHED`
- `CANONICAL_BROKER_MAIN_GUARD_INITIALIZING`
- optional: `CANONICAL_BROKER_FSM_LATCH_REPAIR_RESULT repaired=True`
- `CANONICAL_BROKER_MAIN_GUARD_READY ... hydrated=True capital=<positive> valid_brokers>=1`
- downstream: `RENDER_STARTUP_RECOVERY_COMPLETE`