### PR TITLE
Stop scan wrapper growth and verify three-venue TP routing

### DIFF
--- a/bot/broker_independent_live_execution_patch.py
+++ b/bot/broker_independent_live_execution_patch.py
@@ -22,6 +22,30 @@ _MONITOR_STARTED = False
 _REENTRANT = threading.local()
 
 
+def _chain_has_attr(func: Any, attr: str, *, limit: int = 256) -> bool:
+    """Find an ownership marker anywhere in a linked wrapper chain."""
+    current = func
+    seen: set[int] = set()
+    for _ in range(limit):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, attr, False)):
+            return True
+        wrapped = getattr(current, "__wrapped__", None)
+        if not callable(wrapped):
+            try:
+                code = getattr(current, "__code__", None)
+                closure = tuple(getattr(current, "__closure__", ()) or ())
+                freevars = tuple(getattr(code, "co_freevars", ()) or ())
+                values = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+                wrapped = next((values.get(name) for name in ("original", "original_run_scan_phase", "wrapped", "base") if callable(values.get(name))), None)
+            except Exception:
+                wrapped = None
+        current = wrapped
+    return False
+
+
 def _truthy_value(value: Any) -> bool:
     return str(value or "").strip().lower() in _TRUTHY
 
@@ -378,7 +402,7 @@ def _patch_core_loop_module(module: ModuleType) -> bool:
     original = getattr(cls, "run_scan_phase", None)
     if not callable(original):
         return False
-    if getattr(original, _WRAP_ATTR, False):
+    if _chain_has_attr(original, _WRAP_ATTR):
         _PATCHED = True
         return True
 
@@ -510,6 +534,7 @@ def _patch_core_loop_module(module: ModuleType) -> bool:
         )
 
     setattr(_independent_run_scan_phase, _WRAP_ATTR, True)
+    setattr(_independent_run_scan_phase, "__wrapped__", original)
     setattr(cls, "run_scan_phase", _independent_run_scan_phase)
     _PATCHED = True
     logger.warning("%s core_loop_module=%s", _MARKER, getattr(module, "__name__", "<unknown>"))

--- a/bot/held_trade_cap_guard_patch.py
+++ b/bot/held_trade_cap_guard_patch.py
@@ -15,6 +15,30 @@ _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _CASH_ASSETS = {"USD", "USDT", "USDC", "DAI", "EUR", "GBP", "ZUSD", "USDG"}
 
 
+def _chain_has_attr(func: Any, attr: str, *, limit: int = 256) -> bool:
+    """Find an ownership marker anywhere in a linked wrapper chain."""
+    current = func
+    seen: set[int] = set()
+    for _ in range(limit):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, attr, False)):
+            return True
+        wrapped = getattr(current, "__wrapped__", None)
+        if not callable(wrapped):
+            try:
+                code = getattr(current, "__code__", None)
+                closure = tuple(getattr(current, "__closure__", ()) or ())
+                freevars = tuple(getattr(code, "co_freevars", ()) or ())
+                values = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+                wrapped = next((values.get(name) for name in ("original", "original_run_scan_phase", "wrapped", "base") if callable(values.get(name))), None)
+            except Exception:
+                wrapped = None
+        current = wrapped
+    return False
+
+
 def _truthy(name: str, default: str = "true") -> bool:
     return str(os.environ.get(name, default)).strip().lower() in _TRUE
 
@@ -224,8 +248,8 @@ def _patch_module(module: ModuleType) -> bool:
     if not isinstance(cls, type):
         return False
     original = getattr(cls, "run_scan_phase", None)
-    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
-        return bool(getattr(original, _PATCHED_ATTR, False))
+    if not callable(original) or _chain_has_attr(original, _PATCHED_ATTR):
+        return bool(callable(original) and _chain_has_attr(original, _PATCHED_ATTR))
 
     @wraps(original)
     def run_scan_phase(self: Any, broker: Any, balance: float, symbols: list[str], open_positions_count: int = 0, user_mode: bool = False):
@@ -249,6 +273,7 @@ def _patch_module(module: ModuleType) -> bool:
         return original(self, broker, balance, symbols, open_positions_count, user_mode)
 
     setattr(run_scan_phase, _PATCHED_ATTR, True)
+    setattr(run_scan_phase, "__wrapped__", original)
     setattr(cls, "run_scan_phase", run_scan_phase)
     logger.warning("%s class=NijaCoreLoop cap=%d", _MARKER, _cap())
     print(f"[NIJA-PRINT] HELD_TRADE_CAP_GUARD_PATCHED marker=20260706a cap={_cap()}", flush=True)

--- a/final_runtime_convergence_patch.py
+++ b/final_runtime_convergence_patch.py
@@ -21,6 +21,30 @@ _PATCHED = False
 _WATCHDOG_STARTED = False
 
 
