### PR TITLE
Fix preactivation runtime identity guard syntax

### DIFF
--- a/bot/preactivation_runtime_identity_guard_v36.py
+++ b/bot/preactivation_runtime_identity_guard_v36.py
@@ -180,7 +180,7 @@ def _capital_snapshot() -> dict[str, Any]:
         _truthy_env("NIJA_CAPITAL_READINESS_HANDOFF_V34")
         or _truthy_env("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY")
         or (_truthy_env("CAPITAL_SYSTEM_READY") and _truthy_env("NIJA_CAPITAL_READY"))
-        _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34")
+        or _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34")
         or _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY")
         or (_truthy("CAPITAL_SYSTEM_READY") and _truthy("NIJA_CAPITAL_READY"))
     )


### PR DESCRIPTION
## Summary
- Fixes the startup `SyntaxError` in `bot/preactivation_runtime_identity_guard_v36.py` by adding the missing `or` in the `handoff_ready` readiness expression.
- Keeps the existing fail-closed readiness logic unchanged aside from making the expression syntactically valid.

## Startup Log Evidence
```text
File "/app/bot/preactivation_runtime_identity_guard_v36.py", line 180
    _truthy_env("NIJA_CAPITAL_READINESS_HANDOFF_V34")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

## Validation
- Confirmed the syntax failure location from the provided startup log.
- Reviewed the patched boolean expression for valid Python syntax.
- Full production startup was not run locally because the deployment requires live runtime services and broker/Redis credentials.

## Risk Notes
- No trading logic, sizing, broker routing, credential handling, or risk limits were changed.
- This is a startup syntax repair only.