### PR TITLE
Guard Coinbase and OKX connect recursion in canonical startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,6 +91,22 @@ def _install_logging_format_guard() -> None:
         logger.warning("LOGGING_FORMAT_GUARD_INSTALL_FAILED err=%s", exc)
 
 
+def _install_runtime_auth_endpoint_repair() -> None:
+    """Install Coinbase/OKX auth recursion guards on the canonical path."""
+
+    try:
+        repair = importlib.import_module("runtime_auth_recursion_endpoint_repair_patch")
+        installer = getattr(repair, "install", None) or getattr(repair, "install_import_hook", None)
+        if callable(installer):
+            installer()
+            print("RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALL_REQUESTED", flush=True)
+            logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALL_REQUESTED")
+        else:
+            logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_SKIPPED installer_missing")
+    except Exception as exc:
+        logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_FAILED err=%s", exc)
+
+
 def _install_live_broker_profit_exit_v25() -> None:
     """Install fill-confirmed, fee-aware broker and engine exits."""
 
@@ -153,9 +169,9 @@ def _install_authority_readiness_repair() -> None:
             print("AUTHORITY_READY_REPAIR_INSTALL_REQUESTED", flush=True)
             logger.warning("AUTHORITY_READY_REPAIR_INSTALL_REQUESTED")
         else:
-            logger.warning("AUTHORITY_READY_REPAIR_INSTALL_SKIPPED installer_missing")
+            logger.warning("AUTHORITY_READY_REPAIR_SKIPPED installer_missing")
     except Exception as exc:
-        logger.warning("AUTHORITY_READY_REPAIR_INSTALL_FAILED err=%s", exc)
+        logger.warning("AUTHORITY_READY_REPAIR_FAILED err=%s", exc)
 
 
 def _install_execution_bootstrap_authority_repair() -> None:
@@ -288,6 +304,7 @@ def _install_live_entry_completion_repair() -> None:
 _install_global_runtime_startup_guards()
 _install_preactivation_runtime_identity_guard_v36()
 _install_logging_format_guard()
+_install_runtime_auth_endpoint_repair()
 _install_live_broker_profit_exit_v25()
 _run_pre_startup_sanitization()
 _install_strategy_publication()

--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from functools import wraps
 from types import ModuleType
 from typing import Any, Callable
@@ -13,6 +14,7 @@ logger = logging.getLogger("nija.runtime_auth_endpoint_repair")
 _MARKER = "20260726-coinbase-client-recovery-v4"
 _LOCK = threading.RLock()
 _PATCHED = False
+_WATCHDOG_STARTED = False
 _LOCAL = threading.local()
 
 
@@ -114,6 +116,45 @@ def _patch_coinbase_class(module: ModuleType) -> bool:
         guarded._nija_coinbase_client_guard_v2 = True  # type: ignore[attr-defined]
         guarded.__wrapped__ = original  # type: ignore[attr-defined]
         setattr(cls, method_name, guarded)
+        changed = True
+
+    original_connect = getattr(cls, "connect", None)
+    if callable(original_connect) and not getattr(original_connect, "_nija_coinbase_connect_reentry_guard_v1", False):
+        @wraps(original_connect)
+        def connect(self: Any, *args: Any, __original: Callable[..., Any] = original_connect, **kwargs: Any) -> Any:
+            active = getattr(_LOCAL, "coinbase_connect_active", set())
+            identity = id(self)
+            if identity in active:
+                _mark_coinbase_disconnected(self, "connect_recursion_blocked")
+                logger.error(
+                    "COINBASE_CONNECT_REENTRY_BLOCKED marker=%s class=%s action=fail_closed",
+                    _MARKER,
+                    type(self).__name__,
+                )
+                return False
+
+            active = set(active)
+            active.add(identity)
+            _LOCAL.coinbase_connect_active = active
+            try:
+                return __original(self, *args, **kwargs)
+            except RecursionError as exc:
+                _mark_coinbase_disconnected(self, "connect_recursion_blocked")
+                logger.error(
+                    "COINBASE_CONNECT_RECURSION_FAIL_CLOSED marker=%s class=%s error=%s",
+                    _MARKER,
+                    type(self).__name__,
+                    str(exc)[:160],
+                )
+                return False
+            finally:
+                current = set(getattr(_LOCAL, "coinbase_connect_active", set()))
+                current.discard(identity)
+                _LOCAL.coinbase_connect_active = current
+
+        connect._nija_coinbase_connect_reentry_guard_v1 = True  # type: ignore[attr-defined]
+        connect.__wrapped__ = original_connect  # type: ignore[attr-defined]
+        setattr(cls, "connect", connect)
         changed = True
 
     if changed:
