### PR TITLE
Run canonical broker prebootstrap after Render writer handoff

### DIFF
--- a/bot/render_startup_convergence_patch.py
+++ b/bot/render_startup_convergence_patch.py
@@ -165,6 +165,30 @@ def _canonical_prebootstrap_manager() -> Tuple[Optional[Any], str]:
             break
 
     if module is None:
+        for name in (
+            "nija_canonical_broker_startup_convergence_v24_prebot",
+            "nija_canonical_broker_startup_convergence_v24",
+        ):
+            startup_guard = sys.modules.get(name)
+            loader = getattr(startup_guard, "_load_v22_module", None)
+            if callable(loader):
+                try:
+                    module = loader()
+                except Exception as exc:
+                    logger.error(
+                        "RENDER_STARTUP_CANONICAL_PREBOOTSTRAP_LOAD_FAILED "
+                        "marker=%s err=%s:%s",
+                        _MARKER,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    return None, (
+                        "canonical_prebootstrap_load_failed:"
+                        f"{type(exc).__name__}"
+                    )
+                break
+
+    if module is None:
         return None, "canonical_prebootstrap_module_not_loaded"
 
     prepare = getattr(module, "prepare_canonical_broker_runtime", None)

--- a/bot/render_startup_convergence_patch.py
+++ b/bot/render_startup_convergence_patch.py
@@ -6,11 +6,11 @@ This module repairs two startup-state problems without granting trading authorit
   environment value such as ``NIJA_RUNTIME_EXECUTION_AUTHORITY=true`` is reset
   to ``0`` until the current process owns a writer fencing token and lease
   generation.
-* After writer lineage exists, a bounded monitor asks the already-initialized
-  MultiAccountBrokerManager to re-run its normal capital watchdog refresh.  It
-  never creates brokers, never calls ``initialize()`` from a background thread,
-  and never bypasses capital, heartbeat, writer-lock, kill-switch, or state
-  machine gates.
+* After writer lineage exists, a bounded monitor converges the canonical
+  MultiAccountBrokerManager through its locked prebootstrap when startup import
+  churn has delayed initialization, then re-runs its normal capital watchdog
+  refresh. It never creates a second manager and never bypasses capital,
+  heartbeat, writer-lock, kill-switch, broker, or state-machine gates.
 
 The platform contract treats Kraken as the required primary broker and Coinbase
 as an optional isolated broker, so runtime convergence defaults to one valid
@@ -151,6 +151,50 @@ def _result_summary(result: Any) -> str:
     return f"type={type(result).__name__}"
 
 
+def _canonical_prebootstrap_manager() -> Tuple[Optional[Any], str]:
+    """Run the existing locked canonical prebootstrap after writer verification."""
+
+    module = None
+    for name in (
+        "nija_canonical_broker_prebootstrap_v22",
+        "bot.canonical_broker_prebootstrap_v22",
+    ):
+        candidate = sys.modules.get(name)
+        if candidate is not None:
+            module = candidate
+            break
+
+    if module is None:
+        return None, "canonical_prebootstrap_module_not_loaded"
+
+    prepare = getattr(module, "prepare_canonical_broker_runtime", None)
+    if not callable(prepare):
+        return None, "canonical_prebootstrap_prepare_missing"
+
+    try:
+        manager = prepare()
+    except Exception as exc:
+        logger.critical(
+            "RENDER_STARTUP_CANONICAL_PREBOOTSTRAP_FAILED marker=%s err=%s:%s "
+            "trading_remains_fail_closed=true",
+            _MARKER,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        return None, f"canonical_prebootstrap_failed:{type(exc).__name__}"
+
+    if not bool(getattr(manager, "_fsm_initialized", False)):
+        return None, "canonical_prebootstrap_returned_uninitialized"
+
+    logger.critical(
+        "RENDER_STARTUP_CANONICAL_PREBOOTSTRAP_READY marker=%s generation=%s",
+        _MARKER,
+        os.environ.get("NIJA_WRITER_LEASE_GENERATION", "unknown"),
+    )
+    return manager, "canonical_prebootstrap_ready"
+
+
 def _attempt_recovery_once() -> Tuple[bool, str]:
     """Run one safe convergence attempt.
 
@@ -185,7 +229,9 @@ def _attempt_recovery_once() -> Tuple[bool, str]:
         return False, f"broker_manager_unavailable:{type(exc).__name__}"
 
     if not bool(getattr(manager, "_fsm_initialized", False)):
-        return False, "broker_manager_not_initialized"
+        manager, prebootstrap_reason = _canonical_prebootstrap_manager()
+        if manager is None:
+            return False, prebootstrap_reason
 
     has_sources = getattr(manager, "has_registered_sources", None)
     if not callable(has_sources) or not bool(has_sources()):
@@ -328,4 +374,5 @@ __all__ = [
     "install_import_hook",
     "normalize_derived_runtime_state",
     "_attempt_recovery_once",
+    "_canonical_prebootstrap_manager",
 ]

--- a/bot/tests/test_render_startup_convergence_patch.py
+++ b/bot/tests/test_render_startup_convergence_patch.py
@@ -219,6 +219,57 @@ def test_recovery_runs_canonical_prebootstrap_after_writer_lineage(monkeypatch):
     assert calls == {"prepare": 1, "refresh": 1, "converge": 1}
 
 
+def test_recovery_loads_prebootstrap_from_launcher_guard(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-launcher")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "11")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    manager = SimpleNamespace(_fsm_initialized=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.multi_account_broker_manager",
+        SimpleNamespace(get_broker_manager=lambda: manager),
+    )
+    monkeypatch.delitem(
+        sys.modules,
+        "nija_canonical_broker_prebootstrap_v22",
+        raising=False,
+    )
+    monkeypatch.delitem(
+        sys.modules,
+        "bot.canonical_broker_prebootstrap_v22",
+        raising=False,
+    )
+
+    calls = {"load": 0, "prepare": 0}
+
+    def prepare():
+        calls["prepare"] += 1
+        manager._fsm_initialized = True
+        return manager
+
+    def load():
+        calls["load"] += 1
+        return SimpleNamespace(prepare_canonical_broker_runtime=prepare)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "nija_canonical_broker_startup_convergence_v24_prebot",
+        SimpleNamespace(_load_v22_module=load),
+    )
+
+    module = _load_module()
+    recovered, reason = module._canonical_prebootstrap_manager()
+
+    assert recovered is manager
+    assert reason == "canonical_prebootstrap_ready"
+    assert calls == {"load": 1, "prepare": 1}
+
+
 def test_recovery_keeps_failed_canonical_prebootstrap_fail_closed(monkeypatch):
     _clear_runtime_env(monkeypatch)
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")

--- a/bot/tests/test_render_startup_convergence_patch.py
+++ b/bot/tests/test_render_startup_convergence_patch.py
@@ -143,6 +143,116 @@ def test_recovery_refreshes_existing_manager_and_uses_normal_convergence(monkeyp
     assert calls == {"watchdog": 1, "refresh": 1, "converge": 1}
 
 
+def test_recovery_runs_canonical_prebootstrap_after_writer_lineage(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-recovery")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    calls = {"prepare": 0, "refresh": 0, "converge": 0}
+
+    class FakeManager:
+        _fsm_initialized = False
+        WATCHDOG_REFRESH_TRIGGER = "watchdog"
+
+        @staticmethod
+        def has_registered_sources():
+            return True
+
+        @staticmethod
+        def has_attempted_connections():
+            return True
+
+        @staticmethod
+        def refresh_capital_authority(*, trigger: str):
+            calls["refresh"] += 1
+            assert trigger == "watchdog"
+            return {"ready": True, "total_capital": 125.0, "valid_brokers": 1}
+
+    manager = FakeManager()
+    manager_module = SimpleNamespace(get_broker_manager=lambda: manager)
+    monkeypatch.setitem(sys.modules, "bot.multi_account_broker_manager", manager_module)
+
+    def prepare():
+        calls["prepare"] += 1
+        manager._fsm_initialized = True
+        return manager
+
+    prebootstrap = SimpleNamespace(prepare_canonical_broker_runtime=prepare)
+    monkeypatch.setitem(
+        sys.modules,
+        "nija_canonical_broker_prebootstrap_v22",
+        prebootstrap,
+    )
+
+    convergence = SimpleNamespace()
+
+    def converge(source: str):
+        calls["converge"] += 1
+        assert source == "render_post_lock_recovery"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "LIVE_ACTIVE"
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"
+        return True
+
+    convergence.converge_runtime_authority = converge
+
+    module = _load_module()
+    original_import_module = module.importlib.import_module
+
+    def import_module(name: str):
+        if name == "bot.runtime_authority_convergence_repair_patch":
+            return convergence
+        return original_import_module(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", import_module)
+
+    done, reason = module._attempt_recovery_once()
+
+    assert done is True
+    assert reason == "converged_live_active"
+    assert manager._fsm_initialized is True
+    assert calls == {"prepare": 1, "refresh": 1, "converge": 1}
+
+
+def test_recovery_keeps_failed_canonical_prebootstrap_fail_closed(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-failed")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "10")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+
+    manager = SimpleNamespace(_fsm_initialized=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.multi_account_broker_manager",
+        SimpleNamespace(get_broker_manager=lambda: manager),
+    )
+
+    def fail():
+        raise RuntimeError("broker credentials rejected")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "nija_canonical_broker_prebootstrap_v22",
+        SimpleNamespace(prepare_canonical_broker_runtime=fail),
+    )
+
+    module = _load_module()
+    done, reason = module._attempt_recovery_once()
+
+    assert done is False
+    assert reason == "canonical_prebootstrap_failed:RuntimeError"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"
+
+
 def test_recovery_does_not_import_or_initialize_brokers_before_writer_lineage(monkeypatch):
     _clear_runtime_env(monkeypatch)
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")


### PR DESCRIPTION
## Summary

- allow the bounded Render startup-convergence monitor to invoke the existing locked canonical broker prebootstrap after verified writer lineage exists
- reuse the already-loaded canonical manager singleton instead of creating a second manager
- continue through the normal capital refresh and runtime-authority convergence path only after the manager FSM is initialized
- add regression coverage for successful recovery and credential/prebootstrap failure remaining fail-closed

## Root cause

The deployed merge acquired writer generation 1785 during the pre-bot source guard, but `bot.bot_main.main()` was delayed behind runtime patch imports. The Render recovery monitor observed the canonical manager for at least 39 attempts but explicitly returned `broker_manager_not_initialized` instead of invoking the canonical prebootstrap. As a result, capital stayed at `$0`, brokers stayed at `0`, execution authority stayed disabled, and scan cycles remained at `0`.

## Safety

The recovery runs only after a fencing token and lease generation are present. It delegates to the existing locked canonical prebootstrap and does not force orders, fabricate capital, bypass exchange credentials, weaken risk gates, or enable execution authority directly. Broker/auth/balance failures remain fail-closed.

## Tests

- canonical prebootstrap runs after verified writer lineage and normal authority convergence completes
- a canonical prebootstrap failure leaves runtime state `OFF` with execution authority `0`
- existing tests continue to verify that no broker initialization occurs before writer lineage