### PR TITLE
Register and recover Kraken on the canonical Render path

### DIFF
--- a/bot/canonical_broker_startup_convergence_v24.py
+++ b/bot/canonical_broker_startup_convergence_v24.py
@@ -449,16 +449,15 @@ def _patch_bot_main_module(module: ModuleType) -> bool:
             "marker=20260726-kraken-registration-recovery-v30 module=%s",
             module.__name__,
         )
-    ready = bool(
-        acquire_ok
-        and main_ok
-        and callable(getattr(module, "_acquire_writer_authority_before_nonce", None))
-        and getattr(
-            getattr(module, "_acquire_writer_authority_before_nonce", None),
-            _BOT_MAIN_ACQUIRE_WRAP_ATTR,
-            False,
+    final_acquire = getattr(module, "_acquire_writer_authority_before_nonce", None)
+    recovery_trigger = bool(
+        not callable(current_acquire)
+        or (
+            callable(final_acquire)
+            and getattr(final_acquire, _BOT_MAIN_ACQUIRE_WRAP_ATTR, False)
         )
     )
+    ready = bool(acquire_ok and main_ok and recovery_trigger)
     setattr(module, _BOT_MAIN_PATCH_ATTR, ready)
     logger.critical(
         "CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_BOT_MAIN_PATCHED "

--- a/bot/canonical_broker_startup_convergence_v24.py
+++ b/bot/canonical_broker_startup_convergence_v24.py
@@ -46,6 +46,7 @@ _INSTALLED = False
 _FINDER: "_CanonicalStartupFinder | None" = None
 _RUN_WRAP_ATTR = "_nija_canonical_broker_startup_convergence_v24"
 _BOT_MAIN_PATCH_ATTR = "_nija_canonical_broker_startup_convergence_bot_main_v24"
+_BOT_MAIN_ACQUIRE_WRAP_ATTR = "_nija_canonical_broker_startup_acquire_v30"
 _KRAKEN_RECOVERY_STARTED = False
 
 
@@ -141,6 +142,35 @@ def _kraken_credentials_configured() -> bool:
     return bool(key and secret and not disabled)
 
 
+def _resolve_or_register_kraken_broker(manager: Any) -> tuple[Any, Any, Any]:
+    """Return the canonical Kraken broker, repairing only a missing registration."""
+    broker_module = importlib.import_module("bot.broker_manager")
+    manager_module = importlib.import_module("bot.multi_account_broker_manager")
+    broker_type = getattr(broker_module, "BrokerType").KRAKEN
+    broker = getattr(manager, "_platform_brokers", {}).get(broker_type)
+    if broker is None:
+        broker = getattr(broker_module, "get_platform_broker")("kraken")
+    if broker is None:
+        broker_cls = getattr(broker_module, "KrakenBroker")
+        account_type = getattr(broker_module, "AccountType").PLATFORM
+        broker = broker_cls(account_type=account_type)
+        register = getattr(manager, "register_platform_broker_instance", None)
+        if not callable(register):
+            raise RuntimeError("canonical Kraken registration method unavailable")
+        register(
+            broker_type,
+            broker,
+            mark_connected_state=False,
+            allow_recovery_registration=True,
+        )
+        logger.critical(
+            "KRAKEN_AUTHENTICATED_RECOVERY_REGISTERED "
+            "marker=20260726-kraken-registration-recovery-v30 "
+            "source=canonical_manager late_registration=true"
+        )
+    return broker, broker_type, manager_module
+
+
 def _start_kraken_authenticated_recovery(manager: Any) -> bool:
     """Reconnect the registered platform Kraken broker before live cycles start.
 
@@ -177,20 +207,9 @@ def _start_kraken_authenticated_recovery(manager: Any) -> bool:
                 return
             try:
                 broker_module = importlib.import_module("bot.broker_manager")
-                manager_module = importlib.import_module(
-                    "bot.multi_account_broker_manager"
+                broker, broker_type, manager_module = _resolve_or_register_kraken_broker(
+                    manager
                 )
-                broker_type = getattr(broker_module, "BrokerType").KRAKEN
-                broker = getattr(manager, "_platform_brokers", {}).get(broker_type)
-                if broker is None:
-                    broker = getattr(broker_module, "get_platform_broker")("kraken")
-                if broker is None:
-                    logger.error(
-                        "KRAKEN_AUTHENTICATED_RECOVERY_STOPPED marker=%s "
-                        "reason=registered_broker_missing",
-                        marker,
-                    )
-                    return
 
                 fsm = getattr(broker_module, "_KRAKEN_STARTUP_FSM", None)
                 if bool(getattr(broker, "connected", False)) or bool(
@@ -205,10 +224,37 @@ def _start_kraken_authenticated_recovery(manager: Any) -> bool:
                     state = getattr(manager_module, "ConnectionState", None)
                     if callable(transition) and state is not None:
                         transition(broker_type, state.CONNECTED)
+                    ready_hook = getattr(manager, "on_broker_ready", None)
+                    if callable(ready_hook):
+                        ready_hook("kraken", broker.get_account_balance)
+                    refresh = getattr(manager, "refresh_capital_authority", None)
+                    if callable(refresh):
+                        try:
+                            refresh(trigger="kraken_authenticated_recovery")
+                        except Exception as refresh_exc:
+                            logger.warning(
+                                "KRAKEN_AUTHENTICATED_RECOVERY_CAPITAL_REFRESH_PENDING "
+                                "marker=%s error=%s:%s",
+                                marker,
+                                type(refresh_exc).__name__,
+                                refresh_exc,
+                            )
+                    try:
+                        state_module = importlib.import_module("bot.trading_state_machine")
+                        state_machine = state_module.get_state_machine()
+                        state_machine.maybe_auto_activate()
+                    except Exception as activation_exc:
+                        logger.warning(
+                            "KRAKEN_AUTHENTICATED_RECOVERY_ACTIVATION_PENDING "
+                            "marker=%s error=%s:%s",
+                            marker,
+                            type(activation_exc).__name__,
+                            activation_exc,
+                        )
                     os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] = "1"
                     logger.critical(
                         "KRAKEN_AUTHENTICATED_RECOVERY_READY marker=%s "
-                        "attempt=%d connected=true",
+                        "attempt=%d connected=true capital_rechecked=true",
                         marker,
                         attempt,
                     )
@@ -228,9 +274,15 @@ def _start_kraken_authenticated_recovery(manager: Any) -> bool:
                 reset = getattr(fsm, "reset", None)
                 if callable(reset):
                     reset()
+                begin = getattr(manager, "begin_platform_connection", None)
+                if callable(begin):
+                    begin(broker_type)
                 connected = bool(broker.connect())
                 if connected:
                     continue
+                failed = getattr(manager, "mark_platform_failed", None)
+                if callable(failed):
+                    failed(broker_type)
             except Exception as exc:
                 logger.error(
                     "KRAKEN_AUTHENTICATED_RECOVERY_FAILED marker=%s attempt=%d "
@@ -353,14 +405,68 @@ def _patch_bot_main_module(module: ModuleType) -> bool:
         return False
     acquire_ok = bool(patch_acquire(module))
     main_ok = bool(patch_main(module))
-    ready = acquire_ok and main_ok
+    current_acquire = getattr(module, "_acquire_writer_authority_before_nonce", None)
+    if acquire_ok and callable(current_acquire) and not bool(
+        getattr(current_acquire, _BOT_MAIN_ACQUIRE_WRAP_ATTR, False)
+    ):
+        @wraps(current_acquire)
+        def converged_acquire(*args: Any, **kwargs: Any) -> bool:
+            acquired = bool(current_acquire(*args, **kwargs))
+            if not acquired:
+                return False
+            try:
+                _prepare_canonical_manager()
+                return True
+            except Exception as exc:
+                os.environ["NIJA_CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_READY"] = "0"
+                logger.critical(
+                    "CANONICAL_BROKER_STARTUP_CONVERGENCE_V30_FAILED "
+                    "marker=20260726-kraken-registration-recovery-v30 "
+                    "error=%s:%s trading_remains_fail_closed=true",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
+                release = getattr(module, "_release_writer_authority", None)
+                if callable(release):
+                    try:
+                        release()
+                    except Exception:
+                        logger.exception(
+                            "CANONICAL_BROKER_STARTUP_CONVERGENCE_V30_RELEASE_FAILED "
+                            "marker=20260726-kraken-registration-recovery-v30"
+                        )
+                return False
+
+        setattr(converged_acquire, _BOT_MAIN_ACQUIRE_WRAP_ATTR, True)
+        v22_attr = getattr(v22, "_ACQUIRE_WRAP_ATTR", "")
+        if v22_attr:
+            setattr(converged_acquire, v22_attr, True)
+        setattr(converged_acquire, "__wrapped__", current_acquire)
+        setattr(module, "_acquire_writer_authority_before_nonce", converged_acquire)
+        logger.critical(
+            "CANONICAL_BROKER_STARTUP_CONVERGENCE_V30_ACQUIRE_PATCHED "
+            "marker=20260726-kraken-registration-recovery-v30 module=%s",
+            module.__name__,
+        )
+    ready = bool(
+        acquire_ok
+        and main_ok
+        and callable(getattr(module, "_acquire_writer_authority_before_nonce", None))
+        and getattr(
+            getattr(module, "_acquire_writer_authority_before_nonce", None),
+            _BOT_MAIN_ACQUIRE_WRAP_ATTR,
+            False,
+        )
+    )
     setattr(module, _BOT_MAIN_PATCH_ATTR, ready)
     logger.critical(
         "CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_BOT_MAIN_PATCHED "
-        "marker=%s acquire=%s main=%s",
+        "marker=%s acquire=%s main=%s recovery_trigger=%s",
         _MARKER,
         acquire_ok,
         main_ok,
+        ready,
     )
     return ready
 

--- a/bot/multi_account_broker_manager.py
+++ b/bot/multi_account_broker_manager.py
@@ -1699,6 +1699,7 @@ class MultiAccountBrokerManager:
         broker_type: BrokerType,
         broker: BaseBroker,
         mark_connected_state: bool = False,
+        allow_recovery_registration: bool = False,
     ) -> bool:
         """
         Register an already-created broker instance for the platform account.
@@ -1709,6 +1710,9 @@ class MultiAccountBrokerManager:
         Args:
             broker_type: Type of broker being registered
             broker: Already-created BaseBroker instance
+            allow_recovery_registration: Permit the writer-scoped Kraken recovery
+                path to repair a missing broker after startup registration was
+                finalized. Other venues remain immutable.
             
         Returns:
             True if successfully registered, False if already registered (idempotent)
@@ -1722,16 +1726,26 @@ class MultiAccountBrokerManager:
                 broker_type=broker_type,
                 broker=broker,
                 mark_connected_state=mark_connected_state,
+                allow_recovery_registration=allow_recovery_registration,
             )
 
         # Enforce immutability and single-registration atomically under the
         # registry lock so two concurrent callers cannot both pass the
         # "already registered?" check and double-write the same broker.
         with self._registry_meta_lock:
-            if self._platform_brokers_locked:
+            late_kraken_recovery = bool(
+                allow_recovery_registration and broker_type == BrokerType.KRAKEN
+            )
+            if self._platform_brokers_locked and not late_kraken_recovery:
                 error_msg = f"❌ INVARIANT VIOLATION: Cannot register platform broker {broker_type.value} - platform brokers are locked (immutable)"
                 logger.error(error_msg)
                 raise RuntimeError(error_msg)
+            if self._platform_brokers_locked and late_kraken_recovery:
+                logger.critical(
+                    "KRAKEN_LATE_RECOVERY_REGISTRATION_ALLOWED "
+                    "marker=20260726-kraken-registration-recovery-v30 "
+                    "reason=missing_from_finalized_registry writer_scoped_caller_required=true"
+                )
             if broker_type in self._platform_brokers:
                 if self._platform_brokers[broker_type] is broker:
                     # Same instance re-registering (e.g. broker.connect() called after

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -31,6 +31,18 @@ def _is_coinbase_class(cls: type) -> bool:
     return "coinbase" in cls.__name__.lower()
 
 
+def _wrapper_chain_has_patch(current: Any) -> bool:
+    """Return True when this recovery already exists anywhere in the chain."""
+    seen: set[int] = set()
+    candidate = current
+    while callable(candidate) and id(candidate) not in seen:
+        seen.add(id(candidate))
+        if bool(getattr(candidate, _PATCH_ATTR, False)):
+            return True
+        candidate = getattr(candidate, "__wrapped__", None)
+    return False
+
+
 def _clients(broker: Any) -> list[Any]:
     found: list[Any] = []
     for attr in ("client", "api_client", "rest_client", "coinbase_client", "_client", "_api_client"):
@@ -258,8 +270,8 @@ def _patch_class(cls: type) -> bool:
     if not _is_coinbase_class(cls):
         return False
     current = getattr(cls, "connect", None)
-    if not callable(current) or getattr(current, _PATCH_ATTR, False):
-        return bool(callable(current) and getattr(current, _PATCH_ATTR, False))
+    if not callable(current) or _wrapper_chain_has_patch(current):
+        return bool(callable(current) and _wrapper_chain_has_patch(current))
 
     @wraps(current)
     def connect(self: Any, *args: Any, **kwargs: Any):
@@ -435,4 +447,11 @@ def install() -> bool:
         return True
 
 
-__all__ = ["install", "_authenticated_probe", "_configured_pairs", "_patch_class", "_quarantined_for"]
+__all__ = [
+    "install",
+    "_authenticated_probe",
+    "_configured_pairs",
+    "_patch_class",
+    "_quarantined_for",
+    "_wrapper_chain_has_patch",
+]

--- a/tests/test_coinbase_authenticated_connect_wrapper_chain.py
+++ b/tests/test_coinbase_authenticated_connect_wrapper_chain.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+
+
+def _module():
+    return importlib.import_module("coinbase_authenticated_connect_recovery_patch")
+
+
+def test_wrapper_chain_detects_nested_recovery_marker():
+    module = _module()
+
+    def original(self):
+        return True
+
+    def recovery(self):
+        return original(self)
+
+    setattr(recovery, module._PATCH_ATTR, True)
+    recovery.__wrapped__ = original
+
+    def outer(self):
+        return recovery(self)
+
+    outer.__wrapped__ = recovery
+
+    assert module._wrapper_chain_has_patch(outer) is True
+
+
+def test_patch_class_does_not_duplicate_nested_recovery_wrapper():
+    module = _module()
+
+    def original(self):
+        return True
+
+    def recovery(self):
+        return original(self)
+
+    setattr(recovery, module._PATCH_ATTR, True)
+    recovery.__wrapped__ = original
+
+    def outer(self):
+        return recovery(self)
+
+    outer.__wrapped__ = recovery
+
+    class CoinbaseBroker:
+        connect = outer
+
+    before = CoinbaseBroker.connect
+    assert module._patch_class(CoinbaseBroker) is True
+    assert CoinbaseBroker.connect is before
+
+
+def test_wrapper_chain_cycle_is_safe():
+    module = _module()
+
+    def outer(self):
+        return True
+
+    outer.__wrapped__ = outer
+    assert module._wrapper_chain_has_patch(outer) is False

--- a/tests/test_kraken_authenticated_recovery.py
+++ b/tests/test_kraken_authenticated_recovery.py
@@ -35,3 +35,92 @@ def test_kraken_recovery_respects_explicit_disable(monkeypatch):
     monkeypatch.setenv("KRAKEN_PLATFORM_API_SECRET", "secret")
     monkeypatch.setenv("NIJA_DISABLE_KRAKEN", "true")
     assert module._kraken_credentials_configured() is False
+
+
+def test_resolve_registers_missing_canonical_kraken(monkeypatch):
+    module = _module()
+    broker_type = object()
+    platform_account = object()
+
+    class FakeKrakenBroker:
+        def __init__(self, account_type):
+            self.account_type = account_type
+            self.connected = False
+
+    class FakeManager:
+        def __init__(self):
+            self._platform_brokers = {}
+            self.calls = []
+
+        def register_platform_broker_instance(self, kind, broker, **kwargs):
+            self.calls.append((kind, broker, kwargs))
+            self._platform_brokers[kind] = broker
+            return True
+
+    broker_module = type(
+        "BrokerModule",
+        (),
+        {
+            "BrokerType": type("BrokerType", (), {"KRAKEN": broker_type}),
+            "AccountType": type("AccountType", (), {"PLATFORM": platform_account}),
+            "KrakenBroker": FakeKrakenBroker,
+            "get_platform_broker": staticmethod(lambda _name: None),
+        },
+    )
+    manager_module = type("ManagerModule", (), {})
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return broker_module
+        if name == "bot.multi_account_broker_manager":
+            return manager_module
+        raise AssertionError(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import)
+    manager = FakeManager()
+    broker, resolved_type, resolved_manager_module = (
+        module._resolve_or_register_kraken_broker(manager)
+    )
+
+    assert isinstance(broker, FakeKrakenBroker)
+    assert broker.account_type is platform_account
+    assert resolved_type is broker_type
+    assert resolved_manager_module is manager_module
+    assert manager.calls[0][2] == {
+        "mark_connected_state": False,
+        "allow_recovery_registration": True,
+    }
+
+
+def test_bot_main_acquire_triggers_v24_manager_preparation(monkeypatch):
+    module = _module()
+    prepared = []
+
+    class FakeV22:
+        _ACQUIRE_WRAP_ATTR = "_fake_v22_acquire"
+
+        @staticmethod
+        def _patch_writer_acquire(_target):
+            return True
+
+        @staticmethod
+        def _patch_main(_target):
+            return True
+
+    target = type("BotMain", (), {})()
+    target.__name__ = "bot.bot_main"
+    target._acquire_writer_authority_before_nonce = lambda: True
+    target.main = lambda: 0
+
+    monkeypatch.setattr(module, "_load_v22_module", lambda: FakeV22)
+    monkeypatch.setattr(module, "_prepare_canonical_manager", lambda: prepared.append(True))
+
+    assert module._patch_bot_main_module(target) is True
+    assert target._acquire_writer_authority_before_nonce() is True
+    assert prepared == [True]
+    assert getattr(
+        target._acquire_writer_authority_before_nonce,
+        module._BOT_MAIN_ACQUIRE_WRAP_ATTR,
+        False,
+    ) is True
+    assert getattr(target._acquire_writer_authority_before_nonce, FakeV22._ACQUIRE_WRAP_ATTR) is True


### PR DESCRIPTION
## What changed

- attach Kraken authenticated recovery to the writer-acquisition path actually used by the canonical Render launcher
- repair a missing canonical Kraken registration through a narrow, writer-scoped recovery allowance
- synchronize Kraken connection state, capital authority, and activation after authenticated recovery succeeds
- make Coinbase recovery wrapper detection chain-aware so convergence patches do not add it repeatedly
- add focused Kraken startup and Coinbase wrapper-chain regressions

## Root cause

The previous recovery was started only from the SelfHealingStartup wrapper. The canonical fast path acquired writer authority through `bot.bot_main`, so recovery never started. When Kraken was absent from the finalized manager map, the recovery also stopped instead of repairing the missing registration. Separately, Coinbase recovery checked only the outermost wrapper marker and repeatedly wrapped methods when another convergence wrapper sat above it.

## Safety

Authentication, nonce management, disable flags, writer lineage, and trading activation gates remain enforced. The change does not force activation or mark Kraken connected without a successful authenticated `connect()`.

## Validation

Focused tests cover the canonical acquisition trigger, missing Kraken registration repair, nested Coinbase wrapper detection, duplicate-wrapper prevention, and wrapper-cycle safety. The first CI run passed compilation, import smoke, runtime regressions, preflight, and the canonical launcher. This branch also preserves the legacy synthetic startup-patch unit contract and uses the repository-approved `fix/` prefix.