### PR TITLE
[codex] Fix preactivation strategy convergence

### DIFF
--- a/bot/operator_emergency_stop_clear_patch.py
+++ b/bot/operator_emergency_stop_clear_patch.py
@@ -270,7 +270,7 @@ def run_once() -> int:
                 flush=True,
             )
             return 1
-        logger.info(
+        logger.debug(
             "OPERATOR_EMERGENCY_STOP_CLEAR_NOOP marker=%s reason=no_kill_or_state_file_found env_reason=%s",
             _MARKER,
             reason,

--- a/bot/strategy_publication_patch.py
+++ b/bot/strategy_publication_patch.py
@@ -34,8 +34,11 @@ def _ready() -> tuple[bool, str]:
         return False, "live_capital_not_verified"
     if _truthy("DRY_RUN_MODE") or _truthy("PAPER_MODE"):
         return False, "simulation_mode"
-    if str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip() != "LIVE_ACTIVE":
-        return False, "state_not_live_active"
+    runtime_state = str(
+        os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")
+    ).strip().upper()
+    if runtime_state not in {"LIVE_PENDING_CONFIRMATION", "LIVE_ACTIVE"}:
+        return False, f"state_not_publishable:{runtime_state or 'unset'}"
     if not str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip():
         return False, "writer_token_missing"
     if not str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")).strip():

--- a/bot/tests/test_canonical_strategy_publication_handoff.py
+++ b/bot/tests/test_canonical_strategy_publication_handoff.py
@@ -159,3 +159,23 @@ def test_bot_main_treats_lock_contention_as_safe_standby(monkeypatch) -> None:
     module._writer_authority_last_error = "active_writer_lock_held"
 
     assert module.main() == 0
+
+def test_publication_monitor_accepts_safe_pending_state(monkeypatch) -> None:
+    module = _load(
+        "bot/strategy_publication_patch.py",
+        "nija_test_strategy_publication_pending",
+    )
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1")
+
+    assert module._ready() == (True, "ok")
+
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+    ready, detail = module._ready()
+    assert ready is False
+    assert detail == "state_not_publishable:OFF"
+

--- a/bot/tests/test_preactivation_readiness_convergence_v16_patch.py
+++ b/bot/tests/test_preactivation_readiness_convergence_v16_patch.py
@@ -85,3 +85,16 @@ def test_activation_uses_normal_commit_path(monkeypatch):
     assert active is True
     assert calls == ["commit"]
     assert details["state_after"] == "LIVE_ACTIVE"
+
+def test_starts_strategy_publication_monitor_once(monkeypatch):
+    patch = _module()
+    calls: list[str] = []
+    publication = ModuleType("bot.strategy_publication_patch")
+    publication.start_monitor = lambda: calls.append("start") or True
+    monkeypatch.setitem(sys.modules, "bot.strategy_publication_patch", publication)
+    patch._STRATEGY_PUBLICATION_MONITOR_STARTED = False
+
+    assert patch._ensure_strategy_publication_monitor() == (True, "started")
+    assert patch._ensure_strategy_publication_monitor() == (True, "already_started")
+    assert calls == ["start"]
+

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -2362,8 +2362,17 @@ class TradingStateMachine:
                 )
 
         _heartbeat_required_first = _heartbeat_verification_required()
-        _heartbeat_ok, _heartbeat_err, _heartbeat_meta = _heartbeat_verification_status()
         _heartbeat_trade = _env_truthy("HEARTBEAT_TRADE")
+        if _heartbeat_required_first:
+            _heartbeat_ok, _heartbeat_err, _heartbeat_meta = _heartbeat_verification_status()
+        else:
+            _heartbeat_ok = True
+            _heartbeat_err = "not_required"
+            _heartbeat_meta = {
+                "path": _heartbeat_marker_path(),
+                "required_stage": _heartbeat_min_required_stage(),
+                "max_age_s": _heartbeat_verification_max_age_seconds(),
+            }
 
         if _heartbeat_required_first and not _heartbeat_ok:
             # Bootstrap grace: on a fresh deployment the heartbeat_verified.flag

--- a/preactivation_readiness_convergence_v16_patch.py
+++ b/preactivation_readiness_convergence_v16_patch.py
@@ -34,6 +34,7 @@ _KEYS = (
 _LOCK = threading.RLock()
 _STARTED = False
 _LAST_SIGNATURE = ""
+_STRATEGY_PUBLICATION_MONITOR_STARTED = False
 
 
 def _truthy(name: str, default: str = "false") -> bool:
@@ -56,6 +57,29 @@ def _int(value: Any, default: int = 0) -> int:
 
 def _live_mode() -> bool:
     return _truthy("LIVE_CAPITAL_VERIFIED") and not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
+
+
+def _ensure_strategy_publication_monitor() -> tuple[bool, str]:
+    """Start the safe publisher once live intent enters preactivation."""
+
+    global _STRATEGY_PUBLICATION_MONITOR_STARTED
+    if _STRATEGY_PUBLICATION_MONITOR_STARTED:
+        return True, "already_started"
+    try:
+        try:
+            module = importlib.import_module("bot.strategy_publication_patch")
+        except Exception:
+            module = importlib.import_module("strategy_publication_patch")
+        start = getattr(module, "start_monitor", None)
+        if not callable(start):
+            return False, "start_monitor_unavailable"
+        started = bool(start())
+        if started:
+            _STRATEGY_PUBLICATION_MONITOR_STARTED = True
+            return True, "started"
+        return False, "start_monitor_returned_false"
+    except Exception as exc:
+        return False, f"start_monitor_failed:{type(exc).__name__}:{exc}"
 
 
 def _capital_snapshot() -> dict[str, Any]:
@@ -313,7 +337,13 @@ def _cycle() -> tuple[bool, dict[str, Any]]:
         pass
     if not _live_mode():
         return False, {"live_mode": False}
-    return _attempt_activation()
+    publisher_started, publisher_detail = _ensure_strategy_publication_monitor()
+    active, details = _attempt_activation()
+    details["strategy_publication_monitor"] = {
+        "started": publisher_started,
+        "detail": publisher_detail,
+    }
+    return active, details
 
 
 def _monitor() -> None:


### PR DESCRIPTION
## What changed

- allow the canonical strategy publisher to prepare and wire a strategy in `LIVE_PENDING_CONFIRMATION` as well as `LIVE_ACTIVE`
- start the existing strategy publication monitor from the proof-based preactivation convergence cycle
- keep publication fail-closed on live-capital intent, simulation mode, writer fencing token, lease generation, and entry-ready broker checks
- report optional heartbeat verification as `not_required` instead of a misleading `marker_missing` failure
- demote the repeated no-op emergency-stop scan from info to debug
- add regression coverage for pending-state publication and one-time monitor startup

## Root cause

The July 31 production logs reached writer, venue, and capital readiness but stayed in `LIVE_PENDING_CONFIRMATION` with `Strategy Ready: FALSE`. Preactivation required a published `TradingStrategy`, while the publication monitor only considered `LIVE_ACTIVE` publishable and was not started by the active convergence path. Those conditions formed a circular activation latch.

The change only constructs and wires the strategy while pending. It does not grant execution authority, force a state transition, bypass risk checks, or submit an order. The normal activation commit remains authoritative.

## Validation

- `python -m py_compile` passed for all four changed production modules
- direct regression scenario passed: publisher accepts a fully fenced `LIVE_PENDING_CONFIRMATION` state and rejects `OFF`
- direct regression scenario passed: preactivation starts the publication monitor exactly once
- branch comparison: 6 intended files, 0 commits behind `main`

The container did not have pytest installed, and network policy blocked downloading it, so the two new pytest cases were also executed directly with equivalent assertions. Full repository CI should run on this draft PR.