### PR TITLE
Fix Kraken recovery timing and Coinbase auth fail-closed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # NIJA AI Trading LLC — Current Success State
 
 **Status date:** July 26, 2026  
-**Recovery commit:** [`5eba6f5`](https://github.com/dantelrharrell-debug/Nija/commit/5eba6f504140def3eed45c46a63d3f074bcd907e) via [PR #2273](https://github.com/dantelrharrell-debug/Nija/pull/2273)
+**Deployed checkpoint:** [`033e392`](https://github.com/dantelrharrell-debug/Nija/commit/033e392f10f7e833c3fe4698cb974659e7f83e99)  
+**Active recovery repair:** [PR #2275](https://github.com/dantelrharrell-debug/Nija/pull/2275)
 
 This README is the durable recovery anchor for NIJA. It records what the production logs have actually proved, what the merged recovery changes are intended to repair, and the exact evidence required before declaring all three venues live.
 
@@ -11,24 +12,26 @@ NIJA does not guarantee trades or profits. A connected brokerage may enter a tra
 
 | Area | Proven state |
 |---|---|
-| Source of truth | Kraken canonical-registration recovery and Coinbase wrapper-chain repair are merged into `main` at `5eba6f5`; Render rollout verification is still required |
-| Canonical runtime | `launcher-v26 -> main.py -> bot.bot -> bot.bot_main` entrypoint attestation passed before this recovery merge |
-| Coinbase | Valid ES256 key pair authenticated successfully; a runtime snapshot reported connected, ready, and about $200.21 spendable |
+| Source of truth | Render proved deployed commit `033e392`; follow-up writer-timing and Coinbase auth fail-closed repairs are tracked in PR #2275 |
+| Canonical runtime | `launcher-v26 -> main.py -> bot.bot -> bot.bot_main` entrypoint attestation and runtime guard audit passed on deployed commit `033e392` |
+| Coinbase | Valid ES256 credentials authenticated and about $200.21 was observed; a later 401 exposed stale cached capital being republished as ready, which PR #2275 now prevents |
 | OKX US | Private balance returned HTTP 200; about $144.96 was observed, the US endpoint was selected, and router binding was verified |
-| Kraken before recovery merge | Credentials and user configurations loaded and nonce authority initialized, but the canonical connectivity snapshot still reported `kraken_connected=False` |
-| Kraken recovery now merged | The canonical writer-acquisition path starts authenticated Kraken recovery, repairs a missing Kraken registration narrowly, refreshes capital authority, and re-evaluates normal activation gates |
+| Kraken deployed state | Credentials and user configurations loaded and nonce authority initialized, but repeated deployed snapshots still reported `kraken_connected=False` and no authenticated-recovery handoff marker |
+| Kraken recovery repair | PR #2275 adds a writer-lineage coordinator and retries transient lineage gaps so authenticated Kraken recovery cannot be lost during a rolling Render handoff |
 | Exit protection | Kraken all-account exit protection, verified cost-basis recovery, universal broker exits, and automatic take-profit/stop-loss guards are installed; each venue still requires its own connected broker and verified position data |
-| Coinbase log stability | Recovery wrapper detection is now chain-aware, preventing repeated Coinbase `connect` wrapping during runtime convergence |
+| Coinbase safety | Wrapper detection remains chain-aware; PR #2275 also preserves cached equity only for valuation while clearing connection, funding, activation, and execution readiness after auth loss |
 | Writer authority | Rolling Render instances remain single-writer; a replacement may wait safely on the prior Redis lease |
 | Trading state | The latest supplied logs did not prove `LIVE_ACTIVE`, a submitted order, a confirmed fill, or a completed take-profit exit |
 
 ### Safe continuation from this checkpoint
 
-1. Allow Render to deploy commit `5eba6f5`; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
+1. Merge PR #2275 and allow Render to deploy it; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
 2. Wait for the new instance to acquire and verify writer authority.
-3. Confirm the canonical recovery hook is installed:
+3. Confirm the canonical recovery hook and coordinator are installed:
    ```text
    CANONICAL_BROKER_STARTUP_CONVERGENCE_V30_ACQUIRE_PATCHED
+   KRAKEN_RECOVERY_COORDINATOR_STARTED
+   KRAKEN_RECOVERY_COORDINATOR_HANDOFF
    ```
 4. Confirm authenticated Kraken recovery progresses:
    ```text
@@ -46,6 +49,7 @@ Required evidence to advance this checkpoint:
 ```text
 ENTRYPOINT_WRITER_AUTHORITY_READY
 ENTRYPOINT_WRITER_AUTHORITY_VERIFIED
+KRAKEN_RECOVERY_COORDINATOR_HANDOFF
 KRAKEN_AUTHENTICATED_RECOVERY_READY
 LIVE_BROKER_CONNECTIVITY_SNAPSHOT ... kraken_connected=True coinbase_connected=True okx_connected=True
 BROKER_INDEPENDENT_READINESS

--- a/bot/canonical_broker_startup_convergence_v24.py
+++ b/bot/canonical_broker_startup_convergence_v24.py
@@ -48,6 +48,7 @@ _RUN_WRAP_ATTR = "_nija_canonical_broker_startup_convergence_v24"
 _BOT_MAIN_PATCH_ATTR = "_nija_canonical_broker_startup_convergence_bot_main_v24"
 _BOT_MAIN_ACQUIRE_WRAP_ATTR = "_nija_canonical_broker_startup_acquire_v30"
 _KRAKEN_RECOVERY_STARTED = False
+_KRAKEN_RECOVERY_COORDINATOR_STARTED = False
 
 
 def _truthy(name: str, default: str = "false") -> bool:
@@ -200,11 +201,14 @@ def _start_kraken_authenticated_recovery(manager: Any) -> bool:
             lineage_ready, lineage_reason = _writer_lineage()
             if not lineage_ready:
                 logger.warning(
-                    "KRAKEN_AUTHENTICATED_RECOVERY_STOPPED marker=%s reason=%s",
+                    "KRAKEN_AUTHENTICATED_RECOVERY_WAITING marker=%s reason=%s "
+                    "retry_s=%.1f",
                     marker,
                     lineage_reason,
+                    interval,
                 )
-                return
+                time.sleep(interval)
+                continue
             try:
                 broker_module = importlib.import_module("bot.broker_manager")
                 broker, broker_type, manager_module = _resolve_or_register_kraken_broker(
@@ -310,6 +314,95 @@ def _start_kraken_authenticated_recovery(manager: Any) -> bool:
     logger.warning(
         "KRAKEN_AUTHENTICATED_RECOVERY_STARTED "
         "marker=20260725-kraken-authenticated-recovery-v29"
+    )
+    return True
+
+
+
+def _start_kraken_recovery_coordinator() -> bool:
+    """Close the timing gap between import-hook install and writer acquisition.
+
+    A rolling Render deployment can install this module before the writer
+    fencing environment is published.  The coordinator waits for that lineage
+    instead of relying on a single wrapper callback.  It never connects a
+    broker until writer authority and the canonical manager FSM are both ready.
+    """
+    global _KRAKEN_RECOVERY_COORDINATOR_STARTED
+    with _LOCK:
+        if _KRAKEN_RECOVERY_COORDINATOR_STARTED:
+            return True
+        _KRAKEN_RECOVERY_COORDINATOR_STARTED = True
+
+    def coordinate() -> None:
+        marker = "20260726-kraken-recovery-coordinator-v31"
+        deadline = time.monotonic() + max(
+            120.0,
+            float(
+                os.environ.get(
+                    "NIJA_KRAKEN_RECOVERY_COORDINATOR_WINDOW_S", "1800"
+                )
+                or 1800
+            ),
+        )
+        interval = max(
+            2.0,
+            float(
+                os.environ.get(
+                    "NIJA_KRAKEN_RECOVERY_COORDINATOR_INTERVAL_S", "5"
+                )
+                or 5
+            ),
+        )
+        last_reason = ""
+        while time.monotonic() < deadline:
+            if _KRAKEN_RECOVERY_STARTED:
+                return
+            if not _kraken_credentials_configured():
+                reason = "credentials_not_configured_or_explicitly_disabled"
+            else:
+                lineage_ready, lineage_reason = _writer_lineage()
+                if not lineage_ready:
+                    reason = lineage_reason
+                else:
+                    try:
+                        _prepare_canonical_manager()
+                        if _KRAKEN_RECOVERY_STARTED:
+                            logger.critical(
+                                "KRAKEN_RECOVERY_COORDINATOR_HANDOFF marker=%s "
+                                "writer_lineage=true recovery_started=true",
+                                marker,
+                            )
+                            return
+                        reason = "canonical_manager_ready_recovery_not_started"
+                    except Exception as exc:
+                        reason = f"{type(exc).__name__}:{exc}"
+            if reason != last_reason:
+                logger.warning(
+                    "KRAKEN_RECOVERY_COORDINATOR_WAITING marker=%s reason=%s "
+                    "retry_s=%.1f",
+                    marker,
+                    reason,
+                    interval,
+                )
+                last_reason = reason
+            time.sleep(interval)
+
+        os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] = "0"
+        logger.error(
+            "KRAKEN_RECOVERY_COORDINATOR_EXPIRED marker=%s "
+            "recovery_started=%s trading_remains_fail_closed=true",
+            marker,
+            _KRAKEN_RECOVERY_STARTED,
+        )
+
+    threading.Thread(
+        target=coordinate,
+        name="KrakenRecoveryCoordinatorV31",
+        daemon=True,
+    ).start()
+    logger.warning(
+        "KRAKEN_RECOVERY_COORDINATOR_STARTED "
+        "marker=20260726-kraken-recovery-coordinator-v31"
     )
     return True
 
@@ -532,6 +625,7 @@ def install_import_hook() -> bool:
         if not any(item is _FINDER for item in sys.meta_path):
             sys.meta_path.insert(0, _FINDER)
         _INSTALLED = True
+        _start_kraken_recovery_coordinator()
         os.environ["NIJA_CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_INSTALLED"] = "1"
         logger.critical(
             "CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_INSTALLED "
@@ -558,6 +652,7 @@ __all__ = [
     "_prepare_canonical_manager",
     "_kraken_credentials_configured",
     "_start_kraken_authenticated_recovery",
+    "_start_kraken_recovery_coordinator",
     "_patch_self_healing_module",
     "_patch_bot_main_module",
 ]

--- a/bot/coinbase_capital_consistency_patch.py
+++ b/bot/coinbase_capital_consistency_patch.py
@@ -179,7 +179,7 @@ def _wrap_balance(cls: type, name: str, current: Any) -> Any:
         result = current(self, *args, **kwargs)
         if _auth_failure_detected(self):
             _publish_auth_failed(self)
-            return result
+            return 0.0
         amount = _payload_total(result)
         if amount <= 0 and bool(getattr(self, "connected", False)):
             amount = _known_balance(self)
@@ -208,7 +208,7 @@ def _wrap_connect(cls: type, current: Any) -> Any:
         result = current(self, *args, **kwargs)
         if _auth_failure_detected(self):
             _publish_auth_failed(self)
-            return result
+            return False
         connected = bool(result) or bool(getattr(self, "connected", False))
         if connected:
             amount = _known_balance(self)

--- a/bot/coinbase_capital_consistency_patch.py
+++ b/bot/coinbase_capital_consistency_patch.py
@@ -1,4 +1,4 @@
-"""Keep Coinbase capital and credential diagnostics consistent."""
+"""Keep Coinbase valuation caches separate from execution readiness."""
 from __future__ import annotations
 
 import logging
@@ -8,11 +8,11 @@ import threading
 import time
 from functools import wraps
 from types import ModuleType
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping
 
 logger = logging.getLogger("nija.coinbase_capital_consistency")
-_MARKER = "20260720-coinbase-capital-consistency-v1"
-_PATCH_ATTR = "_nija_coinbase_capital_consistency_v1"
+_MARKER = "20260726-coinbase-capital-auth-fail-closed-v2"
+_PATCH_ATTR = "_nija_coinbase_capital_consistency_v2"
 _LOCK = threading.RLock()
 _STARTED = False
 
@@ -31,7 +31,12 @@ def _payload_total(value: Any) -> float:
         return _number(value)
     if not isinstance(value, Mapping):
         return 0.0
-    for key in ("total_funds", "trading_balance", "total_available", "available_balance"):
+    for key in (
+        "total_funds",
+        "trading_balance",
+        "total_available",
+        "available_balance",
+    ):
         amount = _number(value.get(key))
         if amount > 0:
             return amount
@@ -44,50 +49,154 @@ def _payload_total(value: Any) -> float:
     return total
 
 
+def _broker_targets(broker: Any) -> Iterator[Any]:
+    """Yield an adapter and its canonical broker without following cycles."""
+    current = broker
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        nested = getattr(current, "_broker", None)
+        if nested is None or nested is current:
+            return
+        current = nested
+
+
+def _auth_failure_detected(broker: Any) -> bool:
+    for target in _broker_targets(broker):
+        for attr in (
+            "_auth_failed",
+            "auth_failed",
+            "_permanent_auth_failure",
+            "permanent_auth_failure",
+        ):
+            try:
+                if bool(getattr(target, attr, False)):
+                    return True
+            except Exception:
+                continue
+    return False
+
+
 def _known_balance(broker: Any) -> float:
-    for attr in ("_last_known_balance", "last_known_balance", "_last_balance", "last_balance", "_last_known_balance_payload", "last_balance_payload", "_last_raw_balances", "raw_balances", "_raw_balances"):
-        try:
-            amount = _payload_total(getattr(broker, attr, None))
-        except Exception:
-            amount = 0.0
-        if amount > 0:
-            return amount
+    """Return valuation-only cached equity.
+
+    This value must never make a venue execution-ready after authentication has
+    failed. Callers must check the auth-failure flag before publishing.
+    """
+    for target in _broker_targets(broker):
+        for attr in (
+            "_last_known_balance",
+            "last_known_balance",
+            "_last_balance",
+            "last_balance",
+            "_last_known_balance_payload",
+            "last_balance_payload",
+            "_last_raw_balances",
+            "raw_balances",
+            "_raw_balances",
+        ):
+            try:
+                amount = _payload_total(getattr(target, attr, None))
+            except Exception:
+                amount = 0.0
+            if amount > 0:
+                return amount
     return _number(os.environ.get("NIJA_COINBASE_SPENDABLE_QUOTE"))
 
 
+def _publish_auth_failed(broker: Any) -> None:
+    """Quarantine Coinbase execution while preserving valuation caches."""
+    changed = any(
+        os.environ.get(name) not in {"0", "authentication_failed", "auth_failed"}
+        for name in (
+            "NIJA_COINBASE_CONNECTED",
+            "NIJA_COINBASE_TRADING_READY",
+            "NIJA_COINBASE_ACTIVATED",
+            "NIJA_COINBASE_ACTIVATION_STATE",
+        )
+    )
+    for target in _broker_targets(broker):
+        for attr, value in (
+            ("connected", False),
+            ("_is_available", False),
+            ("exit_only_mode", True),
+        ):
+            try:
+                setattr(target, attr, value)
+            except Exception:
+                pass
+    os.environ.update(
+        {
+            "NIJA_COINBASE_CONNECTED": "0",
+            "NIJA_COINBASE_BALANCE_OBSERVED": "0",
+            "NIJA_COINBASE_SPENDABLE_QUOTE": "0",
+            "NIJA_COINBASE_TRADING_READY": "0",
+            "NIJA_COINBASE_ACTIVATED": "0",
+            "NIJA_COINBASE_ACTIVATION_STATE": "authentication_failed",
+            "NIJA_COINBASE_FUNDING_STATUS": "auth_failed",
+            "NIJA_COINBASE_AUTH_STATE": "authentication_failed",
+        }
+    )
+    if changed:
+        logger.error(
+            "COINBASE_CAPITAL_AUTH_FAIL_CLOSED marker=%s "
+            "cached_equity_preserved_for_valuation=true execution_ready=false",
+            _MARKER,
+        )
+
+
 def _publish(broker: Any, amount: float) -> None:
+    if _auth_failure_detected(broker):
+        _publish_auth_failed(broker)
+        return
     if amount <= 0:
         return
-    for attr in ("_last_known_balance", "last_known_balance"):
-        try:
-            setattr(broker, attr, amount)
-        except Exception:
-            pass
-    os.environ.update({
-        "NIJA_COINBASE_CONNECTED": "1",
-        "NIJA_COINBASE_BALANCE_OBSERVED": "1",
-        "NIJA_COINBASE_SPENDABLE_QUOTE": f"{amount:.8f}",
-        "NIJA_COINBASE_TRADING_READY": "1",
-        "NIJA_COINBASE_ACTIVATED": "1",
-        "NIJA_COINBASE_ACTIVATION_STATE": "ready",
-        "NIJA_COINBASE_FUNDING_STATUS": "funded",
-        "NIJA_COINBASE_PEM_STATE": "valid",
-    })
+    for target in _broker_targets(broker):
+        for attr in ("_last_known_balance", "last_known_balance"):
+            try:
+                setattr(target, attr, amount)
+            except Exception:
+                pass
+    os.environ.update(
+        {
+            "NIJA_COINBASE_CONNECTED": "1",
+            "NIJA_COINBASE_BALANCE_OBSERVED": "1",
+            "NIJA_COINBASE_SPENDABLE_QUOTE": f"{amount:.8f}",
+            "NIJA_COINBASE_TRADING_READY": "1",
+            "NIJA_COINBASE_ACTIVATED": "1",
+            "NIJA_COINBASE_ACTIVATION_STATE": "ready",
+            "NIJA_COINBASE_FUNDING_STATUS": "funded",
+            "NIJA_COINBASE_AUTH_STATE": "authenticated",
+            "NIJA_COINBASE_PEM_STATE": "valid",
+        }
+    )
 
 
 def _wrap_balance(cls: type, name: str, current: Any) -> Any:
     @wraps(current)
     def wrapped(self: Any, *args: Any, **kwargs: Any):
         result = current(self, *args, **kwargs)
+        if _auth_failure_detected(self):
+            _publish_auth_failed(self)
+            return result
         amount = _payload_total(result)
         if amount <= 0 and bool(getattr(self, "connected", False)):
             amount = _known_balance(self)
             if amount > 0:
-                logger.critical("COINBASE_CAPITAL_ZERO_SURFACE_REPAIRED marker=%s class=%s method=%s amount=$%.2f", _MARKER, cls.__name__, name, amount)
+                logger.critical(
+                    "COINBASE_CAPITAL_ZERO_SURFACE_REPAIRED "
+                    "marker=%s class=%s method=%s amount=$%.2f",
+                    _MARKER,
+                    cls.__name__,
+                    name,
+                    amount,
+                )
                 result = amount
         if amount > 0:
             _publish(self, amount)
         return result
+
     setattr(wrapped, _PATCH_ATTR, True)
     wrapped.__wrapped__ = current  # type: ignore[attr-defined]
     return wrapped
@@ -97,6 +206,9 @@ def _wrap_connect(cls: type, current: Any) -> Any:
     @wraps(current)
     def wrapped(self: Any, *args: Any, **kwargs: Any):
         result = current(self, *args, **kwargs)
+        if _auth_failure_detected(self):
+            _publish_auth_failed(self)
+            return result
         connected = bool(result) or bool(getattr(self, "connected", False))
         if connected:
             amount = _known_balance(self)
@@ -104,22 +216,42 @@ def _wrap_connect(cls: type, current: Any) -> Any:
                 _publish(self, amount)
             else:
                 os.environ["NIJA_COINBASE_PEM_STATE"] = "valid"
-            logger.critical("COINBASE_CAPITAL_CONSISTENCY_READY marker=%s class=%s connected=true amount=$%.2f", _MARKER, cls.__name__, amount)
+            logger.critical(
+                "COINBASE_CAPITAL_CONSISTENCY_READY "
+                "marker=%s class=%s connected=true amount=$%.2f",
+                _MARKER,
+                cls.__name__,
+                amount,
+            )
         return result
+
     setattr(wrapped, _PATCH_ATTR, True)
     wrapped.__wrapped__ = current  # type: ignore[attr-defined]
     return wrapped
 
 
+def _chain_has_patch(current: Any) -> bool:
+    seen: set[int] = set()
+    node = current
+    for _ in range(64):
+        if not callable(node) or id(node) in seen:
+            return False
+        seen.add(id(node))
+        if bool(getattr(node, _PATCH_ATTR, False)):
+            return True
+        node = getattr(node, "__wrapped__", None)
+    return False
+
+
 def _patch_class(cls: type) -> bool:
     changed = False
     connect = getattr(cls, "connect", None)
-    if callable(connect) and not getattr(connect, _PATCH_ATTR, False):
+    if callable(connect) and not _chain_has_patch(connect):
         cls.connect = _wrap_connect(cls, connect)
         changed = True
     for name in ("get_account_balance", "get_balance", "fetch_balance"):
         current = getattr(cls, name, None)
-        if callable(current) and not getattr(current, _PATCH_ATTR, False):
+        if callable(current) and not _chain_has_patch(current):
             setattr(cls, name, _wrap_balance(cls, name, current))
             changed = True
     return changed
@@ -127,11 +259,20 @@ def _patch_class(cls: type) -> bool:
 
 def _patch_loaded() -> bool:
     changed = False
-    for module_name in ("bot.broker_manager", "broker_manager", "bot.broker_integration", "broker_integration"):
+    for module_name in (
+        "bot.broker_manager",
+        "broker_manager",
+        "bot.broker_integration",
+        "broker_integration",
+    ):
         module = sys.modules.get(module_name)
         if not isinstance(module, ModuleType):
             continue
-        for class_name in ("CoinbaseBroker", "CoinbaseBrokerAdapter", "_CoinbaseInvalidProductFilter"):
+        for class_name in (
+            "CoinbaseBroker",
+            "CoinbaseBrokerAdapter",
+            "_CoinbaseInvalidProductFilter",
+        ):
             cls = getattr(module, class_name, None)
             if isinstance(cls, type):
                 changed = _patch_class(cls) or changed
@@ -139,12 +280,18 @@ def _patch_loaded() -> bool:
 
 
 def _monitor() -> None:
-    deadline = time.monotonic() + max(120.0, float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600))
+    deadline = time.monotonic() + max(
+        120.0,
+        float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "600") or 600),
+    )
     while time.monotonic() < deadline:
         try:
             _patch_loaded()
         except Exception:
-            logger.exception("COINBASE_CAPITAL_CONSISTENCY_MONITOR_ERROR marker=%s", _MARKER)
+            logger.exception(
+                "COINBASE_CAPITAL_CONSISTENCY_MONITOR_ERROR marker=%s",
+                _MARKER,
+            )
         time.sleep(0.25)
 
 
@@ -154,12 +301,26 @@ def install() -> bool:
         _patch_loaded()
         if not _STARTED:
             _STARTED = True
-            threading.Thread(target=_monitor, name="CoinbaseCapitalConsistency", daemon=True).start()
+            threading.Thread(
+                target=_monitor,
+                name="CoinbaseCapitalConsistencyV2",
+                daemon=True,
+            ).start()
         os.environ["NIJA_COINBASE_CAPITAL_CONSISTENCY_INSTALLED"] = "1"
-        logger.critical("COINBASE_CAPITAL_CONSISTENCY_INSTALLED marker=%s", _MARKER)
+        logger.critical(
+            "COINBASE_CAPITAL_CONSISTENCY_INSTALLED marker=%s",
+            _MARKER,
+        )
         return True
 
 
 install()
 
-__all__ = ["install", "_payload_total", "_known_balance", "_patch_loaded"]
+__all__ = [
+    "install",
+    "_payload_total",
+    "_known_balance",
+    "_auth_failure_detected",
+    "_publish_auth_failed",
+    "_patch_loaded",
+]

--- a/tests/test_coinbase_capital_consistency_auth_fail_closed.py
+++ b/tests/test_coinbase_capital_consistency_auth_fail_closed.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib
+
+
+def _module():
+    return importlib.import_module("bot.coinbase_capital_consistency_patch")
+
+
+def _seed_ready_environment(monkeypatch):
+    monkeypatch.setenv("NIJA_COINBASE_CONNECTED", "1")
+    monkeypatch.setenv("NIJA_COINBASE_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_COINBASE_SPENDABLE_QUOTE", "200.21")
+    monkeypatch.setenv("NIJA_COINBASE_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_COINBASE_ACTIVATED", "1")
+    monkeypatch.setenv("NIJA_COINBASE_ACTIVATION_STATE", "ready")
+    monkeypatch.setenv("NIJA_COINBASE_FUNDING_STATUS", "funded")
+
+
+def test_cached_balance_cannot_restore_readiness_after_401(monkeypatch):
+    module = _module()
+    _seed_ready_environment(monkeypatch)
+
+    class Broker:
+        connected = True
+        _auth_failed = True
+        _is_available = True
+        exit_only_mode = False
+        _last_known_balance = 200.21
+
+        def get_account_balance(self):
+            return self._last_known_balance
+
+    wrapped = module._wrap_balance(
+        Broker,
+        "get_account_balance",
+        Broker.get_account_balance,
+    )
+    broker = Broker()
+
+    assert wrapped(broker) == 200.21
+    assert broker.connected is False
+    assert broker._is_available is False
+    assert broker.exit_only_mode is True
+    assert module.os.environ["NIJA_COINBASE_CONNECTED"] == "0"
+    assert module.os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] == "0"
+    assert module.os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] == "0"
+    assert module.os.environ["NIJA_COINBASE_TRADING_READY"] == "0"
+    assert module.os.environ["NIJA_COINBASE_ACTIVATED"] == "0"
+    assert (
+        module.os.environ["NIJA_COINBASE_ACTIVATION_STATE"]
+        == "authentication_failed"
+    )
+
+
+def test_adapter_detects_nested_broker_auth_failure(monkeypatch):
+    module = _module()
+    _seed_ready_environment(monkeypatch)
+
+    class CanonicalBroker:
+        connected = True
+        _auth_failed = True
+        _last_known_balance = 90.0
+
+    class Adapter:
+        connected = True
+
+        def __init__(self):
+            self._broker = CanonicalBroker()
+
+        def connect(self):
+            return True
+
+    wrapped = module._wrap_connect(Adapter, Adapter.connect)
+    adapter = Adapter()
+
+    assert wrapped(adapter) is True
+    assert adapter.connected is False
+    assert adapter._broker.connected is False
+    assert module.os.environ["NIJA_COINBASE_TRADING_READY"] == "0"
+    assert module.os.environ["NIJA_COINBASE_AUTH_STATE"] == "authentication_failed"
+
+
+def test_capital_wrapper_patch_is_chain_aware():
+    module = _module()
+
+    class Broker:
+        connected = False
+
+        def connect(self):
+            return False
+
+        def get_account_balance(self):
+            return 0.0
+
+    assert module._patch_class(Broker) is True
+    first_connect = Broker.connect
+    first_balance = Broker.get_account_balance
+
+    assert module._patch_class(Broker) is False
+    assert Broker.connect is first_connect
+    assert Broker.get_account_balance is first_balance

