### PR TITLE
[codex] Fix snapshot acceptance telemetry

### DIFF
--- a/bot/capital_authority.py
+++ b/bot/capital_authority.py
@@ -2264,6 +2264,7 @@ class CapitalAuthority:
             _was_already_accepted = self._first_snap_accepted
             if _all_conditions_met and not _was_already_accepted:
                 self._first_snap_accepted = True
+            _accepted_latched = self._first_snap_accepted
 
         _newly_accepted: bool = _all_conditions_met and not _was_already_accepted
 
@@ -2275,12 +2276,14 @@ class CapitalAuthority:
             "  snapshot_timestamp: %s\n"
             "  snapshot_source: %s\n"
             "  accepted: %s\n"
+            "  newly_accepted: %s\n"
             "  reason: %s",
             _gate_ca_hydrated,
             snapshot_real,
             _snap_valid_broker_count,
             _snap_computed_at_iso,
             _snap_source,
+            _accepted_latched,
             _newly_accepted,
             _gate_reason,
         )

--- a/bot/capital_csm_v2.py
+++ b/bot/capital_csm_v2.py
@@ -354,6 +354,7 @@ class CapitalCSMv2:
             _was_already_accepted = self._first_snap_accepted
             if _all_gate_conditions_met and not _was_already_accepted:
                 self._first_snap_accepted = True
+            _accepted_latched = self._first_snap_accepted
 
         _newly_accepted: bool = _all_gate_conditions_met and not _was_already_accepted
 
@@ -365,12 +366,14 @@ class CapitalCSMv2:
             "  snapshot_timestamp: %s\n"
             "  snapshot_source: %s\n"
             "  accepted: %s\n"
+            "  newly_accepted: %s\n"
             "  reason: %s",
             _gate_ca_hydrated,
             real_capital,
             broker_count,
             _snap_timestamp_iso,
             _snap_source,
+            _accepted_latched,
             _newly_accepted,
             _gate_reason,
         )


### PR DESCRIPTION
## What changed

- report the durable first-snapshot acceptance latch as `accepted` in CapitalAuthority
- report the same durable latch in CapitalCSMv2
- add a separate `newly_accepted` field for the one-time false-to-true transition

## Root cause

Both modules were logging `_newly_accepted` under the label `accepted`. After the first valid snapshot set the permanent latch, every subsequent valid snapshot logged:

`accepted: False`
`reason: all conditions met`

The state itself was correct, as confirmed by `FIRST_SNAPSHOT_GATE_LATCH accepted_latched=True` and `CAPITAL_READINESS_HANDOFF_V34_READY`; only the producer telemetry was wrong.

## Safety

This patch does not alter capital values, snapshot eligibility, freshness policy, broker requirements, activation state, risk controls, or execution authority. It only makes the emitted fields match their actual semantics.

## Validation

- `python -m py_compile bot/capital_csm_v2.py bot/capital_authority.py`
- reviewed both call sites for placeholder/argument alignment
- branch contains only two intended files, is two commits ahead, and zero behind `main`
