### PR TITLE
Publish path-loaded runtime patches for live recovery

### DIFF
--- a/bot/tests/test_sitecustomize_patch_module_registration.py
+++ b/bot/tests/test_sitecustomize_patch_module_registration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+from uuid import uuid4
+
+
+SITECUSTOMIZE_PATH = Path(__file__).resolve().parents[2] / "sitecustomize.py"
+
+
+def _load_patch_installer(sitecustomize_file: Path):
+    tree = ast.parse(SITECUSTOMIZE_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_install_patch_module"
+    )
+    isolated = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(isolated)
+    namespace = {
+        "__file__": str(sitecustomize_file),
+        "importlib": importlib,
+        "logger": logging.getLogger("test.sitecustomize.patch_loader"),
+        "Path": Path,
+        "sys": sys,
+    }
+    exec(compile(isolated, str(SITECUSTOMIZE_PATH), "exec"), namespace)
+    return namespace["_install_patch_module"]
+
+
+def test_path_loaded_patch_is_published_before_installer_runs(tmp_path) -> None:
+    bot_dir = tmp_path / "bot"
+    bot_dir.mkdir()
+    filename = "sample_runtime_patch.py"
+    (bot_dir / filename).write_text(
+        "import sys\n"
+        "PUBLISHED_DURING_INSTALL = False\n"
+        "def install_import_hook():\n"
+        "    global PUBLISHED_DURING_INSTALL\n"
+        "    PUBLISHED_DURING_INSTALL = sys.modules.get(__name__) is not None\n",
+        encoding="utf-8",
+    )
+    module_name = f"nija_test_runtime_patch_{uuid4().hex}"
+    installer = _load_patch_installer(tmp_path / "sitecustomize.py")
+
+    try:
+        installer(
+            filename=filename,
+            module_name=module_name,
+            success_log="TEST_PATCH_INSTALLED",
+            error_prefix="test patch",
+        )
+        module = sys.modules.get(module_name)
+        assert module is not None
+        assert module.PUBLISHED_DURING_INSTALL is True
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_failed_patch_load_restores_previous_module(tmp_path) -> None:
+    bot_dir = tmp_path / "bot"
+    bot_dir.mkdir()
+    filename = "broken_runtime_patch.py"
+    (bot_dir / filename).write_text("raise RuntimeError('broken patch')\n", encoding="utf-8")
+    module_name = f"nija_test_runtime_patch_{uuid4().hex}"
+    previous = ModuleType(module_name)
+    sys.modules[module_name] = previous
+    installer = _load_patch_installer(tmp_path / "sitecustomize.py")
+
+    try:
+        installer(
+            filename=filename,
+            module_name=module_name,
+            success_log="TEST_PATCH_INSTALLED",
+            error_prefix="test patch",
+        )
+        assert sys.modules.get(module_name) is previous
+    finally:
+        sys.modules.pop(module_name, None)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import sys
 from pathlib import Path
 
 logger = logging.getLogger("nija.startup_patch")
@@ -232,11 +233,21 @@ def _install_patch_module(*, filename: str, module_name: str, success_log: str, 
         if spec is None or spec.loader is None:
             raise RuntimeError(f"could not load spec for {patch_path}")
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        installer = getattr(module, "install_import_hook", None)
-        if callable(installer):
-            installer()
-            logger.warning(success_log)
+        previous = sys.modules.get(module_name)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+            installer = getattr(module, "install_import_hook", None)
+            if callable(installer):
+                installer()
+                logger.warning(success_log)
+        except Exception:
+            if previous is None:
+                if sys.modules.get(module_name) is module:
+                    sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = previous
+            raise
     except Exception as exc:
         logger.warning("%s unavailable: %s", error_prefix, exc)
 


### PR DESCRIPTION
## Summary

- publish every path-loaded runtime patch in `sys.modules` before executing it
- keep module publication atomic: restore the previous module or remove the new alias when loading/installation fails
- add isolated tests proving the module is discoverable while its installer runs and failed loads roll back cleanly

## Production evidence

Deployment `99087a8618c0` reached `LIVE_ACTIVE` with execution authority `1`, platform and user Kraken positions reconciled, and six held positions mirrored into the execution engine. The nonblocking watchdog repair then ran on schedule but returned:

`NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=false detail=dispatch_bridge_unavailable`

`sitecustomize._install_patch_module()` creates and executes the bridge with `module_from_spec()` but never inserts it into `sys.modules`. After the local loader returns, the watchdog cannot resolve `nija_live_active_dispatch_bridge_patch`.

## Safety

This does not create a strategy, force an entry, alter risk thresholds, or submit an order. It only preserves stable module identity for patches that sitecustomize already executes. Failed patch loads remain fail-closed and cannot leave a partially initialized alias behind.

## Expected runtime confirmation

- `NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=true detail=started`
- `LIVE_ACTIVE_DISPATCH_BRIDGE_ENSURE ... started=true`
- `TRADING LOOP THREAD ALIVE`
- `TRADE_LOOP_HEARTBEAT cycle=1`