--- a/tests/test_coinbase_capital_consistency_auth_fail_closed.py
+++ b/tests/test_coinbase_capital_consistency_auth_fail_closed.py
@@ -38,7 +38,7 @@ def test_cached_balance_cannot_restore_readiness_after_401(monkeypatch):
     )
     broker = Broker()
 
-    assert wrapped(broker) == 200.21
+    assert wrapped(broker) == 0.0
     assert broker.connected is False
     assert broker._is_available is False
     assert broker.exit_only_mode is True
@@ -74,7 +74,7 @@ def test_adapter_detects_nested_broker_auth_failure(monkeypatch):
     wrapped = module._wrap_connect(Adapter, Adapter.connect)
     adapter = Adapter()
 
-    assert wrapped(adapter) is True
+    assert wrapped(adapter) is False
     assert adapter.connected is False
     assert adapter._broker.connected is False
     assert module.os.environ["NIJA_COINBASE_TRADING_READY"] == "0"

--- a/tests/test_kraken_authenticated_recovery.py
+++ b/tests/test_kraken_authenticated_recovery.py
@@ -124,3 +124,145 @@ def test_bot_main_acquire_triggers_v24_manager_preparation(monkeypatch):
         False,
     ) is True
     assert getattr(target._acquire_writer_authority_before_nonce, FakeV22._ACQUIRE_WRAP_ATTR) is True
