### PR TITLE
Make runtime auth watchdog repair idempotent

### DIFF
--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -15,6 +15,7 @@ _MARKER = "20260726-coinbase-client-recovery-v4"
 _LOCK = threading.RLock()
 _PATCHED = False
 _WATCHDOG_STARTED = False
+_CONVERGENCE_HOOK_REPAIRED = False
 _LOCAL = threading.local()
 
 
@@ -229,10 +230,16 @@ def _patch_okx_class(module: ModuleType) -> bool:
     return True
 
 
-def _disable_recursive_convergence_hook() -> None:
+def _disable_recursive_convergence_hook() -> bool:
+    global _CONVERGENCE_HOOK_REPAIRED
     module = sys.modules.get("runtime_convergence_hardening_patch")
     if not isinstance(module, ModuleType):
-        return
+        return False
+
+    existing = getattr(module, "_patch_auth_surface", None)
+    if getattr(existing, "_nija_runtime_convergence_recursion_safe_v2", False):
+        _CONVERGENCE_HOOK_REPAIRED = True
+        return False
 
     def safe_patch_auth_surface(target: ModuleType) -> bool:
         auth = sys.modules.get("broker_auth_recovery_patch")
@@ -270,8 +277,11 @@ def _disable_recursive_convergence_hook() -> None:
                 patched = True
         return patched
 
+    safe_patch_auth_surface._nija_runtime_convergence_recursion_safe_v2 = True  # type: ignore[attr-defined]
     module._patch_auth_surface = safe_patch_auth_surface
+    _CONVERGENCE_HOOK_REPAIRED = True
     logger.warning("RUNTIME_CONVERGENCE_RECURSION_REPAIRED marker=%s", _MARKER)
+    return True
 
 
 def _patch_loaded() -> bool:

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import weakref
 from types import ModuleType
 
@@ -210,3 +211,20 @@ def test_okx_endpoint_is_applied_without_recursion(monkeypatch):
     assert broker.connect() is True
     assert broker.connected is True
     assert broker.base_url == "https://us.okx.com"
+
+
+def test_runtime_convergence_repair_is_idempotent(monkeypatch):
+    module = ModuleType("runtime_convergence_hardening_patch")
+
+    def unsafe_patch_auth_surface(target):
+        return True
+
+    module._patch_auth_surface = unsafe_patch_auth_surface
+    monkeypatch.setitem(sys.modules, "runtime_convergence_hardening_patch", module)
+
+    assert repair._disable_recursive_convergence_hook() is True
+    first = module._patch_auth_surface
+    assert getattr(first, "_nija_runtime_convergence_recursion_safe_v2") is True
+
+    assert repair._disable_recursive_convergence_hook() is False
+    assert module._patch_auth_surface is first


### PR DESCRIPTION
## Summary
- Makes `_disable_recursive_convergence_hook()` idempotent by marking the installed safe hook and returning without relogging on subsequent watchdog ticks.
- Keeps the watchdog active so it can still reapply the safe hook if `runtime_convergence_hardening_patch` is loaded or replaced later.
- Adds regression coverage proving the second repair call is a no-op and preserves the already-safe hook.

## Startup Log Evidence
The latest Render log shows the watchdog repeatedly emitting the same marker every few hundred milliseconds while Kraken startup is in progress:

```text
RUNTIME_CONVERGENCE_RECURSION_REPAIRED marker=20260726-coinbase-client-recovery-v4
RUNTIME_CONVERGENCE_RECURSION_REPAIRED marker=20260726-coinbase-client-recovery-v4
RUNTIME_CONVERGENCE_RECURSION_REPAIRED marker=20260726-coinbase-client-recovery-v4
```

## Root Cause
The watchdog calls `_disable_recursive_convergence_hook()` every 0.25s. That function always replaces `_patch_auth_surface` and logs `RUNTIME_CONVERGENCE_RECURSION_REPAIRED`, even when the safe wrapper is already installed.

## Safety Notes
- Does not grant writer authority, force activation, alter capital readiness, change risk sizing, or submit orders.
- Keeps Coinbase/OKX recursion guards fail-closed.
- Only reduces repeated repair churn/log spam and prevents repeated monkey-patching of the same convergence hook.

## Validation
- Added `test_runtime_convergence_repair_is_idempotent`.
- Full production validation requires Render redeploy; expected behavior is a single repair marker unless the target module is actually reloaded/replaced.