### PR TITLE
Stop startup capital refresh storms

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -8,6 +8,11 @@ on:
       - "secondary_venue_runtime_diagnostics.py"
       - "bot/tests/test_critical_runtime_repairs_v10.py"
       - "bot/bot.py"
+      - "kraken_equity_freshness_v3_patch.py"
+      - "bot/activation_pending_commit_monitor_patch.py"
+      - "bot/runtime_authority_convergence_repair_patch.py"
+      - "bot/capital_authority_live_total_v2_patch.py"
+      - "bot/tests/test_capital_refresh_storm_guard_v29.py"
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
@@ -45,6 +50,11 @@ on:
       - "secondary_venue_runtime_diagnostics.py"
       - "bot/tests/test_critical_runtime_repairs_v10.py"
       - "bot/bot.py"
+      - "kraken_equity_freshness_v3_patch.py"
+      - "bot/activation_pending_commit_monitor_patch.py"
+      - "bot/runtime_authority_convergence_repair_patch.py"
+      - "bot/capital_authority_live_total_v2_patch.py"
+      - "bot/tests/test_capital_refresh_storm_guard_v29.py"
       - "bot/strategy_runtime_integrity_patch.py"
       - "bot/disconnected_coinbase_balance_guard_patch.py"
       - "bot/okx_patch_churn_guard_patch.py"
@@ -119,7 +129,11 @@ jobs:
             bot/stalled_writer_release_guard_v22.py \
             scripts/apply_startup_handoff_fix.py \
             scripts/runtime_entrypoint_attestation.py \
-            bot/bot.py
+            bot/bot.py \
+            kraken_equity_freshness_v3_patch.py \
+            bot/activation_pending_commit_monitor_patch.py \
+            bot/runtime_authority_convergence_repair_patch.py \
+            bot/capital_authority_live_total_v2_patch.py
 
       - name: Run focused regression suite
         id: focused_tests
@@ -127,6 +141,8 @@ jobs:
         run: |
           TEST_LOG="${RUNNER_TEMP}/nija-focused-runtime-tests.log"
           python -m pytest -q \
+            bot/tests/test_capital_refresh_storm_guard_v29.py \
+            bot/tests/test_runtime_authority_convergence_repair_patch.py \
             bot/tests/test_critical_runtime_repairs_v10.py \
             bot/tests/test_strategy_runtime_integrity_patch.py \
             bot/tests/test_disconnected_coinbase_balance_guard_patch.py \

--- a/bot/activation_pending_commit_monitor_patch.py
+++ b/bot/activation_pending_commit_monitor_patch.py
@@ -284,21 +284,84 @@ def _state_machine() -> Any:
     return None
 
 
+
+_BALANCE_TOTAL_KEYS = (
+    "total_funds",
+    "total_balance",
+    "total_equity",
+    "equity",
+    "account_equity",
+    "portfolio_value",
+    "trading_balance",
+    "balance",
+    "usd_value",
+)
+
+
+def _balance_total(value: Any) -> float:
+    if isinstance(value, dict):
+        for key in _BALANCE_TOTAL_KEYS:
+            try:
+                amount = float(value.get(key) or 0.0)
+            except (TypeError, ValueError, OverflowError):
+                amount = 0.0
+            if amount > 0.0:
+                return amount
+        return 0.0
+    try:
+        amount = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return amount if amount > 0.0 else 0.0
+
+
+def _cached_broker_balance(
+    broker_obj: Any,
+    broker_key: str,
+    capital_authority: Any = None,
+) -> tuple[float, str]:
+    """Read an already-published balance without invoking broker I/O."""
+
+    for attr in (
+        "_last_known_balance",
+        "_last_confirmed_balance",
+        "last_known_balance",
+        "cached_balance",
+    ):
+        amount = _balance_total(getattr(broker_obj, attr, None))
+        if amount > 0.0:
+            return amount, attr
+
+    balances = getattr(capital_authority, "_broker_balances", {}) or {}
+    if isinstance(balances, dict):
+        wanted = broker_key.strip().lower()
+        for key, value in balances.items():
+            normalized = str(getattr(key, "value", key)).strip().lower()
+            if normalized == wanted:
+                amount = _balance_total(value)
+                if amount > 0.0:
+                    return amount, "capital_authority"
+
+    return 0.0, "unavailable"
+
+
+
 def _broker_manager_snapshot() -> tuple[bool, dict[str, Any]]:
-    """Pull connected-broker balance payload from the canonical manager.
+    """Observe connected brokers using accepted in-memory balances only.
 
