### PR TITLE
release stalled fail-closed writer leases

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -15,12 +15,16 @@ on:
       - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/runtime_patch_churn_safety_patch.py"
       - "bot/generation_sync_timing_patch.py"
+      - "bot/canonical_broker_main_entry_guard_v20.py"
+      - "bot/stalled_writer_release_guard_v21.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
       - "bot/tests/test_okx_order_wrapper_stability_v2.py"
       - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
+      - "bot/tests/test_canonical_broker_main_entry_guard_v20.py"
+      - "bot/tests/test_stalled_writer_release_guard_v21.py"
       - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
   push:
@@ -38,12 +42,16 @@ on:
       - "bot/live_active_dispatch_bridge_patch.py"
       - "bot/runtime_patch_churn_safety_patch.py"
       - "bot/generation_sync_timing_patch.py"
+      - "bot/canonical_broker_main_entry_guard_v20.py"
+      - "bot/stalled_writer_release_guard_v21.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
       - "bot/tests/test_okx_order_wrapper_stability_v2.py"
       - "bot/tests/test_live_active_dispatch_bridge_recovery.py"
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
+      - "bot/tests/test_canonical_broker_main_entry_guard_v20.py"
+      - "bot/tests/test_stalled_writer_release_guard_v21.py"
       - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
 
@@ -84,6 +92,8 @@ jobs:
             bot/live_active_dispatch_bridge_patch.py \
             bot/runtime_patch_churn_safety_patch.py \
             bot/generation_sync_timing_patch.py \
+            bot/canonical_broker_main_entry_guard_v20.py \
+            bot/stalled_writer_release_guard_v21.py \
             bot/bot.py
 
       - name: Run focused regression suite
@@ -95,4 +105,6 @@ jobs:
             bot/tests/test_okx_patch_churn_guard_patch.py \
             bot/tests/test_okx_order_wrapper_stability_v2.py \
             bot/tests/test_live_active_dispatch_bridge_recovery.py \
-            bot/tests/test_runtime_patch_churn_safety_patch.py
+            bot/tests/test_runtime_patch_churn_safety_patch.py \
+            bot/tests/test_canonical_broker_main_entry_guard_v20.py \
+            bot/tests/test_stalled_writer_release_guard_v21.py

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -112,6 +112,13 @@ try:
 except Exception as exc:
     logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
