### PR TITLE
Enforce canonical v26 launcher during image build

### DIFF
--- a/scripts/apply_startup_handoff_fix.py
+++ b/scripts/apply_startup_handoff_fix.py
@@ -1,13 +1,15 @@
 """Patch ``start.sh`` so preflight Python cannot activate NIJA runtime hooks.
 
 The Docker image installs several ``.pth`` startup hooks. Every Python process
-started before ``main.py`` must see ``NIJA_DEFER_RUNTIME_SITE_HOOKS=1``;
+started before the canonical launcher must see ``NIJA_DEFER_RUNTIME_SITE_HOOKS=1``;
 otherwise a harmless preflight command can acquire writer authority or enter
 standby before the canonical trading runtime starts.
 
-The patch also replaces obsolete root-``bot.py`` diagnostics with checks for the
-real production path and runs a standard-library-only runtime attestation before
-site hooks are enabled.
+The patch also replaces obsolete root-``bot.py`` diagnostics, runs a
+standard-library-only runtime attestation, and permanently rewrites the runtime
+launch to ``scripts/canonical_runtime_launcher_v26.py``. This makes the v26
+ordering guard effective even when a platform overrides the Docker command with
+``bash start.sh``.
 """
 from __future__ import annotations
 
@@ -23,34 +25,32 @@ ATTESTATION_MARKER = "STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_COMPLETE"
 CANONICAL_DIAGNOSTIC_MARKER = "CANONICAL_ENTRYPOINT_DIAGNOSTICS"
 RUNTIME_MARKER = "STARTUP_HANDOFF_RUNTIME_BEGIN"
 RUNTIME_EXIT_MARKER = "STARTUP_HANDOFF_RUNTIME_EXIT"
+LAUNCHER = "scripts/canonical_runtime_launcher_v26.py"
+LEGACY_LAUNCH = "$PY -u main.py"
+CANONICAL_LAUNCH = f"$PY -u {LAUNCHER}"
 
 
 def _insert_early_defer(text: str) -> str:
     if PREFLIGHT_MARKER in text:
         return text
-
     block = (
         f"export {DEFER_FLAG}=1\n"
         'echo "🧭 STARTUP_HANDOFF_PREFLIGHT_BEGIN runtime_site_hooks=deferred"\n'
     )
-
     set_match = re.search(r"(?m)^set -e(?:uo pipefail)?(?:\s+#.*)?$", text)
     if set_match:
         insert_at = set_match.end()
         return text[:insert_at] + "\n" + block + text[insert_at:]
-
     if text.startswith("#!"):
         newline = text.find("\n")
         if newline >= 0:
             return text[: newline + 1] + block + text[newline + 1 :]
-
     return block + text
 
 
 def _insert_redis_checkpoint(text: str) -> str:
     if REDIS_MARKER in text:
         return text
-
     anchor = "_validate_redis_url_or_exit\n_log_redis_lock_source_hint\n"
     if anchor not in text:
         raise RuntimeError("start.sh Redis preflight anchor not found")
@@ -64,7 +64,6 @@ def _insert_redis_checkpoint(text: str) -> str:
 def _replace_legacy_entrypoint_diagnostics(text: str) -> str:
     if CANONICAL_DIAGNOSTIC_MARKER in text:
         return text
