### PR TITLE
Fix broker startup and runtime wrapper convergence

### DIFF
--- a/bot/canonical_broker_prebootstrap_v22.py
+++ b/bot/canonical_broker_prebootstrap_v22.py
@@ -112,6 +112,24 @@ def _initialize_manager(manager: Any) -> None:
         )
         initialize()
 
+    # Some legacy initialize paths return successfully after an InitRegistry
+    # short-circuit without setting the capital-FSM latch. Treat that exact
+    # silent state as recoverable, while keeping all broker/auth/balance
+    # failures fail-closed.
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        silent_latch = RuntimeError(
+            "initialize returned without setting _fsm_initialized"
+        )
+        if not _repair_capital_fsm_latch(manager, silent_latch):
+            raise RuntimeError(
+                "MultiAccountBrokerManager.initialize completed without "
+                "initializing the capital FSM"
+            )
+        logger.critical(
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_SILENT_LATCH_REPAIRED marker=%s",
+            _MARKER,
+        )
+
 
 def _platform_counts(manager: Any) -> tuple[int, int, list[str]]:
     brokers = getattr(manager, "platform_brokers", None)

--- a/bot/tests/test_canonical_broker_prebootstrap_v22.py
+++ b/bot/tests/test_canonical_broker_prebootstrap_v22.py
@@ -64,6 +64,51 @@ def test_initialize_retries_only_missing_fsm_latch():
     assert manager._fsm_initialized is True
 
 
+
+def test_initialize_repairs_silent_missing_fsm_latch():
+    calls = []
+
+    class Manager(_ReadyManager):
+        def __init__(self):
+            super().__init__()
+            self._fsm_initialized = False
+
+        def initialize(self):
+            calls.append("initialize")
+
+        def _init_capital_fsm(self):
+            calls.append("repair")
+            self._fsm_initialized = True
+
+    manager = Manager()
+    guard._initialize_manager(manager)
+
+    assert calls == ["initialize", "repair"]
+    assert manager._fsm_initialized is True
+
+
+def test_initialize_fails_closed_when_silent_latch_cannot_be_repaired():
+    class Manager(_ReadyManager):
+        def __init__(self):
+            super().__init__()
+            self._fsm_initialized = False
+
+        def initialize(self):
+            return None
+
+        def _init_capital_fsm(self):
+            return None
+
+    manager = Manager()
+
+    try:
+        guard._initialize_manager(manager)
+    except RuntimeError as exc:
+        assert "without initializing the capital FSM" in str(exc)
+    else:
+        raise AssertionError("unrepaired capital FSM must remain fail-closed")
+
+
 def test_initialize_does_not_retry_real_broker_failure():
     calls = []
 

--- a/bot/tests/test_runtime_module_identity_zero_state_repair.py
+++ b/bot/tests/test_runtime_module_identity_zero_state_repair.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import runtime_module_identity_convergence_patch as identity
+
+
+def test_audit_reinstalls_missing_zero_signal_state_wrapper(monkeypatch):
+    core = ModuleType("bot.nija_core_loop")
+
+    class NijaCoreLoop:
+        def _phase3_scan_and_enter(
+            self,
+            broker,
+            snapshot,
+            symbols,
+            available_slots,
+            zero_signal_streak=0,
+        ):
+            return 0, 0, 0, {}
+
+    setattr(
+        NijaCoreLoop._phase3_scan_and_enter,
+        identity._ZERO_CAP_ATTR,
+        True,
+    )
+    core.NijaCoreLoop = NijaCoreLoop
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
+
+    risk = ModuleType(identity._RISK_CANONICAL)
+    risk._MARKER = identity._REQUIRED_RISK_MARKER
+    monkeypatch.setitem(sys.modules, identity._RISK_CANONICAL, risk)
+    monkeypatch.setitem(sys.modules, identity._RISK_ALIAS, risk)
+
+    pipeline = ModuleType("bot.execution_pipeline")
+
+    class ExecutionPipeline:
+        def execute(self):
+            return None
+
+    setattr(ExecutionPipeline.execute, identity._V2_RISK_ATTR, True)
+    pipeline.ExecutionPipeline = ExecutionPipeline
+    monkeypatch.setitem(sys.modules, "bot.execution_pipeline", pipeline)
+    monkeypatch.delitem(sys.modules, "execution_pipeline", raising=False)
+
+    monkeypatch.setattr(
+        identity,
+        "canonicalize_loaded_patch_modules",
+        lambda: (True, {}),
+    )
+
+    ready, details = identity.audit()
+
+    assert ready is True
+    assert "state_repair=True" in details["zero_signal_streak_chain"]
+    assert identity.os.environ["NIJA_ZERO_SIGNAL_STREAK_STATE_READY"] == "1"