-    Only observes modules already in sys.modules.  Feeds any non-zero balances
-    into CapitalAuthority via force_accept_feed() so that a stale zero-broker
-    CA can be unblocked without bypassing any gate logic.
-
-    Returns (accepted, meta) where meta mirrors the shape used by
-    _capital_ready_snapshot().
+    Startup monitors are not balance-refresh owners.  They must not call private
+    exchange endpoints or republish CapitalAuthority feeds; those mutations
+    belong to the broker manager and BalanceService.  Missing cached state is a
+    fail-closed result and the monitor will retry after the canonical owner
+    publishes a snapshot.
     """
+
     mabm_mod = _loaded_module(
         "bot.multi_account_broker_manager", "multi_account_broker_manager"
     )
     if mabm_mod is None:
         return False, {"reason": "broker_manager_module_not_loaded"}
+
     try:
         getter = getattr(mabm_mod, "get_broker_manager", None)
         if not callable(getter):
@@ -307,94 +370,78 @@ def _broker_manager_snapshot() -> tuple[bool, dict[str, Any]]:
         if mgr is None:
             return False, {"reason": "broker_manager_none"}
 
-        platform_brokers = getattr(mgr, "_platform_brokers", {})
-        connected_count = 0
-        total_balance = 0.0
-        per_broker: dict[str, float] = {}
-
-        for bt, broker_obj in list(platform_brokers.items()):
-            if broker_obj is None:
-                continue
-            try:
-                connected = bool(getattr(broker_obj, "connected", False))
-                if not connected:
-                    is_pc = getattr(mgr, "is_platform_connected", None)
-                    if callable(is_pc):
-                        connected = bool(is_pc(bt))
-                if not connected:
-                    continue
-                get_bal = getattr(broker_obj, "get_account_balance", None)
-                if not callable(get_bal):
-                    continue
-                raw = get_bal()
-                bal = 0.0
-                if isinstance(raw, dict):
-                    for k in ("trading_balance", "balance", "total", "usd_value"):
-                        v = raw.get(k)
-                        if v is not None:
-                            try:
-                                bal = float(v)
-                                break
-                            except Exception:
-                                pass
-                else:
-                    try:
-                        bal = float(raw or 0.0)
-                    except Exception:
-                        bal = 0.0
-                broker_key = str(getattr(bt, "value", bt))
-                per_broker[broker_key] = bal
-                total_balance += bal
-                connected_count += 1
-            except Exception as exc:
-                logger.debug(
-                    "ACTIVATION_PENDING_COMMIT broker_snapshot_error broker=%s err=%s", bt, exc
-                )
-
-        if connected_count == 0:
-            return False, {
-                "reason": "no_connected_brokers",
-                "hydrated": False,
-                "real_capital": 0.0,
-                "stale": True,
-                "registered_brokers": 0,
-                "accepted_latch": False,
-            }
-
-        # Feed recovered balances into CapitalAuthority to unblock hydration.
+        ca = None
         ca_mod = _loaded_module("bot.capital_authority", "capital_authority")
         if ca_mod is not None:
             ca_getter = getattr(ca_mod, "get_capital_authority", None)
             if callable(ca_getter):
                 try:
                     ca = ca_getter()
-                    if ca is not None:
-                        for broker_key, bal in per_broker.items():
-                            try:
-                                ca.force_accept_feed(broker_key, bal)
-                            except Exception as feed_exc:
-                                logger.debug(
-                                    "ACTIVATION_PENDING_COMMIT force_accept_feed err broker=%s err=%s",
-                                    broker_key,
-                                    feed_exc,
-                                )
-                except Exception as exc:
-                    logger.debug("ACTIVATION_PENDING_COMMIT ca_feed_error err=%s", exc)
+                except Exception:
+                    ca = None
 
-        accepted = connected_count > 0 and total_balance > 0.0
+        total_balance = 0.0
+        per_broker: dict[str, float] = {}
+        sources: dict[str, str] = {}
+        platform_brokers = getattr(mgr, "_platform_brokers", {})
+        for broker_type, broker_obj in list(platform_brokers.items()):
+            if broker_obj is None:
+                continue
+            try:
+                connected = bool(getattr(broker_obj, "connected", False))
+                if not connected:
+                    is_connected = getattr(mgr, "is_platform_connected", None)
+                    if callable(is_connected):
+                        connected = bool(is_connected(broker_type))
+                if not connected:
+                    continue
+
+                broker_key = str(getattr(broker_type, "value", broker_type))
+                balance, source = _cached_broker_balance(broker_obj, broker_key, ca)
+                if balance <= 0.0:
+                    logger.debug(
+                        "ACTIVATION_PENDING_COMMIT cached_balance_unavailable broker=%s",
+                        broker_key,
+                    )
+                    continue
+
+                per_broker[broker_key] = balance
+                sources[broker_key] = source
+                total_balance += balance
+            except Exception as exc:
+                logger.debug(
+                    "ACTIVATION_PENDING_COMMIT broker_snapshot_error broker=%s err=%s",
+                    broker_type,
+                    exc,
+                )
+
+        connected_count = len(per_broker)
+        if connected_count == 0:
+            return False, {
+                "reason": "no_connected_cached_balances",
+                "hydrated": False,
+                "real_capital": 0.0,
+                "stale": True,
+                "registered_brokers": 0,
+                "accepted_latch": False,
+                "source": "broker_manager_cached",
+            }
+
+        accepted = total_balance > 0.0
         meta = {
             "hydrated": accepted,
             "real_capital": total_balance,
             "stale": False,
             "registered_brokers": connected_count,
             "accepted_latch": accepted,
-            "reason": "broker_manager_ok" if accepted else "broker_manager_zero_balance",
+            "reason": "broker_manager_cached_ok" if accepted else "broker_manager_cached_zero",
             "per_broker": per_broker,
-            "source": "broker_manager",
+            "sources": sources,
+            "source": "broker_manager_cached",
         }
         logger.warning(
             "ACTIVATION_PENDING_COMMIT_MONITOR_BROKER_MANAGER_SNAPSHOT "
-            "connected=%d total_balance=$%.2f accepted=%s brokers=%s",
+            "connected=%d total_balance=$%.2f accepted=%s brokers=%s source=cached_only",
             connected_count,
             total_balance,
             accepted,
@@ -404,7 +451,6 @@ def _broker_manager_snapshot() -> tuple[bool, dict[str, Any]]:
     except Exception as exc:
         logger.debug("ACTIVATION_PENDING_COMMIT broker_manager_snapshot_error err=%s", exc)
         return False, {"reason": f"broker_manager_snapshot_error:{exc}"}
-
 
 def _capital_ready_snapshot() -> tuple[bool, dict[str, Any]]:
     module = _loaded_module("bot.capital_authority", "capital_authority")

--- a/bot/activation_pending_commit_monitor_patch.py
+++ b/bot/activation_pending_commit_monitor_patch.py
@@ -439,7 +439,7 @@ def _broker_manager_snapshot() -> tuple[bool, dict[str, Any]]:
             "sources": sources,
             "source": "broker_manager_cached",
         }
-        logger.warning(
+        logger.debug(
             "ACTIVATION_PENDING_COMMIT_MONITOR_BROKER_MANAGER_SNAPSHOT "
             "connected=%d total_balance=$%.2f accepted=%s brokers=%s source=cached_only",
             connected_count,
@@ -507,10 +507,9 @@ def _capital_ready_snapshot() -> tuple[bool, dict[str, Any]]:
         or (hydrated and real > 0.0 and registered > 0 and not stale)
     )
 
-    # If the CA snapshot is not yet accepted (stale/zero-broker), attempt to
-    # recover state directly from the canonical broker manager.  This converts
-    # a recovered broker/capital state into an accepted fresh capital snapshot
-    # without lowering any gate thresholds.
+    # If the CA snapshot is not yet accepted, inspect the canonical broker
+    # manager's already-published balances.  This path is observational only:
+    # it performs no private exchange I/O and republishes no capital feeds.
     if not accepted:
         bm_accepted, bm_meta = _broker_manager_snapshot()
         if bm_accepted:

--- a/bot/capital_authority_live_total_v2_patch.py
+++ b/bot/capital_authority_live_total_v2_patch.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import sys
 import threading
+import time
 from types import ModuleType
 from typing import Any, Callable, Optional
 
@@ -16,6 +17,7 @@ _LOCK = threading.Lock()
 _ORIGINAL_IMPORT: Optional[Callable[..., Any]] = None
 _ORIGINAL_IMPORT_MODULE: Optional[Callable[..., Any]] = None
 _APPLIED = False
+_LOG_INTERVAL_S = 60.0
 
 
 def _num(value: Any) -> float:
@@ -56,7 +58,16 @@ def _patch_module(module: ModuleType) -> bool:
     def live_total(self: Any) -> float:
         snapshot, broker_total, updated = _read_totals(self)
         selected = max(snapshot, broker_total, updated)
-        if selected > snapshot + 0.01:
+        now = time.monotonic()
+        last_log = _num(getattr(self, "_nija_live_total_last_log_monotonic", 0.0))
+        should_log = selected > snapshot + 0.01 and (
+            last_log <= 0.0 or now - last_log >= _LOG_INTERVAL_S
+        )
+        if should_log:
+            try:
+                setattr(self, "_nija_live_total_last_log_monotonic", now)
+            except Exception:
+                pass
             logger.warning(
                 "CAPITAL_AUTHORITY_LIVE_TOTAL_SELECTED marker=20260707b snapshot=$%.2f broker_sum=$%.2f updated=$%.2f selected=$%.2f",
                 snapshot,

--- a/bot/runtime_authority_convergence_repair_patch.py
+++ b/bot/runtime_authority_convergence_repair_patch.py
@@ -47,6 +47,60 @@ def _f(value: Any, default: float = 0.0) -> float:
         return default
 
 
+
+_BALANCE_TOTAL_KEYS = (
+    "total_funds",
+    "total_balance",
+    "total_equity",
+    "equity",
+    "account_equity",
+    "portfolio_value",
+    "trading_balance",
+    "balance",
+    "usd_value",
+)
+
+
+def _balance_total(value: Any) -> float:
+    if isinstance(value, dict):
+        for key in _BALANCE_TOTAL_KEYS:
+            amount = _f(value.get(key))
+            if amount > 0.0:
+                return amount
+        return 0.0
+    return max(0.0, _f(value))
+
+
+def _cached_broker_balance(
+    broker_obj: Any,
+    broker_key: str,
+    capital_authority: Any = None,
+) -> tuple[float, str]:
+    """Read an already-published balance without invoking broker I/O."""
+
+    for attr in (
+        "_last_known_balance",
+        "_last_confirmed_balance",
+        "last_known_balance",
+        "cached_balance",
+    ):
+        amount = _balance_total(getattr(broker_obj, attr, None))
+        if amount > 0.0:
+            return amount, attr
+
+    balances = getattr(capital_authority, "_broker_balances", {}) or {}
+    if isinstance(balances, dict):
+        wanted = broker_key.strip().lower()
+        for key, value in balances.items():
+            normalized = str(getattr(key, "value", key)).strip().lower()
+            if normalized == wanted:
+                amount = _balance_total(value)
+                if amount > 0.0:
+                    return amount, "capital_authority"
+
+    return 0.0, "unavailable"
+
+
 def _i(value: Any, default: int = 0) -> int:
     try:
         return int(float(value or 0))
@@ -108,20 +162,29 @@ def _kill_switch_clear() -> tuple[bool, str]:
     return True, "kill_switch_clear"
 
 
-def _broker_manager_capital_payload() -> dict[str, Any]:
-    """Return connected-broker balance data directly from the canonical manager.
 
