### PR TITLE
Converge funded OKX capital and quarantine Coinbase 401s

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -163,6 +163,7 @@ jobs:
         continue-on-error: true
         run: |
           TEST_LOG="${RUNNER_TEMP}/nija-focused-runtime-tests.log"
+          set +e
           python -m pytest -q \
             bot/tests/test_funded_okx_capital_convergence_v31.py \
             bot/tests/test_capital_refresh_storm_guard_v29.py \
@@ -184,6 +185,7 @@ jobs:
             bot/tests/test_runtime_entrypoint_attestation_v23.py \
             >"${TEST_LOG}" 2>&1
           status=$?
+          set -e
           echo "status=${status}" >> "${GITHUB_OUTPUT}"
           if [ "${status}" -ne 0 ]; then
             echo "::group::Focused runtime test failure tail"

--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -10,6 +10,12 @@ on:
       - "bot/bot.py"
       - "kraken_equity_freshness_v3_patch.py"
       - "bot/activation_pending_commit_monitor_patch.py"
+      - "bot/okx_funding_wallet_readiness_patch.py"
+      - "secondary_venue_activation_patch.py"
+      - "three_venue_execution_readiness.py"
+      - "coinbase_authenticated_connect_recovery_patch.py"
+      - "bot/coinbase_balance_auth_convergence_patch.py"
+      - "bot/tests/test_funded_okx_capital_convergence_v31.py"
       - "bot/runtime_authority_convergence_repair_patch.py"
       - "bot/capital_authority_live_total_v2_patch.py"
       - "bot/tests/test_capital_refresh_storm_guard_v29.py"
@@ -54,6 +60,12 @@ on:
       - "bot/bot.py"
       - "kraken_equity_freshness_v3_patch.py"
       - "bot/activation_pending_commit_monitor_patch.py"
+      - "bot/okx_funding_wallet_readiness_patch.py"
+      - "secondary_venue_activation_patch.py"
+      - "three_venue_execution_readiness.py"
+      - "coinbase_authenticated_connect_recovery_patch.py"
+      - "bot/coinbase_balance_auth_convergence_patch.py"
+      - "bot/tests/test_funded_okx_capital_convergence_v31.py"
       - "bot/runtime_authority_convergence_repair_patch.py"
       - "bot/capital_authority_live_total_v2_patch.py"
       - "bot/tests/test_capital_refresh_storm_guard_v29.py"
@@ -138,6 +150,11 @@ jobs:
             bot/bot.py \
             kraken_equity_freshness_v3_patch.py \
             bot/activation_pending_commit_monitor_patch.py \
+            bot/okx_funding_wallet_readiness_patch.py \
+            secondary_venue_activation_patch.py \
+            three_venue_execution_readiness.py \
+            coinbase_authenticated_connect_recovery_patch.py \
+            bot/coinbase_balance_auth_convergence_patch.py \
             bot/runtime_authority_convergence_repair_patch.py \
             bot/capital_authority_live_total_v2_patch.py
 
@@ -147,6 +164,7 @@ jobs:
         run: |
           TEST_LOG="${RUNNER_TEMP}/nija-focused-runtime-tests.log"
           python -m pytest -q \
+            bot/tests/test_funded_okx_capital_convergence_v31.py \
             bot/tests/test_capital_refresh_storm_guard_v29.py \
             bot/tests/test_runtime_authority_convergence_repair_patch.py \
             bot/tests/test_critical_runtime_repairs_v10.py \

