### PR TITLE
Publish synchronized strategy for live dispatch

### DIFF
--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -101,8 +101,10 @@ def _loop_thread_running() -> bool:
 
 def _state_machine_live_active() -> bool:
     for module_name in ("bot.trading_state_machine", "trading_state_machine"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
         try:
-            module = importlib.import_module(module_name)
             getter = getattr(module, "get_state_machine", None)
             if not callable(getter):
                 continue
@@ -275,8 +277,10 @@ def _module_candidates() -> list[Any]:
 
 def _strategy_class() -> Optional[type]:
     for module_name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
         try:
-            module = importlib.import_module(module_name)
             cls = getattr(module, "TradingStrategy", None)
             if isinstance(cls, type):
                 return cls
@@ -287,6 +291,19 @@ def _strategy_class() -> Optional[type]:
                 exc,
             )
     return None
+
+
+def _strategy_from_completed_position_sync() -> Tuple[Optional[Any], str]:
+    """Return only the exact strategy whose broker snapshots finished syncing."""
+
+    for module_name in ("bot.startup_position_sync", "startup_position_sync"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        strategy = getattr(module, "_LAST_COMPLETED_STRATEGY", None)
+        if strategy is not None:
+            return strategy, f"{module_name}._LAST_COMPLETED_STRATEGY"
+    return None, "position_sync_not_complete"
 
 
 def _strategy_from_initialized_state() -> Tuple[Optional[Any], str]:
@@ -331,6 +348,9 @@ def _strategy_from_gc(cls: Optional[type]) -> Tuple[Optional[Any], str]:
 
 
 def _find_strategy() -> Tuple[Optional[Any], str]:
+    strategy, source = _strategy_from_completed_position_sync()
+    if strategy is not None:
+        return strategy, source
     strategy, source = _strategy_from_initialized_state()
     if strategy is not None:
         return strategy, source
@@ -338,13 +358,15 @@ def _find_strategy() -> Tuple[Optional[Any], str]:
     strategy, source = _strategy_from_module_globals(cls)
     if strategy is not None:
         return strategy, source
-    return _strategy_from_gc(cls)
+    return None, "strategy_not_published"
 
 
 def _set_start_gate() -> None:
     for module_name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
         try:
-            module = importlib.import_module(module_name)
             ready = getattr(module, "TRADING_ENGINE_READY", None)
             if ready is not None and callable(getattr(ready, "set", None)):
                 ready.set()
@@ -369,10 +391,15 @@ def _start_trading_loop(strategy: Any, source: str) -> bool:
                 "LIVE_ACTIVE_DISPATCH_BRIDGE_ALREADY_RUNNING source=%s", source
             )
             return True
-        try:
-            module = importlib.import_module("bot.nija_core_loop")
-        except Exception:
-            module = importlib.import_module("nija_core_loop")
+        module = sys.modules.get("bot.nija_core_loop") or sys.modules.get(
+            "nija_core_loop"
+        )
+        if module is None:
+            logger.error(
+                "LIVE_ACTIVE_DISPATCH_BRIDGE_START_FAILED "
+                "reason=nija_core_loop_not_loaded"
+            )
+            return False
         starter = getattr(module, "start_trading_engine", None)
         if not callable(starter):
             logger.error(

--- a/bot/startup_position_sync.py
+++ b/bot/startup_position_sync.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("nija")
+_LAST_COMPLETED_STRATEGY: Any = None
 
 
 def _get_entry_price_store() -> Optional[Any]:
@@ -331,6 +332,8 @@ def _collect_connected_brokers(strategy: Any) -> Dict[str, Any]:
 
 def sync_exchange_positions_on_startup(strategy: Any) -> int:
     """Reconcile every currently connected platform and user broker."""
+    global _LAST_COMPLETED_STRATEGY
+    _LAST_COMPLETED_STRATEGY = None
     logger.info("EXCHANGE_POSITION_SYNC starting startup position synchronisation")
     eps = _get_entry_price_store()
     connected_brokers = _collect_connected_brokers(strategy)
@@ -368,6 +371,13 @@ def sync_exchange_positions_on_startup(strategy: Any) -> int:
         total_reconciled,
         total_tracked,
     )
+    _LAST_COMPLETED_STRATEGY = strategy
+    logger.critical(
+        "EXCHANGE_POSITION_SYNC_DISPATCH_STRATEGY_READY type=%s connected_brokers=%d total_tracked=%d",
+        type(strategy).__name__,
+        len(connected_brokers),
+        total_tracked,
+    )
     logger.info("PositionTracker initialized: %d tracked positions", total_tracked)
     return total_reconciled
 
