### PR TITLE
Fix canonical startup patch fanout stall

### DIFF
--- a/.github/workflows/canonical-startup-launcher-v26.yml
+++ b/.github/workflows/canonical-startup-launcher-v26.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     paths:
       - "scripts/canonical_runtime_launcher_v26.py"
+      - "scripts/runtime_entrypoint_attestation.py"
       - "scripts/apply_canonical_launcher_v26.py"
       - "scripts/render_entrypoint.sh"
+      - "bot/bot.py"
       - "bot/canonical_broker_startup_convergence_v24.py"
       - "bot/canonical_broker_prebootstrap_v22.py"
       - "bot/tests/test_canonical_runtime_launcher_v26.py"
+      - "bot/tests/test_canonical_fast_entrypoint_v28.py"
       - ".github/workflows/canonical-startup-launcher-v26.yml"
   workflow_dispatch:
 
@@ -43,4 +46,6 @@ jobs:
       - name: Run focused regression tests
         run: |
           python -m pip install --disable-pip-version-check pytest
-          pytest -q bot/tests/test_canonical_runtime_launcher_v26.py
+          NIJA_DEFER_RUNTIME_SITE_HOOKS=1 PYTHONNOUSERSITE=1 pytest -q \
+            bot/tests/test_canonical_runtime_launcher_v26.py \
+            bot/tests/test_canonical_fast_entrypoint_v28.py

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,130 +1,131 @@
-"""Compatibility entrypoint for Railway/main.py."""
+"""Compatibility entrypoint for Railway/main.py.
+
+The canonical Render launcher keeps package-wide runtime hooks deferred while
+``main.py`` installs the audited safety set explicitly.  Replaying every
+historical compatibility installer here delayed ``bot_main.main()`` for many
+minutes while the health server reported the service as live.  The canonical
+fast path therefore installs only narrow guards that are not already owned by
+``main.py``, then hands off immediately.
+
+Direct/non-canonical launches retain the legacy installer set for compatibility.
+"""
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os
 import sys
+from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
+_FAST_PATH_MARKER = "20260725-canonical-fast-entrypoint-v28"
 
