### PR TITLE
Include v27 broker prebootstrap patch in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -111,6 +111,7 @@ scripts/*
 !scripts/apply_startup_handoff_fix.py
 !scripts/apply_canonical_launcher_v26.py
 !scripts/canonical_runtime_launcher_v26.py
+!scripts/apply_direct_broker_prebootstrap_v27.py
 !scripts/install_sitecustomize_defer_guard.py
 !scripts/runtime_entrypoint_attestation.py
 check_*.py


### PR DESCRIPTION
## What changed
- unignores `scripts/apply_direct_broker_prebootstrap_v27.py` in `.dockerignore`
- ensures `COPY scripts/ scripts/` includes the v27 runtime patch

## Why
Render built commit `67d17a89a2ee` but startup failed with:

`python3: can't open file '/app/scripts/apply_direct_broker_prebootstrap_v27.py': [Errno 2] No such file or directory`

The file existed in GitHub but was excluded by the `scripts/*` Docker ignore rule.

## Expected proof after deploy
- no missing-file error
- `DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_PATCH_APPLIED`
- `DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY fsm_initialized=true thread=MainThread`
- broker manager initialization proceeds before SelfHealingStartup

This change does not alter trading gates, capital checks, or writer-lock safety.