### PR TITLE
initialize canonical brokers before self-healing startup

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -17,6 +17,8 @@ on:
       - "bot/generation_sync_timing_patch.py"
       - "bot/canonical_broker_main_entry_guard_v20.py"
       - "bot/stalled_writer_release_guard_v21.py"
+      - "bot/canonical_broker_prebootstrap_v22.py"
+      - "bot/stalled_writer_release_guard_v22.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
@@ -25,6 +27,8 @@ on:
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
       - "bot/tests/test_canonical_broker_main_entry_guard_v20.py"
       - "bot/tests/test_stalled_writer_release_guard_v21.py"
+      - "bot/tests/test_canonical_broker_prebootstrap_v22.py"
+      - "bot/tests/test_stalled_writer_release_guard_v22.py"
       - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
   push:
@@ -44,6 +48,8 @@ on:
       - "bot/generation_sync_timing_patch.py"
       - "bot/canonical_broker_main_entry_guard_v20.py"
       - "bot/stalled_writer_release_guard_v21.py"
+      - "bot/canonical_broker_prebootstrap_v22.py"
+      - "bot/stalled_writer_release_guard_v22.py"
       - "bot/tests/test_strategy_runtime_integrity_patch.py"
       - "bot/tests/test_disconnected_coinbase_balance_guard_patch.py"
       - "bot/tests/test_okx_patch_churn_guard_patch.py"
@@ -52,6 +58,8 @@ on:
       - "bot/tests/test_runtime_patch_churn_safety_patch.py"
       - "bot/tests/test_canonical_broker_main_entry_guard_v20.py"
       - "bot/tests/test_stalled_writer_release_guard_v21.py"
+      - "bot/tests/test_canonical_broker_prebootstrap_v22.py"
+      - "bot/tests/test_stalled_writer_release_guard_v22.py"
       - "scripts/install_sitecustomize_defer_guard.py"
       - ".github/workflows/runtime-repair-regression.yml"
 
@@ -94,6 +102,8 @@ jobs:
             bot/generation_sync_timing_patch.py \
             bot/canonical_broker_main_entry_guard_v20.py \
             bot/stalled_writer_release_guard_v21.py \
+            bot/canonical_broker_prebootstrap_v22.py \
+            bot/stalled_writer_release_guard_v22.py \
             bot/bot.py
 
       - name: Run focused regression suite
@@ -107,4 +117,6 @@ jobs:
             bot/tests/test_live_active_dispatch_bridge_recovery.py \
             bot/tests/test_runtime_patch_churn_safety_patch.py \
             bot/tests/test_canonical_broker_main_entry_guard_v20.py \
-            bot/tests/test_stalled_writer_release_guard_v21.py
+            bot/tests/test_stalled_writer_release_guard_v21.py \
+            bot/tests/test_canonical_broker_prebootstrap_v22.py \
+            bot/tests/test_stalled_writer_release_guard_v22.py

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -113,11 +113,18 @@ except Exception as exc:
     logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
 try:
