### PR TITLE
Recover live trading loop and isolate user capital

### DIFF
--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -402,6 +402,41 @@ def _start_trading_loop(strategy: Any, source: str) -> bool:
         return alive
 
 
+def ensure_live_dispatch(source: str = "external_recovery") -> Tuple[bool, str]:
+    """Perform one idempotent live-loop handoff attempt."""
+
+    if _loop_thread_running():
+        return True, "trading_loop_already_running"
+
+    _ensure_deferred_startup_repairs()
+    if _has_writer_authority() and (
+        not _runtime_execution_authority()
+        or not _state_machine_live_active()
+    ):
+        _attempt_runtime_convergence(source)
+
+    allowed, reason = _dispatch_allowed()
+    if not allowed:
+        return reason == "trading_loop_already_running", reason
+
+    strategy, strategy_source = _find_strategy()
+    if strategy is None:
+        return False, "strategy_not_published"
+
+    started = _start_trading_loop(strategy, strategy_source)
+    detail = "started" if started else "start_failed"
+    logger.log(
+        logging.CRITICAL if started else logging.ERROR,
+        "LIVE_ACTIVE_DISPATCH_BRIDGE_ENSURE source=%s started=%s detail=%s "
+        "strategy_source=%s",
+        source,
+        str(started).lower(),
+        detail,
+        strategy_source,
+    )
+    return started, detail
+
+
 def _monitor() -> None:
     interval = max(
         1.0,
@@ -517,4 +552,5 @@ __all__ = [
     "_attempt_runtime_convergence",
     "_dispatch_allowed",
     "_writer_authority_snapshot",
+    "ensure_live_dispatch",
 ]

--- a/bot/multi_account_broker_manager.py
+++ b/bot/multi_account_broker_manager.py
@@ -185,6 +185,15 @@ if __name__ == "bot.multi_account_broker_manager":
 elif __name__ == "multi_account_broker_manager":
     sys.modules.setdefault("bot.multi_account_broker_manager", sys.modules[__name__])
 
+def _aggregate_user_capital_enabled() -> bool:
+    """Return whether user balances may enter the global authority snapshot."""
+
+    return str(
+        os.environ.get("NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY", "false")
+        or "false"
+    ).strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
+
+
 ACCOUNT_USABLE_BALANCE_MIN = float(
     os.getenv(
         "NIJA_ACCOUNT_USABLE_BALANCE_MIN",
@@ -2266,29 +2275,30 @@ class MultiAccountBrokerManager:
                 )
                 broker_map[broker_type.value] = broker
 
-            # ── User broker aggregation ───────────────────────────────────────
-            # Include connected user account brokers in the capital snapshot so
-            # that user-held balances (e.g. Kraken user accounts, Coinbase user
-            # accounts) are counted toward the total.  Without this loop only
-            # platform-level balances are aggregated, causing CapitalAuthority to
-            # report a fraction of the true account balance and the risk engine to
-            # reject trades based on an artificially low exposure cap.
-            #
-            # Key format mirrors get_all_brokers(): "{user_id}_{broker_type.value}"
-            # This guarantees uniqueness and avoids collisions with platform keys.
-            for _user_id, _user_broker_dict in self.user_brokers.items():
-                for _user_broker_type, _user_broker in _user_broker_dict.items():
-                    if _user_broker is None:
-                        continue
-                    if not getattr(_user_broker, "connected", False):
-                        continue
-                    _user_broker_key = f"{_user_id}_{_user_broker_type.value}"
-                    broker_map[_user_broker_key] = _user_broker
-                    logger.info(
-                        "[CapitalAuthorityRefresh] trigger=%s include user_broker=%s reason=connected",
-                        trigger,
-                        _user_broker_key,
-                    )
+            # User accounts are independently traded and must not inflate the
+            # platform CapitalAuthority used for platform readiness or sizing.
+            # An explicit opt-in remains available for legacy deployments.
+            if _aggregate_user_capital_enabled():
+                for _user_id, _user_broker_dict in self.user_brokers.items():
+                    for _user_broker_type, _user_broker in _user_broker_dict.items():
+                        if _user_broker is None:
+                            continue
+                        if not getattr(_user_broker, "connected", False):
+                            continue
+                        _user_broker_key = f"{_user_id}_{_user_broker_type.value}"
+                        broker_map[_user_broker_key] = _user_broker
+                        logger.warning(
+                            "[CapitalAuthorityRefresh] trigger=%s include "
+                            "user_broker=%s reason=explicit_legacy_opt_in",
+                            trigger,
+                            _user_broker_key,
+                        )
+            elif self.user_brokers:
+                logger.info(
+                    "[CapitalAuthorityRefresh] trigger=%s user_capital_excluded=true "
+                    "reason=independent_account_isolation",
+                    trigger,
+                )
 
             logger.info(
                 "[CapitalAuthorityRefresh] trigger=%s eligible_brokers=%s",

--- a/bot/no_trade_watchdog_runtime_patch.py
+++ b/bot/no_trade_watchdog_runtime_patch.py
@@ -262,6 +262,30 @@ def _install_autowire_worker() -> None:
         threading.Thread(target=_worker, name="no-trade-watchdog-autowire", daemon=True).start()
 
 
+def _recover_live_dispatch() -> tuple[bool, str]:
+    """Ask the installed dispatch bridge for one idempotent recovery attempt."""
+
+    for name in (
+        "nija_live_active_dispatch_bridge_patch",
+        "bot.live_active_dispatch_bridge_patch",
+        "live_active_dispatch_bridge_patch",
+    ):
+        module = sys.modules.get(name)
+        recover = getattr(module, "ensure_live_dispatch", None)
+        if not callable(recover):
+            continue
+        try:
+            return recover("no_trade_watchdog")
+        except Exception as exc:
+            logger.exception(
+                "NO_TRADE_WATCHDOG_DISPATCH_RECOVERY_FAILED module=%s error=%s",
+                name,
+                exc,
+            )
+            return False, f"recovery_error:{type(exc).__name__}"
+    return False, "dispatch_bridge_unavailable"
+
+
 def _install_live_active_monitor() -> None:
     global _MONITOR_STARTED
     if _MONITOR_STARTED:
@@ -293,6 +317,12 @@ def _install_live_active_monitor() -> None:
                         _risk_snapshot(),
                     )
                     _resolve_and_patch_modules()
+                    recovered, recovery_detail = _recover_live_dispatch()
+                    logger.warning(
+                        "NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=%s detail=%s",
+                        str(recovered).lower(),
+                        recovery_detail,
+                    )
                 else:
                     _log_watchdog("live_active_monitor", force=True)
                 next_warn = now + interval

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -124,3 +124,44 @@ def test_runtime_convergence_uses_existing_fail_closed_repair(monkeypatch) -> No
     assert ready is True
     assert detail == "ready"
     assert calls == ["install", "test"]
+
+
+def test_ensure_live_dispatch_starts_existing_strategy_only_when_ready(monkeypatch) -> None:
+    module = _load_module()
+    strategy = object()
+    calls: list[tuple[object, str]] = []
+
+    monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
+    monkeypatch.setattr(module, "_ensure_deferred_startup_repairs", lambda: (True, "ready"))
+    monkeypatch.setattr(module, "_has_writer_authority", lambda: True)
+    monkeypatch.setattr(module, "_runtime_execution_authority", lambda: True)
+    monkeypatch.setattr(module, "_state_machine_live_active", lambda: True)
+    monkeypatch.setattr(module, "_dispatch_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(module, "_find_strategy", lambda: (strategy, "published"))
+    monkeypatch.setattr(
+        module,
+        "_start_trading_loop",
+        lambda candidate, source: calls.append((candidate, source)) or True,
+    )
+
+    started, detail = module.ensure_live_dispatch("watchdog")
+
+    assert started is True
+    assert detail == "started"
+    assert calls == [(strategy, "published")]
+
+
+def test_ensure_live_dispatch_never_constructs_missing_strategy(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
+    monkeypatch.setattr(module, "_ensure_deferred_startup_repairs", lambda: (True, "ready"))
+    monkeypatch.setattr(module, "_has_writer_authority", lambda: True)
+    monkeypatch.setattr(module, "_runtime_execution_authority", lambda: True)
+    monkeypatch.setattr(module, "_state_machine_live_active", lambda: True)
+    monkeypatch.setattr(module, "_dispatch_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(module, "_find_strategy", lambda: (None, "not_found"))
+
+    started, detail = module.ensure_live_dispatch("watchdog")
+
+    assert started is False
+    assert detail == "strategy_not_published"

--- a/bot/tests/test_multi_account_capital_isolation_env.py
+++ b/bot/tests/test_multi_account_capital_isolation_env.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import bot.multi_account_broker_manager as manager
+
+
+def test_user_capital_aggregation_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY", raising=False)
+
+    assert manager._aggregate_user_capital_enabled() is False
+
+
+def test_user_capital_aggregation_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY", "true")
+
+    assert manager._aggregate_user_capital_enabled() is True

--- a/bot/tests/test_no_trade_watchdog_dispatch_recovery.py
+++ b/bot/tests/test_no_trade_watchdog_dispatch_recovery.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from uuid import uuid4
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "no_trade_watchdog_runtime_patch.py"
+
+
+def _load_module():
+    name = f"no_trade_watchdog_dispatch_recovery_{uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_watchdog_uses_path_loaded_dispatch_bridge(monkeypatch):
+    module = _load_module()
+    bridge = ModuleType("nija_live_active_dispatch_bridge_patch")
+    calls: list[str] = []
+
+    def recover(source: str):
+        calls.append(source)
+        return True, "started"
+
+    bridge.ensure_live_dispatch = recover
+    monkeypatch.setitem(
+        sys.modules,
+        "nija_live_active_dispatch_bridge_patch",
+        bridge,
+    )
+
+    recovered, detail = module._recover_live_dispatch()
+
+    assert recovered is True
+    assert detail == "started"
+    assert calls == ["no_trade_watchdog"]
+
+
+def test_watchdog_does_not_import_missing_dispatch_bridge(monkeypatch):
+    module = _load_module()
+    for name in (
+        "nija_live_active_dispatch_bridge_patch",
+        "bot.live_active_dispatch_bridge_patch",
+        "live_active_dispatch_bridge_patch",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    recovered, detail = module._recover_live_dispatch()
+
+    assert recovered is False
+    assert detail == "dispatch_bridge_unavailable"


### PR DESCRIPTION
## Summary

- add an idempotent one-shot dispatch recovery to the existing LIVE_ACTIVE bridge
- have the no-trade watchdog invoke that recovery when runtime authority is live but observed cycles remain zero
- start only an already-published strategy under valid writer lineage, runtime execution authority, and LIVE_ACTIVE state
- exclude user-account balances from platform CapitalAuthority by default, honoring `NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY=false`
- retain explicit legacy opt-in for deployments that intentionally aggregate user funds

## Root cause

The July 25 deployment reached `LIVE_ACTIVE` with runtime execution authority `1`, but the watchdog still reported `cycles=0`. The path-loaded dispatch bridge was present, yet the watchdog only rewired telemetry and did not request the bridge's safe handoff. The same logs showed `daivon_frazier_kraken` included in the platform authority refresh even though NIJA's platform and user accounts are independently traded.

## Safety

This change does not create a strategy, force an entry, bypass signal/risk/exchange gates, or submit an order. It only starts an existing published strategy after all existing authority gates pass. User balances remain available to their own account-local traders and exit managers but no longer inflate platform readiness or position sizing.

## Tests

- ready LIVE_ACTIVE dispatch starts the existing strategy exactly once
- missing strategy remains fail-closed
- watchdog finds the path-loaded bridge without importing new runtime modules
- user capital aggregation is disabled by default and requires explicit opt-in