### PR TITLE
Fix authority heartbeat timeout emergency stop

### DIFF
--- a/bot/authority_heartbeat_timeout_grace_patch.py
+++ b/bot/authority_heartbeat_timeout_grace_patch.py
@@ -1,0 +1,222 @@
+"""Prevent soft authority probe timeouts from forcing emergency stop.
+
+The authority heartbeat can time out while the process still owns the Redis
+writer lock and the local writer generation matches Redis.  In that case the
+failure is a slow status probe, not lost writer authority.  This repair wraps the
+lockdown trigger and grants a bounded grace only when the current process proves
+it still owns the fencing token in Redis.
+
+It does not grant writer authority, bypass generation mismatches, ignore Redis
+outages, change risk sizing, or submit orders.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+logger = logging.getLogger("nija.authority_heartbeat_timeout_grace")
+
+_MARKER = "20260731-authority-heartbeat-timeout-grace-v1"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_INSTALLED = False
+_ORIGINAL_TRIGGER = None
+
+
+def _truthy_env(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _timeout_text(reason: str) -> bool:
+    text = str(reason or "").lower()
+    return "authority check timed out" in text and "redis ping timed out" not in text
+
+
+def _int_string(value: Any) -> str:
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return str(int(str(value).strip()))
+
+
+def _redis_client(redis_url: str, timeout_s: float) -> Any:
+    import redis as redis_lib
+
+    bounded_timeout = max(0.5, min(float(timeout_s or 1.0), 3.0))
+    return redis_lib.from_url(
+        redis_url,
+        socket_connect_timeout=bounded_timeout,
+        socket_timeout=bounded_timeout,
+        decode_responses=False,
+    )
+
+
+def _redis_url() -> str:
+    try:
+        from bot.redis_env import get_redis_url
+    except ImportError:
+        from redis_env import get_redis_url  # type: ignore[import]
+
+    return str(get_redis_url() or "").strip()
+
+
+def _verified_current_writer(timeout_s: float) -> tuple[bool, str]:
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    if not token:
+        return False, "token_missing"
+
+    local_generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+    if not local_generation:
+        return False, "local_generation_missing"
+
+    redis_url = _redis_url()
+    if not redis_url:
+        return False, "redis_url_missing"
+
+    try:
+        client = _redis_client(redis_url, timeout_s)
+
+        generation_key = (
+            os.environ.get("NIJA_LEASE_GENERATION_KEY", "").strip()
+            or "nija:lease:generation"
+        )
+        redis_generation = client.get(generation_key)
+        if redis_generation is None:
+            return False, f"redis_generation_missing:{generation_key}"
+        if _int_string(redis_generation) != _int_string(local_generation):
+            return False, (
+                "generation_mismatch:"
+                f"local={local_generation}:redis={_int_string(redis_generation)}"
+            )
+
+        lock_scope = os.environ.get("NIJA_WRITER_SCOPE", "platform")
+        lock_key = (
+            os.environ.get("NIJA_WRITER_LOCK_KEY", "").strip()
+            or f"nija:writer_lock:{lock_scope}"
+        )
+        lock_value = client.get(lock_key)
+        if lock_value is None:
+            return False, f"writer_lock_missing:{lock_key}"
+        if isinstance(lock_value, bytes):
+            lock_value = lock_value.decode("utf-8", errors="replace")
+        lock_prefix = str(lock_value or "").split(":", 1)[0]
+        if lock_prefix != token:
+            return False, f"writer_lock_token_mismatch:{lock_prefix[:8]}"
+
+        return True, f"generation={local_generation}:lock_key={lock_key}:token_prefix={token[:8]}"
+    except Exception as exc:
+        return False, f"verification_error:{type(exc).__name__}:{exc}"
+
+
+def _refresh_healthy_heartbeat(module: Any, monitor: Any) -> None:
+    now = str(time.time())
+    os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "1"
+    os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = now
+
+    writer = getattr(module, "_write_heartbeat_marker", None)
+    if callable(writer):
+        try:
+            writer()
+        except Exception as exc:
+            logger.warning(
+                "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_MARKER_REFRESH_FAILED marker=%s err=%s",
+                _MARKER,
+                exc,
+            )
+
+    redis_writer = getattr(monitor, "_write_heartbeat_to_redis", None)
+    if callable(redis_writer):
+        try:
+            redis_writer()
+        except Exception as exc:
+            logger.warning(
+                "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_REDIS_REFRESH_FAILED marker=%s err=%s",
+                _MARKER,
+                exc,
+            )
+
+
+def install_import_hook() -> bool:
+    """Install the heartbeat timeout grace wrapper."""
+    global _INSTALLED, _ORIGINAL_TRIGGER
+
+    with _LOCK:
+        if _INSTALLED:
+            return True
+
+        try:
+            try:
+                from bot import authority_heartbeat as module
+            except ImportError:
+                import authority_heartbeat as module  # type: ignore[import]
+
+            cls = getattr(module, "AuthorityHeartbeatMonitor", None)
+            if cls is None:
+                return False
+            current_trigger = getattr(cls, "_trigger_lockdown", None)
+            if not callable(current_trigger):
+                return False
+            if bool(getattr(current_trigger, "_nija_timeout_grace_patch", False)):
+                _INSTALLED = True
+                return True
+
+            _ORIGINAL_TRIGGER = current_trigger
+
+            @functools.wraps(current_trigger)
+            def _trigger_lockdown_with_timeout_grace(self: Any, reason: str) -> None:
+                reason_text = str(reason or "")
+                if (
+                    not _truthy_env("NIJA_AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_DISABLED")
+                    and _timeout_text(reason_text)
+                    and not getattr(self, "_last_failure_is_generation_mismatch", False)
+                ):
+                    timeout_s = float(getattr(self, "_timeout_s", 3.0) or 3.0)
+                    verified, detail = _verified_current_writer(timeout_s)
+                    if verified:
+                        self._consecutive_failures = 0
+                        self._last_failure_reason = ""
+                        self._last_failure_is_generation_mismatch = False
+                        _refresh_healthy_heartbeat(module, self)
+                        logger.warning(
+                            "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_APPLIED marker=%s reason=%s detail=%s",
+                            _MARKER,
+                            reason_text,
+                            detail,
+                        )
+                        return
+                    logger.critical(
+                        "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_DENIED marker=%s reason=%s detail=%s",
+                        _MARKER,
+                        reason_text,
+                        detail,
+                    )
+
+                return current_trigger(self, reason)
+
+            setattr(_trigger_lockdown_with_timeout_grace, "_nija_timeout_grace_patch", True)
+            cls._trigger_lockdown = _trigger_lockdown_with_timeout_grace
+            os.environ["NIJA_AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_PATCH"] = "1"
+            _INSTALLED = True
+            logger.warning(
+                "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_INSTALLED marker=%s",
+                _MARKER,
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_INSTALL_FAILED marker=%s err=%s",
+                _MARKER,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["install", "install_import_hook", "_verified_current_writer"]

--- a/bot/tests/test_authority_heartbeat_timeout_grace_patch.py
+++ b/bot/tests/test_authority_heartbeat_timeout_grace_patch.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+
+
+def test_timeout_grace_suppresses_lockdown_when_writer_lock_matches(monkeypatch):
+    from bot import authority_heartbeat
+    from bot import authority_heartbeat_timeout_grace_patch as patch
+
+    class FakeRedis:
+        def get(self, key):
+            if key == "nija:lease:generation":
+                return b"2881"
+            if key == "nija:writer_lock:platform":
+                return b"token-123:owner"
+            return None
+
+        def set(self, *args, **kwargs):
+            return True
+
+        def expire(self, *args, **kwargs):
+            return True
+
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-123")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "2881")
+    monkeypatch.setenv("NIJA_WRITER_SCOPE", "platform")
+    monkeypatch.setenv("HEARTBEAT_MARKER_PATH", os.devnull)
+    monkeypatch.setattr(patch, "_redis_url", lambda: "redis://example/0")
+    monkeypatch.setattr(patch, "_redis_client", lambda redis_url, timeout_s: FakeRedis())
+    monkeypatch.setattr(authority_heartbeat, "_write_heartbeat_marker", lambda: None)
+
+    assert patch.install_import_hook() is True
+
+    lockdown_called = []
+    monitor = authority_heartbeat.AuthorityHeartbeatMonitor(
+        interval_s=999,
+        timeout_s=5,
+        max_failures=3,
+        lockdown_callback=lambda reason: lockdown_called.append(reason),
+    )
+    monitor._consecutive_failures = 3
+
+    monitor._trigger_lockdown("Authority check timed out after 5.0s")
+
+    assert lockdown_called == []
+    assert monitor.is_locked_down is False
+    assert monitor.consecutive_failures == 0
+    assert os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] == "1"
+
+
+def test_timeout_grace_denies_when_writer_lock_token_differs(monkeypatch):
+    from bot import authority_heartbeat
+    from bot import authority_heartbeat_timeout_grace_patch as patch
+
+    class FakeRedis:
+        def get(self, key):
+            if key == "nija:lease:generation":
+                return b"2881"
+            if key == "nija:writer_lock:platform":
+                return b"other-token:owner"
+            return None
+
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-123")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "2881")
+    monkeypatch.setenv("NIJA_WRITER_SCOPE", "platform")
+    monkeypatch.setattr(patch, "_redis_url", lambda: "redis://example/0")
+    monkeypatch.setattr(patch, "_redis_client", lambda redis_url, timeout_s: FakeRedis())
+
+    assert patch.install_import_hook() is True
+
+    lockdown_called = []
+    monitor = authority_heartbeat.AuthorityHeartbeatMonitor(
+        interval_s=999,
+        timeout_s=5,
+        max_failures=3,
+        lockdown_callback=lambda reason: lockdown_called.append(reason),
+    )
+    monitor._consecutive_failures = 3
+
+    monitor._trigger_lockdown("Authority check timed out after 5.0s")
+
+    assert lockdown_called
+    assert monitor.is_locked_down is True

--- a/main.py
+++ b/main.py
@@ -122,6 +122,21 @@ def _install_current_capital_snapshot_freshness_repair() -> None:
         logger.warning("CURRENT_CAPITAL_SNAPSHOT_FRESHNESS_REPAIR_FAILED err=%s", exc)
 
 
+def _install_authority_heartbeat_timeout_grace_repair() -> None:
+    """Install soft authority-heartbeat timeout grace before the monitor starts."""
+
+    try:
+        repair = importlib.import_module("bot.authority_heartbeat_timeout_grace_patch")
+        installer = getattr(repair, "install_import_hook", None) or getattr(repair, "install", None)
+        if callable(installer) and bool(installer()):
+            print("AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_INSTALL_REQUESTED", flush=True)
+            logger.warning("AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_INSTALL_REQUESTED")
+        else:
+            logger.warning("AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_SKIPPED installer_missing_or_false")
+    except Exception as exc:
+        logger.warning("AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_FAILED err=%s", exc)
+
+
 def _install_live_broker_profit_exit_v25() -> None:
     """Install fill-confirmed, fee-aware broker and engine exits."""
 
@@ -321,6 +336,7 @@ _install_preactivation_runtime_identity_guard_v36()
 _install_logging_format_guard()
 _install_runtime_auth_endpoint_repair()
 _install_current_capital_snapshot_freshness_repair()
+_install_authority_heartbeat_timeout_grace_repair()
 _install_live_broker_profit_exit_v25()
 _run_pre_startup_sanitization()
 _install_strategy_publication()


### PR DESCRIPTION
## Summary
- Add an authority heartbeat timeout grace repair for the latest runtime blocker.
- Install it during canonical startup before the authority heartbeat monitor begins.
- Add tests covering the safe path and denial path.

## Problem
The latest Render log reached live readiness but then forced `EMERGENCY_STOP`:

`AUTHORITY_HEARTBEAT: HEARTBEAT FAILURE #3/3 — Authority check timed out after 5.0s | local_generation=2881 redis_generation=2881 redis_conn=reachable is_generation_mismatch=False`

That shows a slow authority probe, not a confirmed lost writer lease: Redis was reachable and writer generation matched.

## Fix
The repair wraps `AuthorityHeartbeatMonitor._trigger_lockdown` and only suppresses lockdown for this narrow case:
- failure reason is `Authority check timed out`
- generation mismatch is not present
- Redis generation still matches `NIJA_WRITER_LEASE_GENERATION`
- Redis writer lock still belongs to the current `NIJA_WRITER_FENCING_TOKEN`

If any of those checks fail, the original emergency-stop behavior still runs.

## Validation
- Added `bot/tests/test_authority_heartbeat_timeout_grace_patch.py` for matching-token grace and mismatched-token denial.
- Local GitHub clone/test run was blocked by workspace network restrictions, so CI/Render startup logs should be watched after merge.

Expected post-deploy marker: `AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_INSTALLED`. If the same soft timeout happens while lock ownership is valid, watch for `AUTHORITY_HEARTBEAT_TIMEOUT_GRACE_APPLIED` instead of `AUTHORITY_HEARTBEAT_EXPIRED`.