### PR TITLE
Recover Coinbase with matched credential pairs

### DIFF
--- a/bot/tests/test_secondary_venue_runtime_diagnostics.py
+++ b/bot/tests/test_secondary_venue_runtime_diagnostics.py
@@ -109,8 +109,10 @@ def test_existing_cdp_aliases_are_normalized_and_synchronized(monkeypatch):
 
     assert os.environ["NIJA_COINBASE_PEM_STATE"] == "valid"
     assert os.environ["NIJA_COINBASE_PEM_VALID"] == "1"
+    assert os.environ["COINBASE_API_KEY"] == os.environ["CDP_API_KEY_NAME"]
     assert "VALIDCDP" in os.environ["COINBASE_API_SECRET"]
-    assert all(os.environ[name] == os.environ["COINBASE_API_SECRET"] for name in _SECRET_ALIASES)
+    assert "VALIDCDP" in os.environ["CDP_API_KEY_PRIVATE_KEY"]
+    assert os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"].startswith("cdp_name:")
 
 
 def test_malformed_base64_wrapped_pem_is_not_misclassified_as_legacy(monkeypatch):
@@ -155,7 +157,46 @@ def test_later_valid_alias_wins_over_stale_primary_alias(monkeypatch):
     assert os.environ["NIJA_COINBASE_PEM_VALID"] == "1"
     assert os.environ["NIJA_COINBASE_PEM_QUARANTINED"] == "0"
     assert "VALID" in os.environ["COINBASE_API_SECRET"]
-    assert all(os.environ[name] == os.environ["COINBASE_API_SECRET"] for name in _SECRET_ALIASES)
+    assert os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"].startswith(
+        "single_key_fallback:"
+    )
+
+
+def test_matching_key_and_secret_family_wins_over_independent_aliases(monkeypatch):
+    _clear_coinbase_aliases(monkeypatch)
+    monkeypatch.setenv(
+        "COINBASE_API_KEY",
+        "organizations/example/apiKeys/stale",
+    )
+    monkeypatch.setenv("COINBASE_API_SECRET", "stale-broken-secret")
+    monkeypatch.setenv(
+        "COINBASE_PLATFORM_API_KEY",
+        "organizations/example/apiKeys/current",
+    )
+    monkeypatch.setenv(
+        "COINBASE_PLATFORM_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\\nPLATFORMVALID\\n-----END EC PRIVATE KEY-----",
+    )
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "_validate_coinbase_key",
+        lambda secret: (
+            "PLATFORMVALID" in secret,
+            "valid_es256" if "PLATFORMVALID" in secret else "invalid",
+        ),
+    )
+
+    module._normalize_coinbase_env()
+
+    assert (
+        os.environ["COINBASE_API_KEY"]
+        == "organizations/example/apiKeys/current"
+    )
+    assert "PLATFORMVALID" in os.environ["COINBASE_API_SECRET"]
+    assert os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"].startswith(
+        "platform:"
+    )
 
 
 def test_non_cdp_legacy_secret_is_not_falsely_quarantined(monkeypatch):
@@ -197,6 +238,10 @@ def test_quarantine_state_is_restored_after_generic_activation_skip(monkeypatch)
 def test_valid_coinbase_secret_does_not_override_operator_disable_state(monkeypatch):
     _clear_coinbase_aliases(monkeypatch)
     monkeypatch.setenv(
+        "COINBASE_API_KEY",
+        "organizations/example/apiKeys/example",
+    )
+    monkeypatch.setenv(
         "COINBASE_API_SECRET",
         "-----BEGIN EC PRIVATE KEY-----\\nABC\\n-----END EC PRIVATE KEY-----",
     )
