### PR TITLE
Prevent legacy startup hooks from preempting canonical runtime

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -39,8 +39,10 @@ on:
       - "bot/tests/test_startup_handoff_all_fixes.py"
       - "bot/tests/test_runtime_entrypoint_attestation_v23.py"
       - "scripts/apply_startup_handoff_fix.py"
+      - "scripts/canonical_runtime_launcher_v26.py"
       - "scripts/runtime_entrypoint_attestation.py"
       - "scripts/install_sitecustomize_defer_guard.py"
+      - "bot/tests/test_canonical_fast_entrypoint_v28.py"
       - ".github/workflows/runtime-repair-regression.yml"
   push:
     branches: [main]
@@ -81,8 +83,10 @@ on:
       - "bot/tests/test_startup_handoff_all_fixes.py"
       - "bot/tests/test_runtime_entrypoint_attestation_v23.py"
       - "scripts/apply_startup_handoff_fix.py"
+      - "scripts/canonical_runtime_launcher_v26.py"
       - "scripts/runtime_entrypoint_attestation.py"
       - "scripts/install_sitecustomize_defer_guard.py"
+      - "bot/tests/test_canonical_fast_entrypoint_v28.py"
       - ".github/workflows/runtime-repair-regression.yml"
 
 permissions:
@@ -128,7 +132,9 @@ jobs:
             bot/canonical_broker_prebootstrap_v22.py \
             bot/stalled_writer_release_guard_v22.py \
             scripts/apply_startup_handoff_fix.py \
+            scripts/canonical_runtime_launcher_v26.py \
             scripts/runtime_entrypoint_attestation.py \
+            scripts/install_sitecustomize_defer_guard.py \
             bot/bot.py \
             kraken_equity_freshness_v3_patch.py \
             bot/activation_pending_commit_monitor_patch.py \
@@ -156,6 +162,7 @@ jobs:
             bot/tests/test_stalled_writer_release_guard_v22.py \
             bot/tests/test_secondary_venue_runtime_diagnostics.py \
             bot/tests/test_startup_handoff_all_fixes.py \
+            bot/tests/test_canonical_fast_entrypoint_v28.py \
             bot/tests/test_runtime_entrypoint_attestation_v23.py \
             >"${TEST_LOG}" 2>&1
           status=$?

--- a/bot/tests/test_startup_handoff_all_fixes.py
+++ b/bot/tests/test_startup_handoff_all_fixes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PATCHER = ROOT / "scripts" / "apply_startup_handoff_fix.py"
 START_SCRIPT = ROOT / "start.sh"
+DEFER_GUARD = ROOT / "scripts" / "install_sitecustomize_defer_guard.py"
 
 
 def _load_patcher():
@@ -38,11 +39,14 @@ def test_patcher_defers_hooks_before_every_python_preflight() -> None:
     export_pos = patched.index("export NIJA_DEFER_RUNTIME_SITE_HOOKS=1")
     first_python_pos = patched.index("$PY --version")
     attestation_pos = patched.index("STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_COMPLETE")
-    unset_pos = patched.index("unset NIJA_DEFER_RUNTIME_SITE_HOOKS")
-    launcher_pos = patched.index("$PY -u scripts/canonical_runtime_launcher_v26.py")
+    launcher_pos = patched.index(
+        "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 "
+        "$PY -u scripts/canonical_runtime_launcher_v26.py"
+    )
 
     assert export_pos < first_python_pos
-    assert export_pos < attestation_pos < unset_pos < launcher_pos
+    assert export_pos < attestation_pos < launcher_pos
+    assert "unset NIJA_DEFER_RUNTIME_SITE_HOOKS" not in patched
     assert "$PY -u main.py" not in patched
     assert "STARTUP_HANDOFF_PREFLIGHT_BEGIN" in patched
     assert "STARTUP_HANDOFF_REDIS_VALIDATION_COMPLETE" in patched
