### PR TITLE
Require local writer ownership before live dispatch

### DIFF
--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -57,6 +57,52 @@ def _live_mode() -> bool:
     )
 
 
+def _local_entrypoint_writer_authority() -> dict[str, Any]:
+    """Observe authority owned by this process without importing startup modules."""
+
+    for module_name in (
+        "bot.entrypoint_writer_authority",
+        "entrypoint_writer_authority",
+    ):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if not callable(getter):
+            continue
+        try:
+            authority = getter()
+            result = getattr(authority, "result", None)
+            return {
+                "observed": True,
+                "acquired": bool(getattr(authority, "acquired", False)),
+                "lost": bool(getattr(authority, "lost", False)),
+                "instance_id": str(
+                    getattr(result, "instance_id", "")
+                    or getattr(authority, "_instance_id", "")
+                    or ""
+                ),
+            }
+        except Exception as exc:
+            logger.debug(
+                "local entrypoint writer authority probe failed module=%s err=%s",
+                module_name,
+                exc,
+            )
+            return {
+                "observed": True,
+                "acquired": False,
+                "lost": True,
+                "instance_id": "",
+            }
+    return {
+        "observed": False,
+        "acquired": False,
+        "lost": False,
+        "instance_id": "",
+    }
+
+
 def _writer_authority_snapshot() -> dict[str, Any]:
     token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip()
     generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")).strip()
@@ -64,6 +110,7 @@ def _writer_authority_snapshot() -> dict[str, Any]:
     lease = bool(lease_flag or token)
     runtime_auth = _truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY", False)
     heartbeat_active = _truthy("NIJA_WRITER_HEARTBEAT_ACTIVE", False)
+    local = _local_entrypoint_writer_authority()
     return {
         "token": token,
         "token_present": bool(token),
@@ -73,7 +120,18 @@ def _writer_authority_snapshot() -> dict[str, Any]:
         "lease": lease,
         "runtime_auth": runtime_auth,
         "heartbeat_active": heartbeat_active,
-        "ready": bool(token and generation and lease),
+        "local_authority_observed": local["observed"],
+        "local_authority_acquired": local["acquired"],
+        "local_authority_lost": local["lost"],
+        "local_instance_id": local["instance_id"],
+        "ready": bool(
+            token
+            and generation
+            and lease
+            and local["observed"]
+            and local["acquired"]
+            and not local["lost"]
+        ),
     }
 
 

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -19,6 +19,25 @@ def _load_module():
     return module
 
 
+def _install_local_authority(
+    monkeypatch, *, acquired: bool = True, lost: bool = False
+):
+    authority_module = ModuleType("bot.entrypoint_writer_authority")
+    authority = type(
+        "Authority",
+        (),
+        {"acquired": acquired, "lost": lost, "result": None},
+    )()
+    authority_module.get_entrypoint_writer_authority = lambda: authority
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.entrypoint_writer_authority",
+        authority_module,
+    )
+    monkeypatch.delitem(sys.modules, "entrypoint_writer_authority", raising=False)
+    return authority
+
+
 def test_broker_bootstrap_accepts_active_broker_manager_alias(monkeypatch) -> None:
     module = _load_module()
     for name in module._BROKER_MODULE_NAMES:
@@ -66,6 +85,7 @@ def test_deferred_repairs_install_after_broker_manager_load(monkeypatch) -> None
 
 def test_writer_authority_is_separate_from_runtime_authority(monkeypatch) -> None:
     module = _load_module()
+    _install_local_authority(monkeypatch)
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("DRY_RUN_MODE", "false")
     monkeypatch.setenv("PAPER_MODE", "false")
@@ -89,6 +109,7 @@ def test_writer_authority_is_separate_from_runtime_authority(monkeypatch) -> Non
 
 def test_runtime_convergence_uses_existing_fail_closed_repair(monkeypatch) -> None:
     module = _load_module()
+    _install_local_authority(monkeypatch)
     monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "123")
     monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
     monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -224,3 +224,58 @@ def test_find_strategy_returns_quickly_before_position_sync_completes(monkeypatc
 
     assert found is None
     assert detail == "strategy_not_published"
+
+
+def test_writer_snapshot_rejects_standby_process_with_shared_token(monkeypatch) -> None:
+    module = _load_module()
+    authority_module = ModuleType("bot.entrypoint_writer_authority")
+    authority = type(
+        "Authority",
+        (),
+        {"acquired": False, "lost": False, "result": None},
+    )()
+    authority_module.get_entrypoint_writer_authority = lambda: authority
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.entrypoint_writer_authority",
+        authority_module,
+    )
+    monkeypatch.delitem(sys.modules, "entrypoint_writer_authority", raising=False)
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "1139")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1800")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+
+    snapshot = module._writer_authority_snapshot()
+
+    assert snapshot["token_present"] is True
+    assert snapshot["local_authority_observed"] is True
+    assert snapshot["local_authority_acquired"] is False
+    assert snapshot["ready"] is False
+
+
+def test_writer_snapshot_accepts_only_locally_acquired_authority(monkeypatch) -> None:
+    module = _load_module()
+    authority_module = ModuleType("bot.entrypoint_writer_authority")
+    authority = type(
+        "Authority",
+        (),
+        {"acquired": True, "lost": False, "result": None},
+    )()
+    authority_module.get_entrypoint_writer_authority = lambda: authority
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.entrypoint_writer_authority",
+        authority_module,
+    )
+    monkeypatch.delitem(sys.modules, "entrypoint_writer_authority", raising=False)
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "1140")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1801")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+
+    snapshot = module._writer_authority_snapshot()
+
+    assert snapshot["local_authority_acquired"] is True
+    assert snapshot["local_authority_lost"] is False
+    assert snapshot["ready"] is True


### PR DESCRIPTION
## Summary

- require process-local `EntrypointWriterAuthority.acquired` before the live-dispatch bridge considers writer authority ready
- reject shared/stale token and generation strings when the current Render instance is in standby
- keep discovery import-free so writer handoff cannot block on startup module imports
- add regression tests for standby rejection and local-owner acceptance

## Production evidence

During deployment of merge `1baac5e91836`, the new Render instance logged repeated `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` lines because the old instance still owned token `1139`. In the same process, environment-based telemetry reported `LIVE_ACTIVE`, execution authority `1`, token `1139`, and generation `1800`, and the watchdog attempted dispatch recovery.

The bridge previously treated token/generation presence as sufficient authority. Those strings may describe the active holder, not the current process. Canonical local ownership is already available through `get_entrypoint_writer_authority().acquired`.

## Safety

- prevents overlapping Render instances from starting two trading loops
- preserves distributed Redis fencing and heartbeat loss behavior
- does not force state, entries, exits, signals, sizing, or order submission
- remains fail-closed until the local process actually acquires the canonical lease

## Expected runtime behavior

Standby instance:

- `LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=writer_authority_missing`
- no strategy dispatch or trading loop

After local acquisition and post-sync publication:

- `ENTRYPOINT_WRITER_AUTHORITY_READY`
- `EXCHANGE_POSITION_SYNC_DISPATCH_STRATEGY_READY`
- `NO_TRADE_WATCHDOG_DISPATCH_RECOVERY recovered=true detail=started`
- `TRADING LOOP THREAD ALIVE`
- `TRADE_LOOP_HEARTBEAT cycle=1`