### PR TITLE
Fix broker recursion and startup activation safety

### DIFF
--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -12366,7 +12366,7 @@ class _OKXRestClient:
         # any normalization done by sitecustomize._normalize_okx() is honoured even
         # when this module was imported before that normalization ran.
         self.BASE_URL = os.getenv("OKX_BASE_URL", "https://us.okx.com").rstrip("/")
-        logger.warning(
+        logger.debug(
             "OKX_AUTH_DIAG key=%s secret_len=%s passphrase_len=%s base_url=%s simulated=%s",
             bool(api_key),
             len(api_secret or ""),
@@ -12397,12 +12397,13 @@ class _OKXRestClient:
 
     def _headers(self, timestamp: str, method: str, request_path: str, body: str, *, private: bool) -> Dict[str, str]:
         if private:
-            prehash = timestamp + method.upper() + request_path + body
             signature = self._sign(timestamp, method, request_path, body)
-            logger.warning(
-                "OKX_AUTH_DETAIL timestamp=%s prehash=%r signing_algo=Base64-HMAC-SHA256 signature_len=%s",
+            logger.debug(
+                "OKX_AUTH_DETAIL timestamp=%s method=%s path=%s "
+                "signing_algo=Base64-HMAC-SHA256 signature_len=%s",
                 timestamp,
-                prehash,
+                method.upper(),
+                request_path,
                 len(signature),
             )
             headers: Dict[str, str] = {
@@ -12421,7 +12422,7 @@ class _OKXRestClient:
         _sim_active = self.simulated or _sim_env in {"1", "true", "yes", "y", "on"}
         if _sim_active:
             headers["x-simulated-trading"] = "1"
-        logger.warning(
+        logger.debug(
             "OKX_HEADERS_DIAG simulated_instance=%s simulated_env=%r simulated_header_sent=%s headers_keys=%s",
             self.simulated,
             _sim_env or "absent",
@@ -12448,20 +12449,11 @@ class _OKXRestClient:
         body = self._json_body(payload) if method != "GET" else ""
         ts = self._timestamp()
 
-        # Log authentication context (no secrets exposed) before every request
-        # so that any subsequent failure has full context in the log stream.
-        # Sanitize API key for logging (first 4 and last 4 chars only)
-        api_key_sample = ""
-        if self.api_key and len(self.api_key) >= 8:
-            api_key_sample = f"{self.api_key[:4]}...{self.api_key[-4:]}"
-        elif self.api_key:
-            api_key_sample = "***"
-
         _sim_env_val = os.getenv("OKX_SIMULATED_TRADING", "").strip().lower()
         _sim_active = self.simulated or _sim_env_val in {"1", "true", "yes", "y", "on"}
-        logger.warning(
+        logger.debug(
             "OKX_REQUEST_DIAG method=%s path=%s base_url=%s simulated_instance=%s simulated_env=%r "
-            "simulated_header_will_be_sent=%s key_present=%s key_sample=%s passphrase_present=%s "
+            "simulated_header_will_be_sent=%s key_present=%s passphrase_present=%s "
             "timestamp=%s body_empty=%s",
             method,
             request_path,
@@ -12470,7 +12462,6 @@ class _OKXRestClient:
             _sim_env_val or "absent",
             _sim_active,
             bool(self.api_key),
-            api_key_sample,
             bool(self.passphrase),
             ts,
             not body,
@@ -12484,31 +12475,59 @@ class _OKXRestClient:
             headers=request_headers,
             timeout=self.timeout,
         )
-        logger.warning(
-            "OKX_RESPONSE_DIAG status=%s method=%s path=%s response_body=%s",
-            response.status_code,
-            method,
-            request_path,
-            response.text,
-        )
 
-        # Always log the raw OKX response body before raising so the exact
-        # error message from OKX is visible in the log stream.
-        if not response.ok:
+        try:
+            response_body = response.json()
+        except Exception:
+            # Keep malformed-response diagnostics bounded.  Successful market
+            # and instrument payloads can be hundreds of kilobytes, and private
+            # balance bodies contain unnecessary account-level detail.
+            body_preview = str(response.text or "")[:512]
             logger.error(
-                "OKX_REQUEST_FAILED status=%s method=%s path=%s response_body=%s",
+                "OKX_RESPONSE_JSON_INVALID status=%s method=%s path=%s "
+                "body_bytes=%s body_preview=%r",
                 response.status_code,
                 method,
                 request_path,
-                response.text,
+                len((response.text or "").encode("utf-8", errors="replace")),
+                body_preview,
+            )
+            if not response.ok:
+                response.raise_for_status()
+            raise
+
+        okx_code = str(response_body.get("code", "unknown")) if isinstance(response_body, dict) else "unknown"
+        okx_msg = str(response_body.get("msg", "")) if isinstance(response_body, dict) else ""
+        response_data = response_body.get("data", []) if isinstance(response_body, dict) else []
+        data_items = len(response_data) if isinstance(response_data, list) else 0
+        body_bytes = len((response.text or "").encode("utf-8", errors="replace"))
+
+        logger.debug(
+            "OKX_RESPONSE_DIAG status=%s method=%s path=%s okx_code=%s "
+            "data_items=%s body_bytes=%s",
+            response.status_code,
+            method,
+            request_path,
+            okx_code,
+            data_items,
+            body_bytes,
+        )
+
+        if not response.ok:
+            logger.error(
+                "OKX_REQUEST_FAILED status=%s method=%s path=%s "
+                "okx_code=%s okx_msg=%r body_bytes=%s",
+                response.status_code,
+                method,
+                request_path,
+                okx_code,
+                okx_msg[:512],
+                body_bytes,
             )
 
             # Parse the JSON body even on HTTP 4xx responses so we can surface
             # OKX-specific error codes and messages for faster diagnosis.
             try:
-                err_body = response.json()
-                okx_code = err_body.get("code", "unknown")
-                okx_msg = err_body.get("msg", "")
                 logger.error(
                     "OKX_ERROR_DETAIL okx_code=%s okx_msg=%s",
                     okx_code,
@@ -12547,12 +12566,23 @@ class _OKXRestClient:
                         response.status_code,
                     )
             except Exception:
-                # JSON parse failed — the raw body was already logged above.
+                # Error-detail diagnostics are best effort; the bounded request
+                # failure record above remains available.
                 pass
 
             response.raise_for_status()
 
-        return response.json()
+        if okx_code != "0":
+            logger.warning(
+                "OKX_API_ERROR status=%s method=%s path=%s okx_code=%s okx_msg=%r",
+                response.status_code,
+                method,
+                request_path,
+                okx_code,
+                okx_msg[:512],
+            )
+
+        return response_body
 
     def get_balance(self) -> Dict[str, Any]:
         return self._request("GET", "/api/v5/account/balance", private=True)
@@ -12574,6 +12604,30 @@ class _OKXRestClient:
 
     def get_fills(self, instId: str, limit: str = "100") -> Dict[str, Any]:
         return self._request("GET", "/api/v5/trade/fills", params={"instId": instId, "limit": limit}, private=True)
+
+
+_OKX_SPENDABLE_CASH_CURRENCIES = frozenset({"USD", "USDT", "USDC"})
+
+
+def _okx_spendable_cash(details: Any) -> Dict[str, float]:
+    """Return spendable OKX quote cash without pricing stable cash as positions."""
+    balances = {currency: 0.0 for currency in _OKX_SPENDABLE_CASH_CURRENCIES}
+    if not isinstance(details, list):
+        return balances
+    for detail in details:
+        if not isinstance(detail, dict):
+            continue
+        currency = str(detail.get("ccy") or "").strip().upper()
+        if currency not in balances:
+            continue
+        raw_available = detail.get("availBal")
+        if raw_available in (None, ""):
+            raw_available = detail.get("cashBal")
+        try:
+            balances[currency] += max(0.0, float(raw_available or 0.0))
+        except (TypeError, ValueError):
+            continue
+    return balances
 
 
 class OKXBroker(BaseBroker):
@@ -12727,7 +12781,7 @@ class OKXBroker(BaseBroker):
 
     def get_account_balance(self, verbose: bool = True) -> float:
         """
-        Get total equity (USDT + position values) with fail-closed behavior.
+        Get total equity (USD/USDT/USDC + position values) fail-closed.
 
         CRITICAL FIX (Rule #3): Balance = CASH + POSITION VALUE
         Returns total equity (available cash + position market value), not just available balance.
@@ -12742,7 +12796,7 @@ class OKXBroker(BaseBroker):
             verbose: If True, logs detailed balance breakdown (default: True)
 
         Returns:
-            float: Total equity (available USDT + position values)
+            float: Total equity (available USD/USDT/USDC + position values)
                    Returns last known balance on error (not 0)
         """
         try:
@@ -12769,12 +12823,13 @@ class OKXBroker(BaseBroker):
                 if data and len(data) > 0:
                     details = data[0].get('details', [])
 
-                    # Find USDT balance
-                    available = 0.0
-                    for detail in details:
-                        if detail.get('ccy') == 'USDT':
-                            available = float(detail.get('availBal', 0))
-                            break
+                    # OKX US accounts may hold quote cash as USD rather than
+                    # USDT.  Treat USD, USDT, and USDC as spendable quote cash
+                    # and never send them through the position-pricing path.
+                    cash_balances = _okx_spendable_cash(details)
+                    usd_available = cash_balances["USD"] + cash_balances["USDC"]
+                    usdt_available = cash_balances["USDT"]
+                    available = usd_available + usdt_available
 
                     # FIX Rule #3: Get position values and add to available cash
                     position_value = 0.0
@@ -12805,8 +12860,9 @@ class OKXBroker(BaseBroker):
                     # Enhanced logging (only if verbose=True)
                     if verbose:
                         okx_raw = {
-                            "usd": 0.0,
-                            "usdt": available,
+                            "usd": cash_balances["USD"],
+                            "usdc": cash_balances["USDC"],
+                            "usdt": usdt_available,
                             "trading_balance": available,
                             "usd_held": 0.0,
                             "usdt_held": max(0.0, position_value),
@@ -12816,8 +12872,8 @@ class OKXBroker(BaseBroker):
                         _log_balance_snapshot(
                             account_label=f"okx:{getattr(self, 'account_identifier', 'PLATFORM')}",
                             source="okx.get_balance+positions",
-                            usd_available=0.0,
-                            secondary_available=available,
+                            usd_available=usd_available,
+                            secondary_available=usdt_available,
                             secondary_label="USDT",
                             usd_held=0.0,
                             secondary_held=max(0.0, position_value),
@@ -12836,9 +12892,9 @@ class OKXBroker(BaseBroker):
 
                     return total_equity
 
-                # No USDT found - treat as zero balance (not an error)
+                # No quote cash found - treat as zero balance (not an error)
                 if verbose:
-                    logger.warning("⚠️  No USDT balance found in OKX account")
+                    logger.warning("⚠️  No USD/USDT/USDC balance found in OKX account")
                 # Update last known balance to 0 (this is a successful API call, just zero balance)
                 self._last_known_balance = 0.0
                 self._balance_fetch_errors = 0
@@ -13073,9 +13129,12 @@ class OKXBroker(BaseBroker):
             details = data[0].get('details', [])
             raw_holdings = []
             for detail in details:
-                ccy = detail.get('ccy')
-                available = float(detail.get('availBal', 0))
-                if ccy != 'USDT' and available > 0:
+                ccy = str(detail.get('ccy') or '').strip().upper()
+                raw_available = detail.get('availBal')
+                if raw_available in (None, ''):
+                    raw_available = detail.get('cashBal')
+                available = float(raw_available or 0)
+                if ccy not in _OKX_SPENDABLE_CASH_CURRENCIES and available > 0:
                     okx_symbol = f'{ccy}-USDT'
                     raw_holdings.append((ccy, available, okx_symbol))
 

--- a/bot/coinbase_funding_readiness_repair_patch.py
+++ b/bot/coinbase_funding_readiness_repair_patch.py
@@ -26,6 +26,7 @@ _ORIGINAL_IMPORT = None
 _PATCH_ATTR = "_nija_coinbase_connection_funding_v3"
 _LAST_CREDENTIAL_SIGNATURE: tuple[Any, ...] | None = None
 _LAST_CONNECTION_SIGNATURE: tuple[Any, ...] | None = None
+_CONNECT_LOCAL = threading.local()
 
 
 def _clean(value: Any) -> str:
@@ -213,47 +214,92 @@ def _measure_spendable(broker: Any) -> float:
     return 0.0
 
 
+def _wrapper_chain_has_patch(current: Any) -> bool:
+    """Return True when this wrapper is already present anywhere in the chain."""
+    seen: set[int] = set()
+    candidate = current
+    while callable(candidate) and id(candidate) not in seen:
+        seen.add(id(candidate))
+        if bool(getattr(candidate, _PATCH_ATTR, False)):
+            return True
+        candidate = getattr(candidate, "__wrapped__", None)
+    return False
+
+
 def _connect_wrapper(cls: type, current):
     @wraps(current)
     def connect(self: Any, *args: Any, **kwargs: Any):
         global _LAST_CONNECTION_SIGNATURE
-        if not recover_coinbase_environment():
+        identity = id(self)
+        active = set(getattr(_CONNECT_LOCAL, "active_brokers", set()))
+        if identity in active:
             try:
                 self.connected = False
+                self._is_available = False
+                self._nija_coinbase_connect_reentry_blocked = True
             except Exception:
                 pass
             os.environ["NIJA_COINBASE_CONNECTED"] = "0"
             os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
-            os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
-            logger.error("COINBASE_CONNECTION_BLOCKED_INVALID_CREDENTIAL_FORMAT marker=%s class=%s", _MARKER, cls.__name__)
+            os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "connect_recursion_blocked"
+            os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+            logger.error(
+                "COINBASE_CONNECTION_REENTRY_BLOCKED marker=%s class=%s action=fail_closed",
+                _MARKER,
+                cls.__name__,
+            )
             return False
+
+        active.add(identity)
+        _CONNECT_LOCAL.active_brokers = active
         try:
-            result = current(self, *args, **kwargs)
-        except Exception as exc:
+            self._nija_coinbase_connect_reentry_blocked = False
+        except Exception:
+            pass
+        try:
+            if not recover_coinbase_environment():
+                try:
+                    self.connected = False
+                except Exception:
+                    pass
+                os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+                os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+                os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
+                logger.error("COINBASE_CONNECTION_BLOCKED_INVALID_CREDENTIAL_FORMAT marker=%s class=%s", _MARKER, cls.__name__)
+                return False
             try:
-                self.connected = False
-            except Exception:
-                pass
-            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
-            os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
-            os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
-            logger.error("COINBASE_CONNECTION_AUTH_FAILED marker=%s class=%s error_type=%s error=%s", _MARKER, cls.__name__, type(exc).__name__, str(exc)[:240])
-            return False
-        connected = bool(result) or bool(getattr(self, "connected", False))
-        if connected:
-            spendable = _measure_spendable(self)
-            _publish_ready(spendable)
-            signature = (cls.__name__, True, round(spendable, 8))
-            with _LOCK:
-                if signature != _LAST_CONNECTION_SIGNATURE:
-                    _LAST_CONNECTION_SIGNATURE = signature
-                    logger.critical("COINBASE_CONNECTION_RECOVERED marker=%s class=%s connected=true spendable_quote=$%.2f readiness_published=%s", _MARKER, cls.__name__, spendable, spendable > 0)
-        else:
-            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
-            os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
-            os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
-            logger.error("COINBASE_CONNECTION_PROBE_FAILED marker=%s class=%s", _MARKER, cls.__name__)
-        return result
+                result = current(self, *args, **kwargs)
+            except Exception as exc:
+                try:
+                    self.connected = False
+                except Exception:
+                    pass
+                os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+                os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+                os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
+                logger.error("COINBASE_CONNECTION_AUTH_FAILED marker=%s class=%s error_type=%s error=%s", _MARKER, cls.__name__, type(exc).__name__, str(exc)[:240])
+                return False
+            if bool(getattr(self, "_nija_coinbase_connect_reentry_blocked", False)):
+                return False
+            connected = bool(result) or bool(getattr(self, "connected", False))
+            if connected:
+                spendable = _measure_spendable(self)
+                _publish_ready(spendable)
+                signature = (cls.__name__, True, round(spendable, 8))
+                with _LOCK:
+                    if signature != _LAST_CONNECTION_SIGNATURE:
+                        _LAST_CONNECTION_SIGNATURE = signature
+                        logger.critical("COINBASE_CONNECTION_RECOVERED marker=%s class=%s connected=true spendable_quote=$%.2f readiness_published=%s", _MARKER, cls.__name__, spendable, spendable > 0)
+            else:
+                os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+                os.environ["NIJA_COINBASE_BALANCE_OBSERVED"] = "0"
+                os.environ["NIJA_COINBASE_FUNDING_STATUS"] = "auth_unavailable"
+                logger.error("COINBASE_CONNECTION_PROBE_FAILED marker=%s class=%s", _MARKER, cls.__name__)
+            return result
+        finally:
+            remaining = set(getattr(_CONNECT_LOCAL, "active_brokers", set()))
+            remaining.discard(identity)
+            _CONNECT_LOCAL.active_brokers = remaining
 
     setattr(connect, _PATCH_ATTR, True)
     connect.__wrapped__ = current  # type: ignore[attr-defined]
@@ -267,7 +313,7 @@ def _patch_broker_module(module: ModuleType) -> bool:
         current = getattr(cls, "connect", None) if isinstance(cls, type) else None
         if not callable(current):
             continue
-        if getattr(current, _PATCH_ATTR, False):
+        if _wrapper_chain_has_patch(current):
             changed = True
             continue
         cls.connect = _connect_wrapper(cls, current)

--- a/bot/okx_runtime_patch.py
+++ b/bot/okx_runtime_patch.py
@@ -377,7 +377,14 @@ def apply_okx_runtime_patches() -> bool:
             signature = base64.b64encode(
                 hmac.new(self.api_secret.encode("utf-8"), prehash.encode("utf-8"), hashlib.sha256).digest()
             ).decode("utf-8")
-            logger.warning("OKX_AUTH_DETAIL timestamp=%s prehash=%r signing_algo=Base64-HMAC-SHA256 signature_len=%s", timestamp, prehash, len(signature))
+            logger.debug(
+                "OKX_AUTH_DETAIL timestamp=%s method=%s path=%s "
+                "signing_algo=Base64-HMAC-SHA256 signature_len=%s",
+                timestamp,
+                method.upper(),
+                request_path,
+                len(signature),
+            )
             headers: Dict[str, str] = {
                 "OK-ACCESS-KEY": self.api_key,
                 "OK-ACCESS-SIGN": signature,
@@ -390,7 +397,12 @@ def apply_okx_runtime_patches() -> bool:
         _sim_active = bool(getattr(self, "simulated", False)) or _env_truthy("OKX_SIMULATED_TRADING") or _env_truthy("OKX_USE_TESTNET")
         if _sim_active:
             headers["x-simulated-trading"] = "1"
-        logger.warning("OKX_HEADERS_DIAG simulated_instance=%s simulated_header_sent=%s headers_keys=%s", bool(getattr(self, "simulated", False)), _sim_active, list(headers.keys()))
+        logger.debug(
+            "OKX_HEADERS_DIAG simulated_instance=%s simulated_header_sent=%s headers_keys=%s",
+            bool(getattr(self, "simulated", False)),
+            _sim_active,
+            list(headers.keys()),
+        )
         return headers
 
     def _request(self: Any, method: str, path: str, *, params: Optional[Dict[str, Any]] = None, payload: Optional[Dict[str, Any]] = None, private: bool = False) -> Dict[str, Any]:
@@ -399,29 +411,77 @@ def apply_okx_runtime_patches() -> bool:
         inst = str(clean_params.get("instId", "")).upper()
         is_market_data = path in {"/api/v5/market/candles", "/api/v5/market/ticker"}
         if is_market_data and _is_invalid_or_synthetic(inst):
-            logger.warning("OKX_INVALID_INSTRUMENT_CACHE_SKIP marker=20260703z instId=%s path=%s", inst, path)
+            logger.debug("OKX_INVALID_INSTRUMENT_CACHE_SKIP marker=20260703z instId=%s path=%s", inst, path)
             return {"code": "0", "msg": "invalid_or_synthetic_instrument_cached_skip", "data": []}
         query = "?" + urlencode(clean_params) if clean_params else ""
         request_path = f"{path}{query}"
         body = "" if method == "GET" or not payload else json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
         ts = self._timestamp()
         simulated = bool(getattr(self, "simulated", False)) or _env_truthy("OKX_SIMULATED_TRADING") or _env_truthy("OKX_USE_TESTNET")
-        logger.warning("OKX_REQUEST_DIAG method=%s path=%s base_url=%s simulated_instance=%s simulated_active=%s key_present=%s passphrase_present=%s timestamp=%s body_empty=%s", method, request_path, self.BASE_URL, bool(getattr(self, "simulated", False)), simulated, bool(getattr(self, "api_key", "")), bool(getattr(self, "passphrase", "")), ts, body == "")
+        logger.debug(
+            "OKX_REQUEST_DIAG method=%s path=%s base_url=%s simulated_instance=%s "
+            "simulated_active=%s key_present=%s passphrase_present=%s "
+            "timestamp=%s body_empty=%s",
+            method,
+            request_path,
+            self.BASE_URL,
+            bool(getattr(self, "simulated", False)),
+            simulated,
+            bool(getattr(self, "api_key", "")),
+            bool(getattr(self, "passphrase", "")),
+            ts,
+            body == "",
+        )
         request_headers = self._headers(ts, method, request_path, body, private=private)
         response = self.session.request(method, f"{self.BASE_URL}{request_path}", data=body if body else None, headers=request_headers, timeout=self.timeout)
-        logger.warning("OKX_RESPONSE_DIAG status=%s method=%s path=%s response_body=%s", response.status_code, method, request_path, response.text)
+        body_bytes = len((response.text or "").encode("utf-8", errors="replace"))
         try:
             parsed = response.json()
         except ValueError:
-            parsed = {"code": f"HTTP_{response.status_code}", "msg": response.text or "Non-JSON OKX response"}
+            body_preview = str(response.text or "")[:512]
+            parsed = {
+                "code": f"HTTP_{response.status_code}",
+                "msg": "Non-JSON OKX response",
+            }
+            log_fn = logger.error if not response.ok else logger.warning
+            log_fn(
+                "OKX_RESPONSE_JSON_INVALID status=%s method=%s path=%s "
+                "body_bytes=%s body_preview=%r",
+                response.status_code,
+                method,
+                request_path,
+                body_bytes,
+                body_preview,
+            )
         okx_code = str(parsed.get("code", "0"))
+        response_data = parsed.get("data", []) if isinstance(parsed, dict) else []
+        data_items = len(response_data) if isinstance(response_data, list) else 0
+        logger.debug(
+            "OKX_RESPONSE_DIAG status=%s method=%s path=%s okx_code=%s "
+            "data_items=%s body_bytes=%s",
+            response.status_code,
+            method,
+            request_path,
+            okx_code,
+            data_items,
+            body_bytes,
+        )
         if (not response.ok) or okx_code not in {"0", ""}:
             okx_msg = str(parsed.get("msg", ""))
             if is_market_data and okx_code == "51001" and inst:
                 _INVALID_OKX_INST_IDS.add(inst)
                 logger.warning("OKX_INVALID_INSTRUMENT_CACHED marker=20260703z instId=%s path=%s cache_size=%d", inst, path, len(_INVALID_OKX_INST_IDS))
             log_fn = logger.error if not response.ok else logger.warning
-            log_fn("OKX_REQUEST_FAILED status=%s method=%s path=%s okx_code=%s okx_msg=%s response_body=%s", response.status_code, method, request_path, okx_code, okx_msg, response.text)
+            log_fn(
+                "OKX_REQUEST_FAILED status=%s method=%s path=%s "
+                "okx_code=%s okx_msg=%r body_bytes=%s",
+                response.status_code,
+                method,
+                request_path,
+                okx_code,
+                okx_msg[:512],
+                body_bytes,
+            )
             hint = _okx_auth_hint(okx_code, response.status_code)
             if hint:
                 log_fn("OKX_HINT %s", hint)
@@ -432,7 +492,7 @@ def apply_okx_runtime_patches() -> bool:
     def get_ticker(self: Any, instId: str) -> Dict[str, Any]:
         normalized = _normalize_okx_inst_id(instId)
         if _is_invalid_or_synthetic(normalized):
-            logger.warning("OKX_CASH_OR_INVALID_TICKER_SKIPPED marker=20260703z instId=%s", normalized)
+            logger.debug("OKX_CASH_OR_INVALID_TICKER_SKIPPED marker=20260703z instId=%s", normalized)
             return {"code": "0", "msg": "cash_or_invalid_ticker_skipped", "data": []}
         return self._request("GET", "/api/v5/market/ticker", params={"instId": normalized})
 

--- a/bot/tests/test_coinbase_funding_readiness_repair_patch.py
+++ b/bot/tests/test_coinbase_funding_readiness_repair_patch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from types import ModuleType
 
 from bot import coinbase_funding_readiness_repair_patch as patch
 
@@ -14,6 +15,8 @@ def test_combined_json_recovers_key_and_private_key(monkeypatch):
     )
     monkeypatch.delenv("COINBASE_API_KEY", raising=False)
     monkeypatch.delenv("COINBASE_API_SECRET", raising=False)
+    monkeypatch.delenv("NIJA_COINBASE_BALANCE_OBSERVED", raising=False)
+    monkeypatch.delenv("NIJA_COINBASE_FUNDING_STATUS", raising=False)
 
     assert patch.recover_coinbase_environment() is True
     assert patch.os.environ["COINBASE_API_KEY"] == "organizations/test/apiKeys/key"
@@ -65,3 +68,55 @@ def test_measure_spendable_reads_cache_when_client_is_present():
             self._balance_cache = {"usd": 250.0}
 
     assert patch._measure_spendable(Broker()) == 250.0
+
+
+def test_patch_broker_module_detects_marker_inside_wrapper_chain():
+    def original(self):
+        return True
+
+    def recovery(self):
+        return original(self)
+
+    setattr(recovery, patch._PATCH_ATTR, True)
+    recovery.__wrapped__ = original
+
+    def outer(self):
+        return recovery(self)
+
+    outer.__wrapped__ = recovery
+
+    class CoinbaseBroker:
+        connect = outer
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+    before = CoinbaseBroker.connect
+
+    assert patch._patch_broker_module(module) is True
+    assert CoinbaseBroker.connect is before
+
+
+def test_connect_wrapper_blocks_same_thread_reentry(monkeypatch):
+    class CoinbaseBroker:
+        def __init__(self):
+            self.connected = False
+            self._is_available = True
+
+        def connect(self):
+            return self.connect()
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/test/apiKeys/key")
+    monkeypatch.setenv(
+        "COINBASE_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\nTEST\n-----END EC PRIVATE KEY-----",
+    )
+
+    assert patch._patch_broker_module(module) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert broker._is_available is False
+    assert patch.os.environ["NIJA_COINBASE_FUNDING_STATUS"] == "connect_recursion_blocked"

--- a/bot/tests/test_execution_authority_convergence_fsm.py
+++ b/bot/tests/test_execution_authority_convergence_fsm.py
@@ -166,7 +166,7 @@ class TestMaybeAutoActivateDelegation(unittest.TestCase):
                 snap = sm.get_execution_authority_snapshot(gates_ok=True)
                 self.assertFalse(snap["intent_present"])
 
-    def test_startup_override_blocks_live_arming_without_ownership(self) -> None:
+    def test_startup_override_arms_fail_closed_while_ownership_is_pending(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             state_path = os.path.join(tmp, "state.json")
             with patch.dict(
@@ -184,7 +184,11 @@ class TestMaybeAutoActivateDelegation(unittest.TestCase):
                 return_value=(False, "bootstrap_guard_not_held"),
             ):
                 sm = TradingStateMachine(state_file=state_path)
-                self.assertEqual(sm.get_current_state(), TradingState.OFF)
+                self.assertEqual(
+                    sm.get_current_state(),
+                    TradingState.LIVE_PENDING_CONFIRMATION,
+                )
+                self.assertFalse(sm.can_dispatch_trades())
 
     def test_startup_override_arms_live_when_ownership_is_present(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -602,11 +606,64 @@ class TestHeartbeatSafetyGating(unittest.TestCase):
                     "HEARTBEAT_TRADE": "true",
                     "HEARTBEAT_REQUIRED_FIRST_ACTIVATION": "false",
                     "HEARTBEAT_MARKER_PATH": marker_path,
+                    "FORCE_TRADE": "false",
+                    "FORCE_TRADE_MODE": "false",
+                    "FORCE_LIVE_TRANSITION": "false",
+                    "NIJA_FORCE_ACTIVATION": "false",
                 },
                 clear=False,
             ):
                 sm = TradingStateMachine(state_file=state_path)
                 self.assertFalse(sm.commit_activation())
+                self.assertEqual(
+                    sm.get_current_state(),
+                    TradingState.LIVE_PENDING_CONFIRMATION,
+                )
+
+    def test_pending_timeout_never_bypasses_safety_gates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = os.path.join(tmp, "state.json")
+            with patch.dict(
+                os.environ,
+                {
+                    "LIVE_CAPITAL_VERIFIED": "true",
+                    "DRY_RUN_MODE": "false",
+                    "AUTO_ACTIVATE": "false",
+                    "HEARTBEAT_TRADE": "false",
+                    "HEARTBEAT_REQUIRED_FIRST_ACTIVATION": "false",
+                    "NIJA_PENDING_CONFIRMATION_TIMEOUT_S": "30",
+                    "FORCE_TRADE": "false",
+                    "FORCE_TRADE_MODE": "false",
+                    "FORCE_LIVE_TRANSITION": "false",
+                    "NIJA_FORCE_ACTIVATION": "false",
+                },
+                clear=False,
+            ), patch(
+                "bot.trading_state_machine._startup_ownership_gate",
+                return_value=(False, "bootstrap_guard_not_held"),
+            ):
+                sm = TradingStateMachine(state_file=state_path)
+                sm._pending_confirmation_since = time.monotonic() - 31.0
+
+                with patch.object(
+                    sm,
+                    "_force_live_active_transition",
+                    wraps=sm._force_live_active_transition,
+                ) as forced_transition, patch(
+                    "bot.trading_state_machine._heartbeat_verification_required",
+                    return_value=True,
+                ), patch(
+                    "bot.trading_state_machine._heartbeat_verification_status",
+                    return_value=(False, "marker_missing", {}),
+                ):
+                    self.assertFalse(sm.commit_activation())
+
+                forced_transition.assert_not_called()
+                self.assertEqual(
+                    sm.get_current_state(),
+                    TradingState.LIVE_PENDING_CONFIRMATION,
+                )
+                self.assertFalse(sm.can_dispatch_trades())
 
     def test_commit_activation_arms_pending_when_off_with_live_intent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -626,7 +683,10 @@ class TestHeartbeatSafetyGating(unittest.TestCase):
                 return_value=(False, "bootstrap_guard_not_held"),
             ):
                 sm = TradingStateMachine(state_file=state_path)
-                self.assertEqual(sm.get_current_state(), TradingState.OFF)
+                self.assertEqual(
+                    sm.get_current_state(),
+                    TradingState.LIVE_PENDING_CONFIRMATION,
+                )
 
                 class _ReadyCA:
                     is_hydrated = True

--- a/bot/tests/test_okx_cash_handling.py
+++ b/bot/tests/test_okx_cash_handling.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import logging
+
+from bot.broker_manager import OKXBroker, _OKXRestClient, _okx_spendable_cash
+
+
+class _AccountAPI:
+    def __init__(self, details):
+        self._details = details
+
+    def get_balance(self):
+        return {"code": "0", "data": [{"details": self._details}]}
+
+
+def _broker(details):
+    broker = OKXBroker.__new__(OKXBroker)
+    broker.account_api = _AccountAPI(details)
+    broker.market_api = None
+    broker._last_known_balance = None
+    broker._balance_fetch_errors = 0
+    broker._is_available = True
+    broker.account_identifier = "PLATFORM"
+    return broker
+
+
+def test_okx_spendable_cash_sums_usd_usdt_and_usdc():
+    details = [
+        {"ccy": "USD", "availBal": "144.96", "cashBal": "144.96"},
+        {"ccy": "USDT", "availBal": "2.50"},
+        {"ccy": "USDC", "availBal": "", "cashBal": "1.25"},
+        {"ccy": "ETH", "availBal": "3"},
+    ]
+
+    assert _okx_spendable_cash(details) == {
+        "USD": 144.96,
+        "USDT": 2.5,
+        "USDC": 1.25,
+    }
+
+
+def test_okx_account_balance_counts_all_quote_cash(monkeypatch):
+    broker = _broker(
+        [
+            {"ccy": "USD", "availBal": "144.96"},
+            {"ccy": "USDT", "availBal": "2.50"},
+            {"ccy": "USDC", "availBal": "1.25"},
+        ]
+    )
+    monkeypatch.setattr(broker, "get_positions", lambda: [])
+
+    assert broker.get_account_balance(verbose=False) == 148.71
+    assert broker._last_known_balance == 148.71
+
+
+def test_okx_positions_exclude_quote_cash_and_never_request_usd_usdt(monkeypatch):
+    details = [
+        {"ccy": "USD", "availBal": "144.96"},
+        {"ccy": "USDT", "availBal": "2.50"},
+        {"ccy": "USDC", "availBal": "1.25"},
+        {"ccy": "ETH", "availBal": "0.5"},
+    ]
+    broker = _broker(details)
+
+    class _MarketAPI:
+        def get_tickers(self, instType):
+            assert instType == "SPOT"
+            return {
+                "code": "0",
+                "data": [{"instId": "ETH-USDT", "last": "1915.38"}],
+            }
+
+    broker.market_api = _MarketAPI()
+    monkeypatch.setattr(
+        broker,
+        "get_current_price",
+        lambda symbol: (_ for _ in ()).throw(
+            AssertionError(f"unexpected individual ticker request: {symbol}")
+        ),
+    )
+
+    positions = broker.get_positions()
+
+    assert [position["symbol"] for position in positions] == ["ETH-USD"]
+    assert positions[0]["size_usd"] == 957.69
+
+
+class _Response:
+    def __init__(self, body, *, status_code=200, text=None):
+        self._body = body
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 400
+        self.text = text if text is not None else repr(body)
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _Session:
+    def __init__(self, response):
+        self.response = response
+
+    def request(self, *args, **kwargs):
+        return self.response
+
+
+def _rest_client(response):
+    client = _OKXRestClient.__new__(_OKXRestClient)
+    client.api_key = "api-key"
+    client.api_secret = "api-secret"
+    client.passphrase = "passphrase"
+    client.simulated = False
+    client.timeout = 10.0
+    client.BASE_URL = "https://us.okx.com"
+    client.session = _Session(response)
+    return client
+
+
+def test_okx_success_response_does_not_emit_raw_payload_at_warning(caplog):
+    raw_text = '{"code":"0","data":[{"private":"sensitive-balance"}]}'
+    client = _rest_client(
+        _Response(
+            {"code": "0", "msg": "", "data": [{"private": "sensitive-balance"}]},
+            text=raw_text,
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="nija.broker"):
+        result = client.get_balance()
+
+    assert result["code"] == "0"
+    warning_or_higher = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+    assert warning_or_higher == []
+    assert all(raw_text not in record.getMessage() for record in caplog.records)
+    assert all("sensitive-balance" not in record.getMessage() for record in caplog.records)
+    assert any(
+        "OKX_RESPONSE_DIAG" in record.getMessage()
+        and "data_items=1" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_okx_application_error_is_bounded_and_omits_raw_payload(caplog):
+    raw_text = '{"code":"51001","msg":"Instrument does not exist","data":[]}'
+    client = _rest_client(
+        _Response(
+            {"code": "51001", "msg": "Instrument does not exist", "data": []},
+            text=raw_text,
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="nija.broker"):
+        result = client.get_ticker("BAD-USDT")
+
+    assert result["code"] == "51001"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        ("OKX_API_ERROR" in message or "OKX_REQUEST_FAILED" in message)
+        and "okx_code=51001" in message
+        and "Instrument does not exist" in message
+        for message in messages
+    )
+    assert all(raw_text not in message for message in messages)
+    assert all("key_sample" not in message for message in messages)

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib
 import os
+import sys
+from types import ModuleType
 from types import SimpleNamespace
 
 
@@ -115,6 +117,50 @@ def test_one_ready_venue_enables_execution_independently(monkeypatch) -> None:
     assert result["venues"]["kraken"]["ready"] is True
     assert result["venues"]["coinbase"]["ready"] is False
     assert result["venues"]["okx"]["ready"] is False
+
+
+def test_hydrated_fresh_capital_authority_satisfies_capital_gate(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token")
+
+    authority = SimpleNamespace(
+        is_hydrated=True,
+        is_stale=lambda: False,
+        get_real_capital=lambda: 116.09,
+    )
+    capital_module = ModuleType("bot.capital_authority")
+    capital_module.get_capital_authority = lambda: authority
+    monkeypatch.setitem(sys.modules, "bot.capital_authority", capital_module)
+    monkeypatch.delitem(sys.modules, "capital_authority", raising=False)
+
+    kraken = FakeBroker(balance=116.09)
+    manager = SimpleNamespace(
+        _platform_brokers={"kraken": kraken},
+        eligible_brokers={kraken},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
+
+    result = module.evaluate_all()
+
+    assert result["capital_ready"] is True
+    assert result["execution_ready"] is True
+
+
+def test_live_active_state_does_not_substitute_for_capital_readiness(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    monkeypatch.delitem(sys.modules, "bot.capital_authority", raising=False)
+    monkeypatch.delitem(sys.modules, "capital_authority", raising=False)
+
+    assert module._capital_ready() is False
 
 
 def test_publish_sets_independent_compatibility_flags(monkeypatch) -> None:

--- a/bot/tests/test_writer_lock_release_guard.py
+++ b/bot/tests/test_writer_lock_release_guard.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib
+import io
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -104,6 +106,30 @@ def test_mismatched_redis_value_is_not_deleted(monkeypatch) -> None:
     assert module.release_owned_writer_lock("unit_test_mismatch") is False
     assert len(fake.calls) == 1
     assert os.environ["NIJA_WRITER_FENCING_TOKEN"] == "60"
+
+
+def test_atexit_release_suppresses_closed_logging_stream_error(
+    monkeypatch, capsys
+) -> None:
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "_local_authority_proof",
+        lambda: (False, "", "fencing_token_missing"),
+    )
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    module.logger.addHandler(handler)
+    module.logger.propagate = False
+    stream.close()
+    try:
+        module._release_at_exit()
+    finally:
+        module.logger.removeHandler(handler)
+        module.logger.propagate = True
+
+    assert "Logging error" not in capsys.readouterr().err
 
 
 def test_docker_healthcheck_uses_isolated_stdlib_python() -> None:

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -1220,14 +1220,15 @@ class TradingStateMachine:
         self._activation_committed: bool = False
 
         # Timestamp (monotonic) when the FSM first entered LIVE_PENDING_CONFIRMATION.
-        # Used by the 5-minute auto-transition timeout and the 30-second monitoring
-        # log inside commit_activation().  Reset to None whenever the state leaves
-        # LIVE_PENDING_CONFIRMATION (either forward to LIVE_ACTIVE or back to OFF).
+        # Used by the 5-minute stalled-state diagnostic and the 30-second monitoring
+        # log inside commit_activation().  Elapsed time never bypasses activation
+        # gates. Reset to None whenever the state leaves pending confirmation.
         self._pending_confirmation_since: Optional[float] = None
 
         # Timestamp (monotonic) of the last periodic "stuck in LIVE_PENDING_CONFIRMATION"
         # monitoring log emission.  Ensures the log fires at most once every 30 s.
         self._last_pending_log_time: Optional[float] = None
+        self._pending_timeout_reported: bool = False
 
         # Runtime dispatch authority handshake.
         # execution_authority=True is the canonical permission signal for order
@@ -1246,7 +1247,7 @@ class TradingStateMachine:
         # Startup override (operator-intent first):
         # - DRY_RUN_MODE=true          -> DRY_RUN
         # - LIVE_CAPITAL_VERIFIED=true and AUTO_ACTIVATE=true
-        #       -> LIVE_ACTIVE (or LIVE_PENDING_CONFIRMATION if HEARTBEAT_TRADE=true)
+        #       -> LIVE_PENDING_CONFIRMATION until every activation gate passes
         # - LIVE_CAPITAL_VERIFIED=true and AUTO_ACTIVATE=false
         #       -> LIVE_PENDING_CONFIRMATION (armed, not monitor/OFF)
         self._apply_startup_state_override()
@@ -1363,46 +1364,20 @@ class TradingStateMachine:
             if live_verified and (auto_activate or force_live):
                 ownership_ok, ownership_err = _startup_ownership_gate()
                 if not ownership_ok:
-                    # FORCE_TRADE / FORCE_LIVE_TRANSITION bypass: when an operator override
-                    # flag is active, do NOT block at OFF — arm to LIVE_PENDING_CONFIRMATION
-                    # so the 5-minute LPC auto-transition timeout can fire even when Redis /
-                    # distributed writer authority is unavailable.  Without this, the state
-                    # stays at OFF forever and the LPC timeout never triggers.
-                    _force_override = (
-                        _env_truthy("FORCE_TRADE")
-                        or _env_truthy("FORCE_TRADE_MODE")
-                        or _env_truthy("NIJA_FORCE_ACTIVATION")
-                        or _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
-                    )
-                    if _force_override:
-                        logger.critical(
-                            "[STARTUP STATE OVERRIDE] ownership gate failed (%s) but FORCE_TRADE/NIJA_FORCE_ACTIVATION "
-                            "is set — arming to LIVE_PENDING_CONFIRMATION to allow LPC timeout activation. "
-                            "LIVE_CAPITAL_VERIFIED=%s AUTO_ACTIVATE=%s",
-                            ownership_err or "unknown",
-                            live_verified,
-                            auto_activate,
-                        )
-                        self._current_state = TradingState.LIVE_PENDING_CONFIRMATION
-                        self._activation_committed = False
-                        self._execution_authority = False
-                        self._core_loop_owns_execution = True
-                        self._can_dispatch_trades = False
-                        self._pending_confirmation_since = time.monotonic()
-                        self._last_pending_log_time = None
-                        logger.critical(
-                            "[STARTUP STATE OVERRIDE] FORCE_TRADE armed: OFF -> LIVE_PENDING_CONFIRMATION "
-                            "(5-minute LPC timeout will auto-activate to LIVE_ACTIVE)"
-                        )
-                        return
-                    self._current_state = TradingState.OFF
+                    # Arming is fail-closed: LIVE_PENDING_CONFIRMATION cannot
+                    # dispatch orders.  Preserve live intent here so ownership
+                    # and the remaining safety gates can converge after startup.
+                    self._current_state = TradingState.LIVE_PENDING_CONFIRMATION
                     self._activation_committed = False
                     self._execution_authority = False
                     self._core_loop_owns_execution = True
                     self._can_dispatch_trades = False
+                    self._pending_confirmation_since = time.monotonic()
+                    self._last_pending_log_time = None
                     logger.critical(
-                        "[STARTUP STATE OVERRIDE] BLOCKED LIVE ARMING: startup ownership missing reason=%s "
-                        "— set FORCE_TRADE=1 or NIJA_FORCE_ACTIVATION=1 to bypass this gate",
+                        "[STARTUP STATE OVERRIDE] LIVE INTENT ARMED FAIL-CLOSED: "
+                        "OFF -> LIVE_PENDING_CONFIRMATION ownership_pending=%s "
+                        "execution_authority=false",
                         ownership_err or "unknown",
                     )
                     return
@@ -1445,43 +1420,17 @@ class TradingStateMachine:
             if live_verified and not dry_run_mode:
                 ownership_ok, ownership_err = _startup_ownership_gate()
                 if not ownership_ok:
-                    # FORCE_TRADE bypass: same logic as the AUTO_ACTIVATE path above.
-                    # When an operator override flag is active, arm to LIVE_PENDING_CONFIRMATION
-                    # instead of blocking at OFF so the LPC timeout can fire.
-                    _force_override_lcv = (
-                        _env_truthy("FORCE_TRADE")
-                        or _env_truthy("FORCE_TRADE_MODE")
-                        or _env_truthy("NIJA_FORCE_ACTIVATION")
-                        or _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
-                    )
-                    if _force_override_lcv:
-                        logger.critical(
-                            "[STARTUP STATE OVERRIDE] ownership gate failed (%s) but FORCE_TRADE/NIJA_FORCE_ACTIVATION "
-                            "is set — arming to LIVE_PENDING_CONFIRMATION (LPC timeout will activate). "
-                            "LIVE_CAPITAL_VERIFIED=%s",
-                            ownership_err or "unknown",
-                            live_verified,
-                        )
-                        self._current_state = TradingState.LIVE_PENDING_CONFIRMATION
-                        self._activation_committed = False
-                        self._execution_authority = False
-                        self._core_loop_owns_execution = True
-                        self._can_dispatch_trades = False
-                        self._pending_confirmation_since = time.monotonic()
-                        self._last_pending_log_time = None
-                        logger.critical(
-                            "[STARTUP STATE OVERRIDE] FORCE_TRADE armed: OFF -> LIVE_PENDING_CONFIRMATION "
-                            "(5-minute LPC timeout will auto-activate to LIVE_ACTIVE)"
-                        )
-                        return
-                    self._current_state = TradingState.OFF
+                    self._current_state = TradingState.LIVE_PENDING_CONFIRMATION
                     self._activation_committed = False
                     self._execution_authority = False
                     self._core_loop_owns_execution = True
                     self._can_dispatch_trades = False
+                    self._pending_confirmation_since = time.monotonic()
+                    self._last_pending_log_time = None
                     logger.critical(
-                        "[STARTUP STATE OVERRIDE] BLOCKED LIVE ARMING: startup ownership missing reason=%s "
-                        "— set FORCE_TRADE=1 or NIJA_FORCE_ACTIVATION=1 to bypass this gate",
+                        "[STARTUP STATE OVERRIDE] LIVE INTENT ARMED FAIL-CLOSED: "
+                        "OFF -> LIVE_PENDING_CONFIRMATION ownership_pending=%s "
+                        "execution_authority=false",
                         ownership_err or "unknown",
                     )
                     return
@@ -1901,14 +1850,16 @@ class TradingStateMachine:
                 self._can_dispatch_trades = False
                 self._pending_confirmation_since = None
                 self._last_pending_log_time = None
+                self._pending_timeout_reported = False
                 os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
             elif new_state == TradingState.LIVE_PENDING_CONFIRMATION:
                 # Record when we first enter LIVE_PENDING_CONFIRMATION so the
-                # timeout and monitoring log in commit_activation() can measure
+                # stalled-state and monitoring logs in commit_activation() can measure
                 # elapsed time.  Only set if not already set (idempotent).
                 if self._pending_confirmation_since is None:
                     self._pending_confirmation_since = time.monotonic()
                     self._last_pending_log_time = None
+                    self._pending_timeout_reported = False
             elif new_state == TradingState.LIVE_ACTIVE:
                 self._activation_committed = True
                 self._execution_authority = True
@@ -1916,6 +1867,7 @@ class TradingStateMachine:
                 self._can_dispatch_trades = True
                 self._pending_confirmation_since = None
                 self._last_pending_log_time = None
+                self._pending_timeout_reported = False
                 os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"
 
             # Sync NIJA_RUNTIME_TRADING_STATE with the new FSM state so that
@@ -2124,7 +2076,6 @@ class TradingStateMachine:
             _env_truthy("FORCE_TRADE")
             or _env_truthy("FORCE_TRADE_MODE")
             or _env_truthy("FORCE_LIVE_TRANSITION")
-            or (_env_truthy("AUTO_ACTIVATE") and _env_truthy("HEARTBEAT_TRADE"))
         )
         runtime_mode = resolve_runtime_mode_safe(logger)
         _lcv_quick = runtime_mode.is_live if runtime_mode is not None else _env_truthy("LIVE_CAPITAL_VERIFIED")
@@ -2308,13 +2259,11 @@ class TradingStateMachine:
                     _dry_run_quick,
                 )
 
-        # ── 5-minute auto-transition timeout ─────────────────────────────────
+        # ── 5-minute pending-state diagnostic ────────────────────────────────
         # If the bot has been stuck in LIVE_PENDING_CONFIRMATION for longer than
-        # NIJA_PENDING_CONFIRMATION_TIMEOUT_S (default 300 s / 5 min) and the
-        # basic live-trading conditions are met, auto-transition to LIVE_ACTIVE
-        # without requiring the full gate stack to pass.  This prevents the
-        # deadlock where commit_activation() never fires because a distributed
-        # dependency (Redis, heartbeat marker) is permanently unavailable.
+        # NIJA_PENDING_CONFIRMATION_TIMEOUT_S (default 300 s / 5 min), report
+        # the stall once.  Elapsed time is never authority to bypass ownership,
+        # heartbeat, nonce, capital, or dispatch-health gates.
         _pending_timeout_s = max(
             30.0,
             float(os.environ.get("NIJA_PENDING_CONFIRMATION_TIMEOUT_S", "300") or 300),
@@ -2326,41 +2275,17 @@ class TradingStateMachine:
             _cur_state_for_timeout == TradingState.LIVE_PENDING_CONFIRMATION
             and _pending_since_for_timeout is not None
             and (time.monotonic() - _pending_since_for_timeout) >= _pending_timeout_s
-            and _lcv_quick
-            and not _dry_run_quick
+            and not self._pending_timeout_reported
         ):
-            _kill_for_timeout = False
-            try:
-                from kill_switch import get_kill_switch
-                _kill_for_timeout = get_kill_switch().is_active()
-            except Exception:
-                pass
-            if not _kill_for_timeout:
-                _elapsed_timeout = time.monotonic() - _pending_since_for_timeout
-                logger.critical(
-                    "[ACTIVATION TIMEOUT] LIVE_PENDING_CONFIRMATION for %.1fs (limit=%.1fs) — "
-                    "auto-transitioning to LIVE_ACTIVE. "
-                    "LIVE_CAPITAL_VERIFIED=true DRY_RUN_MODE=false kill_switch=inactive. "
-                    "Set NIJA_PENDING_CONFIRMATION_TIMEOUT_S to adjust the timeout.",
-                    _elapsed_timeout,
-                    _pending_timeout_s,
-                )
-                _timeout_ok = self._force_live_active_transition(
-                    f"ACTIVATION_TIMEOUT: auto-transition after {_elapsed_timeout:.1f}s in LIVE_PENDING_CONFIRMATION"
-                )
-                if _timeout_ok:
-                    logger.critical(
-                        "[ACTIVATION TIMEOUT] ✅ LIVE_ACTIVE — bot is now trading "
-                        "(elapsed=%.1fs timeout=%.1fs)",
-                        _elapsed_timeout,
-                        _pending_timeout_s,
-                    )
-                    return True
-                else:
-                    logger.critical(
-                        "[ACTIVATION TIMEOUT] _force_live_active_transition returned False — "
-                        "continuing with normal gate evaluation"
-                    )
+            _elapsed_timeout = time.monotonic() - _pending_since_for_timeout
+            self._pending_timeout_reported = True
+            logger.critical(
+                "[ACTIVATION PENDING THRESHOLD] LIVE_PENDING_CONFIRMATION for %.1fs "
+                "(threshold=%.1fs) — safety gates remain authoritative; "
+                "no timeout bypass applied.",
+                _elapsed_timeout,
+                _pending_timeout_s,
+            )
 
         # ── Pre-gate: eagerly start authority heartbeat monitor ──────────────
         # Must run BEFORE all heartbeat gate checks below.  Two independent
@@ -2409,14 +2334,13 @@ class TradingStateMachine:
         # writer-heartbeat / Redis infrastructure not yet being ready.  When it
         # does, commit_activation() returns False before reaching the
         # OFF→LIVE_PENDING_CONFIRMATION arm at the bottom of this method.  That
-        # keeps state at OFF forever and the 5-minute LPC auto-transition timeout
-        # (which auto-activates when distributed gates are permanently blocked)
-        # never fires because it only applies to LIVE_PENDING_CONFIRMATION state.
+        # keeps state at OFF and loses the operator's fail-closed activation
+        # intent instead of exposing which safety gate is still pending.
         #
         # By arming OFF→LPC eagerly here, we ensure:
         #   1. State reaches LPC regardless of gate failures.
-        #   2. The 5-minute timeout can force-transition to LIVE_ACTIVE even if some distributed gates are blocked.
-        #   3. The timeout path only checks LIVE_CAPITAL_VERIFIED, DRY_RUN_MODE, and kill_switch (not the full gate stack).
+        #   2. Gate failures remain observable and retryable.
+        #   3. Only the full activation gate stack can transition to LIVE_ACTIVE.
         #
         # LPC state is safe: it does NOT execute trades.
         with self._lock:
@@ -2429,7 +2353,7 @@ class TradingStateMachine:
                 )
                 logger.info(
                     "[COMMIT_ACTIVATION] OFF→LIVE_PENDING_CONFIRMATION early arming succeeded — "
-                    "5-minute LPC timeout is now active"
+                    "all activation safety gates remain required"
                 )
             except Exception as _early_arm_err:
                 logger.warning(
@@ -2523,11 +2447,8 @@ class TradingStateMachine:
                 os.environ.get("NIJA_WRITER_HEARTBEAT_ACTIVE", "unset"),
             )
 
-            # FORCE_TRADE fast-path: when FORCE_TRADE=1 (or NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK)
-            # and LIVE_CAPITAL_VERIFIED=true, bypass the live gate immediately via
-            # _force_live_active_transition() instead of waiting for the 5-minute LPC timeout.
-            # This is the same escape hatch used by the supervisor's hard-activation fallback,
-            # but applied here so the first commit_activation() call succeeds immediately.
+            # Explicit FORCE_TRADE fast-path. AUTO_ACTIVATE and HEARTBEAT_TRADE
+            # never enter this path; they must continue through normal gates.
             _ft_fast_path = (
                 _env_truthy("FORCE_TRADE")
                 or _env_truthy("FORCE_TRADE_MODE")

--- a/bot/writer_lock_release_guard.py
+++ b/bot/writer_lock_release_guard.py
@@ -429,6 +429,21 @@ def _signal_handler(signum: int, frame: Any) -> None:
         raise SystemExit(0)
 
 
+def _release_at_exit() -> None:
+    """Release ownership without surfacing logging-handler teardown failures."""
+
+    # Test runners and some process supervisors close captured logging streams
+    # before Python invokes application atexit callbacks. The release itself
+    # must still run, but logging's internal handler failure must not emit a
+    # misleading traceback after an otherwise clean shutdown.
+    previous_raise_exceptions = logging.raiseExceptions
+    logging.raiseExceptions = False
+    try:
+        release_owned_writer_lock("atexit")
+    finally:
+        logging.raiseExceptions = previous_raise_exceptions
+
+
 def install_import_hook() -> None:
     global _INSTALLED
     if _INSTALLED or bool(getattr(builtins, _PROCESS_INSTALL_MARKER, False)):
@@ -451,7 +466,7 @@ def install_import_hook() -> None:
         )
         thread.start()
 
-    atexit.register(lambda: release_owned_writer_lock("atexit"))
+    atexit.register(_release_at_exit)
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:
             _PREVIOUS_HANDLERS[sig] = signal.getsignal(sig)

--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -29,6 +29,7 @@ _PAIR_RETRY_COOLDOWN_S = 300.0
 _CANONICAL_BROKERS: dict[str, weakref.ReferenceType[Any]] = {}
 _CANONICAL_SCOPE_ATTR = "_nija_coinbase_canonical_scope_v4"
 _CANONICAL_FINGERPRINT_ATTR = "_nija_coinbase_canonical_credential_fingerprint_v4"
+_CONNECT_LOCAL = threading.local()
 
 
 def _is_coinbase_class(cls: type) -> bool:
@@ -47,6 +48,62 @@ def _wrapper_chain_has_patch(current: Any) -> bool:
     return False
 
 
+def _same_thread_connect_guard(current: Any):
+    """Stop a wrapper cycle from re-entering the same broker on one thread."""
+
+    @wraps(current)
+    def guarded(self: Any, *args: Any, **kwargs: Any):
+        identity = id(self)
+        active = set(getattr(_CONNECT_LOCAL, "active_brokers", set()))
+        if identity in active:
+            try:
+                self.connected = False
+                self._is_available = False
+                self._nija_coinbase_connect_reentry_blocked = True
+            except Exception:
+                pass
+            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+            os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "connect_recursion_blocked"
+            logger.error(
+                "COINBASE_CONNECT_REENTRY_BLOCKED marker=%s class=%s action=fail_closed",
+                _MARKER,
+                type(self).__name__,
+            )
+            return False
+
+        active.add(identity)
+        _CONNECT_LOCAL.active_brokers = active
+        try:
+            self._nija_coinbase_connect_reentry_blocked = False
+        except Exception:
+            pass
+        try:
+            return current(self, *args, **kwargs)
+        except RecursionError as exc:
+            try:
+                self.connected = False
+                self._is_available = False
+            except Exception:
+                pass
+            os.environ["NIJA_COINBASE_CONNECTED"] = "0"
+            os.environ["NIJA_COINBASE_TRADING_READY"] = "0"
+            os.environ["NIJA_COINBASE_ACTIVATION_STATE"] = "connect_recursion_blocked"
+            logger.error(
+                "COINBASE_CONNECT_RECURSION_FAIL_CLOSED marker=%s class=%s error=%s",
+                _MARKER,
+                type(self).__name__,
+                str(exc)[:160],
+            )
+            return False
+        finally:
+            remaining = set(getattr(_CONNECT_LOCAL, "active_brokers", set()))
+            remaining.discard(identity)
+            _CONNECT_LOCAL.active_brokers = remaining
+
+    return guarded
+
+
 def _clients(broker: Any) -> list[Any]:
     found: list[Any] = []
     for attr in ("client", "api_client", "rest_client", "coinbase_client", "_client", "_api_client"):
@@ -54,7 +111,9 @@ def _clients(broker: Any) -> list[Any]:
             value = getattr(broker, attr, None)
         except Exception:
             value = None
-        if value is not None and value not in found:
+        # SDK clients may implement recursive or non-boolean equality.  Client
+        # deduplication is about object identity, so never invoke ``__eq__``.
+        if value is not None and all(value is not existing for existing in found):
             found.append(value)
     found.insert(0, broker)
     return found
@@ -380,7 +439,7 @@ def _credential_targets(broker: Any) -> list[Any]:
         nested = getattr(broker, "_broker", None)
     except Exception:
         nested = None
-    if nested is not None and nested not in targets:
+    if nested is not None and all(nested is not target for target in targets):
         targets.append(nested)
     return targets
 
@@ -525,6 +584,7 @@ def _patch_class(cls: type) -> bool:
     if not callable(current) or _wrapper_chain_has_patch(current):
         return bool(callable(current) and _wrapper_chain_has_patch(current))
 
+    @_same_thread_connect_guard
     @wraps(current)
     def connect(self: Any, *args: Any, **kwargs: Any):
         primary_key = str(os.environ.get("COINBASE_API_KEY", "") or "")
@@ -577,6 +637,8 @@ def _patch_class(cls: type) -> bool:
         except Exception as exc:
             result = False
             first_error = f"{type(exc).__name__}:{str(exc)[:100]}"
+        if bool(getattr(self, "_nija_coinbase_connect_reentry_blocked", False)):
+            return False
 
         if (
             bool(result) or bool(getattr(self, "connected", False))
@@ -685,7 +747,6 @@ def _patch_class(cls: type) -> bool:
         return False
 
     setattr(connect, _PATCH_ATTR, True)
-    connect.__wrapped__ = current  # type: ignore[attr-defined]
     setattr(cls, "connect", connect)
     logger.warning(
         "COINBASE_AUTHENTICATED_CONNECT_SURFACE_PATCHED marker=%s module=%s class=%s",

--- a/tests/test_coinbase_authenticated_connect_wrapper_chain.py
+++ b/tests/test_coinbase_authenticated_connect_wrapper_chain.py
@@ -1,10 +1,46 @@
 from __future__ import annotations
 
 import importlib
+import sys
+
+import pytest
 
 
 def _module():
     return importlib.import_module("coinbase_authenticated_connect_recovery_patch")
+
+
+@pytest.fixture(autouse=True)
+def _clear_canonical_brokers():
+    module = _module()
+    with module._LOCK:
+        module._CANONICAL_BROKERS.clear()
+    manager = sys.modules.get("bot.broker_manager")
+    saved_registry = None
+    if manager is not None:
+        lock = getattr(manager, "_PLATFORM_BROKER_REGISTRY_LOCK")
+        with lock:
+            saved_registry = (
+                getattr(manager, "GLOBAL_PLATFORM_BROKERS").get("coinbase", False),
+                getattr(manager, "_PLATFORM_BROKER_INSTANCES").get("coinbase"),
+                getattr(manager, "_PLATFORM_BROKER_CONNECTED").get("coinbase", False),
+            )
+            getattr(manager, "GLOBAL_PLATFORM_BROKERS")["coinbase"] = False
+            getattr(manager, "_PLATFORM_BROKER_INSTANCES").pop("coinbase", None)
+            getattr(manager, "_PLATFORM_BROKER_CONNECTED")["coinbase"] = False
+    yield
+    with module._LOCK:
+        module._CANONICAL_BROKERS.clear()
+    if manager is not None and saved_registry is not None:
+        existed, broker, connected = saved_registry
+        lock = getattr(manager, "_PLATFORM_BROKER_REGISTRY_LOCK")
+        with lock:
+            getattr(manager, "GLOBAL_PLATFORM_BROKERS")["coinbase"] = existed
+            if broker is None:
+                getattr(manager, "_PLATFORM_BROKER_INSTANCES").pop("coinbase", None)
+            else:
+                getattr(manager, "_PLATFORM_BROKER_INSTANCES")["coinbase"] = broker
+            getattr(manager, "_PLATFORM_BROKER_CONNECTED")["coinbase"] = connected
 
 
 def test_wrapper_chain_detects_nested_recovery_marker():
@@ -60,6 +96,60 @@ def test_wrapper_chain_cycle_is_safe():
 
     outer.__wrapped__ = outer
     assert module._wrapper_chain_has_patch(outer) is False
+
+
+def test_authenticated_probe_deduplicates_clients_by_identity():
+    module = _module()
+
+    class Client:
+        def __eq__(self, other):
+            raise AssertionError("client equality must never be evaluated")
+
+        def get_accounts(self):
+            return {"accounts": []}
+
+    client = Client()
+    broker = type(
+        "CoinbaseBroker",
+        (),
+        {"client": client, "api_client": client},
+    )()
+
+    authenticated, source = module._authenticated_probe(broker)
+
+    assert authenticated is True
+    assert source == "Client.get_accounts"
+
+
+def test_recursive_connect_reentry_fails_closed(monkeypatch):
+    module = _module()
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.client = None
+            self.connected = False
+            self._is_available = True
+            self._auth_failed = False
+
+        def connect(self):
+            return self.connect()
+
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/test/apiKeys/key")
+    monkeypatch.setenv(
+        "COINBASE_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\nTEST\n-----END EC PRIVATE KEY-----",
+    )
+    monkeypatch.delenv("NIJA_COINBASE_CREDENTIALS_QUARANTINED", raising=False)
+    monkeypatch.setattr(module, "_configured_pairs", lambda: [])
+
+    assert module._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert broker._is_available is False
+    assert module.os.environ["NIJA_COINBASE_CONNECTED"] == "0"
+    assert module.os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "connect_recursion_blocked"
 
 
 def test_disconnected_broker_rebuilds_client_and_clears_transient_auth_latch(monkeypatch):

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -104,6 +104,44 @@ def _truthy(name: str) -> bool:
     }
 
 
+def _capital_ready() -> bool:
+    """Observe canonical capital readiness without using trading state as proof.
+
+    ``LIVE_ACTIVE`` is a consumer of capital readiness, not a valid substitute
+    for it.  Treating the runtime state as proof made this observer circular:
+    a fully hydrated CapitalAuthority could still be reported as unready until
+    activation, while activation diagnostics waited for this observer.
+    """
+    if _truthy("CAPITAL_SYSTEM_READY") or _truthy("NIJA_CAPITAL_READY"):
+        return True
+
+    capital_module = sys.modules.get("bot.capital_authority") or sys.modules.get(
+        "capital_authority"
+    )
+    if not isinstance(capital_module, ModuleType):
+        return False
+    getter = getattr(capital_module, "get_capital_authority", None)
+    if not callable(getter):
+        return False
+    try:
+        authority = getter()
+        if authority is None or not bool(getattr(authority, "is_hydrated", False)):
+            return False
+        stale_reader = getattr(authority, "is_stale", None)
+        if bool(stale_reader() if callable(stale_reader) else True):
+            return False
+        capital_reader = getattr(authority, "get_real_capital", None)
+        real_capital = float(
+            capital_reader()
+            if callable(capital_reader)
+            else getattr(authority, "total_capital", 0.0)
+            or 0.0
+        )
+        return real_capital > 0.0
+    except Exception:
+        return False
+
+
 def _credentials_loaded(venue: str) -> tuple[bool, str]:
     missing: list[str] = []
     for aliases in _CREDENTIALS[venue]:
@@ -378,11 +416,7 @@ def evaluate_all() -> dict[str, Any]:
     writer_ready = _truthy("NIJA_WRITER_LEASE_ACQUIRED") and bool(
         os.getenv("NIJA_WRITER_FENCING_TOKEN", "").strip()
     )
-    capital_ready = (
-        _truthy("CAPITAL_SYSTEM_READY")
-        or _truthy("NIJA_CAPITAL_READY")
-        or str(os.getenv("NIJA_RUNTIME_TRADING_STATE", "")).strip() == "LIVE_ACTIVE"
-    )
+    capital_ready = _capital_ready()
     any_venue_ready = bool(ready_venues)
     all_venues_ready = len(ready_venues) == len(VENUES)
     execution_ready = writer_ready and capital_ready and any_venue_ready


### PR DESCRIPTION
## Summary

- prevent Coinbase connection recursion with identity-safe client comparison, wrapper-chain cycle detection, and same-thread re-entry guards
- count OKX USD, USDT, and USDC correctly as spendable quote cash and stop requesting the invalid synthetic `USD-USDT` ticker
- bound and sanitize OKX diagnostics so credentials, signing prehashes, and full API payloads are not emitted at warning level
- enter fail-closed `LIVE_PENDING_CONFIRMATION` on startup instead of remaining `OFF`
- keep five-minute activation from bypassing safety gates and prevent `AUTO_ACTIVATE + HEARTBEAT_TRADE` from acting like `FORCE_TRADE`
- make capital readiness depend on hydrated, fresh, positive real capital rather than circular runtime-state fallbacks
- suppress closed-stream logging failures during writer-lock atexit cleanup

## Validation

- `81 passed, 1 skipped` across the focused and adjacent regression suites
- Python syntax compilation passed for all changed modules and tests
- `git diff --check` passed
- remote comparison confirms one commit ahead of `main`, 13 changed files, and the exact local Git tree
