### PR TITLE
fix: restore canonical strategy publication and trading cycles

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -326,6 +326,58 @@ def _advance_bootstrap_fsm_to_running_supervised() -> bool:
         return False
 
 
+def _fail_closed_strategy_publication(detail: str) -> None:
+    """Revoke process-local runtime claims when no executable strategy exists."""
+
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+    logger.critical(
+        "CANONICAL_STRATEGY_PUBLICATION_FAILED detail=%s "
+        "runtime_state=OFF execution_authority=0 "
+        "trading_remains_fail_closed=true",
+        detail,
+    )
+
+
+def _publish_canonical_strategy_for_runtime(
+    broker: object,
+) -> Optional[object]:
+    """Build and publish the strategy required by the trading-loop contract."""
+
+    try:
+        from bot.strategy_publication_patch import publish_canonical_strategy
+
+        strategy, detail = publish_canonical_strategy(explicit_broker=broker)
+    except Exception as exc:
+        detail = f"publication_exception:{type(exc).__name__}:{exc}"
+        logger.critical(
+            "CANONICAL_STRATEGY_PUBLICATION_EXCEPTION type=%s err=%s",
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        strategy = None
+
+    if strategy is None or not callable(getattr(strategy, "run_cycle", None)):
+        if strategy is not None:
+            detail = "strategy_run_cycle_unavailable"
+        _fail_closed_strategy_publication(detail)
+        return None
+
+    if getattr(strategy, "broker", None) is None:
+        _fail_closed_strategy_publication("strategy_broker_missing")
+        return None
+
+    logger.critical(
+        "CANONICAL_STRATEGY_HANDOFF_READY detail=%s strategy=%s broker=%s "
+        "run_cycle=true",
+        detail,
+        type(strategy).__name__,
+        type(getattr(strategy, "broker", None)).__name__,
+    )
+    return strategy
+
+
 def _keep_process_alive_after_loop_return() -> None:
     """Keep the main process alive while supervised trading threads run."""
 
@@ -427,6 +479,14 @@ def main() -> int:
             return 1
 
         logger.info("✅ FSM is RUNNING_SUPERVISED")
+
+        logger.info("\n[STEP 2.5] Publishing Canonical Trading Strategy")
+        strategy = _publish_canonical_strategy_for_runtime(broker)
+        if strategy is None:
+            logger.critical(
+                "❌ Canonical TradingStrategy unavailable — exiting fail closed"
+            )
+            return 1
         _startup_complete = True
 
         logger.info("\n[STEP 3] Starting Trading Loop")
@@ -434,7 +494,7 @@ def main() -> int:
             from bot.nija_core_loop import start_trading_engine
 
             logger.info("🎯 Entering trading loop...")
-            start_trading_engine(broker)
+            start_trading_engine(strategy)
             if not _shutdown_event.is_set():
                 _keep_process_alive_after_loop_return()
         except KeyboardInterrupt:

--- a/bot/live_active_dispatch_bridge_patch.py
+++ b/bot/live_active_dispatch_bridge_patch.py
@@ -5,7 +5,9 @@ TradingStateMachine reaches LIVE_ACTIVE, but no TradingLoop thread is actually
 started. It does not relax order admission, set operator overrides, or create a
 second strategy. It starts an already-published TradingStrategy only after the
 canonical distributed writer lease, runtime execution authority, and LIVE_ACTIVE
-state are all present.
+state are all present. If startup missed publication, the bridge invokes the
+canonical publication helper only after those same gates pass; that helper is
+idempotent and never starts a loop or submits an order.
 
 The bridge also repairs a deferred-startup deadlock observed in production:
 ``activation_pending_commit_monitor_patch`` historically waited only for
@@ -419,6 +421,49 @@ def _find_strategy() -> Tuple[Optional[Any], str]:
     return None, "strategy_not_published"
 
 
+def _recover_strategy_publication() -> Tuple[Optional[Any], str]:
+    """Recover a missing publication without bypassing any live gate."""
+
+    module = None
+    for module_name in (
+        "bot.strategy_publication_patch",
+        "strategy_publication_patch",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            break
+        except Exception:
+            continue
+    if module is None:
+        return None, "publication_module_unavailable"
+
+    publisher = getattr(module, "publish_canonical_strategy", None)
+    if not callable(publisher):
+        return None, "publication_helper_unavailable"
+
+    try:
+        strategy, detail = publisher()
+    except Exception as exc:
+        logger.exception(
+            "LIVE_ACTIVE_DISPATCH_STRATEGY_RECOVERY_ERROR type=%s err=%s",
+            type(exc).__name__,
+            exc,
+        )
+        return None, f"publication_error:{type(exc).__name__}"
+
+    if strategy is None:
+        return None, str(detail or "publication_failed")
+    if not callable(getattr(strategy, "run_cycle", None)):
+        return None, "published_strategy_interface_invalid"
+
+    logger.critical(
+        "LIVE_ACTIVE_DISPATCH_STRATEGY_RECOVERED detail=%s strategy_type=%s",
+        detail,
+        type(strategy).__name__,
+    )
+    return strategy, f"publication_recovery:{detail}"
+
+
 def _set_start_gate() -> None:
     for module_name in ("bot.nija_core_loop", "nija_core_loop"):
         module = sys.modules.get(module_name)
@@ -511,6 +556,12 @@ def ensure_live_dispatch(source: str = "external_recovery") -> Tuple[bool, str]:
 
     strategy, strategy_source = _find_strategy()
     if strategy is None:
+        strategy, strategy_source = _recover_strategy_publication()
+    if strategy is None:
+        logger.error(
+            "LIVE_ACTIVE_DISPATCH_STRATEGY_RECOVERY_FAILED detail=%s",
+            strategy_source,
+        )
         return False, "strategy_not_published"
 
     started = _start_trading_loop(strategy, strategy_source)
@@ -597,10 +648,14 @@ def _monitor() -> None:
 
             strategy, source = _find_strategy()
             if strategy is None:
+                strategy, source = _recover_strategy_publication()
+            if strategy is None:
                 if now - last_log >= warn_every:
                     logger.critical(
                         "LIVE_ACTIVE_DISPATCH_BRIDGE_WAITING reason=no_strategy "
-                        "live_active=True writer_authority=True modules=%s",
+                        "recovery_detail=%s live_active=True "
+                        "writer_authority=True modules=%s",
+                        source,
                         sorted(
                             str(getattr(m, "__name__", ""))
                             for m in _module_candidates()

--- a/bot/nija_core_loop.py
+++ b/bot/nija_core_loop.py
@@ -5024,6 +5024,8 @@ def get_nija_core_loop(apex_strategy: Any = None, max_positions: int = 5) -> Nij
 #                    one continuous cycle ever runs.
 _loop_guard = threading.Lock()
 _loop_running = False
+_engine_start_guard = threading.Lock()
+_engine_thread: Optional[threading.Thread] = None
 # Hard trading-active flag.  Set to True only after BOTH the hydration and CSM
 # barriers have passed.  The main while-loop is conditioned on this flag so the
 # loop body never executes until the bot is genuinely ready to trade.
@@ -5095,48 +5097,78 @@ def _exec_test_probe(strategy: Any) -> Dict:
 
 
 def start_trading_engine(strategy: Any) -> threading.Thread:
-    """Single, guaranteed entry point for the trading loop thread.
+    """Start the one canonical trading-loop thread for a TradingStrategy."""
 
-    This is the ONLY function that may spawn a ``run_trading_loop`` thread.
-    All callers (``bot.py`` main, ``NijaCoreLoop.start``, etc.) must go
-    through here — no one else is permitted to call ``threading.Thread``
-    with ``run_trading_loop`` as the target directly.
+    global _engine_thread
 
-    Parameters
-    ----------
-    strategy : TradingStrategy instance (must not be None)
+    run_cycle = getattr(strategy, "run_cycle", None)
+    if strategy is None or not callable(run_cycle):
+        logger.critical(
+            "TRADING_ENGINE_START_REJECTED reason=invalid_strategy_interface "
+            "strategy_type=%s run_cycle=%s",
+            type(strategy).__name__,
+            callable(run_cycle),
+        )
+        raise TypeError(
+            "start_trading_engine requires a TradingStrategy-compatible "
+            "object with callable run_cycle()"
+        )
 
-    Returns
-    -------
-    threading.Thread — the started daemon thread
-    """
-    logger.critical("🚀 STARTING TRADING ENGINE THREAD")
-
-    # Install graceful shutdown handler before spawning the trading thread so
-    # SIGTERM is handled from the main thread (required by Python's signal API).
-    if _GRACEFUL_HANDOFF_AVAILABLE and _get_handoff_coordinator is not None:
-        try:
-            _get_handoff_coordinator().install_shutdown_handler()
-            logger.info(
-                "start_trading_engine: graceful shutdown handler installed "
-                "(SIGTERM will trigger clean lock release)"
-            )
-        except Exception as _hh_exc:
+    with _engine_start_guard:
+        if _engine_thread is not None and _engine_thread.is_alive():
             logger.warning(
-                "start_trading_engine: graceful shutdown handler install failed "
-                "(non-fatal): %s",
-                _hh_exc,
+                "TRADING_ENGINE_START_DEDUP existing_thread=%s ident=%s",
+                _engine_thread.name,
+                _engine_thread.ident,
             )
+            return _engine_thread
 
-    t = threading.Thread(
-        target=run_trading_loop,
-        args=(strategy,),
-        name="TradingLoop",
-        daemon=True,
-    )
-    t.start()
-    logger.critical("LIFECYCLE: entering live trading runtime")
-    return t
+        for existing in threading.enumerate():
+            try:
+                if existing.is_alive() and existing.name == "TradingLoop":
+                    _engine_thread = existing
+                    logger.warning(
+                        "TRADING_ENGINE_START_ADOPTED existing_thread=%s ident=%s",
+                        existing.name,
+                        existing.ident,
+                    )
+                    return existing
+            except Exception:
+                continue
+
+        logger.critical(
+            "🚀 STARTING TRADING ENGINE THREAD strategy_type=%s broker_type=%s",
+            type(strategy).__name__,
+            type(getattr(strategy, "broker", None)).__name__
+            if getattr(strategy, "broker", None) is not None
+            else "none",
+        )
+
+        # Install graceful shutdown handling before spawning the trading thread.
+        if _GRACEFUL_HANDOFF_AVAILABLE and _get_handoff_coordinator is not None:
+            try:
+                _get_handoff_coordinator().install_shutdown_handler()
+                logger.info(
+                    "start_trading_engine: graceful shutdown handler installed "
+                    "(SIGTERM will trigger clean lock release)"
+                )
+            except Exception as _hh_exc:
+                logger.warning(
+                    "start_trading_engine: graceful shutdown handler install failed "
+                    "(non-fatal): %s",
+                    _hh_exc,
+                )
+
+        thread = threading.Thread(
+            target=run_trading_loop,
+            args=(strategy,),
+            name="TradingLoop",
+            daemon=True,
+        )
+        _engine_thread = thread
+        thread.start()
+        logger.critical("LIFECYCLE: entering live trading runtime")
+        return thread
 
 
 # ---------------------------------------------------------------------------

--- a/bot/strategy_publication_patch.py
+++ b/bot/strategy_publication_patch.py
@@ -56,7 +56,14 @@ def _strategy_class() -> Optional[type]:
 
 def _modules() -> list[Any]:
     out: list[Any] = []
-    for name in ("__main__", "bot", "bot.trading_strategy", "trading_strategy"):
+    for name in (
+        "__main__",
+        "bot",
+        "bot.bot",
+        "bot.bot_main",
+        "bot.trading_strategy",
+        "trading_strategy",
+    ):
         try:
             module = sys.modules.get(name) or importlib.import_module(name)
             if module is not None:
@@ -417,8 +424,95 @@ def _build_strategy(cls: type, brokers: dict[Any, dict[str, Any]]) -> Any:
         return strategy
 
 
+def publish_canonical_strategy(
+    explicit_broker: Any = None,
+) -> tuple[Optional[Any], str]:
+    """Synchronously build, hydrate, and publish the canonical live strategy.
+
+    The caller remains responsible for proving startup/live authority before
+    invoking this function.  This helper never changes trading state, grants
+    execution authority, starts a loop, or submits an order.
+    """
+
+    cls = _strategy_class()
+    if cls is None:
+        return None, "class_unavailable"
+
+    with _LOCK:
+        try:
+            existing = _existing(cls)
+            brokers, _ = _broker_results()
+            if explicit_broker is not None:
+                _add_broker(
+                    brokers,
+                    _normal_key(None, explicit_broker),
+                    explicit_broker,
+                    "canonical_runtime_handoff",
+                )
+
+            entry_ready = sorted(
+                str(key)
+                for key, meta in brokers.items()
+                if isinstance(meta, dict) and bool(meta.get("entry_ready"))
+            )
+            if not entry_ready:
+                logger.error(
+                    "STRATEGY_PUBLICATION_BLOCKED reason=no_entry_ready_brokers "
+                    "broker_keys=%s scan=%s explicit_broker=%s",
+                    sorted(str(key) for key in brokers.keys()),
+                    _LAST_SCAN_DETAIL,
+                    type(explicit_broker).__name__
+                    if explicit_broker is not None
+                    else "none",
+                )
+                return None, "no_entry_ready_brokers"
+
+            logger.warning(
+                "STRATEGY_PUBLICATION_BROKERS_READY count=%d keys=%s "
+                "entry_ready=%s",
+                len(brokers),
+                sorted(str(key) for key in brokers.keys()),
+                entry_ready,
+            )
+
+            if existing is not None:
+                if _hydrate_existing_strategy(existing, brokers):
+                    if not callable(getattr(existing, "run_cycle", None)):
+                        return None, "existing_strategy_interface_invalid"
+                    _publish(existing)
+                    return existing, "existing_published"
+                logger.warning(
+                    "STRATEGY_PUBLICATION_EXISTING_UNUSABLE "
+                    "rebuilding_with_live_brokers"
+                )
+
+            strategy = _build_strategy(cls, brokers)
+            if not _strategy_has_entry_broker(strategy):
+                _hydrate_existing_strategy(strategy, brokers)
+            if not _strategy_has_entry_broker(strategy):
+                return None, "built_strategy_has_no_entry_broker"
+            if not callable(getattr(strategy, "run_cycle", None)):
+                return None, "built_strategy_interface_invalid"
+
+            _publish(strategy)
+            return strategy, "built_published"
+        except Exception as exc:
+            logger.exception(
+                "STRATEGY_PUBLICATION_SYNCHRONOUS_ERROR type=%s err=%s",
+                type(exc).__name__,
+                exc,
+            )
+            return None, f"publication_error:{type(exc).__name__}"
+
+
 def _monitor() -> None:
-    interval = max(1.0, float(os.environ.get("NIJA_STRATEGY_PUBLICATION_INTERVAL_S", "3") or 3.0))
+    interval = max(
+        1.0,
+        float(
+            os.environ.get("NIJA_STRATEGY_PUBLICATION_INTERVAL_S", "3")
+            or 3.0
+        ),
+    )
     last_log = 0.0
     logger.warning("STRATEGY_PUBLICATION_MONITOR_STARTED interval_s=%.1f", interval)
     while True:
@@ -431,58 +525,17 @@ def _monitor() -> None:
             time.sleep(interval)
             continue
 
-        cls = _strategy_class()
-        if cls is None:
-            if now - last_log >= 15.0:
-                logger.warning("STRATEGY_PUBLICATION_WAITING reason=class_unavailable")
-                last_log = now
-            time.sleep(interval)
-            continue
-
-        with _LOCK:
-            existing = _existing(cls)
-            brokers, count = _broker_results()
-            if count <= 0:
-                if now - last_log >= 15.0:
-                    logger.warning(
-                        "STRATEGY_PUBLICATION_WAITING reason=no_connected_brokers scan=%s modules=%s existing=%s existing_broker=%s",
-                        _LAST_SCAN_DETAIL,
-                        sorted(name for name in sys.modules if name.endswith("multi_account_broker_manager") or name.endswith("broker_manager"))[:20],
-                        type(existing).__name__ if existing is not None else "none",
-                        type(getattr(existing, "broker", None)).__name__ if existing is not None and getattr(existing, "broker", None) is not None else "none",
-                    )
-                    last_log = now
-                time.sleep(interval)
-                continue
-
-            logger.warning(
-                "STRATEGY_PUBLICATION_BROKERS_READY count=%d keys=%s entry_ready=%s",
-                count,
-                sorted(str(key) for key in brokers.keys()),
-                sorted(str(key) for key, meta in brokers.items() if isinstance(meta, dict) and meta.get("entry_ready")),
-            )
-
-            if existing is not None:
-                if _hydrate_existing_strategy(existing, brokers):
-                    _publish(existing)
-                    return
-                logger.warning("STRATEGY_PUBLICATION_EXISTING_UNUSABLE rebuilding_with_live_brokers")
-
-            try:
-                strategy = _build_strategy(cls, brokers)
-                if not _strategy_has_entry_broker(strategy):
-                    _hydrate_existing_strategy(strategy, brokers)
-                if not _strategy_has_entry_broker(strategy):
-                    logger.warning("STRATEGY_PUBLICATION_BUILD_UNUSABLE retrying broker_keys=%s", sorted(str(key) for key in brokers.keys()))
-                    time.sleep(interval)
-                    continue
-            except Exception as exc:
-                logger.exception("STRATEGY_PUBLICATION_BUILD_ERROR err=%s", exc)
-                time.sleep(interval)
-                continue
-            _publish(strategy)
+        strategy, detail = publish_canonical_strategy()
+        if strategy is not None:
             return
-
+        if now - last_log >= 15.0:
+            logger.warning(
+                "STRATEGY_PUBLICATION_WAITING reason=%s scan=%s",
+                detail,
+                _LAST_SCAN_DETAIL,
+            )
+            last_log = now
+        time.sleep(interval)
 
 def install_import_hook() -> None:
     global _STARTED

--- a/bot/tests/test_activation_pending_startup_order.py
+++ b/bot/tests/test_activation_pending_startup_order.py
@@ -50,7 +50,7 @@ def test_activation_monitor_observes_runtime_without_importing_it(monkeypatch) -
     assert module._state_machine() is None
     ready, detail = module._capital_ready_snapshot()
     assert ready is False
-    assert detail["reason"] == "capital_authority_unavailable"
+    assert detail["reason"] == "broker_manager_module_not_loaded"
     assert calls == []
 
 

--- a/bot/tests/test_canonical_strategy_publication_handoff.py
+++ b/bot/tests/test_canonical_strategy_publication_handoff.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load(relative_path: str, module_name: str):
+    root = Path(__file__).resolve().parents[2]
+    path = root / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_synchronous_publication_builds_and_exports_strategy(monkeypatch) -> None:
+    module = _load(
+        "bot/strategy_publication_patch.py",
+        "nija_test_strategy_publication_patch",
+    )
+    broker = SimpleNamespace(
+        connected=True,
+        exit_only_mode=False,
+        broker_type=SimpleNamespace(value="kraken"),
+    )
+    published_to = ModuleType("published_target")
+
+    class FakeStrategy:
+        def __init__(self, broker_results=None):
+            self.broker = next(iter(broker_results.values()))["broker"]
+            self.symbols = ["BTC-USD"]
+            self.nija_core_loop = object()
+
+        def run_cycle(self):
+            return None
+
+    monkeypatch.setattr(module, "_strategy_class", lambda: FakeStrategy)
+    monkeypatch.setattr(module, "_broker_results", lambda: ({}, 0))
+    monkeypatch.setattr(module, "_modules", lambda: [published_to])
+    module._PUBLISHED = None
+
+    strategy, detail = module.publish_canonical_strategy(
+        explicit_broker=broker,
+    )
+
+    assert isinstance(strategy, FakeStrategy)
+    assert strategy.broker is broker
+    assert detail == "built_published"
+    assert published_to.nija_live_strategy is strategy
+    assert published_to._initialized_state["strategy"] is strategy
+
+
+def test_synchronous_publication_rejects_missing_entry_broker(monkeypatch) -> None:
+    module = _load(
+        "bot/strategy_publication_patch.py",
+        "nija_test_strategy_publication_patch_no_broker",
+    )
+
+    class FakeStrategy:
+        def run_cycle(self):
+            return None
+
+    monkeypatch.setattr(module, "_strategy_class", lambda: FakeStrategy)
+    monkeypatch.setattr(module, "_broker_results", lambda: ({}, 0))
+    module._PUBLISHED = None
+
+    strategy, detail = module.publish_canonical_strategy()
+
+    assert strategy is None
+    assert detail == "no_entry_ready_brokers"
+
+
+def test_bot_main_hands_off_published_strategy(monkeypatch) -> None:
+    module = _load("bot/bot_main.py", "nija_test_bot_main_handoff")
+    broker = SimpleNamespace(connected=True)
+    strategy = SimpleNamespace(broker=broker, run_cycle=lambda: None)
+    publication = ModuleType("bot.strategy_publication_patch")
+    calls: list[object] = []
+
+    def publish_canonical_strategy(explicit_broker=None):
+        calls.append(explicit_broker)
+        return strategy, "built_published"
+
+    publication.publish_canonical_strategy = publish_canonical_strategy
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.strategy_publication_patch",
+        publication,
+    )
+
+    result = module._publish_canonical_strategy_for_runtime(broker)
+
+    assert result is strategy
+    assert calls == [broker]
+
+
+def test_bot_main_revokes_runtime_claims_when_publication_fails(
+    monkeypatch,
+) -> None:
+    module = _load("bot/bot_main.py", "nija_test_bot_main_fail_closed")
+    publication = ModuleType("bot.strategy_publication_patch")
+    publication.publish_canonical_strategy = (
+        lambda explicit_broker=None: (None, "no_entry_ready_brokers")
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.strategy_publication_patch",
+        publication,
+    )
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+
+    result = module._publish_canonical_strategy_for_runtime(
+        SimpleNamespace(connected=True)
+    )
+
+    assert result is None
+    assert module.os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert module.os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -216,7 +216,14 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
             _platform_brokers={"kraken": types.SimpleNamespace(connected=True)},
         )
 
-        def start_trading_engine(_broker):
+        bootstrap_broker = types.SimpleNamespace(connected=True)
+        published_strategy = types.SimpleNamespace(
+            broker=bootstrap_broker,
+            run_cycle=lambda: None,
+        )
+
+        def start_trading_engine(strategy):
+            self.assertIs(strategy, published_strategy)
             order.append("trading")
             self.bot_main._shutdown_event.set()
 
@@ -232,11 +239,16 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
 
         def bootstrap():
             order.append("nonce_and_broker")
-            return True, object(), "kraken"
+            return True, bootstrap_broker, "kraken"
 
         def advance():
             order.append("fsm")
             return True
+
+        def publish_strategy(broker):
+            self.assertIs(broker, bootstrap_broker)
+            order.append("strategy")
+            return published_strategy
 
         previous = sys.modules.get("bot.nija_core_loop")
         sys.modules["bot.nija_core_loop"] = core_loop
@@ -261,6 +273,11 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
                     "_advance_bootstrap_fsm_to_running_supervised",
                     side_effect=advance,
                 ),
+                patch.object(
+                    self.bot_main,
+                    "_publish_canonical_strategy_for_runtime",
+                    side_effect=publish_strategy,
+                ),
                 patch.object(self.bot_main, "_release_writer_authority"),
                 patch.object(self.bot_main.signal, "signal"),
             ):