--- a/bot/activation_pending_commit_monitor_patch.py
+++ b/bot/activation_pending_commit_monitor_patch.py
@@ -341,6 +341,11 @@ def _cached_broker_balance(
         if authoritative > 0.0:
             return authoritative, "okx_authenticated_wallet"
 
+    if normalized_key == "okx":
+        # Do not fall through to a stale generic cache after the authenticated
+        # OKX proof becomes unobserved or non-executable.
+        return 0.0, "okx_authenticated_wallet_unavailable"
+
     for attr in (
         "_last_known_balance",
         "_last_confirmed_balance",

--- a/bot/activation_pending_commit_monitor_patch.py
+++ b/bot/activation_pending_commit_monitor_patch.py
@@ -322,6 +322,25 @@ def _cached_broker_balance(
 ) -> tuple[float, str]:
     """Read an already-published balance without invoking broker I/O."""
 
+    normalized_key = broker_key.strip().lower()
+    if (
+        normalized_key == "okx"
+        and bool(getattr(broker_obj, "connected", False))
+        and str(os.environ.get("NIJA_OKX_BALANCE_OBSERVED", "") or "").strip().lower()
+        in {"1", "true", "yes", "on"}
+        and str(os.environ.get("NIJA_OKX_FUNDING_STATUS", "") or "").strip().lower()
+        == "funded"
+    ):
+        candidates = (
+            getattr(broker_obj, "_okx_trading_total_quote", None),
+            getattr(broker_obj, "_okx_trading_spendable_quote", None),
+            os.environ.get("NIJA_OKX_TRADING_TOTAL_QUOTE"),
+            os.environ.get("NIJA_OKX_TRADING_SPENDABLE_QUOTE"),
+        )
+        authoritative = max((_balance_total(value) for value in candidates), default=0.0)
+        if authoritative > 0.0:
+            return authoritative, "okx_authenticated_wallet"
+
     for attr in (
         "_last_known_balance",
         "_last_confirmed_balance",
@@ -334,10 +353,9 @@ def _cached_broker_balance(
 
     balances = getattr(capital_authority, "_broker_balances", {}) or {}
     if isinstance(balances, dict):
-        wanted = broker_key.strip().lower()
         for key, value in balances.items():
             normalized = str(getattr(key, "value", key)).strip().lower()
-            if normalized == wanted:
+            if normalized == normalized_key:
                 amount = _balance_total(value)
                 if amount > 0.0:
                     return amount, "capital_authority"

--- a/bot/coinbase_balance_auth_convergence_patch.py
+++ b/bot/coinbase_balance_auth_convergence_patch.py
@@ -7,6 +7,7 @@ credential rebind and retry on a 401. Invalid credentials still fail closed.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib
 import logging
 import os
@@ -37,6 +38,16 @@ def _quarantined() -> bool:
 def _quarantine(instance: Any) -> None:
     os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "1"
     os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "1"
+    key = str(os.environ.get("COINBASE_API_KEY", "") or "")
+    secret = str(
+        os.environ.get("COINBASE_API_SECRET", "")
+        or os.environ.get("COINBASE_PEM_CONTENT", "")
+        or ""
+    )
+    if key and secret:
+        os.environ["NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT"] = (
+            hashlib.sha256((key + "\0" + secret).encode("utf-8")).hexdigest()[:16]
+        )
     os.environ["NIJA_COINBASE_CONNECTED"] = "0"
     os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
     os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"

--- a/bot/coinbase_balance_auth_convergence_patch.py
+++ b/bot/coinbase_balance_auth_convergence_patch.py
@@ -28,6 +28,37 @@ def _is_401(exc: BaseException) -> bool:
     return any(token in text for token in ("401", "unauthorized", "invalid api key", "invalid_api_key"))
 
 
+def _quarantined() -> bool:
+    return str(
+        os.environ.get("NIJA_COINBASE_CREDENTIALS_QUARANTINED", "") or ""
+    ).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _quarantine(instance: Any) -> None:
+    os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "1"
+    os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "1"
+    os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+    os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+    os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"
+    os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATED"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "quarantined"
+    try:
+        instance.connected = False
+    except Exception:
+        pass
+    for attr in (
+        "_auth_permanently_failed", "auth_permanently_failed",
+        "_permanent_auth_failure", "_coinbase_auth_failed",
+        "_auth_failed", "_balance_auth_failed",
+    ):
+        try:
+            if hasattr(instance, attr) or attr in {"_auth_failed", "_balance_auth_failed"}:
+                setattr(instance, attr, True)
+        except Exception:
+            pass
+
+
 def _normalise() -> bool:
     try:
         module = importlib.import_module("bot.coinbase_funding_readiness_repair_patch")
@@ -39,6 +70,8 @@ def _normalise() -> bool:
 
 
 def _rebuild_client(instance: Any) -> bool:
+    if _quarantined():
+        return False
     if not _normalise():
         return False
     key = str(os.environ.get("COINBASE_API_KEY", "") or "").strip()
@@ -76,6 +109,8 @@ def _rebuild_client(instance: Any) -> bool:
         logger.critical("COINBASE_BALANCE_AUTH_CLIENT_REBOUND marker=%s class=%s authenticated=true", _MARKER, type(instance).__name__)
         return True
     except Exception as exc:
+        if _is_401(exc):
+            _quarantine(instance)
         logger.error("COINBASE_BALANCE_AUTH_REBIND_FAILED marker=%s class=%s error_type=%s error=%s", _MARKER, type(instance).__name__, type(exc).__name__, str(exc)[:240])
         return False
 
@@ -114,7 +149,14 @@ def _patch_class(cls: type) -> bool:
             continue
         @wraps(current)
         def balance(self: Any, *args: Any, __fn: Callable[..., Any] = current, __name: str = method_name, **kwargs: Any):
-            # A live connected client must not remain suppressed by a stale permanent-401 latch.
+            # A confirmed 401 is terminal for this credential fingerprint. Return
+            # a fail-closed zero without issuing another private request.
+            if _quarantined():
+                _quarantine(self)
+                return 0.0
+
+            # A live connected client must not remain suppressed by a stale
+            # permanent-401 latch before authentication has actually failed.
             if getattr(self, "connected", False) and _normalise():
                 for attr in ("_auth_permanently_failed", "auth_permanently_failed", "_permanent_auth_failure", "_balance_auth_failed"):
                     if hasattr(self, attr):
@@ -122,7 +164,17 @@ def _patch_class(cls: type) -> bool:
                             setattr(self, attr, False)
                         except Exception:
                             pass
-            return __fn(self, *args, **kwargs)
+            try:
+                return __fn(self, *args, **kwargs)
+            except Exception as exc:
+                if not _is_401(exc):
+                    raise
+                _quarantine(self)
+                logger.error(
+                    "COINBASE_BALANCE_AUTH_QUARANTINED marker=%s class=%s method=%s",
+                    _MARKER, type(self).__name__, __name,
+                )
+                return 0.0
         setattr(balance, _PATCH_ATTR, True)
         balance.__wrapped__ = current
         setattr(cls, method_name, balance)
@@ -164,4 +216,4 @@ def install() -> bool:
         return True
 
 
-__all__ = ["install", "_patch_class", "_rebuild_client"]
+__all__ = ["install", "_patch_class", "_rebuild_client", "_quarantined"]

--- a/bot/okx_funding_wallet_readiness_patch.py
+++ b/bot/okx_funding_wallet_readiness_patch.py
@@ -122,11 +122,13 @@ def _funding_wallet(broker: Any) -> tuple[bool, float, float, str]:
     return False, 0.0, 0.0, last_reason
 
 
-def _publish(broker: Any) -> None:
+def _publish(broker: Any) -> float:
+    """Publish one authenticated OKX wallet snapshot and return canonical capital."""
+
     trading_ok, trading_spendable, trading_total, trading_reason = _trading_wallet(broker)
     minimum = _minimum_trade()
 
-    # A funded Trading wallet is sufficient for execution.  Do not issue an
+    # A funded Trading wallet is sufficient for execution. Do not issue an
     # unnecessary Funding request, which previously caused a false auth error.
     if trading_ok and trading_spendable >= minimum:
         funding_ok, funding_spendable, funding_total, funding_reason = False, 0.0, 0.0, "not_required"
@@ -135,6 +137,7 @@ def _publish(broker: Any) -> None:
 
     observed = trading_ok or funding_ok
     total_observed = trading_total + funding_total
+    authoritative_trading = max(trading_spendable, trading_total) if trading_ok else 0.0
 
     if trading_ok and trading_spendable >= minimum:
         status = "funded"
@@ -160,12 +163,26 @@ def _publish(broker: Any) -> None:
         "NIJA_OKX_TRADING_READY": "1" if ready else "0",
         "NIJA_OKX_SPENDABLE_QUOTE": f"{trading_spendable:.8f}" if trading_ok else "unknown",
     }
+    if trading_ok:
+        values["NIJA_OKX_CONNECTED"] = "1"
+        values["NIJA_OKX_ACTIVATED"] = "1" if ready else "0"
+        values["NIJA_OKX_ACTIVATION_STATE"] = "ready" if ready else "connected_unfunded"
     os.environ.update(values)
+
     setattr(broker, "_okx_trading_spendable_quote", trading_spendable if trading_ok else None)
+    setattr(broker, "_okx_trading_total_quote", trading_total if trading_ok else None)
     setattr(broker, "_okx_funding_spendable_quote", funding_spendable if funding_ok else None)
     setattr(broker, "_okx_funding_status", status)
     setattr(broker, "trading_ready", ready)
     setattr(broker, "ready", ready)
+    if trading_ok:
+        setattr(broker, "connected", True)
+        if authoritative_trading > 0.0:
+            # These are the cache surfaces consumed by CapitalAuthority and the
+            # activation monitor. They come only from the authenticated private
+            # account response above.
+            setattr(broker, "_last_known_balance", authoritative_trading)
+            setattr(broker, "_last_confirmed_balance", authoritative_trading)
 
     if observed:
         logger.critical(
@@ -178,6 +195,8 @@ def _publish(broker: Any) -> None:
             "OKX_BALANCE_UNOBSERVED_NOT_UNDERFUNDED marker=%s trading_reason=%s funding_reason=%s",
             _MARKER, trading_reason, funding_reason,
         )
+    return authoritative_trading
+
 
 
 def _patch_class(cls: type) -> bool:
@@ -188,16 +207,20 @@ def _patch_class(cls: type) -> bool:
     @wraps(current)
     def get_account_balance(self: Any, *args: Any, **kwargs: Any) -> float:
         result = current(self, *args, **kwargs)
+        authoritative = 0.0
         try:
-            _publish(self)
+            authoritative = _publish(self)
         except Exception:
             logger.exception("OKX_DUAL_WALLET_PUBLISH_FAILED marker=%s", _MARKER)
-        return float(result or 0.0)
+        # Never let a stale legacy zero overwrite a newer authenticated private
+        # wallet observation.
+        return max(_float(result), authoritative)
 
     setattr(get_account_balance, _PATCH_ATTR, True)
     get_account_balance.__wrapped__ = current  # type: ignore[attr-defined]
     setattr(cls, "get_account_balance", get_account_balance)
     return True
+
 
 
 def _patch_loaded() -> bool:

--- a/bot/tests/test_funded_okx_capital_convergence_v31.py
+++ b/bot/tests/test_funded_okx_capital_convergence_v31.py
@@ -256,6 +256,8 @@ def test_coinbase_balance_quarantine_returns_fail_closed_zero_without_retries(
     monkeypatch,
 ):
     _clear_coinbase_quarantine(monkeypatch)
+    monkeypatch.setenv("COINBASE_API_KEY", "key")
+    monkeypatch.setenv("COINBASE_API_SECRET", "secret")
     monkeypatch.setattr(coinbase_balance, "_normalise", lambda: True)
 
     class CoinbaseBroker:

--- a/bot/tests/test_funded_okx_capital_convergence_v31.py
+++ b/bot/tests/test_funded_okx_capital_convergence_v31.py
@@ -204,7 +204,7 @@ def test_activation_monitor_accepts_only_funded_authenticated_okx_cache(
     amount, source = activation_monitor._cached_broker_balance(
         broker, "okx", None
     )
-    assert amount == 144.96328582635033
+    assert abs(amount - 144.96328583) < 1e-8
     assert source == "okx_authenticated_wallet"
 
     monkeypatch.setenv("NIJA_OKX_FUNDING_STATUS", "under_minimum")

--- a/bot/tests/test_funded_okx_capital_convergence_v31.py
+++ b/bot/tests/test_funded_okx_capital_convergence_v31.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import bot.activation_pending_commit_monitor_patch as activation_monitor
+import bot.coinbase_balance_auth_convergence_patch as coinbase_balance
+import bot.okx_funding_wallet_readiness_patch as okx_wallet
+import coinbase_authenticated_connect_recovery_patch as coinbase_connect
+import secondary_venue_activation_patch as secondary_activation
+import three_venue_execution_readiness as three_venue
+
+
+class _OKXAccountAPI:
+    def get_balance(self):
+        return {
+            "code": "0",
+            "data": [
+                {
+                    "totalEq": "144.96328582635033",
+                    "details": [
+                        {
+                            "ccy": "USD",
+                            "availBal": "144.96287318736722",
+                            "cashBal": "144.96287318736722",
+                        },
+                        {
+                            "ccy": "ETH",
+                            "availBal": "0.0000002208633426",
+                            "eqUsd": "0.0004126389829796",
+                        },
+                    ],
+                }
+            ],
+        }
+
+
+def _clear_coinbase_quarantine(monkeypatch) -> None:
+    for name in (
+        "NIJA_COINBASE_CREDENTIALS_QUARANTINED",
+        "NIJA_COINBASE_RECONNECT_DISABLED",
+        "NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT",
+        "NIJA_COINBASE_CONNECTED",
+        "NIJA_COINBASE_BALANCE_OBSERVED",
+        "NIJA_COINBASE_SPENDABLE_QUOTE",
+        "NIJA_COINBASE_TRADING_READY",
+        "NIJA_COINBASE_ACTIVATED",
+        "NIJA_COINBASE_ACTIVATION_STATE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_okx_private_wallet_value_is_monotonic_through_legacy_wrapper(monkeypatch):
+    monkeypatch.setenv("OKX_MIN_ORDER_USD", "10")
+
+    class OKXBroker:
+        def __init__(self):
+            self.account_api = _OKXAccountAPI()
+            self.connected = True
+
+        def get_account_balance(self):
+            return 0.0
+
+    assert okx_wallet._patch_class(OKXBroker) is True
+    broker = OKXBroker()
+
+    assert broker.get_account_balance() == 144.96328582635033
+    assert broker._last_known_balance == 144.96328582635033
+    assert broker._last_confirmed_balance == 144.96328582635033
+    assert os.environ["NIJA_OKX_CONNECTED"] == "1"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "ready"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "1"
+
+
+def test_secondary_activation_prefers_authenticated_okx_over_zero_router(
+    monkeypatch,
+):
+    secondary_activation._LAST_STATE.clear()
+    for name, value in {
+        "OKX_API_KEY": "key",
+        "OKX_API_SECRET": "secret",
+        "OKX_PASSPHRASE": "passphrase",
+        "OKX_MIN_ORDER_USD": "10",
+        "NIJA_OKX_BALANCE_OBSERVED": "1",
+        "NIJA_OKX_FUNDING_STATUS": "funded",
+        "NIJA_OKX_TRADING_SPENDABLE_QUOTE": "144.96287319",
+        "NIJA_OKX_SPENDABLE_QUOTE": "144.96287319",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    real_import = secondary_activation.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.spendable_quote_routing_patch":
+            return SimpleNamespace(
+                _spendable_usd=lambda broker, venue: (0.0, 0.0, "stale_router")
+            )
+        return real_import(name)
+
+    monkeypatch.setattr(secondary_activation.importlib, "import_module", fake_import)
+
+    class Broker:
+        connected = True
+        _okx_trading_spendable_quote = 144.96287319
+
+        def get_available_markets(self):
+            return ["BTC-USD"]
+
+    broker = Broker()
+
+    class BrokerType:
+        OKX = "okx"
+
+    class Manager:
+        _platform_brokers = {"okx": broker}
+
+        def _mark_platform_connected(self, venue):
+            return None
+
+        def refresh_registry(self):
+            return None
+
+        def refresh_capital_authority(self, trigger="manual"):
+            return {"trigger": trigger}
+
+    state = secondary_activation.activate_once(
+        secondary_activation.VENUES[1],
+        SimpleNamespace(BrokerType=BrokerType),
+        Manager(),
+    )
+
+    assert state == "ready"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "ready"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "1"
+    assert float(os.environ["NIJA_OKX_SPENDABLE_QUOTE"]) == 144.96287319
+
+
+def test_three_venue_gate_uses_authenticated_okx_cache_without_private_refetch(
+    monkeypatch,
+):
+    for name, value in {
+        "OKX_API_KEY": "key",
+        "OKX_API_SECRET": "secret",
+        "OKX_PASSPHRASE": "passphrase",
+        "NIJA_OKX_CONNECTED": "1",
+        "NIJA_OKX_BALANCE_OBSERVED": "1",
+        "NIJA_OKX_FUNDING_STATUS": "funded",
+        "NIJA_OKX_TRADING_SPENDABLE_QUOTE": "144.96287319",
+        "NIJA_OKX_SPENDABLE_QUOTE": "144.96287319",
+        "NIJA_OKX_ACTIVATION_STATE": "ready",
+        "NIJA_OKX_TRADING_READY": "1",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    class Broker:
+        connected = True
+        _okx_trading_spendable_quote = 144.96287319
+
+        def get_account_balance(self):
+            raise AssertionError("authenticated cache should avoid another private probe")
+
+        def get_available_markets(self):
+            return ["BTC-USD"]
+
+        def place_market_order(self, *args, **kwargs):
+            return {"ok": True}
+
+    broker = Broker()
+
+    class BrokerType:
+        OKX = "okx"
+
+    manager = SimpleNamespace(
+        _platform_brokers={"okx": broker},
+        eligible_brokers={broker},
+    )
+    result = three_venue.evaluate_venue(
+        "okx",
+        SimpleNamespace(BrokerType=BrokerType),
+        manager,
+    )
+
+    assert result.ready is True
+    assert result.spendable_quote == 144.96287319
+    assert result.activation_state == "ready"
+
+
+def test_activation_monitor_accepts_only_funded_authenticated_okx_cache(
+    monkeypatch,
+):
+    for name, value in {
+        "NIJA_OKX_BALANCE_OBSERVED": "1",
+        "NIJA_OKX_FUNDING_STATUS": "funded",
+        "NIJA_OKX_TRADING_TOTAL_QUOTE": "144.96328583",
+        "NIJA_OKX_TRADING_SPENDABLE_QUOTE": "144.96287319",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    broker = SimpleNamespace(
+        connected=True,
+        _okx_trading_total_quote=144.96328582635033,
+        _okx_trading_spendable_quote=144.96287318736722,
+    )
+    amount, source = activation_monitor._cached_broker_balance(
+        broker, "okx", None
+    )
+    assert amount == 144.96328582635033
+    assert source == "okx_authenticated_wallet"
+
+    monkeypatch.setenv("NIJA_OKX_FUNDING_STATUS", "under_minimum")
+    amount, source = activation_monitor._cached_broker_balance(
+        SimpleNamespace(connected=True), "okx", None
+    )
+    assert amount == 0.0
+    assert source == "unavailable"
+
+
+def test_coinbase_connect_quarantines_confirmed_401_and_stops_retries(
+    monkeypatch,
+):
+    _clear_coinbase_quarantine(monkeypatch)
+    monkeypatch.setenv("COINBASE_API_KEY", "key")
+    monkeypatch.setenv("COINBASE_API_SECRET", "secret")
+    monkeypatch.setattr(coinbase_connect, "_configured_pairs", lambda: [])
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.connected = False
+            self.connect_calls = 0
+            self.account_calls = 0
+
+        def connect(self):
+            self.connect_calls += 1
+            return False
+
+        def get_accounts(self):
+            self.account_calls += 1
+            raise RuntimeError("401 Unauthorized")
+
+    assert coinbase_connect._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is False
+    assert os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] == "1"
+    assert os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] == "1"
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "quarantined"
+
+    assert broker.connect() is False
+    assert broker.connect_calls == 1
+    assert broker.account_calls == 1
+
+
+def test_coinbase_balance_quarantine_returns_fail_closed_zero_without_retries(
+    monkeypatch,
+):
+    _clear_coinbase_quarantine(monkeypatch)
+    monkeypatch.setattr(coinbase_balance, "_normalise", lambda: True)
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.connected = True
+            self.calls = 0
+
+        def get_account_balance(self):
+            self.calls += 1
+            raise RuntimeError("401 Client Error: Unauthorized")
+
+    assert coinbase_balance._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.get_account_balance() == 0.0
+    assert os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] == "1"
+    assert broker.connected is False
+
+    assert broker.get_account_balance() == 0.0
+    assert broker.calls == 1

--- a/bot/tests/test_funded_okx_capital_convergence_v31.py
+++ b/bot/tests/test_funded_okx_capital_convergence_v31.py
@@ -209,10 +209,12 @@ def test_activation_monitor_accepts_only_funded_authenticated_okx_cache(
 
     monkeypatch.setenv("NIJA_OKX_FUNDING_STATUS", "under_minimum")
     amount, source = activation_monitor._cached_broker_balance(
-        SimpleNamespace(connected=True), "okx", None
+        SimpleNamespace(connected=True, _last_known_balance=144.96328582635033),
+        "okx",
+        None,
     )
     assert amount == 0.0
-    assert source == "unavailable"
+    assert source == "okx_authenticated_wallet_unavailable"
 
 
 def test_coinbase_connect_quarantines_confirmed_401_and_stops_retries(
@@ -270,6 +272,7 @@ def test_coinbase_balance_quarantine_returns_fail_closed_zero_without_retries(
 
     assert broker.get_account_balance() == 0.0
     assert os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] == "1"
+    assert os.environ["NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT"]
     assert broker.connected is False
 
     assert broker.get_account_balance() == 0.0

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -96,6 +96,9 @@ def _publish_connected(broker: Any, source: str) -> None:
     except Exception:
         pass
     spendable = _measure_spendable(broker)
+    os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "0"
+    os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "0"
+    os.environ.pop("NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT", None)
     os.environ["NIJA_COINBASE_CONNECTED"] = "1"
     os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "1"
     os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = f"{spendable:.8f}"
@@ -205,6 +208,52 @@ def _mark_auth_failed(broker: Any) -> None:
                 pass
 
 
+def _flag(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in {
+        "1", "true", "yes", "on", "enabled",
+    }
+
+
+def _quarantined_for(key: str, secret: str) -> bool:
+    if not _flag("NIJA_COINBASE_CREDENTIALS_QUARANTINED"):
+        return False
+    pinned = str(
+        os.environ.get("NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT", "") or ""
+    )
+    current = _pair_fingerprint(key, secret) if key and secret else ""
+    if pinned and current and current != pinned:
+        # A credential rotation is the only automatic release. The new pair must
+        # still pass the private account probe before becoming connected.
+        os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "0"
+        os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "0"
+        os.environ.pop("NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT", None)
+        return False
+    return True
+
+
+def _auth_failure_detail(detail: str) -> bool:
+    value = str(detail or "").lower()
+    return any(
+        token in value
+        for token in ("401", "unauthorized", "invalid api key", "invalid_api_key")
+    )
+
+
+def _quarantine(broker: Any, key: str, secret: str) -> None:
+    _mark_auth_failed(broker)
+    fingerprint = _pair_fingerprint(key, secret) if key and secret else ""
+    os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "1"
+    os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "1"
+    if fingerprint:
+        os.environ["NIJA_COINBASE_QUARANTINED_CREDENTIAL_FINGERPRINT"] = fingerprint
+    os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+    os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+    os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"
+    os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATED"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "quarantined"
+
+
 def _patch_class(cls: type) -> bool:
     if not _is_coinbase_class(cls):
         return False
@@ -224,6 +273,13 @@ def _patch_class(cls: type) -> bool:
             os.environ.get("NIJA_COINBASE_CREDENTIAL_PAIR_SOURCE", "canonical")
             or "canonical"
         )
+
+        if _quarantined_for(primary_key, primary_secret):
+            _mark_auth_failed(self)
+            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+            os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "quarantined"
+            return False
 
         first_error = ""
         try:
@@ -314,16 +370,21 @@ def _patch_class(cls: type) -> bool:
                 primary_secret,
                 reset_failure=False,
             )
-        _mark_auth_failed(self)
-        os.environ["NIJA_COINBASE_CONNECTED"] = "0"
-        os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
-        os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "authentication_failed"
         suffix = ";".join(failure_details[-4:]) or "authenticated_probe_failed"
+        if _auth_failure_detail(suffix):
+            _quarantine(self, primary_key, primary_secret)
+            state = "quarantined"
+        else:
+            _mark_auth_failed(self)
+            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+            os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "authentication_failed"
+            state = "authentication_failed"
         _log_failure_once(
             cls,
-            f"{suffix};alternative_pairs_attempted={attempted}",
+            f"{suffix};alternative_pairs_attempted={attempted};state={state}",
         )
-        return result
+        return False
 
     setattr(connect, _PATCH_ATTR, True)
     connect.__wrapped__ = current  # type: ignore[attr-defined]
@@ -374,4 +435,4 @@ def install() -> bool:
         return True
 
 
-__all__ = ["install", "_authenticated_probe", "_configured_pairs", "_patch_class"]
+__all__ = ["install", "_authenticated_probe", "_configured_pairs", "_patch_class", "_quarantined_for"]

--- a/secondary_venue_activation_patch.py
+++ b/secondary_venue_activation_patch.py
@@ -385,8 +385,12 @@ def activate_once(venue: Venue, broker_module: Any = None, manager: Any = None) 
         _state(venue, "registration_pending")
         return "registration_pending"
     if not _connect(venue, broker, fingerprint):
+        quarantined = (
+            venue.name == "coinbase"
+            and _flag("NIJA_COINBASE_CREDENTIALS_QUARANTINED", False)
+        )
         auth_failed = bool(getattr(broker, "_auth_failed", False) or getattr(broker, "auth_failed", False))
-        state = "authentication_failed" if auth_failed else "connect_failed"
+        state = "quarantined" if quarantined else ("authentication_failed" if auth_failed else "connect_failed")
         _state(venue, state)
         return state
     _mark_connected(manager, broker_module, venue)
@@ -414,7 +418,7 @@ def activate_once(venue: Venue, broker_module: Any = None, manager: Any = None) 
 def _delay(state: str, failures: int) -> float:
     if state == "ready":
         return 60.0
-    if state in {"missing_credentials", "disabled", "authentication_failed"}:
+    if state in {"missing_credentials", "disabled", "authentication_failed", "quarantined"}:
         return 300.0
     if state == "connected_unfunded":
         return 120.0

--- a/secondary_venue_activation_patch.py
+++ b/secondary_venue_activation_patch.py
@@ -278,14 +278,46 @@ def _mark_connected(manager: Any, broker_module: Any, venue: Venue) -> None:
 
 
 def _spendable(venue: Venue, broker: Any) -> tuple[float, str]:
+    resolver_result: Optional[tuple[float, str]] = None
     try:
         module = importlib.import_module("bot.spendable_quote_routing_patch")
         resolver = getattr(module, "_spendable_usd", None)
         if callable(resolver):
             value, _available, source = resolver(broker, venue.name)
-            return max(0.0, float(value or 0.0)), str(source)
+            resolver_result = (max(0.0, float(value or 0.0)), str(source))
+            if resolver_result[0] > 0.0:
+                return resolver_result
     except Exception:
         pass
+
+    # OKX's authenticated wallet observer is the canonical fallback when the
+    # generic routing cache is still zero. Require all private-proof latches so
+    # a stale environment value can never make an unobserved broker executable.
+    if (
+        venue.name == "okx"
+        and _connected(broker)
+        and _flag("NIJA_OKX_BALANCE_OBSERVED", False)
+        and str(os.environ.get("NIJA_OKX_FUNDING_STATUS", "") or "").strip().lower() == "funded"
+    ):
+        candidates: list[float] = []
+        for value in (
+            getattr(broker, "_okx_trading_spendable_quote", None),
+            os.environ.get("NIJA_OKX_TRADING_SPENDABLE_QUOTE"),
+            os.environ.get("NIJA_OKX_SPENDABLE_QUOTE"),
+        ):
+            try:
+                candidates.append(max(0.0, float(value or 0.0)))
+            except (TypeError, ValueError, OverflowError):
+                continue
+        authoritative = max(candidates, default=0.0)
+        if authoritative > 0.0:
+            return authoritative, "okx_authenticated_wallet"
+
+    # Preserve the resolver's fail-closed zero for other venues. In particular,
+    # do not turn a known Coinbase zero into another private 401 probe.
+    if resolver_result is not None:
+        return resolver_result
+
     for method_name in ("get_account_balance_detailed", "get_account_balance"):
         method = getattr(broker, method_name, None)
         if not callable(method):
@@ -304,6 +336,7 @@ def _spendable(venue: Venue, broker: Any) -> tuple[float, str]:
         except Exception:
             pass
     return 0.0, "unavailable"
+
 
 
 def _markets(broker: Any) -> Optional[int]:

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -168,9 +168,39 @@ def _connected(broker: Any) -> bool:
     return False
 
 
-def _balance(broker: Any) -> tuple[bool, float, str]:
+def _okx_authenticated_spendable(broker: Any) -> float:
+    if (
+        broker is None
+        or not _connected(broker)
+        or not _truthy("NIJA_OKX_BALANCE_OBSERVED")
+        or str(os.getenv("NIJA_OKX_FUNDING_STATUS", "") or "").strip().lower() != "funded"
+    ):
+        return 0.0
+    candidates: list[float] = []
+    for value in (
+        getattr(broker, "_okx_trading_spendable_quote", None),
+        os.getenv("NIJA_OKX_TRADING_SPENDABLE_QUOTE"),
+        os.getenv("NIJA_OKX_SPENDABLE_QUOTE"),
+    ):
+        try:
+            candidates.append(max(0.0, float(value or 0.0)))
+        except (TypeError, ValueError, OverflowError):
+            continue
+    return max(candidates, default=0.0)
+
+
+def _balance(venue: str, broker: Any) -> tuple[bool, float, str]:
     if broker is None:
         return False, 0.0, "broker_missing"
+
+    # Consume the authenticated OKX snapshot before invoking another private
+    # balance request. The proof is valid only while the broker is connected and
+    # the observer reports a funded Trading wallet.
+    if venue == "okx":
+        spendable = _okx_authenticated_spendable(broker)
+        if spendable > 0.0:
+            return True, spendable, "okx_authenticated_wallet"
+
     for method_name in ("get_account_balance_detailed", "get_account_balance"):
         method = getattr(broker, method_name, None)
         if not callable(method):
@@ -202,6 +232,7 @@ def _balance(broker: Any) -> tuple[bool, float, str]:
         except Exception as exc:
             return False, 0.0, f"{method_name}:{type(exc).__name__}"
     return False, 0.0, "balance_method_missing"
+
 
 
 def _markets(broker: Any) -> tuple[bool, Optional[int], str]:
@@ -275,7 +306,7 @@ def evaluate_venue(
         else None
     )
     connected = _connected(broker)
-    balance_ok, spendable, balance_reason = _balance(broker)
+    balance_ok, spendable, balance_reason = _balance(venue, broker)
     market_ok, market_count, market_reason = _markets(broker)
     adapter_ok = _adapter_ready(broker)
 


### PR DESCRIPTION
## Summary

- make the authenticated OKX private-wallet snapshot the monotonic capital source instead of allowing a legacy zero to overwrite it
- consume that proof in secondary activation, three-venue execution readiness, and the pending-activation capital monitor without extra private balance probes
- quarantine a Coinbase credential fingerprint after a confirmed 401 and return fail-closed zeroes rather than retrying private endpoints indefinitely
- keep venues independent: a healthy funded OKX can activate while Coinbase and Kraken remain degraded

## Safety

- no forced activation or synthetic balance
- OKX evidence requires a connected broker plus `BALANCE_OBSERVED=1` and `FUNDING_STATUS=funded`
- Coinbase stays disconnected, non-trading, and non-activated while quarantined
- changing the Coinbase credential fingerprint releases the process-local quarantine but still requires an authenticated private probe

## Tests

Adds a focused regression covering:

- legacy OKX zero overridden by the authenticated private wallet value
- zero routing cache converging to the authenticated OKX spendable amount
- readiness and activation-monitor consumption without another private request
- Coinbase connect and balance 401 retry suppression