+
+
+
+def test_coordinator_waits_for_writer_lineage_before_handoff(monkeypatch):
+    module = _module()
+    monkeypatch.setattr(module, "_KRAKEN_RECOVERY_STARTED", False)
+    monkeypatch.setattr(module, "_KRAKEN_RECOVERY_COORDINATOR_STARTED", False)
+    monkeypatch.setattr(module, "_kraken_credentials_configured", lambda: True)
+    monkeypatch.setenv("NIJA_KRAKEN_RECOVERY_COORDINATOR_INTERVAL_S", "5")
+    monkeypatch.setenv("NIJA_KRAKEN_RECOVERY_COORDINATOR_WINDOW_S", "1800")
+
+    lineage = iter(
+        [
+            (False, "fencing_token_missing"),
+            (True, "lineage_ready generation=7"),
+        ]
+    )
+    monkeypatch.setattr(module, "_writer_lineage", lambda: next(lineage))
+    sleeps = []
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
+    prepared = []
+
+    def prepare():
+        prepared.append(True)
+        module._KRAKEN_RECOVERY_STARTED = True
+        return object()
+
+    monkeypatch.setattr(module, "_prepare_canonical_manager", prepare)
+
+    class ImmediateThread:
+        def __init__(self, target, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(module.threading, "Thread", ImmediateThread)
+
+    assert module._start_kraken_recovery_coordinator() is True
+    assert sleeps == [5.0]
+    assert prepared == [True]
+
+
+def test_authenticated_recovery_retries_transient_lineage_gap(monkeypatch):
+    module = _module()
+    monkeypatch.setattr(module, "_KRAKEN_RECOVERY_STARTED", False)
+    monkeypatch.setattr(module, "_kraken_credentials_configured", lambda: True)
+    monkeypatch.setenv("NIJA_KRAKEN_RECOVERY_INTERVAL_S", "30")
+    monkeypatch.setenv("NIJA_KRAKEN_RECOVERY_WINDOW_S", "1200")
+
+    lineage = iter(
+        [
+            (False, "lease_generation_missing"),
+            (True, "lineage_ready generation=8"),
+        ]
+    )
+    monkeypatch.setattr(module, "_writer_lineage", lambda: next(lineage))
+    sleeps = []
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    class Broker:
+        connected = True
+
+        @staticmethod
+        def get_account_balance():
+            return 25.0
+
+    broker = Broker()
+    broker_type = object()
+
+    class ConnectionState:
+        CONNECTED = object()
+
+    manager_module = type(
+        "ManagerModule",
+        (),
+        {"ConnectionState": ConnectionState},
+    )
+    broker_module = type(
+        "BrokerModule",
+        (),
+        {
+            "_KRAKEN_STARTUP_FSM": type(
+                "FSM",
+                (),
+                {"is_connected": False, "is_connecting": False},
+            )(),
+            "register_platform_broker": staticmethod(
+                lambda _name, _broker, connected: connected
+            ),
+        },
+    )
+
+    class Manager:
+        def _transition_platform_state(self, _broker_type, _state):
+            return None
+
+        def on_broker_ready(self, _name, _balance_fn):
+            return None
+
+        def refresh_capital_authority(self, **_kwargs):
+            return None
+
+    manager = Manager()
+    monkeypatch.setattr(
+        module,
+        "_resolve_or_register_kraken_broker",
+        lambda _manager: (broker, broker_type, manager_module),
+    )
+
+    state_machine = type(
+        "StateMachine",
+        (),
+        {"maybe_auto_activate": lambda self: None},
+    )()
+    state_module = type(
+        "StateModule",
+        (),
+        {"get_state_machine": staticmethod(lambda: state_machine)},
+    )
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return broker_module
+        if name == "bot.trading_state_machine":
+            return state_module
+        raise AssertionError(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", fake_import)
+
+    class ImmediateThread:
+        def __init__(self, target, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(module.threading, "Thread", ImmediateThread)
+
+    assert module._start_kraken_authenticated_recovery(manager) is True
+    assert sleeps == [30.0]
+    assert module.os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] == "1"


### PR DESCRIPTION
## Summary

- add a writer-lineage coordinator so Kraken authenticated recovery cannot be missed during rolling Render handoff
- retry transient writer-lineage gaps instead of stopping Kraken recovery permanently
- keep Coinbase cached equity valuation-only after a later 401 and clear all execution-readiness flags
- add regression tests for both recovery paths

## Production evidence addressed

The deployed `033e392` logs showed Coinbase and OKX connected while Kraken remained configured but disconnected, with no authenticated-recovery marker. A later Coinbase 401 was immediately followed by cached capital being republished as ready. This change closes both contradictions without bypassing authentication, writer authority, or normal activation gates.

## Safety

No order gate, risk limit, or take-profit threshold is relaxed. Failed authentication remains fail-closed.