+def _chain_has_attr(func: Any, attr: str, *, limit: int = 256) -> bool:
+    """Find an ownership marker anywhere in a linked wrapper chain."""
+    current = func
+    seen: set[int] = set()
+    for _ in range(limit):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, attr, False)):
+            return True
+        wrapped = getattr(current, "__wrapped__", None)
+        if not callable(wrapped):
+            try:
+                code = getattr(current, "__code__", None)
+                closure = tuple(getattr(current, "__closure__", ()) or ())
+                freevars = tuple(getattr(code, "co_freevars", ()) or ())
+                values = {name: cell.cell_contents for name, cell in zip(freevars, closure)}
+                wrapped = next((values.get(name) for name in ("original", "original_run_scan_phase", "wrapped", "base") if callable(values.get(name))), None)
+            except Exception:
+                wrapped = None
+        current = wrapped
+    return False
+
+
 def _auth_module() -> ModuleType | None:
     module = sys.modules.get("broker_auth_recovery_patch")
     return module if isinstance(module, ModuleType) else None
@@ -153,7 +177,7 @@ def _patch_core_loop(module: ModuleType) -> bool:
     if not isinstance(cls, type):
         return False
     original = getattr(cls, "run_scan_phase", None)
-    if not callable(original) or getattr(original, "_nija_final_result_contract_e", False):
+    if not callable(original) or _chain_has_attr(original, "_nija_final_result_contract_e"):
         return False
 
     def run_scan_phase(self: Any, *args: Any, **kwargs: Any) -> Any:
@@ -188,7 +212,7 @@ def _patch_okx_classes() -> bool:
             if not isinstance(cls, type) or "okx" not in class_name.lower():
                 continue
             original = getattr(cls, "connect", None)
-            if not callable(original) or getattr(original, "_nija_final_okx_endpoint_e", False):
+            if not callable(original) or _chain_has_attr(original, "_nija_final_okx_endpoint_e"):
                 continue
 
             def connect(self: Any, *args: Any, __original: Callable[..., Any] = original, **kwargs: Any) -> Any:

--- a/tests/test_three_venue_tp_wrapper_convergence.py
+++ b/tests/test_three_venue_tp_wrapper_convergence.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from bot import broker_independent_live_execution_patch as independent
+from bot import held_trade_cap_guard_patch as held
+from bot import universal_broker_exit_supervisor_patch as exits
+import final_runtime_convergence_patch as convergence
+
+
+def _layer(inner):
+    def outer(*args, **kwargs):
+        return inner(*args, **kwargs)
+    outer.__wrapped__ = inner
+    return outer
+
+
+@pytest.mark.parametrize(
+    "finder,marker",
+    [
+        (held._chain_has_attr, held._PATCHED_ATTR),
+        (independent._chain_has_attr, independent._WRAP_ATTR),
+        (convergence._chain_has_attr, "_nija_final_result_contract_e"),
+    ],
+)
+def test_wrapper_owner_is_found_below_outer_layers(finder, marker):
+    def owner():
+        return None
+
+    setattr(owner, marker, True)
+    wrapped = _layer(_layer(owner))
+    assert finder(wrapped, marker) is True
+
+
+def test_three_live_venues_are_entry_enabled(monkeypatch):
+    monkeypatch.setenv("NIJA_ALLOWED_EXECUTION_BROKERS", "kraken,coinbase,okx")
+    monkeypatch.delenv("NIJA_DISABLED_BROKERS", raising=False)
+    assert all(independent._broker_enabled(name) for name in ("kraken", "coinbase", "okx"))
+
+
+@pytest.mark.parametrize("venue", ["kraken", "coinbase", "okx"])
+def test_take_profit_trigger_and_exit_submission_for_each_venue(venue):
+    class Broker:
+        broker_type = venue
+
+        def __init__(self):
+            self.orders = []
+
+        def place_market_order(self, **kwargs):
+            self.orders.append(kwargs)
+            return {"status": "filled", "order_id": venue + "-exit", "filled_price": 102.0}
+
+    broker = Broker()
+    position = {
+        "position_id": venue + "-position",
+        "symbol": "ETH-USD",
+        "side": "long",
+        "quantity": 0.1,
+        "entry_price": 100.0,
+        "take_profit_1": 101.0,
+        "take_profit_2": 103.0,
+        "take_profit_3": 105.0,
+    }
+
+    hit, reason, target = exits._trigger(broker, position, 102.0)
+    assert hit is True
+    assert reason == "take_profit_1"
+    assert target == pytest.approx(101.0)
+
+    result = exits.auto_exit._exit_order(broker, position, 102.0)
+    assert exits.auto_exit._ok(result)
+    assert broker.orders == [{"symbol": "ETH-USD", "side": "sell", "size": 0.1}]


### PR DESCRIPTION
## Summary
- make held-trade, final convergence, and broker-independent scan installers detect ownership across the full wrapper chain
- preserve explicit wrapper links so later guards remain chain-aware
- add regression coverage for Kraken, Coinbase, and OKX entry allowlisting and take-profit exit submission

## Runtime issue addressed
Production logs showed scan wrapper depth increasing above the configured maximum, which kept strategy publication out of LIVE_ACTIVE even after Coinbase authentication succeeded.

## Safety
This does not bypass authentication, writer authority, capital readiness, reconciliation, position limits, stop loss, or take-profit gates.