### PR TITLE
Recover stale emergency stop during stalled writer monitoring

### DIFF
--- a/bot/stalled_writer_release_guard_v22.py
+++ b/bot/stalled_writer_release_guard_v22.py
@@ -428,6 +428,52 @@ def _should_release(snapshot: RuntimeSnapshot, elapsed_s: float, timeout_s: floa
     return not snapshot.manager_ready or not snapshot.capital_ready
 
 
+def _attempt_emergency_stop_recovery(source: str) -> int:
+    """Clear only a safe stale emergency-stop latch, then rerun convergence."""
+    try:
+        try:
+            from bot import operator_emergency_stop_clear_patch as clear_patch
+        except ImportError:
+            import operator_emergency_stop_clear_patch as clear_patch  # type: ignore[import]
+        run_once = getattr(clear_patch, "run_once", None)
+        if not callable(run_once):
+            return 0
+        result = int(run_once() or 0)
+    except Exception as exc:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_EMERGENCY_CLEAR_FAILED marker=%s source=%s err=%s",
+            _MARKER,
+            source,
+            exc,
+        )
+        return 0
+
+    if result <= 0:
+        return 0
+
+    try:
+        try:
+            from bot.runtime_authority_convergence_repair_patch import converge_runtime_authority
+        except ImportError:
+            from runtime_authority_convergence_repair_patch import converge_runtime_authority  # type: ignore[import]
+        converge_runtime_authority(f"stalled_writer_emergency_stop_recovery:{source}")
+    except Exception as exc:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_EMERGENCY_CONVERGENCE_FAILED marker=%s source=%s err=%s",
+            _MARKER,
+            source,
+            exc,
+        )
+
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_V22_EMERGENCY_RECOVERY_APPLIED marker=%s source=%s cleared=%s trading_remains_gate_controlled=true",
+        _MARKER,
+        source,
+        result,
+    )
+    return result
+
+
 def _terminate_process(exit_code: int) -> None:
     logging.shutdown()
     os._exit(exit_code)
@@ -554,6 +600,18 @@ def _monitor() -> None:
                 )
                 last_wait_log = now
 
+            if (
+                snapshot.state == "EMERGENCY_STOP"
+                and not snapshot.authority
+                and snapshot.manager_ready
+                and snapshot.capital_ready
+            ):
+                cleared = _attempt_emergency_stop_recovery("stalled_writer_monitor")
+                if cleared > 0:
+                    lease_seen_at = now
+                    last_wait_log = 0.0
+                    continue
+
             if _should_release(snapshot, elapsed_s, timeout_s):
                 confirm = _runtime_snapshot(bot_main)
                 if (
@@ -604,6 +662,7 @@ __all__ = [
     "_production_writer_intent",
     "_runtime_snapshot",
     "_should_release",
+    "_attempt_emergency_stop_recovery",
     "_release_reason",
     "_trigger_release",
 ]


### PR DESCRIPTION
## Summary
- Adds a stalled-writer fallback for the previously observed state where writer lease is held, manager and capital are ready, but runtime state is stuck at `EMERGENCY_STOP` with no execution authority.
- Reuses the existing `operator_emergency_stop_clear_patch.run_once()` safety checks, then runs the existing runtime-authority convergence repair.
- Resets the stalled-writer timer after a successful safe clear so the process has time to converge instead of immediately releasing/exiting.

## Startup Log Evidence
Earlier startup showed the direct blocker:

```text
STALLED_WRITER_RELEASE_GUARD_V22_WAITING ... state=EMERGENCY_STOP authority=False manager_ready=True capital_ready=True
```

That means capital and broker startup were already ready, but the writer path could remain stuck behind a stale emergency-stop latch.

## Safety Notes
- Does not clear kill/state files unless the existing operator clear path approves it.
- Does not clear terminal-risk stop reasons.
- Does not force activation, grant writer authority directly, alter risk sizing, or submit orders.
- Trading remains controlled by the normal convergence gates after the stale latch is cleared.

## Validation
- Reviewed the exact state predicate and reused the existing safe clear/convergence paths.
- Production validation requires Render redeploy. Expected marker if this path is needed: `STALLED_WRITER_RELEASE_GUARD_V22_EMERGENCY_RECOVERY_APPLIED`.