@@ -377,4 +387,5 @@ __all__ = [
     "_adopt_broker_positions",
     "_collect_connected_brokers",
     "_legacy_duplicate_snapshot_detected",
+    "_LAST_COMPLETED_STRATEGY",
 ]

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -190,3 +190,37 @@ def test_ensure_live_dispatch_skips_deferred_repairs_after_live_gates(monkeypatc
 
     assert started is True
     assert detail == "started"
+
+
+def test_find_strategy_prefers_completed_position_sync_without_imports(monkeypatch) -> None:
+    module = _load_module()
+    strategy = object()
+    sync_module = ModuleType("bot.startup_position_sync")
+    sync_module._LAST_COMPLETED_STRATEGY = strategy
+    monkeypatch.setitem(sys.modules, "bot.startup_position_sync", sync_module)
+    monkeypatch.setattr(
+        module,
+        "_strategy_class",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("completed strategy discovery must not import or resolve a class")
+        ),
+    )
+
+    found, source = module._find_strategy()
+
+    assert found is strategy
+    assert source == "bot.startup_position_sync._LAST_COMPLETED_STRATEGY"
+
+
+def test_find_strategy_returns_quickly_before_position_sync_completes(monkeypatch) -> None:
+    module = _load_module()
+    sync_module = ModuleType("bot.startup_position_sync")
+    sync_module._LAST_COMPLETED_STRATEGY = None
+    monkeypatch.setitem(sys.modules, "bot.startup_position_sync", sync_module)
+    monkeypatch.setattr(module, "_strategy_from_initialized_state", lambda: (None, "not_found"))
+    monkeypatch.setattr(module, "_strategy_class", lambda: None)
+
+    found, detail = module._find_strategy()
+
+    assert found is None
+    assert detail == "strategy_not_published"

--- a/bot/tests/test_startup_position_sync_dispatch_publication.py
+++ b/bot/tests/test_startup_position_sync_dispatch_publication.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "startup_position_sync.py"
+
+
+def _load_module():
+    name = f"startup_position_sync_dispatch_{uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_strategy_is_published_only_after_position_sync_completes(monkeypatch) -> None:
+    module = _load_module()
+    strategy = object()
+    broker = SimpleNamespace(position_tracker=None, _startup_position_sync_adopted=True)
+
+    monkeypatch.setattr(
+        module,
+        "_collect_connected_brokers",
+        lambda candidate: {"platform:kraken": broker},
+    )
+    monkeypatch.setattr(module, "_get_entry_price_store", lambda: None)
+    monkeypatch.setattr(module, "_adopt_broker_positions", lambda *args: 0)
+    monkeypatch.setattr(module, "_tracker_count", lambda tracker: 0)
+
+    assert module._LAST_COMPLETED_STRATEGY is None
+
+    module.sync_exchange_positions_on_startup(strategy)
+
+    assert module._LAST_COMPLETED_STRATEGY is strategy
+
+
+def test_strategy_is_not_published_when_no_broker_is_connected(monkeypatch) -> None:
+    module = _load_module()
+    strategy = object()
+    monkeypatch.setattr(module, "_collect_connected_brokers", lambda candidate: {})
+    monkeypatch.setattr(module, "_get_entry_price_store", lambda: None)
+
+    module.sync_exchange_positions_on_startup(strategy)
+
+    assert module._LAST_COMPLETED_STRATEGY is None


### PR DESCRIPTION
## Summary

- publish the exact initialized strategy object only after startup position synchronization completes
- make the live-dispatch bridge prefer that post-sync strategy
- remove synchronous imports and GC scanning from state, strategy-class, start-gate, and core-loop discovery
- return `strategy_not_published` quickly while synchronization is still running so the watchdog remains responsive
- add regression coverage for post-sync publication, no-broker fail-closed behavior, and import-free strategy discovery

## Production evidence

Deployment `ef3f9382d18c` fixed bridge module registration. At `14:55:47`, the watchdog reached the bridge while runtime state was `LIVE_ACTIVE`, execution authority was `1`, and writer token/generation were valid. Unlike the previous deployment, it did not return `dispatch_bridge_unavailable`; instead, the recovery call stopped returning while startup position sync continued for more than a minute.

The exact live strategy already exists because `sync_exchange_positions_on_startup(strategy)` is actively reconciling it. Publishing that object at synchronization completion avoids class imports, duplicate construction, GC scans, and entry/exit concurrency during reconciliation.

## Safety

- never constructs a replacement strategy
- never starts dispatch before at least one connected broker completes the startup sync function
- preserves writer, runtime authority, LIVE_ACTIVE, live-mode, and existing-strategy gates
- does not alter entries, exits, position sizing, signals, cost basis, or exchange credentials
- MOVR/ORCA and any other unverified cost-basis positions retain their existing automatic-exit block

## Expected runtime confirmation

- `EXCHANGE_POSITION_SYNC_DISPATCH_STRATEGY_READY`
- `NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=true detail=started`
- `LIVE_ACTIVE_DISPATCH_BRIDGE_ENSURE ... started=true`
- `TRADING LOOP THREAD ALIVE`
- `TRADE_LOOP_HEARTBEAT cycle=1`