--- a/runtime_module_identity_convergence_patch.py
+++ b/runtime_module_identity_convergence_patch.py
@@ -184,6 +184,33 @@ def normalize_runtime_limits() -> None:
     os.environ["NIJA_CORE_LOOP_PROGRESS_LIMITS_NORMALIZED"] = "1"
 
 
+
+def _ensure_zero_signal_state_repair() -> bool:
+    """Synchronously restore the required Phase-3 state wrapper when it drifts."""
+
+    try:
+        module = __import__(
+            "bot.zero_signal_streak_state_repair_patch",
+            fromlist=["_try_loaded"],
+        )
+        repair = getattr(module, "_try_loaded", None)
+        repaired = bool(repair()) if callable(repair) else False
+        if repaired:
+            logger.warning(
+                "ZERO_SIGNAL_STATE_REPAIR_RECONVERGED marker=%s source=module_identity_audit",
+                _MARKER,
+            )
+        return repaired
+    except Exception as exc:
+        logger.error(
+            "ZERO_SIGNAL_STATE_REPAIR_RECONVERGENCE_FAILED marker=%s error=%s:%s",
+            _MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def audit() -> tuple[bool, dict[str, str]]:
     modules_ready, details = canonicalize_loaded_patch_modules()
     normalize_runtime_limits()
@@ -212,6 +239,10 @@ def audit() -> tuple[bool, dict[str, str]]:
         phase3 = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
         capped, cap_cycle, cap_depth = _chain_has_attr(phase3, _ZERO_CAP_ATTR)
         state, state_cycle, state_depth = _chain_has_attr(phase3, _ZERO_STATE_ATTR)
+        if not state and not state_cycle and _ensure_zero_signal_state_repair():
+            phase3 = getattr(cls, "_phase3_scan_and_enter", None)
+            capped, cap_cycle, cap_depth = _chain_has_attr(phase3, _ZERO_CAP_ATTR)
+            state, state_cycle, state_depth = _chain_has_attr(phase3, _ZERO_STATE_ATTR)
         cycle = cap_cycle or state_cycle
         details["zero_signal_streak_chain"] = (
             f"cap_guard={capped};state_repair={state};cycle={cycle};depth={max(cap_depth, state_depth)}"
@@ -271,4 +302,5 @@ __all__ = [
     "install", "install_import_hook", "audit", "canonicalize_loaded_patch_modules",
     "recover_unregistered_patch_modules_from_threads", "normalize_runtime_limits",
     "_current_duplicates", "_chain_has_attr", "_wrapper_chain_status",
+    "_ensure_zero_signal_state_repair",
 ]


### PR DESCRIPTION
## Summary

- repair the canonical broker manager when `initialize()` silently returns without setting its capital-FSM latch
- keep credential, exchange, balance, network, writer-authority, and risk failures fail-closed
- make the runtime module-identity audit synchronously restore the required zero-signal state wrapper before evaluating release readiness
- add regression tests for successful bounded recovery and unrecoverable fail-closed behavior

## Why

The July 25 Render logs show the canonical broker manager never becoming initialized (`broker_manager_not_initialized`), leaving capital at `$0`, brokers at `0`, execution authority at `0`, and scan cycles at `0`. Later audits also show `state_repair=False`, which keeps the release manifest unsafe even when the wrapper can be restored.

## Safety

This does not force entries, bypass account isolation, weaken pre-trade checks, or promise profitable outcomes. Orders remain conditional on valid credentials, observed spendable balances, exchange acceptance, strategy signals, and existing risk/exit controls. Exit paths continue to bypass entry-only gates as designed.

## Tests

- silent missing FSM latch is repaired once
- unrepaired FSM latch remains fail-closed
- real broker initialization failures are not retried as latch failures
- missing zero-signal state wrapper is restored during the identity audit