+try:
+    from bot.stalled_writer_release_guard_v21 import install_import_hook as _install_stalled_writer_release_guard
+    _install_stalled_writer_release_guard()
+    logger.warning("STALLED_WRITER_RELEASE_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
+except Exception as exc:
+    logger.warning("STALLED_WRITER_RELEASE_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+
 from bot.bot_main import main
 
 if __name__ == "__main__":

--- a/bot/stalled_writer_release_guard_v21.py
+++ b/bot/stalled_writer_release_guard_v21.py
@@ -1,0 +1,433 @@
+"""Release a fail-closed writer lease when startup cannot become execution-ready.
+
+A Render process can acquire the distributed writer lease and then remain stuck in
+``LIVE_PENDING_CONFIRMATION`` with no execution authority, no initialized canonical
+broker manager, no hydrated capital, and zero scan cycles.  Keeping that failed
+process alive indefinitely blocks a corrected deployment from becoming the writer.
+
+This guard is deliberately narrow:
+
+* it applies only to verified live mode;
+* it requires a real writer token and lease generation;
+* it never runs after ``LIVE_ACTIVE`` or execution authority is granted;
+* it waits a bounded startup timeout before acting;
+* it requests shutdown, releases the current process's own lease through bot_main,
+  and exits the failed process so Render can replace it.
+
+It does not delete Redis keys directly, take over another process's lease, grant
+trading authority, initialize brokers from a background thread, or submit orders.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger("nija.stalled_writer_release_guard")
+
+_MARKER = "20260723-stalled-writer-release-v21"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_INSTALLED = False
+_THREAD: Optional[threading.Thread] = None
+_STOP = threading.Event()
+
+
+def _truthy_value(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _truthy_env(name: str, default: str = "false") -> bool:
+    return _truthy_value(os.environ.get(name, default))
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default)) or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _live_mode() -> bool:
+    return (
+        _truthy_env("LIVE_CAPITAL_VERIFIED")
+        and not _truthy_env("DRY_RUN_MODE")
+        and not _truthy_env("PAPER_MODE")
+    )
+
+
+def _manager_snapshot() -> tuple[bool, bool, bool]:
+    """Return ``(fsm_initialized, sources_registered, attempts_finalized)``.
+
+    The watchdog never imports the manager module merely to inspect it.  It only
+    observes an already-loaded canonical module, preserving bootstrap ownership.
+    """
+
+    module = sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get(
+        "multi_account_broker_manager"
+    )
+    if module is None:
+        return False, False, False
+
+    manager = getattr(module, "multi_account_broker_manager", None)
+    if manager is None:
+        getter = getattr(module, "get_broker_manager", None)
+        if callable(getter):
+            try:
+                manager = getter()
+            except Exception:
+                manager = None
+    if manager is None:
+        return False, False, False
+
+    fsm_initialized = bool(getattr(manager, "_fsm_initialized", False))
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    try:
+        sources_registered = bool(has_sources()) if callable(has_sources) else False
+    except Exception:
+        sources_registered = False
+
+    attempted = getattr(manager, "has_attempted_connections", None)
+    try:
+        attempts_finalized = bool(attempted()) if callable(attempted) else False
+    except Exception:
+        attempts_finalized = False
+
+    return fsm_initialized, sources_registered, attempts_finalized
+
+
+def _capital_snapshot() -> tuple[bool, float, bool, int]:
+    """Return ``(hydrated, capital, stale, valid_brokers)`` without creating CA."""
+
+    module = sys.modules.get("bot.capital_authority") or sys.modules.get("capital_authority")
+    if module is None:
+        return False, 0.0, True, 0
+
+    getter = getattr(module, "get_capital_authority", None)
+    if not callable(getter):
+        return False, 0.0, True, 0
+
+    try:
+        authority = getter()
+    except Exception:
+        return False, 0.0, True, 0
+    if authority is None:
+        return False, 0.0, True, 0
+
+    hydrated_raw = getattr(authority, "is_hydrated", False)
+    try:
+        hydrated = bool(hydrated_raw() if callable(hydrated_raw) else hydrated_raw)
+    except Exception:
+        hydrated = False
+
+    try:
+        capital = float(authority.get_real_capital() or 0.0)
+    except Exception:
+        try:
+            capital = float(getattr(authority, "total_capital", 0.0) or 0.0)
+        except Exception:
+            capital = 0.0
+
+    try:
+        stale = bool(authority.is_stale())
+    except Exception:
+        stale = True
+
+    valid = 0
+    for attr in ("valid_brokers", "broker_count", "_valid_broker_count"):
+        try:
+            candidate = int(getattr(authority, attr, 0) or 0)
+        except Exception:
+            candidate = 0
+        if candidate > 0:
+            valid = candidate
+            break
+
+    return hydrated, capital, stale, valid
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    live_mode: bool
+    writer_acquired: bool
+    token: str
+    generation: str
+    state: str
+    authority: bool
+    startup_complete: bool
+    shutdown_requested: bool
+    fsm_initialized: bool
+    sources_registered: bool
+    attempts_finalized: bool
+    hydrated: bool
+    capital: float
+    stale: bool
+    valid_brokers: int
+
+    @property
+    def manager_ready(self) -> bool:
+        return self.fsm_initialized and self.sources_registered and self.attempts_finalized
+
+    @property
+    def capital_ready(self) -> bool:
+        return self.hydrated and not self.stale and self.capital > 0.0 and self.valid_brokers >= 1
+
+
+def _runtime_snapshot(bot_main: Any) -> RuntimeSnapshot:
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+    writer_acquired = (
+        _truthy_env("NIJA_WRITER_LEASE_ACQUIRED") and bool(token) and bool(generation)
+    )
+    fsm_initialized, sources_registered, attempts_finalized = _manager_snapshot()
+    hydrated, capital, stale, valid_brokers = _capital_snapshot()
+
+    shutdown_event = getattr(bot_main, "_shutdown_event", None)
+    shutdown_requested = bool(
+        shutdown_event is not None
+        and callable(getattr(shutdown_event, "is_set", None))
+        and shutdown_event.is_set()
+    )
+
+    return RuntimeSnapshot(
+        live_mode=_live_mode(),
+        writer_acquired=writer_acquired,
+        token=token,
+        generation=generation,
+        state=str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "OFF") or "OFF")
+        .strip()
+        .upper(),
+        authority=_truthy_env("NIJA_RUNTIME_EXECUTION_AUTHORITY"),
+        startup_complete=bool(getattr(bot_main, "_startup_complete", False)),
+        shutdown_requested=shutdown_requested,
+        fsm_initialized=fsm_initialized,
+        sources_registered=sources_registered,
+        attempts_finalized=attempts_finalized,
+        hydrated=hydrated,
+        capital=capital,
+        stale=stale,
+        valid_brokers=valid_brokers,
+    )
+
+
+def _release_reason(snapshot: RuntimeSnapshot) -> str:
+    reasons: list[str] = []
+    if not snapshot.manager_ready:
+        reasons.append("broker_manager_not_initialized")
+    if not snapshot.capital_ready:
+        reasons.append(
+            "capital_not_ready"
+            f":hydrated={snapshot.hydrated}"
+            f":capital={snapshot.capital:.8f}"
+            f":stale={snapshot.stale}"
+            f":brokers={snapshot.valid_brokers}"
+        )
+    if snapshot.state != "LIVE_ACTIVE":
+        reasons.append(f"state={snapshot.state}")
+    if not snapshot.authority:
+        reasons.append("execution_authority=0")
+    return ",".join(reasons) or "startup_not_ready"
+
+
+def _should_release(snapshot: RuntimeSnapshot, elapsed_s: float, timeout_s: float) -> bool:
+    if elapsed_s < timeout_s:
+        return False
+    if not snapshot.live_mode or not snapshot.writer_acquired:
+        return False
+    if snapshot.shutdown_requested or snapshot.startup_complete:
+        return False
+    if snapshot.authority or snapshot.state == "LIVE_ACTIVE":
+        return False
+    return not snapshot.manager_ready or not snapshot.capital_ready
+
+
+def _terminate_process(exit_code: int) -> None:
+    """Hard-exit only after this process has released its own writer lease."""
+
+    logging.shutdown()
+    os._exit(exit_code)
+
+
+def _trigger_release(bot_main: Any, snapshot: RuntimeSnapshot, reason: str) -> None:
+    """Request shutdown and release this process's own writer lease."""
+
+    os.environ["NIJA_STALLED_WRITER_RELEASE_TRIGGERED"] = "1"
+    os.environ["NIJA_STALLED_WRITER_RELEASE_REASON"] = reason
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_TRIGGERED marker=%s token_prefix=%s "
+        "generation=%s reason=%s trading_remains_fail_closed=true",
+        _MARKER,
+        snapshot.token[:8],
+        snapshot.generation,
+        reason,
+    )
+
+    shutdown_event = getattr(bot_main, "_shutdown_event", None)
+    if shutdown_event is not None and callable(getattr(shutdown_event, "set", None)):
+        shutdown_event.set()
+
+    release = getattr(bot_main, "_release_writer_authority", None)
+    release_error = ""
+    try:
+        if callable(release):
+            release()
+        else:
+            release_error = "release_function_missing"
+    except Exception as exc:  # final defensive boundary before process exit
+        release_error = f"{type(exc).__name__}:{exc}"
+        logger.critical(
+            "STALLED_WRITER_RELEASE_CALL_FAILED marker=%s err=%s",
+            _MARKER,
+            release_error,
+            exc_info=True,
+        )
+
+    token_after = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    lease_after = _truthy_env("NIJA_WRITER_LEASE_ACQUIRED")
+    release_verified = not token_after and not lease_after
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_RELEASED marker=%s verified=%s "
+        "release_error=%s exit_enabled=%s",
+        _MARKER,
+        release_verified,
+        release_error or "none",
+        _truthy_env("NIJA_STALLED_WRITER_EXIT_PROCESS", "true"),
+    )
+
+    if _truthy_env("NIJA_STALLED_WRITER_EXIT_PROCESS", "true"):
+        _terminate_process(_int_env("NIJA_STALLED_WRITER_EXIT_CODE", 78))
+
+
+def _ensure_canonical_guard() -> None:
+    """Re-assert the v20 startup guard without taking broker ownership."""
+
+    try:
+        from bot.canonical_broker_main_entry_guard_v20 import install_import_hook
+
+        install_import_hook()
+    except Exception as exc:
+        logger.critical(
+            "STALLED_WRITER_CANONICAL_GUARD_REINSTALL_FAILED marker=%s err=%s",
+            _MARKER,
+            exc,
+            exc_info=True,
+        )
+
+
+def _monitor() -> None:
+    try:
+        import bot.bot_main as bot_main
+    except Exception as exc:
+        logger.critical(
+            "STALLED_WRITER_RELEASE_GUARD_IMPORT_FAILED marker=%s err=%s",
+            _MARKER,
+            exc,
+            exc_info=True,
+        )
+        return
+
+    timeout_s = max(30.0, _float_env("NIJA_STALLED_WRITER_RELEASE_TIMEOUT_S", 360.0))
+    poll_s = max(1.0, _float_env("NIJA_STALLED_WRITER_RELEASE_POLL_S", 5.0))
+    lease_seen_at: Optional[float] = None
+    observed_token = ""
+    observed_generation = ""
+
+    while not _STOP.is_set():
+        snapshot = _runtime_snapshot(bot_main)
+        now = time.monotonic()
+
+        if snapshot.writer_acquired:
+            if (
+                lease_seen_at is None
+                or snapshot.token != observed_token
+                or snapshot.generation != observed_generation
+            ):
+                lease_seen_at = now
+                observed_token = snapshot.token
+                observed_generation = snapshot.generation
+                logger.warning(
+                    "STALLED_WRITER_RELEASE_GUARD_LEASE_OBSERVED marker=%s "
+                    "token_prefix=%s generation=%s timeout_s=%.1f",
+                    _MARKER,
+                    snapshot.token[:8],
+                    snapshot.generation,
+                    timeout_s,
+                )
+        else:
+            lease_seen_at = None
+            observed_token = ""
+            observed_generation = ""
+
+        if lease_seen_at is not None:
+            elapsed_s = now - lease_seen_at
+            if _should_release(snapshot, elapsed_s, timeout_s):
+                # Re-read immediately so a last-moment LIVE_ACTIVE transition or
+                # fencing-token handoff cannot be mistaken for the stalled process.
+                confirm = _runtime_snapshot(bot_main)
+                if (
+                    confirm.token == snapshot.token
+                    and confirm.generation == snapshot.generation
+                    and _should_release(confirm, elapsed_s, timeout_s)
+                ):
+                    _trigger_release(bot_main, confirm, _release_reason(confirm))
+                    return
+
+        _STOP.wait(poll_s)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED, _THREAD
+    with _LOCK:
+        if _INSTALLED and _THREAD is not None and _THREAD.is_alive():
+            return True
+
+        _ensure_canonical_guard()
+        _STOP.clear()
+        _THREAD = threading.Thread(
+            target=_monitor,
+            name="stalled-writer-release-guard-v21",
+            daemon=True,
+        )
+        _THREAD.start()
+        _INSTALLED = bool(_THREAD.is_alive())
+        os.environ["NIJA_STALLED_WRITER_RELEASE_GUARD_INSTALLED"] = (
+            "1" if _INSTALLED else "0"
+        )
+        logger.critical(
+            "STALLED_WRITER_RELEASE_GUARD_INSTALLED marker=%s thread_alive=%s "
+            "timeout_s=%s",
+            _MARKER,
+            _THREAD.is_alive(),
+            os.environ.get("NIJA_STALLED_WRITER_RELEASE_TIMEOUT_S", "360"),
+        )
+        return _INSTALLED
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "RuntimeSnapshot",
+    "install",
+    "install_import_hook",
+    "_runtime_snapshot",
+    "_should_release",
+    "_release_reason",
+    "_trigger_release",
+]