@@ -274,7 +291,14 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(
             order,
-            ["authority", "prebootstrap", "nonce_and_broker", "fsm", "trading"],
+            [
+                "authority",
+                "prebootstrap",
+                "nonce_and_broker",
+                "fsm",
+                "strategy",
+                "trading",
+            ],
         )
 
     def test_prebootstrap_requires_connected_platform_broker(self):

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -172,8 +172,11 @@ def test_ensure_live_dispatch_starts_existing_strategy_only_when_ready(monkeypat
     assert calls == [(strategy, "published")]
 
 
-def test_ensure_live_dispatch_never_constructs_missing_strategy(monkeypatch) -> None:
+def test_ensure_live_dispatch_recovers_missing_strategy_after_gates(monkeypatch) -> None:
     module = _load_module()
+    strategy = type("Strategy", (), {"run_cycle": lambda self: None})()
+    calls: list[tuple[object, str]] = []
+
     monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
     monkeypatch.setattr(module, "_ensure_deferred_startup_repairs", lambda: (True, "ready"))
     monkeypatch.setattr(module, "_has_writer_authority", lambda: True)
@@ -181,6 +184,41 @@ def test_ensure_live_dispatch_never_constructs_missing_strategy(monkeypatch) -> 
     monkeypatch.setattr(module, "_state_machine_live_active", lambda: True)
     monkeypatch.setattr(module, "_dispatch_allowed", lambda: (True, "ok"))
     monkeypatch.setattr(module, "_find_strategy", lambda: (None, "not_found"))
+    monkeypatch.setattr(
+        module,
+        "_recover_strategy_publication",
+        lambda: (strategy, "publication_recovery:built_published"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_start_trading_loop",
+        lambda candidate, source: calls.append((candidate, source)) or True,
+    )
+
+    started, detail = module.ensure_live_dispatch("watchdog")
+
+    assert started is True
+    assert detail == "started"
+    assert calls == [(strategy, "publication_recovery:built_published")]
+
+
+def test_ensure_live_dispatch_remains_fail_closed_when_recovery_fails(
+    monkeypatch,
+) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
+    monkeypatch.setattr(module, "_ensure_deferred_startup_repairs", lambda: (True, "ready"))
+    monkeypatch.setattr(module, "_has_writer_authority", lambda: True)
+    monkeypatch.setattr(module, "_runtime_execution_authority", lambda: True)
+    monkeypatch.setattr(module, "_state_machine_live_active", lambda: True)
+    monkeypatch.setattr(module, "_dispatch_allowed", lambda: (True, "ok"))
+    monkeypatch.setattr(module, "_find_strategy", lambda: (None, "not_found"))
+    monkeypatch.setattr(
+        module,
+        "_recover_strategy_publication",
+        lambda: (None, "no_entry_ready_brokers"),
+    )
 
     started, detail = module.ensure_live_dispatch("watchdog")
 


### PR DESCRIPTION
## Summary

Fixes the production condition where Render reached `LIVE_ACTIVE` with valid writer authority and hydrated capital, but the trading watchdog remained at `cycles=0` with `strategy_not_published`.

## Root cause

The canonical runtime handoff called `start_trading_engine(broker)` even though that function requires a `TradingStrategy`. The broker adapter survived the loose non-null guard, creating a misleading `TradingLoop` lifecycle without a publishable strategy or executable `run_cycle()`.

## Changes

- synchronously build, hydrate, and publish the canonical `TradingStrategy` after broker/FSM readiness
- pass that strategy—not the broker adapter—to the trading engine
- fail closed and revoke process-local live claims if publication fails
- reject invalid strategy interfaces before spawning a trading thread
- enforce one canonical `TradingLoop` owner
- recover a missing publication from the live dispatch bridge only after writer, runtime-authority, and `LIVE_ACTIVE` gates pass
- add regression tests for successful handoff, gated recovery, and fail-closed behavior

## Safety

This change does not force entries, weaken risk gates, bypass writer fencing, change broker credentials, or guarantee profitability. Existing order admission, stop/exit logic, exchange constraints, and account isolation remain authoritative.

## Production acceptance signals

After deployment, logs should show:

- `STRATEGY_PUBLICATION_READY`
- `CANONICAL_STRATEGY_HANDOFF_READY`
- `STARTING TRADING ENGINE THREAD strategy_type=TradingStrategy`
- cycle count increasing above zero

The recurring `strategy_not_published` watchdog failure should stop.