### PR TITLE
Superseded: Fix Coinbase client-loss reconnect lifecycle

### DIFF
--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -2973,6 +2973,13 @@ class CoinbaseBroker(BaseBroker):
                     self._accounts_cache_time = time.time()
 
                     self.connected = True
+                    # A successful private accounts request is authoritative:
+                    # clear any transient fail-closed state left by a lost SDK
+                    # client so balance/readiness checks can resume.
+                    self._auth_failed = False
+                    self._auth_failed_last_logged = 0.0
+                    self._is_available = True
+                    self._balance_fetch_errors = 0
 
                     if attempt > 1:
                         logging.info(f"✅ Connected to Coinbase Advanced Trade API (succeeded on attempt {attempt})")

--- a/bot/tests/test_secondary_venue_runtime_diagnostics.py
+++ b/bot/tests/test_secondary_venue_runtime_diagnostics.py
@@ -354,8 +354,11 @@ def test_authenticated_recovery_restores_primary_after_all_pairs_fail(monkeypatc
 
     assert broker.connect() is False
     assert broker.connected is False
-    assert broker._auth_failed is True
+    # A private-probe transport failure is not proof that credentials are bad.
+    # The venue remains fail-closed, but future authenticated reconnects stay enabled.
+    assert broker._auth_failed is False
     assert os.environ["COINBASE_API_KEY"] == primary_key
     assert os.environ["COINBASE_API_SECRET"] == primary_secret
-    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "authentication_failed"
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
+    assert os.environ.get("NIJA_COINBASE_RECONNECT_DISABLED", "0") != "1"
 

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from typing import Any, Mapping, Sequence
 
 logger = logging.getLogger("nija.coinbase_authenticated_connect_recovery")
-_MARKER = "20260720-coinbase-authenticated-connect-v1"
+_MARKER = "20260726-coinbase-authenticated-reconnect-v2"
 _PATCH_ATTR = "_nija_coinbase_authenticated_connect_v1"
 _LOCK = threading.RLock()
 _STARTED = False
@@ -103,10 +103,26 @@ def _measure_spendable(broker: Any) -> float:
 
 
 def _publish_connected(broker: Any, source: str) -> None:
-    try:
-        setattr(broker, "connected", True)
-    except Exception:
-        pass
+    for target in _credential_targets(broker):
+        for attr, value in (
+            ("connected", True),
+            ("_auth_failed", False),
+            ("auth_failed", False),
+            ("_is_available", True),
+            ("_balance_fetch_errors", 0),
+        ):
+            try:
+                if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
+                    setattr(target, attr, value)
+            except Exception:
+                pass
+        manager = getattr(target, "_connection_stability_manager", None)
+        mark_connected = getattr(manager, "mark_connected", None)
+        if callable(mark_connected):
+            try:
+                mark_connected()
+            except Exception:
+                pass
     spendable = _measure_spendable(broker)
     os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "0"
     os.environ["NIJA_COINBASE_RECONNECT_DISABLED"] = "0"
@@ -194,12 +210,21 @@ def _apply_pair(
             for attr, value in (
                 ("connected", False),
                 ("client", None),
+                ("api_client", None),
+                ("rest_client", None),
+                ("coinbase_client", None),
+                ("_client", None),
+                ("_api_client", None),
                 ("_auth_failed", False),
                 ("auth_failed", False),
                 ("_is_available", True),
+                ("_accounts_cache", None),
+                ("_accounts_cache_time", None),
+                ("_balance_cache", None),
+                ("_balance_cache_time", None),
             ):
                 try:
-                    if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
+                    if hasattr(target, attr) or attr in {"connected", "client", "_auth_failed"}:
                         setattr(target, attr, value)
                 except Exception:
                     pass
@@ -216,6 +241,29 @@ def _mark_auth_failed(broker: Any) -> None:
             try:
                 if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
                     setattr(target, attr, value)
+            except Exception:
+                pass
+
+
+def _mark_connectivity_failed(broker: Any) -> None:
+    """Keep the venue fail-closed while allowing authenticated reconnects."""
+    for target in _credential_targets(broker):
+        for attr, value in (
+            ("connected", False),
+            ("_auth_failed", False),
+            ("auth_failed", False),
+            ("_is_available", False),
+        ):
+            try:
+                if hasattr(target, attr) or attr in {"connected", "_auth_failed"}:
+                    setattr(target, attr, value)
+            except Exception:
+                pass
+        manager = getattr(target, "_connection_stability_manager", None)
+        mark_disconnected = getattr(manager, "mark_disconnected", None)
+        if callable(mark_disconnected):
+            try:
+                mark_disconnected("coinbase_authenticated_reconnect_pending")
             except Exception:
                 pass
 
@@ -293,6 +341,18 @@ def _patch_class(cls: type) -> bool:
             os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "quarantined"
             return False
 
+        # Rebuild the authenticated SDK client on every disconnected retry.
+        # This also clears transient client-lifecycle failures, while explicit
+        # 401 quarantines remain blocked by _quarantined_for() above.
+        if primary_key and primary_secret and not bool(getattr(self, "connected", False)):
+            _apply_pair(
+                self,
+                primary_source,
+                primary_key,
+                primary_secret,
+                reset_failure=True,
+            )
+
         first_error = ""
         try:
             result = current(self, *args, **kwargs)
@@ -301,7 +361,8 @@ def _patch_class(cls: type) -> bool:
             first_error = f"{type(exc).__name__}:{str(exc)[:100]}"
 
         if bool(result) or bool(getattr(self, "connected", False)):
-            return result
+            _publish_connected(self, "connect_result")
+            return True
         authenticated, detail = _authenticated_probe(self)
         if authenticated:
             _publish_connected(self, detail)
@@ -387,11 +448,14 @@ def _patch_class(cls: type) -> bool:
             _quarantine(self, primary_key, primary_secret)
             state = "quarantined"
         else:
-            _mark_auth_failed(self)
+            _mark_connectivity_failed(self)
             os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+            os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+            os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"
             os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
-            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "authentication_failed"
-            state = "authentication_failed"
+            os.environ["NIJA_COINBASE_ACTIVATED"] = "0"
+            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "reconnect_pending"
+            state = "reconnect_pending"
         _log_failure_once(
             cls,
             f"{suffix};alternative_pairs_attempted={attempted};state={state}",

--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -10,7 +10,7 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.runtime_auth_endpoint_repair")
-_MARKER = "20260716-auth-endpoint-v2"
+_MARKER = "20260726-coinbase-client-recovery-v3"
 _LOCK = threading.RLock()
 _PATCHED = False
 _LOCAL = threading.local()
@@ -44,15 +44,37 @@ def _zero_coinbase_balance() -> dict[str, Any]:
 
 
 def _mark_coinbase_disconnected(instance: Any, reason: str) -> None:
-    for attr, value in (("connected", False), ("_is_available", False), ("_auth_failed", True)):
+    """Fail closed for a missing client without poisoning credential state.
+
+    An uninitialized client is a transport/lifecycle failure, not proof that the
+    configured key pair is invalid. Only an authenticated 401 response may set
+    the permanent auth-failure latch and quarantine credentials.
+    """
+    for attr, value in (("connected", False), ("_is_available", False)):
         try:
             setattr(instance, attr, value)
+        except Exception:
+            pass
+    manager = getattr(instance, "_connection_stability_manager", None)
+    mark_disconnected = getattr(manager, "mark_disconnected", None)
+    if callable(mark_disconnected):
+        try:
+            mark_disconnected(reason)
         except Exception:
             pass
     os.environ["NIJA_COINBASE_CONNECTED"] = "0"
     os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
     os.environ["NIJA_COINBASE_SPENDABLE_QUOTE"] = "0.00000000"
     os.environ["NIJA_COINBASE_FUNDING_STATUS"] = reason
+    os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATED"] = "0"
+    os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "reconnect_pending"
+
+
+def _coinbase_uninitialized_fallback(method_name: str) -> Any:
+    if method_name == "_get_account_balance_detailed":
+        return _zero_coinbase_balance()
+    return 0.0
 
 
 def _patch_coinbase_class(module: ModuleType) -> bool:
@@ -78,7 +100,7 @@ def _patch_coinbase_class(module: ModuleType) -> bool:
                     _MARKER,
                     __method_name,
                 )
-                return _zero_coinbase_balance()
+                return _coinbase_uninitialized_fallback(__method_name)
             return __original(self, *args, **kwargs)
 
         guarded._nija_coinbase_client_guard_v2 = True  # type: ignore[attr-defined]

--- a/tests/test_coinbase_authenticated_connect_wrapper_chain.py
+++ b/tests/test_coinbase_authenticated_connect_wrapper_chain.py
@@ -60,3 +60,81 @@ def test_wrapper_chain_cycle_is_safe():
 
     outer.__wrapped__ = outer
     assert module._wrapper_chain_has_patch(outer) is False
+
+
+def test_disconnected_broker_rebuilds_client_and_clears_transient_auth_latch(monkeypatch):
+    module = _module()
+
+    class Client:
+        def get_accounts(self):
+            return {"accounts": []}
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.client = None
+            self.connected = False
+            self._auth_failed = True
+            self._is_available = False
+            self._balance_fetch_errors = 3
+
+        def connect(self):
+            assert self._auth_failed is False
+            assert self.client is None
+            self.client = Client()
+            self.connected = True
+            return True
+
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/test/apiKeys/key")
+    monkeypatch.setenv(
+        "COINBASE_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\nTEST\n-----END EC PRIVATE KEY-----",
+    )
+    monkeypatch.delenv("NIJA_COINBASE_CREDENTIALS_QUARANTINED", raising=False)
+    monkeypatch.delenv("NIJA_COINBASE_RECONNECT_DISABLED", raising=False)
+    monkeypatch.setattr(module, "_measure_spendable", lambda broker: 200.25)
+
+    assert module._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is True
+    assert broker.connected is True
+    assert broker.client is not None
+    assert broker._auth_failed is False
+    assert broker._is_available is True
+    assert broker._balance_fetch_errors == 0
+    assert module.os.environ["NIJA_COINBASE_CONNECTED"] == "1"
+    assert module.os.environ["NIJA_COINBASE_TRADING_READY"] == "1"
+    assert module.os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "ready"
+
+
+def test_transient_connect_failure_stays_retryable(monkeypatch):
+    module = _module()
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.client = None
+            self.connected = False
+            self._auth_failed = False
+            self._is_available = True
+
+        def connect(self):
+            return False
+
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/test/apiKeys/key")
+    monkeypatch.setenv(
+        "COINBASE_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\nTEST\n-----END EC PRIVATE KEY-----",
+    )
+    monkeypatch.delenv("NIJA_COINBASE_CREDENTIALS_QUARANTINED", raising=False)
+    monkeypatch.delenv("NIJA_COINBASE_RECONNECT_DISABLED", raising=False)
+    monkeypatch.setattr(module, "_configured_pairs", lambda: [])
+
+    assert module._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert broker._auth_failed is False
+    assert broker._is_available is False
+    assert module.os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
+    assert module.os.environ.get("NIJA_COINBASE_RECONNECT_DISABLED", "0") != "1"

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -7,13 +7,29 @@ import runtime_auth_recursion_endpoint_repair_patch as repair
 
 
 def test_coinbase_balance_fails_closed_when_client_is_missing(monkeypatch):
+    class Stability:
+        def __init__(self):
+            self.reasons = []
+
+        def mark_disconnected(self, reason):
+            self.reasons.append(reason)
+
     class CoinbaseBroker:
         def __init__(self):
             self.client = None
             self.connected = True
+            self._is_available = True
+            self._auth_failed = False
+            self._connection_stability_manager = Stability()
 
         def _get_account_balance_detailed(self, verbose=False):
-            raise AssertionError("uninitialized client must not reach original balance method")
+            raise AssertionError("uninitialized client must not reach original detailed method")
+
+        def get_account_balance(self, verbose=False):
+            raise AssertionError("uninitialized client must not reach original float method")
+
+        def get_balance(self):
+            raise AssertionError("uninitialized client must not reach original float method")
 
     module = ModuleType("bot.broker_manager")
     module.CoinbaseBroker = CoinbaseBroker
@@ -25,9 +41,19 @@ def test_coinbase_balance_fails_closed_when_client_is_missing(monkeypatch):
     assert payload["total_funds"] == 0.0
     assert payload["trading_balance"] == 0.0
     assert payload["connected"] is False
+    assert broker.get_account_balance() == 0.0
+    assert broker.get_balance() == 0.0
     assert broker.connected is False
+    assert broker._is_available is False
+    assert broker._auth_failed is False
+    assert broker._connection_stability_manager.reasons == [
+        "client_uninitialized",
+        "client_uninitialized",
+        "client_uninitialized",
+    ]
     assert os.environ["NIJA_COINBASE_CONNECTED"] == "0"
     assert os.environ["NIJA_COINBASE_FUNDING_STATUS"] == "client_uninitialized"
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
 
 
 def test_okx_recursive_connect_is_blocked(monkeypatch):


### PR DESCRIPTION
Superseded by #2277, which contains the identical approved commit on a branch name that satisfies repository policy.