--- a/bot/tests/test_stalled_writer_release_guard_v21.py
+++ b/bot/tests/test_stalled_writer_release_guard_v21.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import threading
+import types
+
+import bot.stalled_writer_release_guard_v21 as guard
+
+
+def _snapshot(**overrides):
+    values = {
+        "live_mode": True,
+        "writer_acquired": True,
+        "token": "token-1234",
+        "generation": "42",
+        "state": "LIVE_PENDING_CONFIRMATION",
+        "authority": False,
+        "startup_complete": False,
+        "shutdown_requested": False,
+        "fsm_initialized": False,
+        "sources_registered": False,
+        "attempts_finalized": False,
+        "hydrated": False,
+        "capital": 0.0,
+        "stale": True,
+        "valid_brokers": 0,
+    }
+    values.update(overrides)
+    return guard.RuntimeSnapshot(**values)
+
+
+def test_releases_only_after_timeout_for_nonlive_uninitialized_writer():
+    snapshot = _snapshot()
+
+    assert not guard._should_release(snapshot, elapsed_s=359.9, timeout_s=360.0)
+    assert guard._should_release(snapshot, elapsed_s=360.0, timeout_s=360.0)
+    assert "broker_manager_not_initialized" in guard._release_reason(snapshot)
+    assert "execution_authority=0" in guard._release_reason(snapshot)
+
+
+def test_never_releases_live_active_or_authorized_runtime():
+    live_active = _snapshot(
+        state="LIVE_ACTIVE",
+        authority=True,
+        startup_complete=True,
+        fsm_initialized=True,
+        sources_registered=True,
+        attempts_finalized=True,
+        hydrated=True,
+        capital=125.0,
+        stale=False,
+        valid_brokers=1,
+    )
+    authorized_pending = _snapshot(authority=True)
+
+    assert not guard._should_release(live_active, elapsed_s=999.0, timeout_s=30.0)
+    assert not guard._should_release(authorized_pending, elapsed_s=999.0, timeout_s=30.0)
+
+
+def test_trigger_requests_shutdown_releases_own_lease_and_exits(monkeypatch):
+    shutdown_event = threading.Event()
+    release_calls = []
+    exit_codes = []
+
+    def release():
+        release_calls.append(True)
+        os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
+        os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
+        os.environ.pop("NIJA_WRITER_LEASE_GENERATION", None)
+
+    fake_bot_main = types.SimpleNamespace(
+        _shutdown_event=shutdown_event,
+        _release_writer_authority=release,
+    )
+
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-1234")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "42")
+    monkeypatch.setenv("NIJA_STALLED_WRITER_EXIT_PROCESS", "true")
+    monkeypatch.setattr(guard, "_terminate_process", lambda code: exit_codes.append(code))
+
+    snapshot = _snapshot()
+    guard._trigger_release(fake_bot_main, snapshot, "broker_manager_not_initialized")
+
+    assert shutdown_event.is_set()
+    assert release_calls == [True]
+    assert exit_codes == [78]
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"
+    assert os.environ["NIJA_STALLED_WRITER_RELEASE_TRIGGERED"] == "1"
+
+
+def test_does_not_release_when_writer_lineage_is_missing():
+    snapshot = _snapshot(writer_acquired=False, token="", generation="")
+    assert not guard._should_release(snapshot, elapsed_s=999.0, timeout_s=30.0)