-    Only observes modules already in sys.modules so this helper never triggers
-    premature broker-manager construction.  Feeds any non-zero balances into
-    CapitalAuthority via force_accept_feed() to unblock a stale zero-broker CA.
-    Returns a dict with keys: connected_count, total_balance, per_broker.
+def _broker_manager_capital_payload() -> dict[str, Any]:
+    """Observe connected brokers using accepted in-memory balances only.
+
+    This recovery monitor must never own exchange refreshes.  The broker manager
+    and BalanceService are the only components allowed to call private balance
+    endpoints and publish CapitalAuthority feeds.  Returning no balance here is
+    intentionally fail-closed until one of those owners publishes a snapshot.
     """
-    result: dict[str, Any] = {"connected_count": 0, "total_balance": 0.0, "per_broker": {}}
+
+    result: dict[str, Any] = {
+        "connected_count": 0,
+        "total_balance": 0.0,
+        "per_broker": {},
+        "sources": {},
+        "source": "cached_only",
+    }
     mabm_mod = sys.modules.get("bot.multi_account_broker_manager") or sys.modules.get(
         "multi_account_broker_manager"
     )
     if mabm_mod is None:
         return result
+
     try:
         getter = getattr(mabm_mod, "get_broker_manager", None)
         if not callable(getter):