@@ -233,20 +274,58 @@ def _disable_recursive_convergence_hook() -> None:
     logger.warning("RUNTIME_CONVERGENCE_RECURSION_REPAIRED marker=%s", _MARKER)
 
 
+def _patch_loaded() -> bool:
+    changed = False
+    for name in (
+        "bot.broker_manager",
+        "broker_manager",
+        "bot.broker_integration",
+        "broker_integration",
+    ):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_coinbase_class(module) or changed
+            changed = _patch_okx_class(module) or changed
+    return changed
+
+
+def _watchdog() -> None:
+    global _PATCHED
+    deadline = time.monotonic() + max(
+        60.0,
+        float(os.environ.get("NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_WATCHDOG_S", "600") or 600),
+    )
+    while time.monotonic() < deadline:
+        try:
+            _disable_recursive_convergence_hook()
+            _PATCHED = _patch_loaded() or _PATCHED
+        except Exception as exc:
+            logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_RETRY marker=%s err=%s", _MARKER, exc)
+        time.sleep(0.25)
+
+
 def install() -> None:
+    global _PATCHED, _WATCHDOG_STARTED
     with _LOCK:
         _disable_recursive_convergence_hook()
-        for name in ("bot.broker_manager", "broker_manager"):
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
-                _patch_coinbase_class(module)
-                _patch_okx_class(module)
+        _PATCHED = _patch_loaded() or _PATCHED
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="RuntimeAuthEndpointRepairWatchdog",
+                daemon=True,
+            ).start()
         os.environ["NIJA_RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED"] = "1"
-        logger.warning("RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED marker=%s patched=%s", _MARKER, _PATCHED)
+        logger.warning(
+            "RUNTIME_AUTH_ENDPOINT_REPAIR_INSTALLED marker=%s patched=%s watchdog=true",
+            _MARKER,
+            _PATCHED,
+        )
 
 
 def installed() -> bool:
-    return _PATCHED
+    return _PATCHED or _WATCHDOG_STARTED
 
 
 __all__ = [

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -135,6 +135,40 @@ def test_coinbase_canonical_client_is_never_shared_between_users():
     assert daivon.client is None
 
 
+def test_coinbase_recursive_connect_is_blocked(monkeypatch):
+    class Stability:
+        def __init__(self):
+            self.reasons = []
+
+        def mark_disconnected(self, reason):
+            self.reasons.append(reason)
+
+    class CoinbaseBroker:
+        def __init__(self):
+            self.connected = True
+            self._is_available = True
+            self._auth_failed = False
+            self._connection_stability_manager = Stability()
+
+        def connect(self):
+            return self.connect()
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+
+    assert repair._patch_coinbase_class(module) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is False
+    assert broker.connected is False
+    assert broker._is_available is False
+    assert broker._auth_failed is False
+    assert broker._connection_stability_manager.reasons == ["connect_recursion_blocked"]
+    assert os.environ["NIJA_COINBASE_CONNECTED"] == "0"
+    assert os.environ["NIJA_COINBASE_FUNDING_STATUS"] == "connect_recursion_blocked"
+    assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
+
+
 def test_okx_recursive_connect_is_blocked(monkeypatch):
     class OKXBroker:
         def __init__(self):


### PR DESCRIPTION
## Summary
- Installs `runtime_auth_recursion_endpoint_repair_patch` directly from the canonical `main.py` startup path.
- Adds a watchdog so the repair patches broker classes when they are loaded after installer startup.
- Adds a Coinbase `connect()` re-entry/`RecursionError` fail-closed guard matching the existing OKX protection.
- Extends the repair coverage to broker modules loaded under `bot.broker_integration` aliases.

## Startup Log Evidence
```text
Platform COINBASE connect() raised: maximum recursion depth exceeded in comparison
Platform OKX connect() raised: maximum recursion depth exceeded
```

## Safety Notes
- Does not bypass writer authority, capital readiness, broker credentials, order adapters, or risk controls.
- Recursive connect failures are converted to clean `False` results and disconnected/reconnect-pending markers so the platform broker manager can continue fail-closed and retry normally.

## Validation
- Added regression coverage for Coinbase recursive `connect()` blocking.
- Existing OKX recursive `connect()` coverage remains in place.
- Full production validation still requires Render runtime services, Redis writer authority, and live broker credentials.