### PR TITLE
Casefold stale emergency-stop env latch checks

### DIFF
--- a/bot/operator_emergency_stop_clear_patch.py
+++ b/bot/operator_emergency_stop_clear_patch.py
@@ -203,11 +203,12 @@ def _safe_to_clear_stale_env_only() -> tuple[bool, str]:
     present, text = _env_only_stop_present()
     if not present:
         return False, "no_stop_env_latch_present"
-    if any(token in text for token in _TERMINAL_RISK_TOKENS):
+    text_l = str(text or "").lower()
+    if any(token in text_l for token in _TERMINAL_RISK_TOKENS):
         return False, "terminal_risk_reason_present"
-    if text and any(token in text for token in _MANUAL_CLEAR_ALLOWED_TOKENS):
+    if text_l and any(token in text_l for token in _MANUAL_CLEAR_ALLOWED_TOKENS):
         return True, "stale_manual_env_latch_no_kill_file"
-    if "runtime_state=emergency_stop" in text:
+    if "runtime_state=emergency_stop" in text_l:
         return True, "stale_runtime_env_latch_no_kill_file"
     return False, "unknown_emergency_stop_reason"
 


### PR DESCRIPTION
## Summary
- Casefold the env-only emergency stop detector text before terminal/manual/runtime comparisons.
- Allows the deferred emergency-stop monitor to clear a stale `NIJA_RUNTIME_TRADING_STATE=EMERGENCY_STOP` env latch when no kill/state file or terminal-risk reason exists.
- Keeps fail-closed behavior for real stop artifacts, unsafe bypass flags, and terminal-risk reasons.

## Evidence
The latest startup log shows capital and broker readiness are now green, but writer release is still blocked by an env-backed emergency stop state:

```text
CAPITAL_READINESS_HANDOFF_V34_READY ... capital=467.06 broker_count=3 fresh=true
LIVE_BROKER_CONNECTIVITY_SNAPSHOT ... all_configured_connected=True
STALLED_WRITER_RELEASE_GUARD_V22_WAITING ... state=EMERGENCY_STOP authority=False manager_ready=True capital_ready=True
```

## Root cause
`_env_only_stop_present()` reports `runtime_state=EMERGENCY_STOP`, while `_safe_to_clear_stale_env_only()` checked for the lowercase literal `runtime_state=emergency_stop` without normalizing the text first. That made the stale env-only latch look like an unknown emergency stop reason, so the deferred clear from the previous PR could not release it.

## Safety notes
- Does not clear kill/state files without explicit operator approval.
- Does not clear terminal-risk stop reasons.
- Does not enable unsafe bypass flags, force writer authority, or place orders.

## Validation
- Reviewed the targeted emergency-stop latch logic.
- Production validation requires a Render redeploy. Expected marker after deploy: `OPERATOR_EMERGENCY_STOP_ENV_ONLY_CLEAR_APPLIED ... reason=stale_runtime_env_latch_no_kill_file`.