### PR TITLE
Treat authenticated OKX spendable balance as ready

### DIFF
--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -377,6 +377,13 @@ def evaluate_venue(
     balance_ok, spendable, balance_reason = _balance(venue, broker)
     market_ok, market_count, market_reason = _markets(broker)
     adapter_ok = _adapter_ready(broker)
+    authenticated_okx_wallet_ready = (
+        venue == "okx"
+        and connected
+        and balance_ok
+        and spendable > 0.0
+        and balance_reason == "okx_authenticated_wallet"
+    )
 
     if venue == "kraken":
         marked_ready = connected and balance_ok and spendable > 0
@@ -384,6 +391,12 @@ def evaluate_venue(
         marked_ready = activation == "ready" and _truthy(
             f"NIJA_{venue.upper()}_TRADING_READY"
         )
+        if authenticated_okx_wallet_ready:
+            marked_ready = True
+            activation = "ready"
+            os.environ["NIJA_OKX_ACTIVATION_STATE"] = "ready"
+            os.environ["NIJA_OKX_TRADING_READY"] = "1"
+            os.environ["NIJA_OKX_ACTIVATED"] = "1"
         if activation == "ready" and market_count is None:
             market_ok = True
             market_reason = "activation_ready:adapter_managed"


### PR DESCRIPTION
## Summary
- Fixes the OKX readiness contradiction from the startup log where OKX reported authenticated balance data with `spendable=144.96` but remained `activation=connected_unfunded` and `marked_ready=False`.
- Allows the three-venue verifier to treat the authenticated OKX wallet proof (`okx_authenticated_wallet`) as readiness evidence when the broker is connected and spendable quote balance is positive.
- Publishes corrected OKX activation markers (`NIJA_OKX_ACTIVATION_STATE=ready`, `NIJA_OKX_TRADING_READY=1`, `NIJA_OKX_ACTIVATED=1`) from that authenticated proof.

## Startup Log Evidence
```text
THREE_VENUE_STAGE venue=okx credentials=True authentication=True balance=True markets=True adapter=True marked_ready=False eligible=False spendable=144.96 activation=connected_unfunded reason=activation=connected_unfunded;not_execution_eligible
```

## Validation
- Verified the changed section on the PR branch.
- Full production startup was not run locally because this path depends on live broker objects, Redis writer authority, and deployment credentials.

## Risk Notes
- Does not bypass writer authority, capital readiness, market metadata, order adapter, or manager eligibility checks.
- Kraken and Coinbase log warnings still appear to reflect runtime connectivity/authentication state and are not patched by this PR.