-    from bot.stalled_writer_release_guard_v21 import install_import_hook as _install_stalled_writer_release_guard
-    _install_stalled_writer_release_guard()
-    logger.warning("STALLED_WRITER_RELEASE_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
+    from bot.canonical_broker_prebootstrap_v22 import install_import_hook as _install_canonical_broker_prebootstrap
+    _install_canonical_broker_prebootstrap()
+    logger.warning("CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALL_REQUESTED source=bot_entrypoint")
 except Exception as exc:
-    logger.warning("STALLED_WRITER_RELEASE_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+    logger.warning("CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+
+try:
+    from bot.stalled_writer_release_guard_v22 import install_import_hook as _install_stalled_writer_release_guard
+    _install_stalled_writer_release_guard()
+    logger.warning("STALLED_WRITER_RELEASE_GUARD_V22_INSTALL_REQUESTED source=bot_entrypoint")
+except Exception as exc:
+    logger.warning("STALLED_WRITER_RELEASE_GUARD_V22_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
 from bot.bot_main import main
 

--- a/bot/canonical_broker_prebootstrap_v22.py
+++ b/bot/canonical_broker_prebootstrap_v22.py
@@ -6,24 +6,30 @@ SelfHealingStartup itself delegates broker connection to that manager, creating 
 circular dependency that can leave the writer process in LIVE_PENDING_CONFIRMATION
 with no manager, no capital snapshot, and no scan cycles.
 
-This module is called synchronously by bot_main only after distributed writer
-authority has been acquired and verified. It initializes the existing canonical
-manager singleton, repairs only that singleton's missing capital-FSM latch when an
-earlier InitRegistry claimant left it unwired, and requires at least one connected
-platform broker before startup may continue.
+This module patches the canonical bot_main writer-acquisition function. After
+Redis writer authority is acquired and synchronously verified, the existing
+canonical manager singleton is initialized on the main bootstrap thread before
+SelfHealingStartup runs. A failed prebootstrap releases only this process's own
+lease and returns startup failure; no order, authority, or state gate is bypassed.
 """
 from __future__ import annotations
 
 import importlib
 import logging
+import os
 import threading
-from typing import Any
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
 
 logger = logging.getLogger("nija.canonical_broker_prebootstrap")
 
 _MARKER = "20260723-canonical-broker-prebootstrap-v22"
 _LOCK = threading.RLock()
 _READY = False
+_INSTALLED = False
+_ACQUIRE_WRAP_ATTR = "_nija_canonical_broker_prebootstrap_acquire_v22"
+_MAIN_WRAP_ATTR = "_nija_canonical_broker_prebootstrap_main_v22"
 
 
 def _canonical_manager() -> Any:
@@ -92,6 +98,10 @@ def _initialize_manager(manager: Any) -> None:
     try:
         initialize()
     except Exception as first_exc:
+        # Retry only the confirmed stale InitRegistry/FSM-latch case. Broker,
+        # credential, balance, and network failures must remain fail-closed.
+        if bool(getattr(manager, "_fsm_initialized", False)):
+            raise
         if not _repair_capital_fsm_latch(manager, first_exc):
             raise
         logger.warning(
@@ -163,6 +173,7 @@ def prepare_canonical_broker_runtime() -> Any:
             )
 
         _READY = True
+        os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_V22_READY"] = "1"
         logger.critical(
             "CANONICAL_BROKER_PREBOOTSTRAP_V22_READY marker=%s fsm_initialized=true registered=%d connected=%d brokers=%s",
             _MARKER,
@@ -173,10 +184,129 @@ def prepare_canonical_broker_runtime() -> Any:
         return manager
 
 
+def _unwrap(current: Callable[..., Any]) -> Callable[..., Any]:
+    seen: set[int] = set()
+    base = current
+    while callable(getattr(base, "__wrapped__", None)) and id(base) not in seen:
+        seen.add(id(base))
+        candidate = getattr(base, "__wrapped__")
+        if not callable(candidate):
+            break
+        base = candidate
+    return base
+
+
+def _patch_writer_acquire(module: ModuleType) -> bool:
+    current = getattr(module, "_acquire_writer_authority_before_nonce", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _ACQUIRE_WRAP_ATTR, False)):
+        return True
+
+    base = _unwrap(current)
+
+    @wraps(base)
+    def guarded_acquire(*args: Any, **kwargs: Any) -> bool:
+        acquired = bool(base(*args, **kwargs))
+        if not acquired:
+            return False
+        try:
+            prepare_canonical_broker_runtime()
+            return True
+        except Exception as exc:
+            os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_V22_READY"] = "0"
+            logger.critical(
+                "CANONICAL_BROKER_PREBOOTSTRAP_V22_FAILED marker=%s err=%s:%s trading_remains_fail_closed=true",
+                _MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            release = getattr(module, "_release_writer_authority", None)
+            if callable(release):
+                try:
+                    release()
+                except Exception as release_exc:
+                    logger.critical(
+                        "CANONICAL_BROKER_PREBOOTSTRAP_V22_RELEASE_FAILED marker=%s err=%s:%s",
+                        _MARKER,
+                        type(release_exc).__name__,
+                        release_exc,
+                        exc_info=True,
+                    )
+            return False
+
+    setattr(guarded_acquire, _ACQUIRE_WRAP_ATTR, True)
+    setattr(guarded_acquire, "__wrapped__", base)
+    setattr(module, "_acquire_writer_authority_before_nonce", guarded_acquire)
+    logger.critical(
+        "CANONICAL_BROKER_PREBOOTSTRAP_V22_ACQUIRE_PATCHED marker=%s module=%s legacy_layers_unwrapped=%s",
+        _MARKER,
+        module.__name__,
+        base is not current,
+    )
+    return True
+
+
+def _patch_main(module: ModuleType) -> bool:
+    current = getattr(module, "main", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _MAIN_WRAP_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def guarded_main(*args: Any, **kwargs: Any):
+        if not _patch_writer_acquire(module):
+            logger.critical(
+                "CANONICAL_BROKER_PREBOOTSTRAP_V22_REPATCH_FAILED marker=%s trading_remains_fail_closed=true",
+                _MARKER,
+            )
+            return 1
+        return current(*args, **kwargs)
+
+    setattr(guarded_main, _MAIN_WRAP_ATTR, True)
+    setattr(guarded_main, "__wrapped__", current)
+    setattr(module, "main", guarded_main)
+    logger.critical(
+        "CANONICAL_BROKER_PREBOOTSTRAP_V22_MAIN_PATCHED marker=%s module=%s",
+        _MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        module = importlib.import_module("bot.bot_main")
+        acquire_patched = _patch_writer_acquire(module)
+        main_patched = _patch_main(module)
+        _INSTALLED = bool(acquire_patched and main_patched)
+        os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED"] = (
+            "1" if _INSTALLED else "0"
+        )
+        logger.critical(
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED marker=%s acquire_patched=%s main_patched=%s",
+            _MARKER,
+            acquire_patched,
+            main_patched,
+        )
+        return _INSTALLED
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
 __all__ = [
+    "install",
+    "install_import_hook",
     "prepare_canonical_broker_runtime",
     "_canonical_manager",
     "_manager_contract",
     "_initialize_manager",
     "_platform_counts",
+    "_patch_writer_acquire",
+    "_patch_main",
 ]

--- a/bot/canonical_broker_prebootstrap_v22.py
+++ b/bot/canonical_broker_prebootstrap_v22.py
@@ -1,0 +1,182 @@
+"""Initialize the canonical broker manager before SelfHealingStartup.
+
+The production startup path previously waited for SelfHealingStartup to return a
+connected broker before initializing the canonical MultiAccountBrokerManager.
+SelfHealingStartup itself delegates broker connection to that manager, creating a
+circular dependency that can leave the writer process in LIVE_PENDING_CONFIRMATION
+with no manager, no capital snapshot, and no scan cycles.
+
+This module is called synchronously by bot_main only after distributed writer
+authority has been acquired and verified. It initializes the existing canonical
+manager singleton, repairs only that singleton's missing capital-FSM latch when an
+earlier InitRegistry claimant left it unwired, and requires at least one connected
+platform broker before startup may continue.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from typing import Any
+
+logger = logging.getLogger("nija.canonical_broker_prebootstrap")
+
+_MARKER = "20260723-canonical-broker-prebootstrap-v22"
+_LOCK = threading.RLock()
+_READY = False
+
+
+def _canonical_manager() -> Any:
+    module = importlib.import_module("bot.multi_account_broker_manager")
+    manager = getattr(module, "multi_account_broker_manager", None)
+    if manager is None:
+        getter = getattr(module, "get_broker_manager", None)
+        manager = getter() if callable(getter) else None
+    if manager is None:
+        raise RuntimeError("canonical MultiAccountBrokerManager singleton unavailable")
+    return manager
+
+
+def _manager_contract(manager: Any) -> tuple[bool, str]:
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        return False, "fsm_not_initialized"
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    if callable(has_sources):
+        try:
+            if not bool(has_sources()):
+                return False, "no_registered_platform_source"
+        except Exception as exc:
+            return False, f"source_contract_error:{type(exc).__name__}:{exc}"
+
+    attempted = getattr(manager, "has_attempted_connections", None)
+    if callable(attempted):
+        try:
+            if not bool(attempted()):
+                return False, "broker_registration_not_finalized"
+        except Exception as exc:
+            return False, f"attempt_contract_error:{type(exc).__name__}:{exc}"
+
+    return True, "manager_ready"
+
+
+def _repair_capital_fsm_latch(manager: Any, cause: BaseException) -> bool:
+    if bool(getattr(manager, "_fsm_initialized", False)):
+        return True
+
+    repair = getattr(manager, "_init_capital_fsm", None)
+    if not callable(repair):
+        return False
+
+    logger.critical(
+        "CANONICAL_BROKER_PREBOOTSTRAP_V22_LATCH_REPAIR_BEGIN marker=%s cause=%s:%s",
+        _MARKER,
+        type(cause).__name__,
+        cause,
+    )
+    repair()
+    repaired = bool(getattr(manager, "_fsm_initialized", False))
+    logger.critical(
+        "CANONICAL_BROKER_PREBOOTSTRAP_V22_LATCH_REPAIR_RESULT marker=%s repaired=%s",
+        _MARKER,
+        repaired,
+    )
+    return repaired
+
+
+def _initialize_manager(manager: Any) -> None:
+    initialize = getattr(manager, "initialize", None)
+    if not callable(initialize):
+        raise RuntimeError("MultiAccountBrokerManager.initialize is unavailable")
+
+    try:
+        initialize()
+    except Exception as first_exc:
+        if not _repair_capital_fsm_latch(manager, first_exc):
+            raise
+        logger.warning(
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_INITIALIZE_RETRY marker=%s first_error=%s:%s",
+            _MARKER,
+            type(first_exc).__name__,
+            first_exc,
+        )
+        initialize()
+
+
+def _platform_counts(manager: Any) -> tuple[int, int, list[str]]:
+    brokers = getattr(manager, "platform_brokers", None)
+    if callable(brokers):
+        brokers = brokers()
+    if brokers is None:
+        brokers = getattr(manager, "_platform_brokers", {})
+
+    try:
+        items = list(dict(brokers or {}).items())
+    except Exception:
+        items = []
+
+    connected_names: list[str] = []
+    for broker_type, broker in items:
+        if broker is None or not bool(getattr(broker, "connected", False)):
+            continue
+        name = getattr(broker_type, "value", None) or str(broker_type)
+        connected_names.append(str(name).lower())
+
+    return len(items), len(connected_names), sorted(set(connected_names))
+
+
+def prepare_canonical_broker_runtime() -> Any:
+    """Synchronously prepare the canonical manager after writer verification."""
+
+    global _READY
+    with _LOCK:
+        manager = _canonical_manager()
+        contract_ok, _ = _manager_contract(manager)
+        registered, connected, names = _platform_counts(manager)
+        if _READY and contract_ok and connected >= 1:
+            logger.info(
+                "CANONICAL_BROKER_PREBOOTSTRAP_V22_ALREADY_READY marker=%s registered=%d connected=%d brokers=%s",
+                _MARKER,
+                registered,
+                connected,
+                ",".join(names),
+            )
+            return manager
+
+        logger.critical(
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_BEGIN marker=%s thread=%s",
+            _MARKER,
+            threading.current_thread().name,
+        )
+        _initialize_manager(manager)
+
+        contract_ok, contract_reason = _manager_contract(manager)
+        registered, connected, names = _platform_counts(manager)
+        if not contract_ok:
+            raise RuntimeError(
+                f"canonical broker prebootstrap contract failed: {contract_reason}"
+            )
+        if connected < 1:
+            raise RuntimeError(
+                "canonical broker prebootstrap has no connected platform broker "
+                f"(registered={registered}, connected={connected})"
+            )
+
+        _READY = True
+        logger.critical(
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_READY marker=%s fsm_initialized=true registered=%d connected=%d brokers=%s",
+            _MARKER,
+            registered,
+            connected,
+            ",".join(names),
+        )
+        return manager
+
+
+__all__ = [
+    "prepare_canonical_broker_runtime",
+    "_canonical_manager",
+    "_manager_contract",
+    "_initialize_manager",
+    "_platform_counts",
+]

--- a/bot/stalled_writer_release_guard_v22.py
+++ b/bot/stalled_writer_release_guard_v22.py
@@ -1,0 +1,425 @@
+"""Release a stalled production writer lease without bypassing safety gates.
+
+This supersedes v21.  The earlier guard could remain disabled when
+LIVE_CAPITAL_VERIFIED was temporarily false even though the process held a real
+writer lease and was visibly stuck in LIVE_PENDING_CONFIRMATION.  It also trusted
+only the environment copy of lease state and excluded any process whose generic
+startup_complete flag had drifted true.
+
+The v22 guard treats verified Redis writer lineage as authoritative, infers
+production intent from the actual runtime state and execution flags, and releases
+only the current process's own compare-and-delete lease when broker/capital startup
+remains unready beyond a bounded timeout.  It never grants authority, connects a
+broker, fabricates capital, changes risk thresholds, or submits an order.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger("nija.stalled_writer_release_guard_v22")
+
+_MARKER = "20260723-stalled-writer-release-v22"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_STOP = threading.Event()
+_THREAD: Optional[threading.Thread] = None
+_INSTALLED = False
+
+
+def _truthy_value(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _truthy_env(name: str, default: str = "false") -> bool:
+    return _truthy_value(os.environ.get(name, default))
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default)) or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime_state() -> str:
+    return str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "OFF") or "OFF").strip().upper()
+
+
+def _production_writer_intent() -> bool:
+    if _truthy_env("DRY_RUN_MODE") or _truthy_env("PAPER_MODE"):
+        return False
+
+    state = _runtime_state()
+    return bool(
+        _truthy_env("LIVE_CAPITAL_VERIFIED")
+        or _truthy_env("NIJA_EXECUTION_ACTIVE")
+        or _truthy_env("NIJA_RUNTIME_EXECUTION_AUTHORITY")
+        or state == "LIVE_ACTIVE"
+        or state.startswith("LIVE_")
+    )
+
+
+def _manager_snapshot() -> tuple[bool, bool, bool]:
+    module = sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get(
+        "multi_account_broker_manager"
+    )
+    if module is None:
+        return False, False, False
+
+    manager = getattr(module, "multi_account_broker_manager", None)
+    if manager is None:
+        getter = getattr(module, "get_broker_manager", None)
+        if callable(getter):
+            try:
+                manager = getter()
+            except Exception:
+                manager = None
+    if manager is None:
+        return False, False, False
+
+    fsm_initialized = bool(getattr(manager, "_fsm_initialized", False))
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    try:
+        sources_registered = bool(has_sources()) if callable(has_sources) else False
+    except Exception:
+        sources_registered = False
+
+    attempted = getattr(manager, "has_attempted_connections", None)
+    try:
+        attempts_finalized = bool(attempted()) if callable(attempted) else False
+    except Exception:
+        attempts_finalized = False
+
+    return fsm_initialized, sources_registered, attempts_finalized
+
+
+def _capital_snapshot() -> tuple[bool, float, bool, int]:
+    module = sys.modules.get("bot.capital_authority") or sys.modules.get("capital_authority")
+    if module is None:
+        return False, 0.0, True, 0
+
+    getter = getattr(module, "get_capital_authority", None)
+    if not callable(getter):
+        return False, 0.0, True, 0
+
+    try:
+        authority = getter()
+    except Exception:
+        return False, 0.0, True, 0
+    if authority is None:
+        return False, 0.0, True, 0
+
+    hydrated_raw = getattr(authority, "is_hydrated", False)
+    try:
+        hydrated = bool(hydrated_raw() if callable(hydrated_raw) else hydrated_raw)
+    except Exception:
+        hydrated = False
+
+    try:
+        capital = float(authority.get_real_capital() or 0.0)
+    except Exception:
+        try:
+            capital = float(getattr(authority, "total_capital", 0.0) or 0.0)
+        except Exception:
+            capital = 0.0
+
+    try:
+        stale = bool(authority.is_stale())
+    except Exception:
+        stale = True
+
+    valid = 0
+    for attr in ("valid_brokers", "broker_count", "_valid_broker_count"):
+        try:
+            candidate = int(getattr(authority, attr, 0) or 0)
+        except Exception:
+            candidate = 0
+        if candidate > 0:
+            valid = candidate
+            break
+
+    return hydrated, capital, stale, valid
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    production_intent: bool
+    writer_acquired: bool
+    token: str
+    generation: str
+    state: str
+    authority: bool
+    shutdown_requested: bool
+    fsm_initialized: bool
+    sources_registered: bool
+    attempts_finalized: bool
+    hydrated: bool
+    capital: float
+    stale: bool
+    valid_brokers: int
+
+    @property
+    def manager_ready(self) -> bool:
+        return self.fsm_initialized and self.sources_registered and self.attempts_finalized
+
+    @property
+    def capital_ready(self) -> bool:
+        return self.hydrated and not self.stale and self.capital > 0.0 and self.valid_brokers >= 1
+
+
+def _runtime_snapshot(bot_main: Any) -> RuntimeSnapshot:
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+
+    runtime = getattr(bot_main, "_writer_authority_runtime", None)
+    try:
+        runtime_acquired = bool(runtime is not None and getattr(runtime, "acquired", False))
+    except Exception:
+        runtime_acquired = False
+
+    writer_acquired = bool(
+        token
+        and generation
+        and (_truthy_env("NIJA_WRITER_LEASE_ACQUIRED") or runtime_acquired)
+    )
+
+    fsm_initialized, sources_registered, attempts_finalized = _manager_snapshot()
+    hydrated, capital, stale, valid_brokers = _capital_snapshot()
+
+    shutdown_event = getattr(bot_main, "_shutdown_event", None)
+    shutdown_requested = bool(
+        shutdown_event is not None
+        and callable(getattr(shutdown_event, "is_set", None))
+        and shutdown_event.is_set()
+    )
+
+    return RuntimeSnapshot(
+        production_intent=_production_writer_intent(),
+        writer_acquired=writer_acquired,
+        token=token,
+        generation=generation,
+        state=_runtime_state(),
+        authority=_truthy_env("NIJA_RUNTIME_EXECUTION_AUTHORITY"),
+        shutdown_requested=shutdown_requested,
+        fsm_initialized=fsm_initialized,
+        sources_registered=sources_registered,
+        attempts_finalized=attempts_finalized,
+        hydrated=hydrated,
+        capital=capital,
+        stale=stale,
+        valid_brokers=valid_brokers,
+    )
+
+
+def _release_reason(snapshot: RuntimeSnapshot) -> str:
+    reasons: list[str] = []
+    if not snapshot.manager_ready:
+        reasons.append("broker_manager_not_initialized")
+    if not snapshot.capital_ready:
+        reasons.append(
+            "capital_not_ready"
+            f":hydrated={snapshot.hydrated}"
+            f":capital={snapshot.capital:.8f}"
+            f":stale={snapshot.stale}"
+            f":brokers={snapshot.valid_brokers}"
+        )
+    reasons.append(f"state={snapshot.state}")
+    reasons.append(f"execution_authority={int(snapshot.authority)}")
+    return ",".join(reasons)
+
+
+def _should_release(snapshot: RuntimeSnapshot, elapsed_s: float, timeout_s: float) -> bool:
+    if elapsed_s < timeout_s:
+        return False
+    if not snapshot.production_intent or not snapshot.writer_acquired:
+        return False
+    if snapshot.shutdown_requested:
+        return False
+    if snapshot.authority or snapshot.state == "LIVE_ACTIVE":
+        return False
+    return not snapshot.manager_ready or not snapshot.capital_ready
+
+
+def _terminate_process(exit_code: int) -> None:
+    logging.shutdown()
+    os._exit(exit_code)
+
+
+def _trigger_release(bot_main: Any, snapshot: RuntimeSnapshot, reason: str) -> None:
+    os.environ["NIJA_STALLED_WRITER_RELEASE_TRIGGERED"] = "1"
+    os.environ["NIJA_STALLED_WRITER_RELEASE_REASON"] = reason
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_V22_TRIGGERED marker=%s token_prefix=%s generation=%s reason=%s trading_remains_fail_closed=true",
+        _MARKER,
+        snapshot.token[:8],
+        snapshot.generation,
+        reason,
+    )
+
+    shutdown_event = getattr(bot_main, "_shutdown_event", None)
+    if shutdown_event is not None and callable(getattr(shutdown_event, "set", None)):
+        shutdown_event.set()
+
+    release = getattr(bot_main, "_release_writer_authority", None)
+    release_error = ""
+    try:
+        if callable(release):
+            release()
+        else:
+            release_error = "release_function_missing"
+    except Exception as exc:
+        release_error = f"{type(exc).__name__}:{exc}"
+        logger.critical(
+            "STALLED_WRITER_RELEASE_GUARD_V22_RELEASE_CALL_FAILED marker=%s err=%s",
+            _MARKER,
+            release_error,
+            exc_info=True,
+        )
+
+    token_after = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    lease_after = _truthy_env("NIJA_WRITER_LEASE_ACQUIRED")
+    release_verified = not token_after and not lease_after
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_V22_RELEASED marker=%s verified=%s release_error=%s exit_enabled=%s",
+        _MARKER,
+        release_verified,
+        release_error or "none",
+        _truthy_env("NIJA_STALLED_WRITER_EXIT_PROCESS", "true"),
+    )
+
+    if _truthy_env("NIJA_STALLED_WRITER_EXIT_PROCESS", "true"):
+        _terminate_process(_int_env("NIJA_STALLED_WRITER_EXIT_CODE", 78))
+
+
+def _monitor() -> None:
+    try:
+        import bot.bot_main as bot_main
+    except Exception as exc:
+        logger.critical(
+            "STALLED_WRITER_RELEASE_GUARD_V22_IMPORT_FAILED marker=%s err=%s",
+            _MARKER,
+            exc,
+            exc_info=True,
+        )
+        return
+
+    timeout_s = max(30.0, _float_env("NIJA_STALLED_WRITER_RELEASE_TIMEOUT_S", 360.0))
+    poll_s = max(1.0, _float_env("NIJA_STALLED_WRITER_RELEASE_POLL_S", 5.0))
+    lease_seen_at: Optional[float] = None
+    observed_token = ""
+    observed_generation = ""
+    last_wait_log = 0.0
+
+    while not _STOP.is_set():
+        snapshot = _runtime_snapshot(bot_main)
+        now = time.monotonic()
+
+        if snapshot.writer_acquired:
+            if (
+                lease_seen_at is None
+                or snapshot.token != observed_token
+                or snapshot.generation != observed_generation
+            ):
+                lease_seen_at = now
+                observed_token = snapshot.token
+                observed_generation = snapshot.generation
+                logger.warning(
+                    "STALLED_WRITER_RELEASE_GUARD_V22_LEASE_OBSERVED marker=%s token_prefix=%s generation=%s timeout_s=%.1f production_intent=%s state=%s",
+                    _MARKER,
+                    snapshot.token[:8],
+                    snapshot.generation,
+                    timeout_s,
+                    snapshot.production_intent,
+                    snapshot.state,
+                )
+        else:
+            lease_seen_at = None
+            observed_token = ""
+            observed_generation = ""
+
+        if lease_seen_at is not None:
+            elapsed_s = now - lease_seen_at
+            if now - last_wait_log >= 60.0:
+                logger.warning(
+                    "STALLED_WRITER_RELEASE_GUARD_V22_WAITING marker=%s elapsed_s=%.1f timeout_s=%.1f production_intent=%s state=%s authority=%s manager_ready=%s capital_ready=%s",
+                    _MARKER,
+                    elapsed_s,
+                    timeout_s,
+                    snapshot.production_intent,
+                    snapshot.state,
+                    snapshot.authority,
+                    snapshot.manager_ready,
+                    snapshot.capital_ready,
+                )
+                last_wait_log = now
+
+            if _should_release(snapshot, elapsed_s, timeout_s):
+                confirm = _runtime_snapshot(bot_main)
+                if (
+                    confirm.token == snapshot.token
+                    and confirm.generation == snapshot.generation
+                    and _should_release(confirm, elapsed_s, timeout_s)
+                ):
+                    _trigger_release(bot_main, confirm, _release_reason(confirm))
+                    return
+
+        _STOP.wait(poll_s)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED, _THREAD
+    with _LOCK:
+        if _INSTALLED and _THREAD is not None and _THREAD.is_alive():
+            return True
+
+        _STOP.clear()
+        _THREAD = threading.Thread(
+            target=_monitor,
+            name="stalled-writer-release-guard-v22",
+            daemon=True,
+        )
+        _THREAD.start()
+        _INSTALLED = bool(_THREAD.is_alive())
+        os.environ["NIJA_STALLED_WRITER_RELEASE_GUARD_V22_INSTALLED"] = (
+            "1" if _INSTALLED else "0"
+        )
+        logger.critical(
+            "STALLED_WRITER_RELEASE_GUARD_V22_INSTALLED marker=%s thread_alive=%s timeout_s=%s",
+            _MARKER,
+            _THREAD.is_alive(),
+            os.environ.get("NIJA_STALLED_WRITER_RELEASE_TIMEOUT_S", "360"),
+        )
+        return _INSTALLED
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "RuntimeSnapshot",
+    "install",
+    "install_import_hook",
+    "_production_writer_intent",
+    "_runtime_snapshot",
+    "_should_release",
+    "_release_reason",
+    "_trigger_release",
+]

--- a/bot/tests/test_canonical_broker_prebootstrap_v22.py
+++ b/bot/tests/test_canonical_broker_prebootstrap_v22.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import types
+
+import bot.canonical_broker_prebootstrap_v22 as guard
+
+
+class _BrokerType:
+    value = "kraken"
+
+
+class _Broker:
+    connected = True
+
+
+class _ReadyManager:
+    def __init__(self):
+        self._fsm_initialized = True
+        self._platform_brokers = {_BrokerType(): _Broker()}
+        self.initialize_calls = 0
+
+    def initialize(self):
+        self.initialize_calls += 1
+
+    def has_registered_sources(self):
+        return True
+
+    def has_attempted_connections(self):
+        return True
+
+
+def test_prepare_initializes_canonical_manager_before_self_healing(monkeypatch):
+    manager = _ReadyManager()
+    monkeypatch.setattr(guard, "_canonical_manager", lambda: manager)
+    monkeypatch.setattr(guard, "_READY", False)
+
+    result = guard.prepare_canonical_broker_runtime()
+
+    assert result is manager
+    assert manager.initialize_calls == 1
+
+
+def test_initialize_retries_only_missing_fsm_latch():
+    calls = []
+
+    class Manager(_ReadyManager):
+        def __init__(self):
+            super().__init__()
+            self._fsm_initialized = False
+
+        def initialize(self):
+            calls.append("initialize")
+            if len(calls) == 1:
+                raise RuntimeError("stale init registry latch")
+
+        def _init_capital_fsm(self):
+            calls.append("repair")
+            self._fsm_initialized = True
+
+    manager = Manager()
+    guard._initialize_manager(manager)
+
+    assert calls == ["initialize", "repair", "initialize"]
+    assert manager._fsm_initialized is True
+
+
+def test_initialize_does_not_retry_real_broker_failure():
+    calls = []
+
+    class Manager(_ReadyManager):
+        def initialize(self):
+            calls.append("initialize")
+            raise RuntimeError("no exchange balance")
+
+    manager = Manager()
+
+    try:
+        guard._initialize_manager(manager)
+    except RuntimeError as exc:
+        assert "no exchange balance" in str(exc)
+    else:
+        raise AssertionError("real broker failure must remain fail-closed")
+
+    assert calls == ["initialize"]
+
+
+def test_writer_wrapper_runs_prebootstrap_after_authority(monkeypatch):
+    sequence = []
+    module = types.SimpleNamespace(
+        __name__="bot.bot_main",
+        _acquire_writer_authority_before_nonce=lambda: sequence.append("authority") or True,
+        _release_writer_authority=lambda: sequence.append("release"),
+    )
+    monkeypatch.setattr(
+        guard,
+        "prepare_canonical_broker_runtime",
+        lambda: sequence.append("prebootstrap"),
+    )
+
+    assert guard._patch_writer_acquire(module)
+    assert module._acquire_writer_authority_before_nonce() is True
+    assert sequence == ["authority", "prebootstrap"]
+
+
+def test_writer_wrapper_releases_own_lease_on_prebootstrap_failure(monkeypatch):
+    sequence = []
+    module = types.SimpleNamespace(
+        __name__="bot.bot_main",
+        _acquire_writer_authority_before_nonce=lambda: sequence.append("authority") or True,
+        _release_writer_authority=lambda: sequence.append("release"),
+    )
+
+    def fail():
+        sequence.append("prebootstrap")
+        raise RuntimeError("manager unavailable")
+
+    monkeypatch.setattr(guard, "prepare_canonical_broker_runtime", fail)
+
+    assert guard._patch_writer_acquire(module)
+    assert module._acquire_writer_authority_before_nonce() is False
+    assert sequence == ["authority", "prebootstrap", "release"]

--- a/bot/tests/test_stalled_writer_release_guard_v22.py
+++ b/bot/tests/test_stalled_writer_release_guard_v22.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import threading
+import types
+
+import bot.stalled_writer_release_guard_v22 as guard
+
+
+def _snapshot(**overrides):
+    values = {
+        "production_intent": True,
+        "writer_acquired": True,
+        "token": "1090",
+        "generation": "1738",
+        "state": "LIVE_PENDING_CONFIRMATION",
+        "authority": False,
+        "shutdown_requested": False,
+        "fsm_initialized": False,
+        "sources_registered": False,
+        "attempts_finalized": False,
+        "hydrated": False,
+        "capital": 0.0,
+        "stale": True,
+        "valid_brokers": 0,
+    }
+    values.update(overrides)
+    return guard.RuntimeSnapshot(**values)
+
+
+def test_live_pending_is_production_intent_without_live_capital_verified(monkeypatch):
+    monkeypatch.delenv("LIVE_CAPITAL_VERIFIED", raising=False)
+    monkeypatch.delenv("NIJA_EXECUTION_ACTIVE", raising=False)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+
+    assert guard._production_writer_intent() is True
+
+
+def test_runtime_object_proves_lease_when_env_boolean_drifts(monkeypatch):
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "1090")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1738")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setattr(guard, "_manager_snapshot", lambda: (False, False, False))
+    monkeypatch.setattr(guard, "_capital_snapshot", lambda: (False, 0.0, True, 0))
+
+    bot_main = types.SimpleNamespace(
+        _writer_authority_runtime=types.SimpleNamespace(acquired=True),
+        _shutdown_event=threading.Event(),
+    )
+
+    snapshot = guard._runtime_snapshot(bot_main)
+
+    assert snapshot.writer_acquired is True
+    assert snapshot.production_intent is True
+
+
+def test_releases_unready_writer_after_timeout():
+    snapshot = _snapshot()
+
+    assert not guard._should_release(snapshot, elapsed_s=359.9, timeout_s=360.0)
+    assert guard._should_release(snapshot, elapsed_s=360.0, timeout_s=360.0)
+    assert "broker_manager_not_initialized" in guard._release_reason(snapshot)
+
+
+def test_never_releases_live_active_or_authorized_runtime():
+    live_active = _snapshot(
+        state="LIVE_ACTIVE",
+        authority=True,
+        fsm_initialized=True,
+        sources_registered=True,
+        attempts_finalized=True,
+        hydrated=True,
+        capital=125.0,
+        stale=False,
+        valid_brokers=1,
+    )
+    authorized_pending = _snapshot(authority=True)
+
+    assert not guard._should_release(live_active, elapsed_s=999.0, timeout_s=30.0)
+    assert not guard._should_release(authorized_pending, elapsed_s=999.0, timeout_s=30.0)
+
+
+def test_trigger_releases_current_lease_and_exits(monkeypatch):
+    shutdown_event = threading.Event()
+    release_calls = []
+    exit_codes = []
+
+    def release():
+        release_calls.append(True)
+        os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
+        os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
+        os.environ.pop("NIJA_WRITER_LEASE_GENERATION", None)
+
+    fake_bot_main = types.SimpleNamespace(
+        _shutdown_event=shutdown_event,
+        _release_writer_authority=release,
+    )
+
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "1090")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1738")
+    monkeypatch.setenv("NIJA_STALLED_WRITER_EXIT_PROCESS", "true")
+    monkeypatch.setattr(guard, "_terminate_process", lambda code: exit_codes.append(code))
+
+    guard._trigger_release(fake_bot_main, _snapshot(), "broker_manager_not_initialized")
+
+    assert shutdown_event.is_set()
+    assert release_calls == [True]
+    assert exit_codes == [78]
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"


### PR DESCRIPTION
## Root cause

The new Render process acquired writer token `1090` / lease generation `1738`, but remained in `LIVE_PENDING_CONFIRMATION` with execution authority `0`, zero scan cycles, an uninitialized canonical broker manager, and a stale `$0.00` capital snapshot.

Two ordering defects remained:

1. The v20 canonical guard initialized the manager only after `SelfHealingStartup` returned a connected broker, while `SelfHealingStartup` itself delegates broker connection to that manager. This preserved a circular startup dependency.
2. The v21 stalled-writer guard required `LIVE_CAPITAL_VERIFIED=true`, so it could ignore a real production writer visibly stuck in `LIVE_PENDING_CONFIRMATION` and continue renewing the lease indefinitely.

## Fix

- Add `canonical_broker_prebootstrap_v22` and install it from the production `bot.bot` entrypoint.
- Patch the canonical writer-acquisition function so the existing singleton `MultiAccountBrokerManager` initializes synchronously immediately after distributed writer authority is acquired and verified, before `SelfHealingStartup` begins.
- Retry only the confirmed missing capital-FSM latch case; real credential, network, broker, or zero-balance failures remain fail-closed.
- Require the canonical manager contract plus at least one connected platform broker before startup proceeds.
- On prebootstrap failure, release only this process's own compare-and-delete writer lease and return startup failure.
- Replace v21 with `stalled_writer_release_guard_v22` in the production entrypoint.
- Infer production intent from `LIVE_PENDING_CONFIRMATION`, `LIVE_ACTIVE`, execution flags, or verified live capital while still excluding paper and dry-run modes.
- Treat the live writer runtime object as authoritative when the environment lease boolean drifts.
- Remove the generic `startup_complete` bypass; a process without authority and without broker/capital readiness may not retain the writer lease.
- Add periodic waiting telemetry and focused regression coverage for the exact token `1090` / generation `1738` failure shape.

## Safety

This change never deletes another process's lock, never grants execution authority, never forces `LIVE_ACTIVE`, never fabricates capital, never bypasses nonce/risk/readiness gates, and never submits orders. Broker and balance failures terminate startup and release the current process's own lease.

## Expected markers

- `CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED`
- `CANONICAL_BROKER_PREBOOTSTRAP_V22_BEGIN`
- `CANONICAL_BROKER_PREBOOTSTRAP_V22_READY`
- `STALLED_WRITER_RELEASE_GUARD_V22_INSTALLED`
- `STALLED_WRITER_RELEASE_GUARD_V22_LEASE_OBSERVED`

On unrecovered startup only:

- `CANONICAL_BROKER_PREBOOTSTRAP_V22_FAILED`
- or after the bounded timeout, `STALLED_WRITER_RELEASE_GUARD_V22_TRIGGERED`
- `STALLED_WRITER_RELEASE_GUARD_V22_RELEASED verified=True`