@@ -129,83 +192,67 @@ def _broker_manager_capital_payload() -> dict[str, Any]:
         mgr = getter()
         if mgr is None:
             return result
-        # Enumerate connected platform brokers (Coinbase, Kraken, OKX, …).
-        platform_brokers = getattr(mgr, "_platform_brokers", {})
-        broker_type_cls = getattr(mabm_mod, "BrokerType", None)
-        if broker_type_cls is None:
-            # Fall back to broker_manager module for the enum.
-            bm_mod = sys.modules.get("bot.broker_manager") or sys.modules.get("broker_manager")
-            if bm_mod is not None:
-                broker_type_cls = getattr(bm_mod, "BrokerType", None)
-        connected_count = 0
+
+        ca = None
+        ca_mod = sys.modules.get("bot.capital_authority") or sys.modules.get(
+            "capital_authority"
+        )
+        if ca_mod is not None:
+            ca_getter = getattr(ca_mod, "get_capital_authority", None)
+            if callable(ca_getter):
+                try:
+                    ca = ca_getter()
+                except Exception:
+                    ca = None
+
         total_balance = 0.0
         per_broker: dict[str, float] = {}
-        for bt, broker_obj in list(platform_brokers.items()):
+        sources: dict[str, str] = {}
+        platform_brokers = getattr(mgr, "_platform_brokers", {})
+        for broker_type, broker_obj in list(platform_brokers.items()):
             if broker_obj is None:
                 continue
             try:
                 connected = bool(getattr(broker_obj, "connected", False))
                 if not connected:
-                    # Also accept sticky-connected via is_platform_connected.
-                    is_pc = getattr(mgr, "is_platform_connected", None)
-                    if callable(is_pc):
-                        connected = bool(is_pc(bt))
+                    is_connected = getattr(mgr, "is_platform_connected", None)
+                    if callable(is_connected):
+                        connected = bool(is_connected(broker_type))
                 if not connected:
                     continue
-                get_bal = getattr(broker_obj, "get_account_balance", None)
-                if not callable(get_bal):
+
+                broker_key = str(getattr(broker_type, "value", broker_type))
+                balance, source = _cached_broker_balance(broker_obj, broker_key, ca)
+                if balance <= 0.0:
+                    logger.debug(
+                        "RUNTIME_AUTHORITY_CONVERGENCE cached_balance_unavailable broker=%s",
+                        broker_key,
+                    )
                     continue
-                raw = get_bal()
-                bal = 0.0
-                if isinstance(raw, dict):
-                    for k in ("trading_balance", "balance", "total", "usd_value"):
-                        v = raw.get(k)
-                        if v is not None:
-                            try:
-                                bal = float(v)
-                                break
-                            except Exception:
-                                pass
-                else:
-                    try:
-                        bal = float(raw or 0.0)
-                    except Exception:
-                        bal = 0.0
-                broker_key = str(getattr(bt, "value", bt))
-                per_broker[broker_key] = bal
-                total_balance += bal
-                connected_count += 1
+
+                per_broker[broker_key] = balance
+                sources[broker_key] = source
+                total_balance += balance
             except Exception as exc:
                 logger.debug(
-                    "RUNTIME_AUTHORITY_CONVERGENCE broker_payload_error broker=%s err=%s", bt, exc
+                    "RUNTIME_AUTHORITY_CONVERGENCE broker_payload_error broker=%s err=%s",
+                    broker_type,
+                    exc,
                 )
-        result = {"connected_count": connected_count, "total_balance": total_balance, "per_broker": per_broker}
-        if connected_count == 0 or total_balance <= 0.0:
-            return result
-        # Feed recovered balances into CapitalAuthority so that is_hydrated
-        # and valid_broker_count become non-zero.
-        try:
-            ca_mod = sys.modules.get("bot.capital_authority") or sys.modules.get("capital_authority")
-            if ca_mod is not None:
-                ca_getter = getattr(ca_mod, "get_capital_authority", None)
-                if callable(ca_getter):
-                    ca = ca_getter()
-                    if ca is not None:
-                        for broker_key, bal in per_broker.items():
-                            try:
-                                ca.force_accept_feed(broker_key, bal)
-                            except Exception as feed_exc:
-                                logger.debug(
-                                    "RUNTIME_AUTHORITY_CONVERGENCE force_accept_feed err broker=%s err=%s",
-                                    broker_key,
-                                    feed_exc,
-                                )
-        except Exception as exc:
-            logger.debug("RUNTIME_AUTHORITY_CONVERGENCE ca_feed_error err=%s", exc)
-    except Exception as exc:
-        logger.debug("RUNTIME_AUTHORITY_CONVERGENCE broker_manager_payload_error err=%s", exc)
-    return result
 