### PR DESCRIPTION
## Root cause

The latest Render process acquired writer token `1089` / lease generation `1737`, but remained in `LIVE_PENDING_CONFIRMATION` with `NIJA_RUNTIME_EXECUTION_AUTHORITY=0`, zero scan cycles, an uninitialized canonical broker manager, and an unaccepted `$0.00` capital snapshot. After startup recovery exhausted, the process stayed alive and continued holding its own writer lease, blocking corrected deployments from becoming the active writer.

## Fix

- Add `stalled_writer_release_guard_v21` to the production `bot.bot` entrypoint.
- Re-assert the v20 canonical broker main guard when the new guard installs.
- Observe the current process's writer token and lease generation without importing or initializing broker/capital modules from the watchdog thread.
- Wait a bounded startup interval, default 360 seconds from writer acquisition.
- Trigger only when all of the following remain true:
  - verified live mode;
  - this process still owns a writer token and generation;
  - runtime state is not `LIVE_ACTIVE`;
  - execution authority remains disabled;
  - startup is incomplete;
  - the canonical broker manager or authoritative capital snapshot remains unready.
- Re-check the same token and generation immediately before release to avoid racing a successful activation or lease handoff.
- Request shutdown, call `bot_main._release_writer_authority()` so only this process's lease is compare-and-deleted, reset derived runtime authority to fail-closed, and exit the failed process so Render can replace it.
- Add regression tests proving the guard waits for timeout, excludes healthy/authorized runtimes, releases only its own lease, and does nothing without writer lineage.

## Safety

This change never deletes Redis writer keys directly, never takes over another process's lease, never grants `LIVE_ACTIVE`, never initializes brokers from a background thread, never fabricates capital, never bypasses nonce/risk/admission gates, and never submits orders. Healthy or authorized runtimes are explicitly excluded.

## Expected runtime markers

- `STALLED_WRITER_RELEASE_GUARD_INSTALLED`
- `STALLED_WRITER_RELEASE_GUARD_LEASE_OBSERVED`
- on unrecovered startup only: `STALLED_WRITER_RELEASE_GUARD_TRIGGERED`
- `STALLED_WRITER_RELEASE_GUARD_RELEASED verified=True`

A successful startup should instead progress through the existing v20 markers and never trigger the release guard.