-
     pattern = re.compile(
         r'echo "🔄 Starting live trading bot\.\.\."\n.*?\n# Start the canonical Python entrypoint',
         re.DOTALL,
@@ -72,15 +71,15 @@ def _replace_legacy_entrypoint_diagnostics(text: str) -> str:
     match = pattern.search(text)
     if match is None:
         return text
-
     replacement = (
         'echo "🔄 Starting live trading bot..."\n'
         'echo "Working directory: $(pwd)"\n'
-        'echo "🧭 CANONICAL_ENTRYPOINT_DIAGNOSTICS path=main.py->bot.bot->bot.bot_main release=v24"\n'
+        'echo "🧭 CANONICAL_ENTRYPOINT_DIAGNOSTICS path=launcher-v26->main.py->bot.bot->bot.bot_main release=v26"\n'
         'for _runtime_file in main.py bot/bot.py bot/bot_main.py '
         'bot/canonical_broker_prebootstrap_v22.py '
         'bot/canonical_broker_startup_convergence_v24.py '
         'bot/stalled_writer_release_guard_v22.py '
+        'scripts/canonical_runtime_launcher_v26.py '
         'scripts/runtime_entrypoint_attestation.py; do\n'
         '    if [ ! -f "${_runtime_file}" ]; then\n'
         '        echo "❌ Canonical runtime file missing: ${_runtime_file}"\n'
@@ -91,6 +90,7 @@ def _replace_legacy_entrypoint_diagnostics(text: str) -> str:
         'bot/canonical_broker_prebootstrap_v22.py '
         'bot/canonical_broker_startup_convergence_v24.py '
         'bot/stalled_writer_release_guard_v22.py '
+        'scripts/canonical_runtime_launcher_v26.py '
         'scripts/runtime_entrypoint_attestation.py\n'
         'echo "--- canonical bot/bot.py (head) ---"\n'
         'head -n 14 bot/bot.py || true\n'
@@ -108,9 +108,9 @@ def _replace_legacy_entrypoint_diagnostics(text: str) -> str:
 
 def _attestation_block() -> str:
     return (
-        'echo "🧾 STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_BEGIN canonical=main.py->bot.bot->bot.bot_main release=v24"\n'
+        'echo "🧾 STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_BEGIN canonical=launcher-v26->main.py->bot.bot->bot.bot_main release=v26"\n'
         f'{DEFER_FLAG}=1 $PY -S scripts/runtime_entrypoint_attestation.py\n'
-        'echo "🧾 STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_COMPLETE release=v24"\n'
+        'echo "🧾 STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_COMPLETE release=v26"\n'
     )
 
 
@@ -122,22 +122,30 @@ def _insert_runtime_handoff(text: str) -> str:
                 raise RuntimeError("start.sh runtime defer-unset anchor not found")
             text = text.replace(unset_anchor, _attestation_block() + unset_anchor, 1)
         return text
-
     anchor = "set +e\n$PY -u main.py\nstatus=$?\n"
     if anchor not in text:
         raise RuntimeError("start.sh runtime launch anchor not found")
     replacement = (
         _attestation_block()
         + f"unset {DEFER_FLAG}\n"
-        + 'echo "🚀 STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=main.py '
-        'canonical=main.py->bot.bot->bot.bot_main runtime_site_hooks=enabled '
-        'release=v24 commit=${GIT_COMMIT_SHORT:-${GIT_COMMIT:-unknown}}"\n'
+        + 'echo "🚀 STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=canonical_runtime_launcher_v26.py '
+        'canonical=launcher-v26->main.py->bot.bot->bot.bot_main runtime_site_hooks=enabled '
+        'release=v26 commit=${GIT_COMMIT_SHORT:-${GIT_COMMIT:-unknown}}"\n'
         + "set +e\n"
-        + "$PY -u main.py\n"
+        + CANONICAL_LAUNCH + "\n"
         + "status=$?\n"
         + 'echo "🧭 STARTUP_HANDOFF_RUNTIME_EXIT status=${status}"\n'
     )
     return text.replace(anchor, replacement, 1)
+
+
+def _enforce_v26_launcher(text: str) -> str:
+    text = text.replace(LEGACY_LAUNCH, CANONICAL_LAUNCH)
+    if LEGACY_LAUNCH in text:
+        raise RuntimeError("legacy direct main.py launch remains")
+    if text.count(CANONICAL_LAUNCH) != 1:
+        raise RuntimeError("canonical v26 launcher count invalid")
+    return text
 
 
 def _validate(text: str) -> None:
@@ -150,17 +158,17 @@ def _validate(text: str) -> None:
     ):
         if text.count(marker) != 1:
             raise RuntimeError(f"startup handoff marker count invalid: {marker}")
-
     export_pos = text.index(f"export {DEFER_FLAG}=1")
     attestation_pos = text.index(ATTESTATION_MARKER)
     unset_pos = text.index(f"unset {DEFER_FLAG}")
-    main_pos = text.index("$PY -u main.py")
-    if not export_pos < attestation_pos < unset_pos < main_pos:
+    launcher_pos = text.index(CANONICAL_LAUNCH)
+    if not export_pos < attestation_pos < unset_pos < launcher_pos:
         raise RuntimeError("startup handoff ordering invalid")
-
-    pre_main = text[:main_pos]
+    if LEGACY_LAUNCH in text:
+        raise RuntimeError("legacy direct main.py launch remains")
+    pre_launcher = text[:launcher_pos]
     python_tokens = ("$PY ", '"${PY}" ', "${PY} ", "python3 ", "python ")
-    early_positions = [pre_main.find(token) for token in python_tokens]
+    early_positions = [pre_launcher.find(token) for token in python_tokens]
     early_positions = [position for position in early_positions if position >= 0]
     if early_positions and export_pos > min(early_positions):
         raise RuntimeError("runtime hooks are not deferred before the first Python preflight")
@@ -171,6 +179,7 @@ def patch_text(text: str) -> str:
     patched = _insert_redis_checkpoint(patched)
     patched = _replace_legacy_entrypoint_diagnostics(patched)
     patched = _insert_runtime_handoff(patched)
+    patched = _enforce_v26_launcher(patched)
     _validate(patched)
     return patched
 
@@ -181,7 +190,8 @@ def main() -> None:
     START_PATH.write_text(patched, encoding="utf-8")
     print(
         "NIJA_STARTUP_HANDOFF_PATCH_APPLIED "
-        "early_defer=true canonical_attestation=true portable_root=true release=v24 idempotent=true"
+        "early_defer=true canonical_attestation=true portable_root=true "
+        "launcher=v26 release=v26 idempotent=true"
     )
 
 


### PR DESCRIPTION
## What changed
- updates `scripts/apply_startup_handoff_fix.py` so Docker build-time patching permanently rewrites `start.sh` to `scripts/canonical_runtime_launcher_v26.py`
- removes reliance on Render executing `scripts/render_entrypoint.sh` correctly
- fails closed if a direct `$PY -u main.py` launch remains
- validates exactly one v26 launcher invocation and preserves preflight hook deferral

## Why
Cold-start logs from commit `6a817680417218c068b129de297a4b756cdc7b73` still showed `STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=main.py`, followed by `broker_manager_not_initialized`, zero brokers, stale zero capital, and no runtime authority. This means the platform startup path can still bypass the runtime-only v26 rewrite.

## Expected proof after deployment
- `NIJA_STARTUP_HANDOFF_PATCH_APPLIED ... launcher=v26 release=v26`
- `STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=canonical_runtime_launcher_v26.py`
- `CANONICAL_RUNTIME_LAUNCHER_V26_BEGIN`
- `CANONICAL_RUNTIME_LAUNCHER_V26_READY`
- canonical broker convergence and positive hydrated capital before activation