+        return {
+            "connected_count": len(per_broker),
+            "total_balance": total_balance,
+            "per_broker": per_broker,
+            "sources": sources,
+            "source": "cached_only",
+        }
+    except Exception as exc:
+        logger.debug(
+            "RUNTIME_AUTHORITY_CONVERGENCE broker_manager_payload_error err=%s",
+            exc,
+        )
+        return result
 
 def _capital_authority_ready() -> tuple[bool, str, dict[str, Any]]:
     if not _truthy("LIVE_CAPITAL_VERIFIED"):

--- a/bot/runtime_authority_convergence_repair_patch.py
+++ b/bot/runtime_authority_convergence_repair_patch.py
@@ -259,10 +259,8 @@ def _capital_authority_ready() -> tuple[bool, str, dict[str, Any]]:
         return False, "live_capital_not_verified", {}
     if _truthy("DRY_RUN_MODE") or _truthy("PAPER_MODE"):
         return False, "simulation_mode", {}
-    # Attempt to repair a stale/zero-broker CapitalAuthority by pulling live
-    # balance directly from the canonical broker manager before we interrogate
-    # the authority.  This converts a recovered broker state into an accepted
-    # fresh capital snapshot without bypassing any gate logic.
+    # Observe balances already published by the canonical broker manager.
+    # Recovery monitors never call private exchange endpoints or mutate feeds.
     _broker_manager_capital_payload()
     try:
         try:

