### PR TITLE
Fix Coinbase canonical client and watchdog convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Deployed checkpoint:** [`84c9302`](https://github.com/dantelrharrell-debug/Nija/commit/84c9302f91bd38d4dd54ef41c302c920a3ff2089)
 
-**Active recovery repair:** Coinbase canonical-client convergence (pending merge from `fix/coinbase-canonical-client-convergence`)
+**Active recovery repair:** [PR #2279](https://github.com/dantelrharrell-debug/Nija/pull/2279) — Coinbase canonical-client convergence
 
 This README is the durable recovery anchor for NIJA. It records what the production logs have actually proved, what the merged recovery changes are intended to repair, and the exact evidence required before declaring all three venues live.
 
@@ -27,7 +27,7 @@ NIJA does not guarantee trades or profits. A connected brokerage may enter a tra
 
 ### Safe continuation from this checkpoint
 
-1. Merge the Coinbase canonical-client repair and allow Render to deploy it; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
+1. Merge [PR #2279](https://github.com/dantelrharrell-debug/Nija/pull/2279) and allow Render to deploy it; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
 2. Wait for the new instance to acquire and verify writer authority.
 3. Confirm the canonical recovery hook and coordinator are installed:
    ```text

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # NIJA AI Trading LLC — Current Success State
 
-**Status date:** July 26, 2026  
-**Deployed checkpoint:** [`033e392`](https://github.com/dantelrharrell-debug/Nija/commit/033e392f10f7e833c3fe4698cb974659e7f83e99)  
-**Active recovery repair:** [PR #2275](https://github.com/dantelrharrell-debug/Nija/pull/2275)
+**Status date:** July 26, 2026
+
+**Deployed checkpoint:** [`84c9302`](https://github.com/dantelrharrell-debug/Nija/commit/84c9302f91bd38d4dd54ef41c302c920a3ff2089)
+
+**Active recovery repair:** Coinbase canonical-client convergence (pending merge from `fix/coinbase-canonical-client-convergence`)
 
 This README is the durable recovery anchor for NIJA. It records what the production logs have actually proved, what the merged recovery changes are intended to repair, and the exact evidence required before declaring all three venues live.
 
@@ -12,43 +14,49 @@ NIJA does not guarantee trades or profits. A connected brokerage may enter a tra
 
 | Area | Proven state |
 |---|---|
-| Source of truth | Render proved deployed commit `033e392`; follow-up writer-timing and Coinbase auth fail-closed repairs are tracked in PR #2275 |
-| Canonical runtime | `launcher-v26 -> main.py -> bot.bot -> bot.bot_main` entrypoint attestation and runtime guard audit passed on deployed commit `033e392` |
-| Coinbase | Valid ES256 credentials authenticated and about $200.21 was observed; a later 401 exposed stale cached capital being republished as ready, which PR #2275 now prevents |
-| OKX US | Private balance returned HTTP 200; about $144.96 was observed, the US endpoint was selected, and router binding was verified |
-| Kraken deployed state | Credentials and user configurations loaded and nonce authority initialized, but repeated deployed snapshots still reported `kraken_connected=False` and no authenticated-recovery handoff marker |
-| Kraken recovery repair | PR #2275 adds a writer-lineage coordinator and retries transient lineage gaps so authenticated Kraken recovery cannot be lost during a rolling Render handoff |
+| Source of truth | Render proved deployed commit `84c9302`; the supplied post-deploy window reached simultaneous broker-local connectivity before Coinbase was downgraded by a stale duplicate instance |
+| Canonical runtime | `launcher-v26 -> main.py -> bot.bot -> bot.bot_main` entrypoint attestation passed on deployed commit `84c9302` |
+| Coinbase | Valid ES256 credentials authenticated; $100.11 spendable was observed, with the remaining account value held in crypto positions. Five seconds after all-three readiness, a duplicate broker with `client=None` incorrectly published `reconnect_pending` |
+| Coinbase canonical-client repair | The active repair preserves a healthy nested adapter client, adopts only a same-account authenticated canonical client, rebinds the connection watchdog to that broker, and keeps missing-client/401 paths fail-closed |
+| OKX US | Private balance returned HTTP 200; $144.96 was observed, the US endpoint was selected, dual-wallet funding status was `funded`, and router binding was verified |
+| Kraken deployed state | Nonce authority initialized and later broker-local readiness reported `kraken connected=true`; the supplied window still did not prove positive Kraken platform spendable capital or `trading_ready=true` |
 | Exit protection | Kraken all-account exit protection, verified cost-basis recovery, universal broker exits, and automatic take-profit/stop-loss guards are installed; each venue still requires its own connected broker and verified position data |
-| Coinbase safety | Wrapper detection remains chain-aware; PR #2275 also preserves cached equity only for valuation while clearing connection, funding, activation, and execution readiness after auth loss |
+| Coinbase safety | Platform clients cannot be shared with user accounts, one user's client cannot be shared with another user, and a genuine 401 still quarantines only Coinbase |
 | Writer authority | Rolling Render instances remain single-writer; a replacement may wait safely on the prior Redis lease |
 | Trading state | The latest supplied logs did not prove `LIVE_ACTIVE`, a submitted order, a confirmed fill, or a completed take-profit exit |
 
 ### Safe continuation from this checkpoint
 
-1. Merge PR #2275 and allow Render to deploy it; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
+1. Merge the Coinbase canonical-client repair and allow Render to deploy it; do not repeatedly restart while `ENTRYPOINT_WRITER_AUTHORITY_STANDBY` is present.
 2. Wait for the new instance to acquire and verify writer authority.
 3. Confirm the canonical recovery hook and coordinator are installed:
    ```text
-   CANONICAL_BROKER_STARTUP_CONVERGENCE_V30_ACQUIRE_PATCHED
+   COINBASE_AUTHENTICATED_CONNECT_RECOVERY_INSTALLED marker=20260726-coinbase-canonical-client-v4
    KRAKEN_RECOVERY_COORDINATOR_STARTED
    KRAKEN_RECOVERY_COORDINATOR_HANDOFF
    ```
-4. Confirm authenticated Kraken recovery progresses:
+4. Confirm Coinbase remains ready through at least two connection-watchdog intervals. A stale alias may be repaired with:
+   ```text
+   COINBASE_CANONICAL_CLIENT_ADOPTED
+   ```
+   It must not be followed by `COINBASE_CLIENT_UNINITIALIZED_FAIL_CLOSED` for the same account.
+5. Confirm authenticated Kraken recovery progresses:
    ```text
    KRAKEN_AUTHENTICATED_RECOVERY_STARTED
    KRAKEN_AUTHENTICATED_RECOVERY_REGISTERED   # expected only if Kraken was absent
    KRAKEN_AUTHENTICATED_RECOVERY_READY ... connected=true capital_rechecked=true
    ```
-5. Confirm one final connectivity snapshot reports all intended venues independently connected and ready. Early startup snapshots may be transient; use the latest post-recovery snapshot.
-6. Confirm normal activation gates commit `LIVE_ACTIVE` without force flags.
-7. Confirm each connected venue is registered with the universal exit supervisor before relying on automatic take-profit protection.
-8. Never use forced activation, synthetic capital, credential bypasses, nonce bypasses, or writer-lock deletion to manufacture readiness.
+6. Confirm one final connectivity snapshot reports all intended venues independently connected and ready. Early startup snapshots may be transient; use the latest post-recovery snapshot.
+7. Confirm normal activation gates commit `LIVE_ACTIVE` without force flags.
+8. Confirm each connected venue is registered with the universal exit supervisor before relying on automatic take-profit protection.
+9. Never use forced activation, synthetic capital, credential bypasses, nonce bypasses, or writer-lock deletion to manufacture readiness.
 
 Required evidence to advance this checkpoint:
 
 ```text
 ENTRYPOINT_WRITER_AUTHORITY_READY
 ENTRYPOINT_WRITER_AUTHORITY_VERIFIED
+COINBASE_AUTHENTICATED_CONNECT_RECOVERED
 KRAKEN_RECOVERY_COORDINATOR_HANDOFF
 KRAKEN_AUTHENTICATED_RECOVERY_READY
 LIVE_BROKER_CONNECTIVITY_SNAPSHOT ... kraken_connected=True coinbase_connected=True okx_connected=True

--- a/bot/connection_stability_manager.py
+++ b/bot/connection_stability_manager.py
@@ -130,6 +130,7 @@ class ConnectionStabilityManager:
         self._broker: Optional[Any] = None
         self._reconnect_fn: Optional[Callable[[], bool]] = None
         self._health_probe_fn: Optional[Callable[[], bool]] = None
+        self._registration_lock = threading.Lock()
 
         # Post-reconnect hooks: callables fired after each successful reconnect.
         # Each hook receives no arguments and its return value is ignored.
@@ -156,13 +157,18 @@ class ConnectionStabilityManager:
         broker: Any,
         reconnect_fn: Callable[[], bool],
         health_probe_fn: Optional[Callable[[], bool]] = None,
+        *,
+        replace_existing: bool = False,
     ) -> None:
         """
         Register a broker instance and its connection callbacks.
 
-        If a broker is already registered this call is a no-op so that
+        If a broker is already registered this call is normally a no-op so
         repeated connect() calls during polling / watchdog re-entry do not
-        re-register the same broker multiple times.
+        re-register the same broker multiple times.  A caller that has just
+        completed an authenticated replacement lifecycle may set
+        ``replace_existing=True`` to move watchdog ownership away from a stale
+        instance.
 
         Args:
             broker: Broker object (used for logging context only).
@@ -171,16 +177,37 @@ class ConnectionStabilityManager:
             health_probe_fn: Optional lightweight callable that returns
                 ``True`` when the connection is alive.  If omitted the
                 watchdog calls ``reconnect_fn`` to test liveness.
+            replace_existing: Replace a different registered instance and its
+                callbacks.  This is intended for explicit, verified lifecycle
+                handoffs; routine duplicate registrations should leave it
+                ``False``.
         """
-        if self._broker is not None:
-            logger.debug(
-                f"[{self.broker_name}] Broker already registered — skipping duplicate registration"
+        with self._registration_lock:
+            existing = self._broker
+            if existing is broker:
+                # Refresh callbacks for the same object because runtime wrappers
+                # may have been installed after its first registration.
+                self._reconnect_fn = reconnect_fn
+                self._health_probe_fn = health_probe_fn
+                return
+            if existing is not None and not replace_existing:
+                logger.debug(
+                    f"[{self.broker_name}] Broker already registered — skipping duplicate registration"
+                )
+                return
+            self._broker = broker
+            self._reconnect_fn = reconnect_fn
+            self._health_probe_fn = health_probe_fn
+        if existing is None:
+            logger.info(f"🔌 [{self.broker_name}] Broker registered with ConnectionStabilityManager")
+        else:
+            logger.warning(
+                "🔄 [%s] Connection watchdog ownership moved to authenticated replacement "
+                "(old=%s new=%s)",
+                self.broker_name,
+                type(existing).__name__,
+                type(broker).__name__,
             )
-            return
-        self._broker = broker
-        self._reconnect_fn = reconnect_fn
-        self._health_probe_fn = health_probe_fn
-        logger.info(f"🔌 [{self.broker_name}] Broker registered with ConnectionStabilityManager")
 
     def register_pre_reconnect_hook(self, hook: Callable[[], None]) -> None:
         """Register a callable to be invoked before each reconnect attempt.

--- a/bot/tests/test_funded_okx_capital_convergence_v31.py
+++ b/bot/tests/test_funded_okx_capital_convergence_v31.py
@@ -252,6 +252,48 @@ def test_coinbase_connect_quarantines_confirmed_401_and_stops_retries(
     assert broker.account_calls == 1
 
 
+def test_coinbase_adapter_does_not_reset_healthy_nested_client(
+    monkeypatch,
+):
+    _clear_coinbase_quarantine(monkeypatch)
+    monkeypatch.setenv("COINBASE_API_KEY", "key")
+    monkeypatch.setenv("COINBASE_API_SECRET", "secret")
+    monkeypatch.setattr(coinbase_connect, "_measure_spendable", lambda broker: 100.11)
+
+    expected_client = object()
+
+    class ConcreteBroker:
+        account_type = SimpleNamespace(value="platform")
+        user_id = None
+
+        def __init__(self):
+            self.client = expected_client
+            self.connected = True
+            self._auth_failed = False
+            self._is_available = True
+
+        def connect(self):
+            return True
+
+    class CoinbaseBrokerAdapter:
+        def __init__(self):
+            self._broker = ConcreteBroker()
+            self.connected = False
+
+        def connect(self):
+            assert self._broker.client is expected_client
+            self.connected = True
+            return True
+
+    assert coinbase_connect._patch_class(CoinbaseBrokerAdapter) is True
+    adapter = CoinbaseBrokerAdapter()
+
+    assert adapter.connect() is True
+    assert adapter._broker.client is expected_client
+    assert adapter._broker.connected is True
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "ready"
+
+
 def test_coinbase_balance_quarantine_returns_fail_closed_zero_without_retries(
     monkeypatch,
 ):

--- a/bot/tests/test_nonce_reconnect_resync.py
+++ b/bot/tests/test_nonce_reconnect_resync.py
@@ -48,6 +48,26 @@ def _make_csm(broker_name: str = "test_broker") -> ConnectionStabilityManager:
 
 class TestConnectionStabilityManagerHooks(unittest.TestCase):
 
+    def test_verified_replacement_moves_watchdog_ownership(self):
+        csm = _make_csm("coinbase_platform")
+        stale = MagicMock(name="stale_coinbase")
+        verified = MagicMock(name="verified_coinbase")
+        stale_reconnect = MagicMock(return_value=False)
+        verified_reconnect = MagicMock(return_value=True)
+
+        csm.register_broker(broker=stale, reconnect_fn=stale_reconnect)
+        csm.register_broker(
+            broker=verified,
+            reconnect_fn=verified_reconnect,
+            replace_existing=True,
+        )
+
+        self.assertIs(csm._broker, verified)
+        self.assertIs(csm._reconnect_fn, verified_reconnect)
+        self.assertTrue(csm._probe_connection())
+        verified_reconnect.assert_called_once_with()
+        stale_reconnect.assert_not_called()
+
     def test_register_pre_reconnect_hook_stored(self):
         csm = _make_csm()
         hook = MagicMock()

--- a/bot/tests/test_secondary_venue_runtime_diagnostics.py
+++ b/bot/tests/test_secondary_venue_runtime_diagnostics.py
@@ -291,6 +291,7 @@ def test_authenticated_recovery_retries_complete_alternative_pair(monkeypatch):
     class CoinbasePairBroker:
         def __init__(self):
             self.connected = False
+            self.client = None
             self._auth_failed = False
 
         def connect(self):
@@ -299,6 +300,7 @@ def test_authenticated_recovery_retries_complete_alternative_pair(monkeypatch):
                 and os.environ.get("COINBASE_API_SECRET") == good_secret
             )
             self.connected = matched
+            self.client = object() if matched else None
             self._auth_failed = not matched
             return matched
 
@@ -361,4 +363,3 @@ def test_authenticated_recovery_restores_primary_after_all_pairs_fail(monkeypatc
     assert os.environ["COINBASE_API_SECRET"] == primary_secret
     assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
     assert os.environ.get("NIJA_COINBASE_RECONNECT_DISABLED", "0") != "1"
-

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -13,18 +13,20 @@ import os
 import sys
 import threading
 import time
+import weakref
 from functools import wraps
 from types import ModuleType
 from typing import Any, Mapping, Sequence
 
 logger = logging.getLogger("nija.coinbase_authenticated_connect_recovery")
-_MARKER = "20260726-coinbase-authenticated-reconnect-v2"
+_MARKER = "20260726-coinbase-canonical-client-v4"
 _PATCH_ATTR = "_nija_coinbase_authenticated_connect_v1"
 _LOCK = threading.RLock()
 _STARTED = False
 _LAST_FAILURE: dict[str, float] = {}
 _FAILED_PAIR_AT: dict[str, float] = {}
 _PAIR_RETRY_COOLDOWN_S = 300.0
+_CANONICAL_BROKERS: dict[str, weakref.ReferenceType[Any]] = {}
 
 
 def _is_coinbase_class(cls: type) -> bool:
@@ -54,6 +56,155 @@ def _clients(broker: Any) -> list[Any]:
             found.append(value)
     found.insert(0, broker)
     return found
+
+
+def _account_scope(broker: Any) -> str:
+    """Return a stable account key so clients never cross account boundaries."""
+    targets = _credential_targets(broker)
+    target = targets[-1]
+    account_type = getattr(target, "account_type", None)
+    account_value = str(getattr(account_type, "value", account_type) or "platform").lower()
+    if account_value.endswith(".platform"):
+        account_value = "platform"
+    elif account_value.endswith(".user"):
+        account_value = "user"
+    user_id = str(getattr(target, "user_id", "") or "").strip().lower()
+    return f"{account_value}:{user_id}" if user_id else account_value
+
+
+def _client_target(broker: Any) -> Any | None:
+    """Find the concrete broker object that owns an authenticated SDK client."""
+    for target in reversed(_credential_targets(broker)):
+        client = getattr(target, "client", None)
+        if (
+            client is not None
+            and not bool(getattr(target, "_auth_failed", False))
+            and not bool(getattr(target, "auth_failed", False))
+        ):
+            return target
+    return None
+
+
+def _remember_canonical(broker: Any) -> Any | None:
+    """Record and publish the verified concrete broker for its account scope."""
+    target = _client_target(broker)
+    if target is None:
+        return None
+    scope = _account_scope(target)
+    with _LOCK:
+        _CANONICAL_BROKERS[scope] = weakref.ref(target)
+
+    manager = getattr(target, "_connection_stability_manager", None)
+    register = getattr(manager, "register_broker", None)
+    reconnect = getattr(target, "connect", None)
+    if callable(register) and callable(reconnect):
+        try:
+            register(
+                broker=target,
+                reconnect_fn=reconnect,
+                replace_existing=True,
+            )
+        except TypeError:
+            # Compatibility with a lightweight/legacy manager that predates
+            # explicit replacement.  The broker remains canonical locally.
+            pass
+        except Exception:
+            logger.debug(
+                "COINBASE_CANONICAL_WATCHDOG_REBIND_PENDING marker=%s scope=%s",
+                _MARKER,
+                scope,
+            )
+
+    if scope == "platform":
+        try:
+            manager_module = importlib.import_module("bot.broker_manager")
+            register_platform = getattr(manager_module, "register_platform_broker", None)
+            if callable(register_platform):
+                register_platform("coinbase", target, connected=True)
+        except Exception:
+            logger.debug(
+                "COINBASE_CANONICAL_PLATFORM_REGISTRY_PENDING marker=%s",
+                _MARKER,
+            )
+    return target
+
+
+def _canonical_for(broker: Any) -> Any | None:
+    scope = _account_scope(broker)
+    with _LOCK:
+        reference = _CANONICAL_BROKERS.get(scope)
+        target = reference() if reference is not None else None
+        if reference is not None and target is None:
+            _CANONICAL_BROKERS.pop(scope, None)
+    if target is None and scope == "platform":
+        try:
+            manager_module = importlib.import_module("bot.broker_manager")
+            getter = getattr(manager_module, "get_platform_broker", None)
+            target = getter("coinbase") if callable(getter) else None
+        except Exception:
+            target = None
+    if target is None or target is broker:
+        return None
+    if _client_target(target) is None or not bool(getattr(target, "connected", False)):
+        return None
+    return target
+
+
+def adopt_canonical_client(broker: Any) -> bool:
+    """Adopt a verified client from the same account's canonical broker.
+
+    This repairs duplicate/stale runtime objects without converting missing
+    transport state into authentication success.  Platform and user clients
+    are never shared, and different users are isolated by ``user_id``.
+    """
+    if _client_target(broker) is not None:
+        return True
+    canonical = _canonical_for(broker)
+    if canonical is None:
+        return False
+    source = _client_target(canonical)
+    if source is None:
+        return False
+
+    client = getattr(source, "client", None)
+    if client is None:
+        return False
+    for target in _credential_targets(broker):
+        try:
+            target.client = client
+            target.connected = True
+            target._auth_failed = False
+            target._is_available = True
+        except Exception:
+            pass
+        for attr in (
+            "_accounts_cache",
+            "_accounts_cache_time",
+            "_balance_cache",
+            "_balance_cache_time",
+            "_last_known_balance",
+            "_balance_last_updated",
+            "portfolio_uuid",
+        ):
+            try:
+                if hasattr(source, attr) and hasattr(target, attr):
+                    setattr(target, attr, getattr(source, attr))
+            except Exception:
+                pass
+    logger.warning(
+        "COINBASE_CANONICAL_CLIENT_ADOPTED marker=%s scope=%s target=%s source=%s",
+        _MARKER,
+        _account_scope(broker),
+        type(broker).__name__,
+        type(source).__name__,
+    )
+    return True
+
+
+def _forget_canonical(broker: Any) -> None:
+    scope = _account_scope(broker)
+    with _LOCK:
+        _CANONICAL_BROKERS.pop(scope, None)
 
 
 def _payload_success(payload: Any) -> bool:
@@ -103,6 +254,7 @@ def _measure_spendable(broker: Any) -> float:
 
 
 def _publish_connected(broker: Any, source: str) -> None:
+    _remember_canonical(broker)
     for target in _credential_targets(broker):
         for attr, value in (
             ("connected", True),
@@ -300,6 +452,7 @@ def _auth_failure_detail(detail: str) -> bool:
 
 
 def _quarantine(broker: Any, key: str, secret: str) -> None:
+    _forget_canonical(broker)
     _mark_auth_failed(broker)
     fingerprint = _pair_fingerprint(key, secret) if key and secret else ""
     os.environ["NIJA_COINBASE_CREDENTIALS_QUARANTINED"] = "1"
@@ -345,10 +498,20 @@ def _patch_class(cls: type) -> bool:
         # when the client is absent despite connected=True.  A None client with
         # connected=True is an inconsistent state: the broker must re-authenticate
         # before recovery is declared; cached balances must not bypass this check.
-        _client_missing = getattr(self, "client", None) is None
-        if primary_key and primary_secret and (
-            not bool(getattr(self, "connected", False)) or _client_missing
-        ):
+        # Adapters own their concrete broker in ``_broker`` and intentionally
+        # have no direct ``client`` attribute.  Inspect the full credential
+        # target chain so an adapter reconnect cannot clear a healthy nested
+        # client.
+        _client_missing = _client_target(self) is None
+        if _client_missing:
+            adopt_canonical_client(self)
+            _client_missing = _client_target(self) is None
+        # Only clear credentials/client state when the complete adapter/broker
+        # chain truly has no client.  An adapter's own ``connected`` flag may
+        # still be False while its nested canonical broker is already healthy;
+        # resetting on that flag would destroy the authenticated client just
+        # before the adapter reuses it.
+        if primary_key and primary_secret and _client_missing:
             _apply_pair(
                 self,
                 primary_source,
@@ -364,7 +527,9 @@ def _patch_class(cls: type) -> bool:
             result = False
             first_error = f"{type(exc).__name__}:{str(exc)[:100]}"
 
-        if bool(result) or bool(getattr(self, "connected", False)):
+        if (
+            bool(result) or bool(getattr(self, "connected", False))
+        ) and _client_target(self) is not None:
             _publish_connected(self, "connect_result")
             return True
         authenticated, detail = _authenticated_probe(self)
@@ -410,7 +575,9 @@ def _patch_class(cls: type) -> bool:
                 retry_result = False
                 retry_error = f"{type(exc).__name__}:{str(exc)[:100]}"
 
-            if bool(retry_result) or bool(getattr(self, "connected", False)):
+            if (
+                bool(retry_result) or bool(getattr(self, "connected", False))
+            ) and _client_target(self) is not None:
                 _publish_connected(self, f"credential_pair:{source}")
                 logger.critical(
                     "COINBASE_AUTHENTICATED_PAIR_RECOVERED marker=%s "
@@ -518,6 +685,7 @@ def install() -> bool:
 __all__ = [
     "install",
     "_authenticated_probe",
+    "adopt_canonical_client",
     "_configured_pairs",
     "_patch_class",
     "_quarantined_for",

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -27,6 +27,8 @@ _LAST_FAILURE: dict[str, float] = {}
 _FAILED_PAIR_AT: dict[str, float] = {}
 _PAIR_RETRY_COOLDOWN_S = 300.0
 _CANONICAL_BROKERS: dict[str, weakref.ReferenceType[Any]] = {}
+_CANONICAL_SCOPE_ATTR = "_nija_coinbase_canonical_scope_v4"
+_CANONICAL_FINGERPRINT_ATTR = "_nija_coinbase_canonical_credential_fingerprint_v4"
 
 
 def _is_coinbase_class(cls: type) -> bool:
@@ -85,12 +87,41 @@ def _client_target(broker: Any) -> Any | None:
     return None
 
 
+def _credential_fingerprint_for_broker(broker: Any) -> str:
+    """Return a non-secret identity for the credential pair used by *broker*."""
+    key = ""
+    secret = ""
+    for target in reversed(_credential_targets(broker)):
+        key = str(getattr(target, "api_key", "") or key)
+        secret = str(
+            getattr(target, "api_secret", "")
+            or getattr(target, "secret", "")
+            or getattr(target, "private_key", "")
+            or secret
+        )
+        if key and secret:
+            break
+    key = key or str(os.environ.get("COINBASE_API_KEY", "") or "")
+    secret = secret or str(
+        os.environ.get("COINBASE_API_SECRET", "")
+        or os.environ.get("COINBASE_PEM_CONTENT", "")
+        or ""
+    )
+    return _pair_fingerprint(key, secret) if key and secret else ""
+
+
 def _remember_canonical(broker: Any) -> Any | None:
     """Record and publish the verified concrete broker for its account scope."""
     target = _client_target(broker)
     if target is None:
         return None
     scope = _account_scope(target)
+    fingerprint = _credential_fingerprint_for_broker(target)
+    try:
+        setattr(target, _CANONICAL_SCOPE_ATTR, scope)
+        setattr(target, _CANONICAL_FINGERPRINT_ATTR, fingerprint)
+    except Exception:
+        pass
     with _LOCK:
         _CANONICAL_BROKERS[scope] = weakref.ref(target)
 
@@ -131,6 +162,7 @@ def _remember_canonical(broker: Any) -> Any | None:
 
 def _canonical_for(broker: Any) -> Any | None:
     scope = _account_scope(broker)
+    from_platform_registry = False
     with _LOCK:
         reference = _CANONICAL_BROKERS.get(scope)
         target = reference() if reference is not None else None
@@ -141,9 +173,28 @@ def _canonical_for(broker: Any) -> Any | None:
             manager_module = importlib.import_module("bot.broker_manager")
             getter = getattr(manager_module, "get_platform_broker", None)
             target = getter("coinbase") if callable(getter) else None
+            from_platform_registry = target is not None
         except Exception:
             target = None
     if target is None or target is broker:
+        return None
+    canonical_scope = str(getattr(target, _CANONICAL_SCOPE_ATTR, "") or "")
+    canonical_fingerprint = str(
+        getattr(target, _CANONICAL_FINGERPRINT_ATTR, "") or ""
+    )
+    current_fingerprint = _credential_fingerprint_for_broker(broker)
+    # The process-wide platform registry can outlive a module reload or a
+    # credential rotation.  Adopt from it only when this patch previously
+    # verified that exact account scope, and never cross credential families.
+    if from_platform_registry and canonical_scope != scope:
+        return None
+    if canonical_scope and canonical_scope != scope:
+        return None
+    if (
+        canonical_fingerprint
+        and current_fingerprint
+        and canonical_fingerprint != current_fingerprint
+    ):
         return None
     if _client_target(target) is None or not bool(getattr(target, "connected", False)):
         return None

--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -10,7 +10,7 @@ from types import ModuleType
 from typing import Any, Callable
 
 logger = logging.getLogger("nija.runtime_auth_endpoint_repair")
-_MARKER = "20260726-coinbase-client-recovery-v3"
+_MARKER = "20260726-coinbase-client-recovery-v4"
 _LOCK = threading.RLock()
 _PATCHED = False
 _LOCAL = threading.local()
@@ -93,6 +93,14 @@ def _patch_coinbase_class(module: ModuleType) -> bool:
         def guarded(self: Any, *args: Any, __original: Callable[..., Any] = original,
                     __method_name: str = method_name, **kwargs: Any) -> Any:
             client = getattr(self, "client", None)
+            if client is None:
+                try:
+                    recovery = __import__("coinbase_authenticated_connect_recovery_patch")
+                    adopt = getattr(recovery, "adopt_canonical_client", None)
+                    if callable(adopt) and adopt(self):
+                        client = getattr(self, "client", None)
+                except Exception:
+                    client = None
             if client is None:
                 _mark_coinbase_disconnected(self, "client_uninitialized")
                 logger.error(

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os
+import weakref
 from types import ModuleType
 
+import coinbase_authenticated_connect_recovery_patch as recovery
 import runtime_auth_recursion_endpoint_repair_patch as repair
 
 
@@ -54,6 +56,83 @@ def test_coinbase_balance_fails_closed_when_client_is_missing(monkeypatch):
     assert os.environ["NIJA_COINBASE_CONNECTED"] == "0"
     assert os.environ["NIJA_COINBASE_FUNDING_STATUS"] == "client_uninitialized"
     assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
+
+
+def test_coinbase_stale_instance_adopts_same_account_canonical_client(monkeypatch):
+    class AccountType:
+        value = "platform"
+
+    class Client:
+        def get_accounts(self):
+            return {"accounts": []}
+
+    class Stability:
+        def __init__(self):
+            self.reasons = []
+
+        def mark_disconnected(self, reason):
+            self.reasons.append(reason)
+
+    class CoinbaseBroker:
+        account_type = AccountType()
+        user_id = None
+
+        def __init__(self, client=None):
+            self.client = client
+            self.connected = client is not None
+            self._is_available = client is not None
+            self._auth_failed = False
+            self._connection_stability_manager = Stability()
+
+        def _get_account_balance_detailed(self, verbose=False):
+            assert self.client is canonical.client
+            return {"total_funds": 142.76, "trading_balance": 100.11}
+
+        def get_account_balance(self, verbose=False):
+            return self._get_account_balance_detailed()["trading_balance"]
+
+        def get_balance(self):
+            return self.get_account_balance()
+
+    canonical = CoinbaseBroker(Client())
+    stale = CoinbaseBroker()
+    with recovery._LOCK:
+        recovery._CANONICAL_BROKERS["platform"] = weakref.ref(canonical)
+    monkeypatch.setenv("NIJA_COINBASE_CONNECTED", "1")
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+    assert repair._patch_coinbase_class(module) is True
+
+    payload = stale._get_account_balance_detailed()
+
+    assert payload["total_funds"] == 142.76
+    assert stale.client is canonical.client
+    assert stale.connected is True
+    assert stale._connection_stability_manager.reasons == []
+    assert os.environ["NIJA_COINBASE_CONNECTED"] == "1"
+
+
+def test_coinbase_canonical_client_is_never_shared_between_users():
+    class AccountType:
+        value = "user"
+
+    class CoinbaseBroker:
+        account_type = AccountType()
+
+        def __init__(self, user_id, client=None):
+            self.user_id = user_id
+            self.client = client
+            self.connected = client is not None
+            self._auth_failed = False
+
+    tania = CoinbaseBroker("tania", object())
+    daivon = CoinbaseBroker("daivon")
+    with recovery._LOCK:
+        recovery._CANONICAL_BROKERS["user:tania"] = weakref.ref(tania)
+
+    assert recovery.adopt_canonical_client(daivon) is False
+    assert daivon.client is None
 
 
 def test_okx_recursive_connect_is_blocked(monkeypatch):


### PR DESCRIPTION
## What this fixes

Production authenticated Coinbase successfully, then a stale duplicate broker with `client=None` published a process-wide disconnect. The adapter recovery wrapper could also clear a healthy nested broker client because it inspected only the adapter's own connection flag.

## Changes

- preserve a healthy client anywhere in the Coinbase adapter/broker chain
- remember the authenticated canonical broker per account scope
- allow stale same-account instances to adopt that verified client
- isolate platform and user clients, including one user from another
- move the connection watchdog from a stale broker to the authenticated replacement
- keep missing-client reads fail-closed when no canonical client exists
- retain confirmed-401 credential quarantine
- update README with the July 26 recovery checkpoint and required post-deploy proof

## Verification

- 31 focused Coinbase, watchdog, OKX-capital, and reconnect tests passed
- 13 secondary-venue runtime diagnostic tests passed
- 5 universal broker exit supervisor tests passed
- Python compilation passed for all changed modules/tests
- canonical runtime entrypoint attestation passed

This change does not bypass writer authority, balance readiness, trade admission, stop-loss, or take-profit gates, and it does not claim or guarantee profitable trades.