@@ -210,3 +255,107 @@ def test_valid_coinbase_secret_does_not_override_operator_disable_state(monkeypa
     assert os.environ["NIJA_COINBASE_PEM_VALID"] == "1"
     assert os.environ["NIJA_COINBASE_PEM_QUARANTINED"] == "0"
     assert os.environ["NIJA_DISABLE_COINBASE"] == "true"
+
+def test_authenticated_recovery_retries_complete_alternative_pair(monkeypatch):
+    module = importlib.reload(
+        importlib.import_module("coinbase_authenticated_connect_recovery_patch")
+    )
+    module._FAILED_PAIR_AT.clear()
+    bad_key = "organizations/example/apiKeys/stale"
+    good_key = "organizations/example/apiKeys/current"
+    bad_secret = "stale-pem"
+    good_secret = "current-pem"
+    monkeypatch.setenv("COINBASE_API_KEY", bad_key)
+    monkeypatch.setenv("COINBASE_API_SECRET", bad_secret)
+    monkeypatch.setenv("COINBASE_PEM_CONTENT", bad_secret)
+    monkeypatch.setenv("NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE", "canonical")
+    monkeypatch.setattr(
+        module,
+        "_configured_pairs",
+        lambda: [
+            ("canonical", bad_key, bad_secret),
+            ("platform", good_key, good_secret),
+        ],
+    )
+    monkeypatch.setattr(
+        module,
+        "_authenticated_probe",
+        lambda _broker: (False, "private_probe_failed"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_publish_connected",
+        lambda broker, _source: setattr(broker, "connected", True),
+    )
+
+    class CoinbasePairBroker:
+        def __init__(self):
+            self.connected = False
+            self._auth_failed = False
+
+        def connect(self):
+            matched = (
+                os.environ.get("COINBASE_API_KEY") == good_key
+                and os.environ.get("COINBASE_API_SECRET") == good_secret
+            )
+            self.connected = matched
+            self._auth_failed = not matched
+            return matched
+
+    assert module._patch_class(CoinbasePairBroker) is True
+    broker = CoinbasePairBroker()
+
+    assert broker.connect() is True
+    assert broker.connected is True
+    assert os.environ["COINBASE_API_KEY"] == good_key
+    assert os.environ["COINBASE_API_SECRET"] == good_secret
+    assert os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"] == "platform"
+
+
+def test_authenticated_recovery_restores_primary_after_all_pairs_fail(monkeypatch):
+    module = importlib.reload(
+        importlib.import_module("coinbase_authenticated_connect_recovery_patch")
+    )
+    module._FAILED_PAIR_AT.clear()
+    primary_key = "organizations/example/apiKeys/primary"
+    primary_secret = "primary-pem"
+    monkeypatch.setenv("COINBASE_API_KEY", primary_key)
+    monkeypatch.setenv("COINBASE_API_SECRET", primary_secret)
+    monkeypatch.setenv("COINBASE_PEM_CONTENT", primary_secret)
+    monkeypatch.setenv("NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE", "canonical")
+    monkeypatch.setattr(
+        module,
+        "_configured_pairs",
+        lambda: [
+            ("canonical", primary_key, primary_secret),
+            (
+                "platform",
+                "organizations/example/apiKeys/alternate",
+                "alternate-pem",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        module,
+        "_authenticated_probe",
+        lambda _broker: (False, "private_probe_failed"),
+    )
+
+    class CoinbaseFailingBroker:
+        def __init__(self):
+            self.connected = False
+            self._auth_failed = False
+
+        def connect(self):
+            return False
+
+    assert module._patch_class(CoinbaseFailingBroker) is True
+    broker = CoinbaseFailingBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert broker._auth_failed is True
+    assert os.environ["COINBASE_API_KEY"] == primary_key
+    assert os.environ["COINBASE_API_SECRET"] == primary_secret
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "authentication_failed"
+

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -6,6 +6,7 @@ private account endpoint succeeds on the broker or its authenticated SDK client.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib
 import logging
 import os
@@ -22,6 +23,8 @@ _PATCH_ATTR = "_nija_coinbase_authenticated_connect_v1"
 _LOCK = threading.RLock()
 _STARTED = False
 _LAST_FAILURE: dict[str, float] = {}
+_FAILED_PAIR_AT: dict[str, float] = {}
+_PAIR_RETRY_COOLDOWN_S = 300.0
 
 
 def _is_coinbase_class(cls: type) -> bool:
@@ -118,6 +121,90 @@ def _log_failure_once(cls: type, detail: str) -> None:
     )
 
 
+def _configured_pairs() -> list[tuple[str, str, str]]:
+    try:
+        diagnostics = importlib.import_module("secondary_venue_runtime_diagnostics")
+        discover = getattr(diagnostics, "_configured_coinbase_pairs", None)
+        if callable(discover):
+            return list(discover())
+    except Exception as exc:
+        logger.debug(
+            "COINBASE_CREDENTIAL_PAIR_DISCOVERY_PENDING marker=%s error=%s",
+            _MARKER,
+            type(exc).__name__,
+        )
+    return []
+
+
+def _pair_fingerprint(key: str, secret: str) -> str:
+    return hashlib.sha256((key + "\0" + secret).encode("utf-8")).hexdigest()[:16]
+
+
+def _credential_targets(broker: Any) -> list[Any]:
+    targets = [broker]
+    try:
+        nested = getattr(broker, "_broker", None)
+    except Exception:
+        nested = None
+    if nested is not None and nested not in targets:
+        targets.append(nested)
+    return targets
+
+
+def _apply_pair(
+    broker: Any,
+    source: str,
+    key: str,
+    secret: str,
+    *,
+    reset_failure: bool = True,
+) -> None:
+    os.environ["COINBASE_API_KEY"] = key
+    os.environ["COINBASE_API_SECRET"] = secret
+    os.environ["COINBASE_PEM_CONTENT"] = secret
+    os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"] = source
+    for target in _credential_targets(broker):
+        for attr, value in (
+            ("api_key", key),
+            ("api_secret", secret),
+            ("secret", secret),
+            ("private_key", secret),
+        ):
+            try:
+                if hasattr(target, attr):
+                    setattr(target, attr, value)
+            except Exception:
+                pass
+        if reset_failure:
+            for attr, value in (
+                ("connected", False),
+                ("client", None),
+                ("_auth_failed", False),
+                ("auth_failed", False),
+                ("_is_available", True),
+            ):
+                try:
+                    if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
+                        setattr(target, attr, value)
+                except Exception:
+                    pass
+
+
+def _mark_auth_failed(broker: Any) -> None:
+    for target in _credential_targets(broker):
+        for attr, value in (
+            ("connected", False),
+            ("_auth_failed", True),
+            ("auth_failed", True),
+            ("_is_available", False),
+        ):
+            try:
+                if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
+                    setattr(target, attr, value)
+            except Exception:
+                pass
+
+
 def _patch_class(cls: type) -> bool:
     if not _is_coinbase_class(cls):
         return False
@@ -127,16 +214,112 @@ def _patch_class(cls: type) -> bool:
 
     @wraps(current)
     def connect(self: Any, *args: Any, **kwargs: Any):
-        result = current(self, *args, **kwargs)
+        primary_key = str(os.environ.get("COINBASE_API_KEY", "") or "")
+        primary_secret = str(
+            os.environ.get("COINBASE_API_SECRET", "")
+            or os.environ.get("COINBASE_PEM_CONTENT", "")
+            or ""
+        )
+        primary_source = str(
+            os.environ.get("NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE", "canonical")
+            or "canonical"
+        )
+
+        first_error = ""
+        try:
+            result = current(self, *args, **kwargs)
+        except Exception as exc:
+            result = False
+            first_error = f"{type(exc).__name__}:{str(exc)[:100]}"
+
         if bool(result) or bool(getattr(self, "connected", False)):
             return result
         authenticated, detail = _authenticated_probe(self)
         if authenticated:
             _publish_connected(self, detail)
             return True
+
+        primary_fp = (
+            _pair_fingerprint(primary_key, primary_secret)
+            if primary_key and primary_secret
+            else ""
+        )
+        now = time.monotonic()
+        attempted = 0
+        failure_details = [value for value in (first_error, detail) if value]
+
+        for source, key, secret in _configured_pairs():
+            fingerprint = _pair_fingerprint(key, secret)
+            if fingerprint == primary_fp:
+                continue
+            with _LOCK:
+                failed_at = _FAILED_PAIR_AT.get(fingerprint, 0.0)
+            if now - failed_at < _PAIR_RETRY_COOLDOWN_S:
+                continue
+
+            attempted += 1
+            logger.warning(
+                "COINBASE_AUTHENTICATED_PAIR_RETRY marker=%s "
+                "class=%s source=%s attempt=%d",
+                _MARKER,
+                cls.__name__,
+                source,
+                attempted,
+            )
+            _apply_pair(self, source, key, secret)
+            retry_error = ""
+            try:
+                retry_result = current(self, *args, **kwargs)
+            except Exception as exc:
+                retry_result = False
+                retry_error = f"{type(exc).__name__}:{str(exc)[:100]}"
+
+            if bool(retry_result) or bool(getattr(self, "connected", False)):
+                _publish_connected(self, f"credential_pair:{source}")
+                logger.critical(
+                    "COINBASE_AUTHENTICATED_PAIR_RECOVERED marker=%s "
+                    "class=%s source=%s",
+                    _MARKER,
+                    cls.__name__,
+                    source,
+                )
+                return True
+
+            authenticated, retry_detail = _authenticated_probe(self)
+            if authenticated:
+                _publish_connected(self, f"{source}:{retry_detail}")
+                logger.critical(
+                    "COINBASE_AUTHENTICATED_PAIR_RECOVERED marker=%s "
+                    "class=%s source=%s",
+                    _MARKER,
+                    cls.__name__,
+                    source,
+                )
+                return True
+
+            with _LOCK:
+                _FAILED_PAIR_AT[fingerprint] = time.monotonic()
+            failure_details.extend(
+                value for value in (retry_error, retry_detail) if value
+            )
+
+        if primary_key and primary_secret:
+            _apply_pair(
+                self,
+                primary_source,
+                primary_key,
+                primary_secret,
+                reset_failure=False,
+            )
+        _mark_auth_failed(self)
         os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+        os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
         os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "authentication_failed"
-        _log_failure_once(cls, detail)
+        suffix = ";".join(failure_details[-4:]) or "authenticated_probe_failed"
+        _log_failure_once(
+            cls,
+            f"{suffix};alternative_pairs_attempted={attempted}",
+        )
         return result
 
     setattr(connect, _PATCH_ATTR, True)
@@ -147,7 +330,6 @@ def _patch_class(cls: type) -> bool:
         _MARKER, cls.__module__, cls.__name__,
     )
     return True
-
 
 def _patch_module(module: ModuleType) -> bool:
     changed = False
@@ -189,4 +371,4 @@ def install() -> bool:
         return True
 
 
-__all__ = ["install", "_authenticated_probe", "_patch_class"]
+__all__ = ["install", "_authenticated_probe", "_configured_pairs", "_patch_class"]

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -253,8 +253,11 @@ def _patch_class(cls: type) -> bool:
             if fingerprint == primary_fp:
                 continue
             with _LOCK:
-                failed_at = _FAILED_PAIR_AT.get(fingerprint, 0.0)
-            if now - failed_at < _PAIR_RETRY_COOLDOWN_S:
+                failed_at = _FAILED_PAIR_AT.get(fingerprint)
+            if (
+                failed_at is not None
+                and now - failed_at < _PAIR_RETRY_COOLDOWN_S
+            ):
                 continue
 
             attempted += 1

--- a/secondary_venue_runtime_diagnostics.py
+++ b/secondary_venue_runtime_diagnostics.py
@@ -33,6 +33,39 @@ _COINBASE_KEY_ALIASES = (
     "CDP_API_KEY_NAME",
 )
 
+_COINBASE_CREDENTIAL_FAMILIES = (
+    (
+        "canonical",
+        "COINBASE_API_KEY",
+        (
+            "COINBASE_API_SECRET",
+            "COINBASE_PEM_CONTENT",
+            "COINBASE_API_PRIVATE_KEY",
+            "COINBASE_PRIVATE_KEY",
+        ),
+    ),
+    (
+        "platform",
+        "COINBASE_PLATFORM_API_KEY",
+        ("COINBASE_PLATFORM_API_SECRET",),
+    ),
+    (
+        "advanced",
+        "COINBASE_ADVANCED_API_KEY",
+        ("COINBASE_ADVANCED_API_SECRET",),
+    ),
+    (
+        "cdp",
+        "COINBASE_CDP_API_KEY",
+        ("COINBASE_CDP_API_SECRET",),
+    ),
+    (
+        "cdp_name",
+        "CDP_API_KEY_NAME",
+        ("CDP_API_KEY_PRIVATE_KEY",),
+    ),
+)
+
 
 def _strip_outer_quotes(value: str) -> str:
     value = value.strip()
@@ -178,6 +211,58 @@ def _restore_coinbase_quarantine_state() -> None:
     os.environ["COINBASE_LIVE_TRADING_ENABLED"] = "false"
 
 
+def _configured_coinbase_pairs() -> list[tuple[str, str, str]]:
+    """Return complete, cryptographically valid Coinbase key/PEM pairs.
+
+    Key and secret aliases are evaluated as families.  They must not be selected
+    independently because two individually valid values may belong to different
+    CDP API keys and Coinbase will correctly reject that combination with 401.
+    """
+
+    pairs: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    configured_keys: dict[str, str] = {}
+    valid_secrets: dict[str, str] = {}
+
+    for name in _COINBASE_KEY_ALIASES:
+        value = str(os.environ.get(name, "") or "").strip()
+        if value:
+            configured_keys[name] = value
+
+    for name in _COINBASE_SECRET_ALIASES:
+        raw = str(os.environ.get(name, "") or "").strip()
+        if not raw:
+            continue
+        normalized = normalize_coinbase_private_key(raw)
+        valid, _category = _validate_coinbase_key(normalized)
+        if valid:
+            valid_secrets[name] = normalized
+
+    for family, key_name, secret_names in _COINBASE_CREDENTIAL_FAMILIES:
+        key = configured_keys.get(key_name, "")
+        if not key:
+            continue
+        for secret_name in secret_names:
+            secret = valid_secrets.get(secret_name, "")
+            if not secret or (key, secret) in seen:
+                continue
+            seen.add((key, secret))
+            pairs.append((f"{family}:{key_name}+{secret_name}", key, secret))
+
+    # Preserve compatibility with deployments that use one key alias and one
+    # differently named PEM alias.  This is safe only when the key is unique.
+    distinct_keys = list(dict.fromkeys(configured_keys.values()))
+    if len(distinct_keys) == 1:
+        key = distinct_keys[0]
+        for secret_name, secret in valid_secrets.items():
+            if (key, secret) in seen:
+                continue
+            seen.add((key, secret))
+            pairs.append((f"single_key_fallback:{secret_name}", key, secret))
+
+    return pairs
+
+
 def _normalize_coinbase_env() -> None:
     candidates = [
         (name, str(os.environ.get(name, "") or "").strip())
@@ -192,24 +277,55 @@ def _normalize_coinbase_env() -> None:
         logger.error("COINBASE_PEM_INVALID marker=%s reason=missing_secret", _MARKER)
         return
 
-    selected_secret = ""
-    for _source, raw in candidates:
-        normalized = normalize_coinbase_private_key(raw)
-        valid, _category = _validate_coinbase_key(normalized)
-        if valid:
-            selected_secret = normalized
-            break
-
-    if selected_secret:
-        for name in _COINBASE_SECRET_ALIASES:
-            os.environ[name] = selected_secret
+    pairs = _configured_coinbase_pairs()
+    if pairs:
+        source, selected_key, selected_secret = pairs[0]
+        # Only publish the canonical pair.  Do not overwrite the other aliases:
+        # authenticated recovery may need a later complete pair if the primary
+        # Coinbase key was revoked or rotated.
+        os.environ["COINBASE_API_KEY"] = selected_key
+        os.environ["COINBASE_API_SECRET"] = selected_secret
+        os.environ["COINBASE_PEM_CONTENT"] = selected_secret
+        os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE"] = source
+        os.environ["NIJA_COINBASE_CREDENTIAL_PAIR_COUNT"] = str(len(pairs))
         os.environ["NIJA_COINBASE_PEM_STATE"] = "valid"
         os.environ["NIJA_COINBASE_PEM_VALID"] = "1"
         os.environ["NIJA_COINBASE_PEM_QUARANTINED"] = "0"
         os.environ.pop("NIJA_COINBASE_PEM_INVALID_REASON", None)
         logger.warning(
-            "COINBASE_PEM_CANONICALIZED marker=%s validation=es256",
+            "COINBASE_PEM_CANONICALIZED marker=%s validation=es256 "
+            "pair_source=%s pair_count=%d key_shape=%s",
             _MARKER,
+            source,
+            len(pairs),
+            "cdp" if "organizations/" in selected_key and "/apiKeys/" in selected_key else "other",
+        )
+        return
+
+    valid_secrets = []
+    for source, raw in candidates:
+        normalized = normalize_coinbase_private_key(raw)
+        valid, _category = _validate_coinbase_key(normalized)
+        if valid:
+            valid_secrets.append((source, normalized))
+
+    if valid_secrets:
+        os.environ["NIJA_COINBASE_PEM_STATE"] = "credential_pair_ambiguous"
+        os.environ["NIJA_COINBASE_PEM_VALID"] = "1"
+        os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+        os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+        logger.error(
+            "COINBASE_CREDENTIAL_PAIR_AMBIGUOUS marker=%s "
+            "keys=%d valid_secrets=%d action=fail_closed",
+            _MARKER,
+            len(
+                {
+                    str(os.environ.get(name, "") or "").strip()
+                    for name in _COINBASE_KEY_ALIASES
+                    if str(os.environ.get(name, "") or "").strip()
+                }
+            ),
+            len(valid_secrets),
         )
         return
 
@@ -230,7 +346,6 @@ def _normalize_coinbase_env() -> None:
         _MARKER,
     )
     _quarantine_coinbase()
-
 
 def _log_state(venue: str, *, force: bool = False) -> None:
     now = time.monotonic()


### PR DESCRIPTION
## Summary

- treat Coinbase API keys and PEM secrets as complete alias-family pairs instead of selecting them independently
- preserve configured alternative credential pairs during early Render normalization
- retry a bounded set of complete configured pairs after a private Coinbase authentication failure
- retain a five-minute cooldown for rejected alternatives and restore the primary pair when every probe fails
- add focused regressions for alias-family selection, successful alternative recovery, and fail-closed exhaustion

## Root cause

Production reported a cryptographically valid ES256 PEM followed by `authentication_failed`. Startup previously selected the first key alias and first valid PEM alias independently, then copied that PEM across all aliases. When Render contains an older and a rotated Coinbase credential set, that can pair a key with a PEM belonging to another key. Coinbase correctly rejects the mismatched pair with 401.

## Safety

- uses only credentials already configured in Render
- validates PEM material before considering a pair
- proves connection through the existing private account/balance flow
- never uses public market data as authentication proof
- never submits a probe order
- never marks Coinbase connected after all private probes fail
- does not change Kraken, OKX, writer fencing, risk limits, or order admission

## Expected deployment evidence

Success:
- `COINBASE_PEM_CANONICALIZED ... pair_source=... pair_count=...`
- optional `COINBASE_AUTHENTICATED_PAIR_RETRY`
- `COINBASE_AUTHENTICATED_PAIR_RECOVERED`
- authenticated Coinbase balance and `NIJA_COINBASE_TRADING_READY=1` when funded

Invalid/revoked credentials:
- `COINBASE_AUTHENTICATED_CONNECT_FAILED ... alternative_pairs_attempted=N`
- Coinbase remains fail-closed while Kraken and OKX continue independently
