### PR TITLE
[codex] Unblock strategy bootstrap from OFF

### DIFF
--- a/bot/strategy_publication_patch.py
+++ b/bot/strategy_publication_patch.py
@@ -37,7 +37,7 @@ def _ready() -> tuple[bool, str]:
     runtime_state = str(
         os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")
     ).strip().upper()
-    if runtime_state not in {"LIVE_PENDING_CONFIRMATION", "LIVE_ACTIVE"}:
+    if runtime_state not in {"OFF", "LIVE_PENDING_CONFIRMATION", "LIVE_ACTIVE"}:
         return False, f"state_not_publishable:{runtime_state or 'unset'}"
     if not str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")).strip():
         return False, "writer_token_missing"

--- a/bot/tests/test_canonical_strategy_publication_handoff.py
+++ b/bot/tests/test_canonical_strategy_publication_handoff.py
@@ -160,7 +160,7 @@ def test_bot_main_treats_lock_contention_as_safe_standby(monkeypatch) -> None:
 
     assert module.main() == 0
 
-def test_publication_monitor_accepts_safe_pending_state(monkeypatch) -> None:
+def test_publication_monitor_accepts_safe_preactivation_states(monkeypatch) -> None:
     module = _load(
         "bot/strategy_publication_patch.py",
         "nija_test_strategy_publication_pending",
@@ -175,7 +175,10 @@ def test_publication_monitor_accepts_safe_pending_state(monkeypatch) -> None:
     assert module._ready() == (True, "ok")
 
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+    assert module._ready() == (True, "ok")
+
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "EMERGENCY_STOP")
     ready, detail = module._ready()
     assert ready is False
-    assert detail == "state_not_publishable:OFF"
+    assert detail == "state_not_publishable:EMERGENCY_STOP"
 


### PR DESCRIPTION
## What changed

- allow the canonical strategy publisher to prepare a strategy while the runtime FSM is `OFF`
- retain the existing requirements for verified live capital, non-simulation mode, writer fencing token, lease generation, and an entry-ready broker
- continue to reject `EMERGENCY_STOP` and unknown runtime states
- extend regression coverage across `OFF`, `LIVE_PENDING_CONFIRMATION`, and `EMERGENCY_STOP`

## Root cause

The deployment of merge commit `28beaa80` confirms the preactivation publication monitor now starts, but the supplied logs repeatedly show:

`STRATEGY_PUBLICATION_WAITING reason=state_not_publishable:OFF`

The preactivation proof requires a published strategy before it invokes the normal activation commit, so requiring the FSM to leave `OFF` before publication preserves a circular startup latch.

Publishing here only constructs and wires the strategy object. It does not grant execution authority, transition the FSM, start order dispatch, or bypass risk controls.

## Validation

- `python -m py_compile bot/strategy_publication_patch.py`
- direct assertions passed for:
  - `OFF -> (True, "ok")`
  - `LIVE_PENDING_CONFIRMATION -> (True, "ok")`
  - `EMERGENCY_STOP -> (False, "state_not_publishable:EMERGENCY_STOP")`
- branch is two intended commits ahead and zero behind `main`