--- a/bot/tests/test_capital_refresh_storm_guard_v29.py
+++ b/bot/tests/test_capital_refresh_storm_guard_v29.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+
+import kraken_equity_freshness_v3_patch as freshness
+from bot import activation_pending_commit_monitor_patch as activation
+from bot import capital_authority_live_total_v2_patch as live_total
+from bot import runtime_authority_convergence_repair_patch as convergence
+
+
+class _Broker:
+    connected = True
+
+    def __init__(self, cached=226.62):
+        self._last_known_balance = cached
+        self.live_calls = 0
+
+    def get_account_balance(self):
+        self.live_calls += 1
+        raise AssertionError("startup monitor must not call private balance API")
+
+
+class _Manager:
+    def __init__(self, broker):
+        self._platform_brokers = {"kraken": broker}
+
+    def is_platform_connected(self, _broker_type):
+        return True
+
+
+class _CapitalAuthority:
+    def __init__(self, balance=226.62):
+        self._broker_balances = {"kraken": balance} if balance else {}
+        self.feed_calls = 0
+
+    def force_accept_feed(self, *_args, **_kwargs):
+        self.feed_calls += 1
+        raise AssertionError("startup monitor must not republish capital feed")
+
+
+def _install_cached_modules(monkeypatch, broker, capital_authority):
+    manager_module = ModuleType("bot.multi_account_broker_manager")
+    manager_module.get_broker_manager = lambda: _Manager(broker)
+    capital_module = ModuleType("bot.capital_authority")
+    capital_module.get_capital_authority = lambda: capital_authority
+    monkeypatch.setitem(sys.modules, "bot.multi_account_broker_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "bot.capital_authority", capital_module)
+
+
+def test_runtime_convergence_uses_cached_balance_without_private_io(monkeypatch):
+    broker = _Broker(cached={"total_funds": 226.62})
+    capital_authority = _CapitalAuthority()
+    _install_cached_modules(monkeypatch, broker, capital_authority)
+
+    payload = convergence._broker_manager_capital_payload()
+
+    assert payload["source"] == "cached_only"
+    assert payload["connected_count"] == 1
+    assert payload["total_balance"] == 226.62
+    assert payload["per_broker"] == {"kraken": 226.62}
+    assert broker.live_calls == 0
+    assert capital_authority.feed_calls == 0
+
+
+def test_activation_snapshot_uses_cached_balance_without_private_io(monkeypatch):
+    broker = _Broker(cached=226.62)
+    capital_authority = _CapitalAuthority()
+    _install_cached_modules(monkeypatch, broker, capital_authority)
+
+    accepted, meta = activation._broker_manager_snapshot()
+
+    assert accepted is True
+    assert meta["source"] == "broker_manager_cached"
+    assert meta["real_capital"] == 226.62
+    assert broker.live_calls == 0
+    assert capital_authority.feed_calls == 0
+
+
+def test_recovery_monitors_fail_closed_without_published_balance(monkeypatch):
+    broker = _Broker(cached=0.0)
+    capital_authority = _CapitalAuthority(balance=0.0)
+    _install_cached_modules(monkeypatch, broker, capital_authority)
+
+    payload = convergence._broker_manager_capital_payload()
+    accepted, meta = activation._broker_manager_snapshot()
+
+    assert payload["connected_count"] == 0
+    assert payload["total_balance"] == 0.0
+    assert accepted is False
+    assert meta["reason"] == "no_connected_cached_balances"
+    assert broker.live_calls == 0
+    assert capital_authority.feed_calls == 0
+
+
+def test_kraken_private_equity_refresh_is_ttl_coalesced(monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_PRIVATE_EQUITY_MIN_REFRESH_S", "60")
+
+    class KrakenBrokerForTest:
+        def __init__(self):
+            self.calls = 0
+
+        def get_account_balance(self):
+            self.calls += 1
+            return {"total_funds": 226.62, "source": "private"}
+
+    assert freshness._patch_class(KrakenBrokerForTest) is True
+    broker = KrakenBrokerForTest()
+
+    first = broker.get_account_balance()
+    second = broker.get_account_balance()
+
+    assert broker.calls == 1
+    assert first["total_funds"] == 226.62
+    assert second["total_funds"] == 226.62
+    assert second["equity_cached_within_ttl"] is True
+
+
+def test_live_total_selector_logs_once_per_interval(monkeypatch, caplog):
+    class CapitalAuthorityForTest:
+        def __init__(self):
+            self._last_typed_snapshot = SimpleNamespace(real_capital=155.21)
+            self._broker_balances = {"kraken": 226.62}
+            self._last_updated_total = 155.21
+
+        def get_real_capital(self):
+            return 226.62
+
+    module = ModuleType("capital_authority_for_storm_guard_test")
+    module.CapitalAuthority = CapitalAuthorityForTest
+    monkeypatch.setattr(live_total, "_APPLIED", False)
+    assert live_total._patch_module(module) is True
+
+    authority = CapitalAuthorityForTest()
+    with caplog.at_level(logging.WARNING, logger=live_total.logger.name):
+        assert authority.total_capital == 226.62
+        assert authority.total_capital == 226.62
+
+    selected = [
+        record for record in caplog.records
+        if "CAPITAL_AUTHORITY_LIVE_TOTAL_SELECTED" in record.getMessage()
+    ]
+    assert len(selected) == 1

--- a/kraken_equity_freshness_v3_patch.py
+++ b/kraken_equity_freshness_v3_patch.py
@@ -67,6 +67,41 @@ def _is_kraken(cls: type) -> bool:
     return "kraken" in cls.__name__.lower()
 
 
+def _refresh_interval_s() -> float:
+    try:
+        configured = float(
+            os.environ.get("NIJA_KRAKEN_PRIVATE_EQUITY_MIN_REFRESH_S", "30")
+            or 30.0
+        )
+    except (TypeError, ValueError, OverflowError):
+        configured = 30.0
+    return max(5.0, configured)
+
+
+def _selected_payload(value: Any, total: float, *, cached: bool = False) -> Any:
+    if isinstance(value, Mapping):
+        updated = dict(value)
+        updated["total_balance"] = total
+        updated["total_funds"] = total
+        updated["equity_fresh"] = True
+        if cached:
+            updated["equity_cached_within_ttl"] = True
+        return updated
+    return total
+
+
+def _cached_private_equity(self: Any, now: float, ttl_s: float) -> tuple[Any, float]:
+    total = _f(getattr(self, "_nija_last_fresh_private_equity", 0.0))
+    observed_at = _f(
+        getattr(self, "_nija_last_fresh_private_equity_monotonic", 0.0)
+    )
+    if total <= 0.0 or observed_at <= 0.0 or now - observed_at >= ttl_s:
+        return None, 0.0
+    payload = getattr(self, "_nija_last_fresh_private_payload", total)
+    return _selected_payload(payload, total, cached=True), total
+
+
+
 def _patch_class(cls: type) -> bool:
     current = getattr(cls, "get_account_balance", None)
     if not _is_kraken(cls) or not callable(current):
@@ -78,33 +113,68 @@ def _patch_class(cls: type) -> bool:
 
     @wraps(current)
     def get_account_balance(self: Any, *args: Any, **kwargs: Any):
+        ttl_s = _refresh_interval_s()
+        now = time.monotonic()
+        cached_payload, cached_total = _cached_private_equity(self, now, ttl_s)
+        if cached_total > 0.0:
+            return cached_payload
+
+        refresh_lock = getattr(self, "_nija_private_equity_refresh_lock", None)
+        if refresh_lock is None:
+            with _LOCK:
+                refresh_lock = getattr(
+                    self, "_nija_private_equity_refresh_lock", None
+                )
+                if refresh_lock is None:
+                    refresh_lock = threading.Lock()
+                    setattr(self, "_nija_private_equity_refresh_lock", refresh_lock)
+
         fresh_value: Any = None
         fresh_total = 0.0
         fresh_error = ""
-        try:
-            fresh_value = live_method(self, *args, **kwargs)
-            fresh_total = _total(fresh_value)
-        except Exception as exc:
-            fresh_error = f"{type(exc).__name__}:{str(exc)[:180]}"
-
-        if fresh_total > 0:
-            try:
-                setattr(self, "_last_known_balance", fresh_total)
-                setattr(self, "_nija_last_fresh_private_equity", fresh_total)
-                setattr(self, "_nija_last_fresh_private_equity_at", time.time())
-            except Exception:
-                pass
-            logger.critical(
-                "KRAKEN_EQUITY_FRESH_PRIVATE_SELECTED marker=%s fresh=$%.8f cache_policy=fallback_only",
-                _MARKER, fresh_total,
+        with refresh_lock:
+            now = time.monotonic()
+            cached_payload, cached_total = _cached_private_equity(
+                self, now, ttl_s
             )
-            if isinstance(fresh_value, Mapping):
-                updated = dict(fresh_value)
-                updated["total_balance"] = fresh_total
-                updated["total_funds"] = fresh_total
-                updated["equity_fresh"] = True
-                return updated
-            return fresh_total
+            if cached_total > 0.0:
+                return cached_payload
+            try:
+                fresh_value = live_method(self, *args, **kwargs)
+                fresh_total = _total(fresh_value)
+            except Exception as exc:
+                fresh_error = f"{type(exc).__name__}:{str(exc)[:180]}"
+
+            if fresh_total > 0.0:
+                selected = _selected_payload(fresh_value, fresh_total)
+                try:
+                    setattr(self, "_last_known_balance", fresh_total)
+                    setattr(self, "_nija_last_fresh_private_equity", fresh_total)
+                    setattr(
+                        self,
+                        "_nija_last_fresh_private_equity_monotonic",
+                        time.monotonic(),
+                    )
+                    setattr(
+                        self,
+                        "_nija_last_fresh_private_equity_at",
+                        time.time(),
+                    )
+                    setattr(
+                        self,
+                        "_nija_last_fresh_private_payload",
+                        selected,
+                    )
+                except Exception:
+                    pass
+                logger.critical(
+                    "KRAKEN_EQUITY_FRESH_PRIVATE_SELECTED marker=%s "
+                    "fresh=$%.8f cache_policy=ttl_fallback_only ttl_s=%.1f",
+                    _MARKER,
+                    fresh_total,
+                    ttl_s,
+                )
+                return selected
 
         fallback = current(self, *args, **kwargs)
         fallback_total = _total(fallback)
@@ -122,7 +192,6 @@ def _patch_class(cls: type) -> bool:
         _MARKER, cls.__module__, cls.__name__,
     )
     return True
-
 
 def _patch_module(module: ModuleType) -> bool:
     changed = False


### PR DESCRIPTION
## Summary
- make runtime-authority and activation recovery monitors consume only already-published broker/capital balances
- prevent recovery monitors from calling private exchange balance endpoints or republishing unchanged CapitalAuthority feeds
- coalesce Kraken private equity refreshes with a 30-second minimum TTL and a per-instance concurrency lock
- rate-limit repeated live-total selection warnings
- add focused regressions proving monitor reads are I/O-free, missing cache fails closed, Kraken refreshes coalesce, and selector logging is throttled

## Runtime evidence addressed
The deployed `86e784cb` runtime repeatedly emitted `KRAKEN_EQUITY_FRESH_PRIVATE_SELECTED`, `KRAKEN_EQUITY_CANONICAL`, `force_accept_feed ACCEPTED`, and `CAPITAL_AUTHORITY_LIVE_TOTAL_SELECTED` several times per second. The convergence monitor called `get_account_balance()` on every convergence/import-hook pass and force-fed the same balance back into capital authority. This change restores a single live-refresh owner: the broker manager/BalanceService.

## Safety
No entry, risk, writer-authority, exit, or venue gate is relaxed. Recovery remains fail-closed when no previously published positive balance exists.

Supersedes #2265 with an identical head SHA on a repository-approved branch name.