@@ -66,11 +70,11 @@ def test_repository_start_script_uses_canonical_entrypoint_diagnostics() -> None
     assert first_python_candidates
     assert export_pos < min(first_python_candidates)
     assert patched.index("STARTUP_HANDOFF_ENTRYPOINT_ATTESTATION_COMPLETE") < patched.index(
-        "unset NIJA_DEFER_RUNTIME_SITE_HOOKS"
-    )
-    assert patched.index("unset NIJA_DEFER_RUNTIME_SITE_HOOKS") < patched.index(
+        "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 "
         "$PY -u scripts/canonical_runtime_launcher_v26.py"
     )
+    assert "unset NIJA_DEFER_RUNTIME_SITE_HOOKS" not in patched
+    assert "runtime_site_hooks=deferred" in patched
     assert "CANONICAL_ENTRYPOINT_DIAGNOSTICS" in patched
     assert "bot/canonical_broker_prebootstrap_v22.py" in patched
     assert "bot/stalled_writer_release_guard_v22.py" in patched
@@ -105,3 +109,36 @@ def test_patcher_rejects_missing_runtime_anchor() -> None:
         assert "runtime launch anchor" in str(exc)
     else:
         raise AssertionError("expected missing runtime anchor to fail closed")
+
+
+def test_patcher_migrates_old_defer_unset_handoff() -> None:
+    module = _load_patcher()
+    current = module.patch_text(_startup_source())
+    legacy = current.replace(
+        "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 "
+        "$PY -u scripts/canonical_runtime_launcher_v26.py",
+        "unset NIJA_DEFER_RUNTIME_SITE_HOOKS\n"
+        "$PY -u scripts/canonical_runtime_launcher_v26.py",
+        1,
+    )
+
+    migrated = module.patch_text(legacy)
+
+    assert migrated == current
+    assert "unset NIJA_DEFER_RUNTIME_SITE_HOOKS" not in migrated
+
+
+def test_defer_guard_blocks_sitecustomize_and_usercustomize() -> None:
+    spec = importlib.util.spec_from_file_location(
+        "install_sitecustomize_defer_guard_test",
+        DEFER_GUARD,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    content = module.guard_content("/app")
+
+    assert 'sys.modules.setdefault("sitecustomize"' in content
+    assert 'sys.modules.setdefault("usercustomize"' in content
+    assert "NIJA_DEFER_RUNTIME_SITE_HOOKS" in content

--- a/scripts/apply_startup_handoff_fix.py
+++ b/scripts/apply_startup_handoff_fix.py
@@ -6,10 +6,10 @@ otherwise a harmless preflight command can acquire writer authority or enter
 standby before the canonical trading runtime starts.
 
 The patch also replaces obsolete root-``bot.py`` diagnostics, runs a
-standard-library-only runtime attestation, and permanently rewrites the runtime
-launch to ``scripts/canonical_runtime_launcher_v26.py``. This makes the v26
-ordering guard effective even when a platform overrides the Docker command with
-``bash start.sh``.
+standard-library-only runtime attestation, and permanently rewrites the runtime launch to
+``scripts/canonical_runtime_launcher_v26.py`` while preserving the defer flag
+through interpreter startup. This makes the v26 ordering guard effective even
+when a platform overrides the Docker command with ``bash start.sh``.
 """
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ RUNTIME_EXIT_MARKER = "STARTUP_HANDOFF_RUNTIME_EXIT"
 LAUNCHER = "scripts/canonical_runtime_launcher_v26.py"
 LEGACY_LAUNCH = "$PY -u main.py"
 CANONICAL_LAUNCH = f"$PY -u {LAUNCHER}"
+CANONICAL_DEFERRED_LAUNCH = f"{DEFER_FLAG}=1 {CANONICAL_LAUNCH}"
 
 
 def _insert_early_defer(text: str) -> str:
@@ -115,38 +116,53 @@ def _attestation_block() -> str:
 
 
 def _insert_runtime_handoff(text: str) -> str:
+    # Earlier releases removed the defer flag immediately before starting the
+    # canonical interpreter. Python imports .pth, sitecustomize and usercustomize
+    # before launcher code executes, so that ordering let legacy repair fanout
+    # preempt the canonical runtime. Migrate already-patched scripts in place.
+    text = text.replace(f"unset {DEFER_FLAG}\n", "")
+
     if RUNTIME_MARKER in text:
         if ATTESTATION_MARKER not in text:
-            unset_anchor = f"unset {DEFER_FLAG}\n"
-            if unset_anchor not in text:
-                raise RuntimeError("start.sh runtime defer-unset anchor not found")
-            text = text.replace(unset_anchor, _attestation_block() + unset_anchor, 1)
+            runtime_anchor = 'echo "🚀 STARTUP_HANDOFF_RUNTIME_BEGIN'
+            runtime_pos = text.find(runtime_anchor)
+            if runtime_pos < 0:
+                raise RuntimeError("start.sh runtime marker anchor not found")
+            text = text[:runtime_pos] + _attestation_block() + text[runtime_pos:]
+        if CANONICAL_DEFERRED_LAUNCH not in text:
+            if CANONICAL_LAUNCH not in text:
+                raise RuntimeError("start.sh canonical launcher anchor not found")
+            text = text.replace(
+                CANONICAL_LAUNCH,
+                CANONICAL_DEFERRED_LAUNCH,
+                1,
+            )
         return text
+
     anchor = "set +e\n$PY -u main.py\nstatus=$?\n"
     if anchor not in text:
         raise RuntimeError("start.sh runtime launch anchor not found")
     replacement = (
         _attestation_block()
-        + f"unset {DEFER_FLAG}\n"
         + 'echo "🚀 STARTUP_HANDOFF_RUNTIME_BEGIN entrypoint=canonical_runtime_launcher_v26.py '
-        'canonical=launcher-v26->main.py->bot.bot->bot.bot_main runtime_site_hooks=enabled '
+        'canonical=launcher-v26->main.py->bot.bot->bot.bot_main runtime_site_hooks=deferred '
         'release=v26 commit=${GIT_COMMIT_SHORT:-${GIT_COMMIT:-unknown}}"\n'
         + "set +e\n"
-        + CANONICAL_LAUNCH + "\n"
+        + CANONICAL_DEFERRED_LAUNCH + "\n"
         + "status=$?\n"
         + 'echo "🧭 STARTUP_HANDOFF_RUNTIME_EXIT status=${status}"\n'
     )
     return text.replace(anchor, replacement, 1)
 
-
 def _enforce_v26_launcher(text: str) -> str:
-    text = text.replace(LEGACY_LAUNCH, CANONICAL_LAUNCH)
+    text = text.replace(LEGACY_LAUNCH, CANONICAL_DEFERRED_LAUNCH)
     if LEGACY_LAUNCH in text:
         raise RuntimeError("legacy direct main.py launch remains")
     if text.count(CANONICAL_LAUNCH) != 1:
         raise RuntimeError("canonical v26 launcher count invalid")
+    if text.count(CANONICAL_DEFERRED_LAUNCH) != 1:
+        raise RuntimeError("canonical v26 launcher must preserve runtime defer")
     return text
-
 
 def _validate(text: str) -> None:
     for marker in (
@@ -160,10 +176,11 @@ def _validate(text: str) -> None:
             raise RuntimeError(f"startup handoff marker count invalid: {marker}")
     export_pos = text.index(f"export {DEFER_FLAG}=1")
     attestation_pos = text.index(ATTESTATION_MARKER)
-    unset_pos = text.index(f"unset {DEFER_FLAG}")
-    launcher_pos = text.index(CANONICAL_LAUNCH)
-    if not export_pos < attestation_pos < unset_pos < launcher_pos:
+    launcher_pos = text.index(CANONICAL_DEFERRED_LAUNCH)
+    if not export_pos < attestation_pos < launcher_pos:
         raise RuntimeError("startup handoff ordering invalid")
+    if f"unset {DEFER_FLAG}" in text:
+        raise RuntimeError("runtime defer flag must persist through canonical launch")
     if LEGACY_LAUNCH in text:
         raise RuntimeError("legacy direct main.py launch remains")
     pre_launcher = text[:launcher_pos]
@@ -191,7 +208,7 @@ def main() -> None:
     print(
         "NIJA_STARTUP_HANDOFF_PATCH_APPLIED "
         "early_defer=true canonical_attestation=true portable_root=true "
-        "launcher=v26 release=v26 idempotent=true"
+        "launcher=v26 runtime_defer_persisted=true release=v26 idempotent=true"
     )
 
 

--- a/scripts/install_sitecustomize_defer_guard.py
+++ b/scripts/install_sitecustomize_defer_guard.py
@@ -7,10 +7,10 @@ writer, broker, activation, or execution monitors before ``main.py``. The
 existing .pth and ``bot.__init__`` guards did not stop Python's automatic
 ``sitecustomize`` import.
 
-This installer creates an early .pth file that places a no-op ``sitecustomize``
-module in ``sys.modules`` only for deferred preflight processes. The canonical
-``main.py`` process starts after the flag is removed and therefore imports the
-real ``sitecustomize.py`` normally.
+This installer creates an early .pth file that places no-op ``sitecustomize``
+and ``usercustomize`` modules in ``sys.modules`` only for deferred processes.
+The canonical launcher now keeps the flag set from the shell boundary through
+``main.py`` so neither historical startup hook can preempt canonical ownership.
 """
 
 from __future__ import annotations
@@ -27,7 +27,8 @@ def guard_content(app_root: str = "/app") -> str:
     code = (
         'import os,sys,types; '
         f'os.environ.get("{DEFER_FLAG}", "0") == "1" and '
-        'sys.modules.setdefault("sitecustomize", types.ModuleType("sitecustomize"))'
+        '(sys.modules.setdefault("sitecustomize", types.ModuleType("sitecustomize")), '
+        'sys.modules.setdefault("usercustomize", types.ModuleType("usercustomize")))'
     )
     return f"{root}\n{code}\n"
 
@@ -49,7 +50,7 @@ def main() -> None:
     target = install()
     print(
         "NIJA_SITECUSTOMIZE_DEFER_GUARD_INSTALLED "
-        f"path={target} flag={DEFER_FLAG}"
+        f"path={target} flag={DEFER_FLAG} modules=sitecustomize,usercustomize"
     )
 
 


### PR DESCRIPTION
## What changed

- Keep `NIJA_DEFER_RUNTIME_SITE_HOOKS=1` across the shell-to-Python canonical launcher boundary.
- Preseed no-op `sitecustomize` and `usercustomize` modules for the deferred canonical interpreter.
- Migrate already-patched startup scripts that still unset the flag before launch.
- Extend focused CI with canonical fast-path, migration, idempotence, and startup-hook guard coverage.

## Root cause

Python imports `.pth` hooks, `sitecustomize`, and `usercustomize` before `canonical_runtime_launcher_v26.py` executes. The generated `start.sh` removed the defer flag immediately before starting Python, so historical runtime repair installers could start first, import `bot.bot` without complete launcher attestation, and select `mode=legacy_compatibility`. Production then accumulated a 23-layer scan wrapper chain and never reached trading-engine cycles.

## Safety

The change does not grant writer authority, synthesize capital, loosen risk gates, or submit orders. The canonical launcher, `main.py`, and `bot.bot_main` still install and verify the reviewed writer, broker, execution, risk, and fill-confirmed exit protections. Startup remains fail closed on any canonical guard failure.

## Validation

The focused workflow compiles the affected startup modules and runs the existing runtime repair suite plus canonical fast-path and new shell-boundary regressions.