### PR TITLE
Add stalled writer emergency recovery coverage

### DIFF
--- a/bot/tests/test_stalled_writer_release_guard_v22.py
+++ b/bot/tests/test_stalled_writer_release_guard_v22.py
@@ -189,6 +189,24 @@ def test_does_not_release_dry_run_early_boot_stall(monkeypatch):
     assert not guard._should_release(dry_run, elapsed_s=999.0, timeout_s=30.0)
 
 
+def test_attempt_emergency_stop_recovery_clears_and_converges(monkeypatch):
+    calls = []
+
+    clear_module = types.SimpleNamespace(run_once=lambda: 1)
+    convergence_module = types.SimpleNamespace(
+        converge_runtime_authority=lambda source: calls.append(source)
+    )
+    monkeypatch.setitem(guard.sys.modules, "bot.operator_emergency_stop_clear_patch", clear_module)
+    monkeypatch.setitem(
+        guard.sys.modules,
+        "bot.runtime_authority_convergence_repair_patch",
+        convergence_module,
+    )
+
+    assert guard._attempt_emergency_stop_recovery("unit_test") == 1
+    assert calls == ["stalled_writer_emergency_stop_recovery:unit_test"]
+
+
 def test_trigger_releases_current_lease_and_exits(monkeypatch):
     shutdown_event = threading.Event()
     release_calls = []


### PR DESCRIPTION
## Summary
- Adds regression coverage for the stalled-writer emergency-stop recovery helper added in PR #2316.
- Verifies a successful safe clear calls runtime authority convergence with the stalled-writer recovery source.

## Why
The recovery path is intentionally narrow and safety-sensitive: it should reuse the existing operator emergency-stop clear path, then ask normal authority convergence to decide whether execution may proceed. This test locks down that behavior without changing live trading code.

## Safety Notes
- Test-only change.
- Does not alter startup behavior, writer authority, capital readiness, risk sizing, or order execution.

## Validation
- Added focused unit coverage in `bot/tests/test_stalled_writer_release_guard_v22.py`.