### PR TITLE
Run canonical broker prebootstrap directly on the main startup thread

### DIFF
--- a/scripts/apply_direct_broker_prebootstrap_v27.py
+++ b/scripts/apply_direct_broker_prebootstrap_v27.py
@@ -1,0 +1,45 @@
+"""Patch bot_main so canonical broker preparation runs directly on the main thread.
+
+This removes reliance on import-hook wrappers for the safety-critical transition
+between verified writer authority and SelfHealingStartup. The patch is idempotent
+and fail-closed: if canonical broker preparation fails, startup returns failure
+before SelfHealingStartup, capital hydration, or trading can proceed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BOT_MAIN = ROOT / "bot" / "bot_main.py"
+MARKER = "DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27"
+
+ANCHOR = '''    try:\n        logger.info("\\n[STEP 1] Self-Healing Bootstrap")\n'''
+
+BLOCK = '''    try:\n        logger.info("\\n[STEP 0.5] Canonical Broker Prebootstrap")\n        try:\n            from bot.canonical_broker_prebootstrap_v22 import (\n                prepare_canonical_broker_runtime,\n            )\n\n            manager = prepare_canonical_broker_runtime()\n            if not bool(getattr(manager, "_fsm_initialized", False)):\n                raise RuntimeError("canonical broker manager FSM is not initialized")\n            logger.critical(\n                "DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY "\n                "fsm_initialized=true thread=%s",\n                threading.current_thread().name,\n            )\n            os.environ["NIJA_DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY"] = "1"\n        except Exception as broker_exc:\n            os.environ["NIJA_DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY"] = "0"\n            logger.critical(\n                "DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_FAILED err=%s:%s "\n                "trading_remains_fail_closed=true",\n                type(broker_exc).__name__,\n                broker_exc,\n                exc_info=True,\n            )\n            return 1\n\n        logger.info("\\n[STEP 1] Self-Healing Bootstrap")\n'''
+
+
+def patch_text(text: str) -> str:
+    if MARKER in text:
+        if text.count(MARKER) < 2:
+            raise RuntimeError("v27 direct prebootstrap marker is incomplete")
+        return text
+    if ANCHOR not in text:
+        raise RuntimeError("bot_main startup anchor not found")
+    patched = text.replace(ANCHOR, BLOCK, 1)
+    if MARKER not in patched:
+        raise RuntimeError("v27 direct prebootstrap patch was not installed")
+    return patched
+
+
+def main() -> None:
+    original = BOT_MAIN.read_text(encoding="utf-8")
+    patched = patch_text(original)
+    BOT_MAIN.write_text(patched, encoding="utf-8")
+    print(
+        "DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_PATCH_APPLIED "
+        "main_thread=true fail_closed=true idempotent=true"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_entrypoint.sh
+++ b/scripts/render_entrypoint.sh
@@ -42,12 +42,12 @@ _promote_secret_alias KRAKEN_PLATFORM_API_SECRET \
     KRAKEN_MASTER_SECRET \
     KRAKEN_PLATFORM_SECRET
 
-# Docker builds already apply the legacy handoff patch. Running it again is
-# intentionally idempotent and closes the source-runtime gap for an existing
-# Render service that executes repository files without rebuilding the layer.
+# Apply every startup-order repair before any normal Python interpreter can load
+# NIJA runtime hooks. All patchers are idempotent and fail closed.
 export NIJA_DEFER_RUNTIME_SITE_HOOKS=1
 python3 -S scripts/apply_startup_handoff_fix.py
 python3 -S scripts/apply_canonical_launcher_v26.py
+python3 -S scripts/apply_direct_broker_prebootstrap_v27.py
 bash -n start.sh
 python3 -S -m py_compile \
     main.py \
@@ -61,6 +61,7 @@ python3 -S -m py_compile \
     bot/stalled_writer_release_guard_v22.py \
     scripts/canonical_runtime_launcher_v26.py \
     scripts/apply_canonical_launcher_v26.py \
+    scripts/apply_direct_broker_prebootstrap_v27.py \
     scripts/runtime_entrypoint_attestation.py
 
 grep -Fq '$PY -u scripts/canonical_runtime_launcher_v26.py' start.sh
@@ -68,8 +69,9 @@ if grep -Fq '$PY -u main.py' start.sh; then
     echo "❌ Legacy direct main.py launch remains after v26 patch"
     exit 78
 fi
+grep -Fq 'DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY' bot/bot_main.py
 
-echo "🧭 RENDER_ENTRYPOINT_CANONICAL_HANDOFF_READY marker=20260724-render-entrypoint-v26 launcher=canonical_runtime_launcher_v26"
+echo "🧭 RENDER_ENTRYPOINT_CANONICAL_HANDOFF_READY marker=20260724-render-entrypoint-v27 launcher=canonical_runtime_launcher_v26 direct_broker_prebootstrap=v27"
 unset NIJA_DEFER_RUNTIME_SITE_HOOKS
 
 exec bash scripts/production_bootstrap.sh "$@"


### PR DESCRIPTION
## What changed
- adds an idempotent v27 source patch for `bot/bot_main.py`
- runs `prepare_canonical_broker_runtime()` directly after writer authority verification and before `SelfHealingStartup`
- fails closed and releases through the existing `bot_main` finally path when broker preparation fails
- updates the Render entrypoint to apply, compile, and attest the v27 patch before production bootstrap

## Why
The latest Render logs still show `broker_manager_not_initialized`, `hydrated=False`, `$0.00` capital, and `brokers=0`. The existing v22/v24 import-hook wrappers are present but can still be bypassed by import ordering. This change removes that dependency from the critical startup sequence.

## Expected runtime proof
- `DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_PATCH_APPLIED`
- `DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY fsm_initialized=true thread=MainThread`
- `CANONICAL_BROKER_PREBOOTSTRAP_V22_READY`
- no `broker_manager_not_initialized`
- accepted, non-stale capital snapshot with at least one connected platform broker before activation

## Safety
The patch does not fabricate broker connectivity, capital, authority, signals, orders, or profits. Any preparation failure remains fail closed.