### PR TITLE
Make live dispatch recovery nonblocking

### DIFF
--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -408,11 +408,16 @@ def ensure_live_dispatch(source: str = "external_recovery") -> Tuple[bool, str]:
     if _loop_thread_running():
         return True, "trading_loop_already_running"
 
-    _ensure_deferred_startup_repairs()
-    if _has_writer_authority() and (
-        not _runtime_execution_authority()
-        or not _state_machine_live_active()
-    ):
+    writer_ready = _has_writer_authority()
+    runtime_ready = _runtime_execution_authority()
+    state_ready = _state_machine_live_active()
+
+    # Deferred startup repair installers may synchronously wait on imports. Once
+    # every live gate is already satisfied, they cannot improve dispatch
+    # readiness and must not delay the existing-strategy handoff.
+    if not (writer_ready and runtime_ready and state_ready):
+        _ensure_deferred_startup_repairs()
+    if writer_ready and (not runtime_ready or not state_ready):
         _attempt_runtime_convergence(source)
 
     allowed, reason = _dispatch_allowed()

--- a/bot/no_trade_watchdog_runtime_patch.py
+++ b/bot/no_trade_watchdog_runtime_patch.py
@@ -286,6 +286,24 @@ def _recover_live_dispatch() -> tuple[bool, str]:
     return False, "dispatch_bridge_unavailable"
 
 
+def _recover_before_runtime_probes() -> tuple[bool, str]:
+    """Attempt the gated live handoff before any synchronous import probes."""
+
+    recovered, recovery_detail = _recover_live_dispatch()
+    logger.warning(
+        "NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=%s detail=%s",
+        str(recovered).lower(),
+        recovery_detail,
+    )
+    patched = _patch_loaded_modules()
+    if patched:
+        logger.warning(
+            "NO_TRADE_WATCHDOG_LOADED_MODULES_PATCHED patched_modules=%d",
+            patched,
+        )
+    return recovered, recovery_detail
+
+
 def _install_live_active_monitor() -> None:
     global _MONITOR_STARTED
     if _MONITOR_STARTED:
@@ -316,13 +334,7 @@ def _install_live_active_monitor() -> None:
                         delay,
                         _risk_snapshot(),
                     )
-                    _resolve_and_patch_modules()
-                    recovered, recovery_detail = _recover_live_dispatch()
-                    logger.warning(
-                        "NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=%s detail=%s",
-                        str(recovered).lower(),
-                        recovery_detail,
-                    )
+                    _recover_before_runtime_probes()
                 else:
                     _log_watchdog("live_active_monitor", force=True)
                 next_warn = now + interval

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -165,3 +165,28 @@ def test_ensure_live_dispatch_never_constructs_missing_strategy(monkeypatch) -> 
 
     assert started is False
     assert detail == "strategy_not_published"
+
+
+def test_ensure_live_dispatch_skips_deferred_repairs_after_live_gates(monkeypatch) -> None:
+    module = _load_module()
+    strategy = object()
+
+    monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
+    monkeypatch.setattr(module, "_has_writer_authority", lambda: True)
+    monkeypatch.setattr(module, "_runtime_execution_authority", lambda: True)
+    monkeypatch.setattr(module, "_state_machine_live_active", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "_ensure_deferred_startup_repairs",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("live dispatch must not wait on deferred startup repair")
+        ),
+    )
+    monkeypatch.setattr(module, "_dispatch_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(module, "_find_strategy", lambda: (strategy, "published"))
+    monkeypatch.setattr(module, "_start_trading_loop", lambda candidate, source: True)
+
+    started, detail = module.ensure_live_dispatch("watchdog")
+
+    assert started is True
+    assert detail == "started"

--- a/bot/tests/test_no_trade_watchdog_dispatch_recovery.py
+++ b/bot/tests/test_no_trade_watchdog_dispatch_recovery.py
@@ -56,3 +56,25 @@ def test_watchdog_does_not_import_missing_dispatch_bridge(monkeypatch):
 
     assert recovered is False
     assert detail == "dispatch_bridge_unavailable"
+
+
+def test_zero_cycle_recovery_precedes_loaded_module_patching(monkeypatch):
+    module = _load_module()
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        module,
+        "_recover_live_dispatch",
+        lambda: order.append("recover") or (True, "started"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_patch_loaded_modules",
+        lambda: order.append("patch_loaded") or 0,
+    )
+
+    recovered, detail = module._recover_before_runtime_probes()
+
+    assert recovered is True
+    assert detail == "started"
+    assert order == ["recover", "patch_loaded"]


### PR DESCRIPTION
## Summary

- invoke the existing gated live-dispatch recovery before synchronous module import probes
- restrict post-recovery watchdog rewiring to modules that are already loaded
- skip deferred startup repair work in the one-shot handoff when writer authority, runtime execution authority, and `LIVE_ACTIVE` are already verified
- add regression tests for recovery ordering and the live-gate fast path

## Production evidence

The deployment from merge `52120ff` reached:

- `NIJA_RUNTIME_TRADING_STATE=LIVE_ACTIVE`
- `NIJA_RUNTIME_EXECUTION_AUTHORITY=1`
- Kraken CapitalAuthority ready with one eligible platform broker
- held ETH adopted into the execution engine

But the watchdog then emitted `TRADE_LOOP_NOT_OBSERVED ... cycles=0`, logged one `NO_TRADE_WATCHDOG_CYCLE_WIRED`, and never emitted `NO_TRADE_WATCHDOG_DISPATCH_RECOVERY`. That sequence shows the synchronous `_resolve_and_patch_modules()` probe did not return before recovery.

## Safety

This does not force an entry, construct a strategy, change signal/risk thresholds, bypass the writer lease, or submit an order. The handoff still requires live mode, a valid writer token and generation, runtime execution authority, `LIVE_ACTIVE`, and an already-published strategy.

## Expected runtime confirmation

- `NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=true detail=started`
- `LIVE_ACTIVE_DISPATCH_BRIDGE_ENSURE ... started=true`
- `TRADING LOOP THREAD ALIVE`
- `TRADE_LOOP_HEARTBEAT cycle=1`