-try:
-    from bot.okx_patch_churn_guard_patch import install_import_hook as _install_okx_patch_churn_guard
-    _install_okx_patch_churn_guard()
-    logger.warning("OKX_PATCH_CHURN_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("OKX_PATCH_CHURN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+# Each tuple is (module, success log label).  Names remain explicit so startup
+# attestation and source audits can prove which guards are eligible.
+_FAST_PATH_INSTALLERS = (
+    ("bot.okx_patch_churn_guard_patch", "OKX_PATCH_CHURN_GUARD"),
+    ("bot.disconnected_coinbase_balance_guard_patch", "COINBASE_BALANCE_DISCONNECTED_GUARD"),
+    ("bot.live_capital_first_snapshot_latch_patch", "LIVE_CAPITAL_FIRST_SNAPSHOT_LATCH"),
+    ("bot.startup_authority_prereq_repair_patch", "STARTUP_AUTHORITY_PREREQ_REPAIR"),
+    ("bot.okx_execution_min_notional_lift_patch", "OKX_EXECUTION_MIN_NOTIONAL_LIFT"),
+    ("bot.okx_order_instid_payload_repair_patch", "OKX_ORDER_INSTID_PAYLOAD_REPAIR"),
+    ("bot.okx_final_order_submission_bridge_patch", "OKX_FINAL_ORDER_SUBMISSION_BRIDGE"),
+    ("bot.stalled_writer_release_guard_v22", "STALLED_WRITER_RELEASE_GUARD_V22"),
+)
 
-try:
-    from bot.disconnected_coinbase_balance_guard_patch import install_import_hook as _install_coinbase_balance_guard
-    _install_coinbase_balance_guard()
-    logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("COINBASE_BALANCE_DISCONNECTED_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+_LEGACY_INSTALLERS = (
+    *_FAST_PATH_INSTALLERS,
+    ("bot.bootstrap_i12_capital_authority_repair_patch", "BOOTSTRAP_I12_CAPITAL_AUTHORITY_REPAIR"),
+    ("bot.trading_engine_strategy_wrapper_patch", "TRADING_ENGINE_STRATEGY_WRAPPER"),
+    ("bot.strategy_runtime_integrity_patch", "STRATEGY_RUNTIME_INTEGRITY"),
+    ("bot.live_entry_scan_adoption_timeout_patch", "SCAN_POSITION_ADOPTION_TIMEOUT"),
+    ("bot.writer_heartbeat_stale_repair_patch", "WRITER_HEARTBEAT_STALE_REPAIR"),
+    ("bot.ecel_okx_synthetic_contract_patch", "ECEL_OKX_SYNTHETIC_CONTRACT"),
+    ("bot.fallback_strict_score_floor_adaptive_patch", "FALLBACK_FLOOR_CALIBRATION"),
+    ("bot.canonical_broker_main_entry_guard_v20", "CANONICAL_BROKER_MAIN_GUARD"),
+    ("bot.canonical_broker_prebootstrap_v22", "CANONICAL_BROKER_PREBOOTSTRAP_V22"),
+)
 
-try:
-    from bot.live_capital_first_snapshot_latch_patch import install_import_hook as _install_live_capital_first_snapshot_latch
-    _install_live_capital_first_snapshot_latch()
-    logger.warning("LIVE_CAPITAL_FIRST_SNAPSHOT_LATCH_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("LIVE_CAPITAL_FIRST_SNAPSHOT_LATCH_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
-try:
-    from bot.startup_authority_prereq_repair_patch import install_import_hook as _install_startup_authority_repair
-    _install_startup_authority_repair()
-    logger.warning("STARTUP_AUTHORITY_PREREQ_REPAIR_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("STARTUP_AUTHORITY_PREREQ_REPAIR_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+        "y",
+    }
 
-try:
-    from bot.bootstrap_i12_capital_authority_repair_patch import install_import_hook as _install_bootstrap_i12_ca_repair
-    _install_bootstrap_i12_ca_repair()
-    logger.warning("BOOTSTRAP_I12_CAPITAL_AUTHORITY_REPAIR_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("BOOTSTRAP_I12_CAPITAL_AUTHORITY_REPAIR_FAILED source=bot_entrypoint err=%s", exc)
 
-try:
-    from bot.trading_engine_strategy_wrapper_patch import install_import_hook as _install_strategy_wrapper
-    _install_strategy_wrapper()
-    logger.warning("TRADING_ENGINE_STRATEGY_WRAPPER_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("TRADING_ENGINE_STRATEGY_WRAPPER_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+def _canonical_fast_path_enabled() -> bool:
+    return bool(
+        _truthy("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH")
+        and _truthy("NIJA_DEFER_RUNTIME_SITE_HOOKS")
+        and os.environ.get("NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY") == "1"
+    )
 
-try:
-    from bot.strategy_runtime_integrity_patch import install_import_hook as _install_strategy_runtime_integrity
-    _install_strategy_runtime_integrity()
-    logger.warning("STRATEGY_RUNTIME_INTEGRITY_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("STRATEGY_RUNTIME_INTEGRITY_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
 
-try:
-    from bot.live_entry_scan_adoption_timeout_patch import install_import_hook as _install_scan_adoption_timeout
-    _install_scan_adoption_timeout()
-    logger.warning("SCAN_POSITION_ADOPTION_TIMEOUT_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("SCAN_POSITION_ADOPTION_TIMEOUT_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+def _install_guards(specs: Iterable[tuple[str, str]], *, mode: str) -> bool:
+    ready = True
+    installed: list[str] = []
+    for module_name, label in specs:
+        try:
+            module = importlib.import_module(module_name)
+            installer = getattr(module, "install_import_hook", None) or getattr(
+                module, "install", None
+            )
+            if not callable(installer):
+                raise RuntimeError("installer_missing")
+            result = installer()
+            if result is False:
+                raise RuntimeError("installer_returned_false")
+            installed.append(label)
+            logger.warning(
+                "%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s",
+                label,
+                mode,
+            )
+        except Exception as exc:
+            ready = False
+            logger.critical(
+                "%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s",
+                label,
+                mode,
+                exc,
+                exc_info=True,
+            )
+    logger.critical(
+        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s "
+        "installed=%s",
+        _FAST_PATH_MARKER,
+        mode,
+        ready,
+        ",".join(installed) or "none",
+    )
+    return ready
 
-try:
-    from bot.writer_heartbeat_stale_repair_patch import install_import_hook as _install_writer_heartbeat_stale_repair
-    _install_writer_heartbeat_stale_repair()
-    logger.warning("WRITER_HEARTBEAT_STALE_REPAIR_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("WRITER_HEARTBEAT_STALE_REPAIR_FAILED source=bot_entrypoint err=%s", exc)
 
-try:
-    from bot.ecel_okx_synthetic_contract_patch import install_import_hook as _install_ecel_okx_contract_repair
-    _install_ecel_okx_contract_repair()
-    logger.warning("ECEL_OKX_SYNTHETIC_CONTRACT_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("ECEL_OKX_SYNTHETIC_CONTRACT_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.fallback_strict_score_floor_adaptive_patch import install_import_hook as _install_fallback_floor_calibration
-    _install_fallback_floor_calibration()
-    logger.warning("FALLBACK_FLOOR_CALIBRATION_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("FALLBACK_FLOOR_CALIBRATION_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.okx_execution_min_notional_lift_patch import install_import_hook as _install_okx_execution_min_lift
-    _install_okx_execution_min_lift()
-    logger.warning("OKX_EXECUTION_MIN_NOTIONAL_LIFT_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("OKX_EXECUTION_MIN_NOTIONAL_LIFT_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.okx_order_instid_payload_repair_patch import install_import_hook as _install_okx_order_instid_payload_repair
-    _install_okx_order_instid_payload_repair()
-    logger.warning("OKX_ORDER_INSTID_PAYLOAD_REPAIR_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("OKX_ORDER_INSTID_PAYLOAD_REPAIR_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.okx_final_order_submission_bridge_patch import install_import_hook as _install_okx_final_order_submission_bridge
-    _install_okx_final_order_submission_bridge()
-    logger.warning("OKX_FINAL_ORDER_SUBMISSION_BRIDGE_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("OKX_FINAL_ORDER_SUBMISSION_BRIDGE_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.canonical_broker_main_entry_guard_v20 import install_import_hook as _install_canonical_broker_main_guard
-    _install_canonical_broker_main_guard()
-    logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("CANONICAL_BROKER_MAIN_GUARD_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.canonical_broker_prebootstrap_v22 import install_import_hook as _install_canonical_broker_prebootstrap
-    _install_canonical_broker_prebootstrap()
-    logger.warning("CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
-
-try:
-    from bot.stalled_writer_release_guard_v22 import install_import_hook as _install_stalled_writer_release_guard
-    _install_stalled_writer_release_guard()
-    logger.warning("STALLED_WRITER_RELEASE_GUARD_V22_INSTALL_REQUESTED source=bot_entrypoint")
-except Exception as exc:
-    logger.warning("STALLED_WRITER_RELEASE_GUARD_V22_INSTALL_FAILED source=bot_entrypoint err=%s", exc)
+if _canonical_fast_path_enabled():
+    if not _install_guards(_FAST_PATH_INSTALLERS, mode="canonical_fast"):
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+        raise RuntimeError(
+            "canonical fast-path safety guards failed; trading remains fail closed"
+        )
+    logger.critical(
+        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s "
+        "package_hook_fanout=deferred handoff=bot.bot_main",
+        _FAST_PATH_MARKER,
+    )
+else:
+    logger.warning(
+        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s "
+        "canonical_fast_path=false",
+        _FAST_PATH_MARKER,
+    )
+    _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")
 
 from bot.bot_main import main
 

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
+BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
+ATTESTATION = ROOT / "scripts" / "runtime_entrypoint_attestation.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launcher_preserves_defer_flag_through_main_handoff(
+    monkeypatch, tmp_path
+) -> None:
+    launcher = _load("test_canonical_fast_entrypoint_v28", LAUNCHER)
+    fake_main = tmp_path / "main.py"
+    fake_main.write_text("pass\n", encoding="utf-8")
+    observed: dict[str, str] = {}
+
+    monkeypatch.delenv("NIJA_DEFER_RUNTIME_SITE_HOOKS", raising=False)
+    monkeypatch.delenv("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH", raising=False)
+    monkeypatch.setattr(launcher, "MAIN_PATH", fake_main)
+    monkeypatch.setattr(launcher, "install_canonical_startup_guard", lambda: object())
+
+    def _run_path(path: str, *, run_name: str) -> None:
+        observed["path"] = path
+        observed["run_name"] = run_name
+        observed["defer"] = os.environ.get("NIJA_DEFER_RUNTIME_SITE_HOOKS", "")
+        observed["fast"] = os.environ.get("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH", "")
+
+    monkeypatch.setattr(launcher.runpy, "run_path", _run_path)
+
+    assert launcher.main() == 0
+    assert observed == {
+        "path": str(fake_main),
+        "run_name": "__main__",
+        "defer": "1",
+        "fast": "1",
+    }
+
+
+def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
+    source = BOT_ENTRYPOINT.read_text(encoding="utf-8")
+
+    assert "CANONICAL_ENTRYPOINT_FAST_PATH_READY" in source
+    assert "package_hook_fanout=deferred" in source
+    assert 'os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"' in source
+    assert 'os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"' in source
+
+    fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
+        ")\n\n_LEGACY_INSTALLERS", 1
+    )[0]
+    assert "okx_final_order_submission_bridge_patch" in fast_block
+    assert "startup_authority_prereq_repair_patch" in fast_block
+    assert "stalled_writer_release_guard_v22" in fast_block
+    assert "trading_engine_strategy_wrapper_patch" not in fast_block
+    assert "canonical_broker_main_entry_guard_v20" not in fast_block
+
+
+def test_runtime_attestation_requires_fast_path_and_strategy_handoff() -> None:
+    source = ATTESTATION.read_text(encoding="utf-8")
+
+    assert "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED" in source
+    assert "CANONICAL_ENTRYPOINT_FAST_PATH_READY" in source
+    assert "_publish_canonical_strategy_for_runtime" in source
+    assert "CANONICAL_STRATEGY_HANDOFF_READY" in source

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -76,9 +76,21 @@ def install_canonical_startup_guard() -> ModuleType:
 
 
 def main() -> int:
+    # Keep package-wide hook fanout deferred for the whole canonical handoff.
+    # main.py installs the audited global, authority, execution, risk and
+    # fill-confirmed exit guards explicitly; bot.bot installs the remaining
+    # narrow venue guards before importing bot_main.
+    os.environ["NIJA_DEFER_RUNTIME_SITE_HOOKS"] = "1"
+    os.environ["NIJA_CANONICAL_ENTRYPOINT_FAST_PATH"] = "1"
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
+    print(
+        "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED "
+        "marker=20260725-canonical-fast-entrypoint-v28 "
+        "package_hook_fanout=deferred",
+        flush=True,
+    )
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
     return 0
 

--- a/scripts/runtime_entrypoint_attestation.py
+++ b/scripts/runtime_entrypoint_attestation.py
@@ -39,10 +39,20 @@ _CONTRACTS = (
         ),
     ),
     FileContract(
+        "scripts/canonical_runtime_launcher_v26.py",
+        (
+            "NIJA_DEFER_RUNTIME_SITE_HOOKS",
+            "NIJA_CANONICAL_ENTRYPOINT_FAST_PATH",
+            "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED",
+        ),
+    ),
+    FileContract(
         "bot/bot.py",
         (
             "canonical_broker_prebootstrap_v22",
             "stalled_writer_release_guard_v22",
+            "CANONICAL_ENTRYPOINT_FAST_PATH_READY",
+            "_FAST_PATH_INSTALLERS",
             "from bot.bot_main import main",
         ),
     ),
@@ -51,6 +61,8 @@ _CONTRACTS = (
         (
             "_acquire_writer_authority_before_nonce",
             "_run_self_healing_startup",
+            "_publish_canonical_strategy_for_runtime",
+            "CANONICAL_STRATEGY_HANDOFF_READY",
             "_release_writer_authority",
         ),
     ),


### PR DESCRIPTION
## What changed

- keep `NIJA_DEFER_RUNTIME_SITE_HOOKS=1` through the canonical launcher handoff
- replace the compatibility entrypoint's full historical patch fanout with a small audited fast-path guard bundle
- retain the legacy installer path for non-canonical launches
- fail closed by revoking runtime execution authority if any fast-path safety guard fails
- attest both the fast-path handoff and canonical TradingStrategy publication
- add regression coverage for the launcher environment and source contracts

## Root cause

Render's health server became live while `bot.__init__` and `bot.bot` synchronously replayed dozens of patch installers. Production logs showed the entrypoint spending more than 14 minutes in that compatibility chain and never reaching `bot_main.main()`, so the merged strategy-publication fix could not execute.

## Safety

The synchronous global trailing protection, fill-confirmed v25 broker/engine exits, writer authority, capital, execution, and risk guards remain owned by `main.py`. The fast path additionally installs the narrow Coinbase-disconnected, OKX final-order, startup-authority, and stalled-writer guards before handing off to `bot_main`.

## Validation

GitHub Actions is expected to run the new `test_canonical_fast_entrypoint_v28.py` regression suite together with the existing startup, attestation, import-smoke, and live-exit workflows.