### PR TITLE
[codex] Fix recursive live activation convergence

### DIFF
--- a/bot/runtime_authority_convergence_repair_patch.py
+++ b/bot/runtime_authority_convergence_repair_patch.py
@@ -14,6 +14,7 @@ _MARKER = "20260709u"
 _HOOK_FLAG = "_NIJA_RUNTIME_AUTHORITY_CONVERGENCE_REPAIR_HOOK_V20260709U"
 _MONITOR_STARTED = False
 _MONITOR_LOCK = threading.Lock()
+_CONVERGENCE_LOCAL = threading.local()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _UNSAFE_REASON_TOKENS = (
     "manual",
@@ -392,7 +393,7 @@ def _safe_to_recover() -> tuple[bool, str, dict[str, Any]]:
     return True, f"{kill_detail}; {capital_detail}; {hb_detail}; {writer_detail}", capital_meta
 
 
-def converge_runtime_authority(source: str = "manual") -> bool:
+def _converge_runtime_authority_once(source: str = "manual") -> bool:
     if not _truthy("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_REPAIR_ENABLED", "true"):
         return False
     env_state = os.environ.get("NIJA_RUNTIME_TRADING_STATE", "").strip().upper()
@@ -439,7 +440,14 @@ def converge_runtime_authority(source: str = "manual") -> bool:
                 except Exception as exc:
                     logger.warning("RUNTIME_AUTHORITY_CONVERGENCE_COMMIT_FAILED marker=%s err=%s", _MARKER, exc)
             if not committed:
-                sm.transition_to(TradingState.LIVE_ACTIVE, f"runtime-authority convergence repair marker={_MARKER} source={source}")
+                logger.warning(
+                    "RUNTIME_AUTHORITY_CONVERGENCE_COMMIT_REJECTED marker=%s "
+                    "source=%s state=%s activation_gates_remain_authoritative=true",
+                    _MARKER,
+                    source,
+                    state_value,
+                )
+                return False
         with getattr(sm, "_lock", threading.Lock()):
             if hasattr(sm, "_activation_committed"):
                 sm._activation_committed = True
@@ -466,6 +474,23 @@ def converge_runtime_authority(source: str = "manual") -> bool:
     except Exception as exc:
         logger.warning("RUNTIME_AUTHORITY_CONVERGENCE_FAILED marker=%s source=%s err=%s", _MARKER, source, exc)
         return False
+
+
+def converge_runtime_authority(source: str = "manual") -> bool:
+    """Converge authority once per thread without recursive activation calls."""
+
+    if bool(getattr(_CONVERGENCE_LOCAL, "active", False)):
+        logger.debug(
+            "RUNTIME_AUTHORITY_CONVERGENCE_REENTRY_BLOCKED marker=%s source=%s",
+            _MARKER,
+            source,
+        )
+        return False
+    _CONVERGENCE_LOCAL.active = True
+    try:
+        return _converge_runtime_authority_once(source)
+    finally:
+        _CONVERGENCE_LOCAL.active = False
 
 
 def _monitor() -> None:

--- a/bot/tests/test_runtime_authority_convergence_repair_patch.py
+++ b/bot/tests/test_runtime_authority_convergence_repair_patch.py
@@ -134,3 +134,59 @@ def test_safe_to_recover_when_kill_switch_clear_capital_ready_and_writer_ok(monk
     assert "kill_switch_clear" in reason
     assert "capital_ready" in reason
     assert detail["usable"] == 568.30
+
+def test_convergence_blocks_same_thread_reentry(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        patch,
+        "_converge_runtime_authority_once",
+        lambda source: calls.append(source) or True,
+    )
+    monkeypatch.setattr(patch._CONVERGENCE_LOCAL, "active", True, raising=False)
+
+    assert patch.converge_runtime_authority("nested") is False
+    assert calls == []
+
+
+def test_rejected_activation_commit_does_not_force_live_transition(monkeypatch):
+    import bot.trading_state_machine as tsm
+
+    class FakeStateMachine:
+        def __init__(self):
+            self.state = tsm.TradingState.OFF
+            self.commit_calls = 0
+            self.transitions = []
+
+        def get_current_state(self):
+            return self.state
+
+        def commit_activation(self, cycle_capital=None):
+            self.commit_calls += 1
+            return False
+
+        def transition_to(self, state, reason):
+            self.transitions.append((state, reason))
+            self.state = state
+            return True
+
+    sm = FakeStateMachine()
+    monkeypatch.setenv("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_REPAIR_ENABLED", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setattr(
+        patch,
+        "_safe_to_recover",
+        lambda: (
+            True,
+            "all safety proofs passed",
+            {"valid_brokers": 3, "hydrated": True, "fresh": True, "real": 466.21},
+        ),
+    )
+    monkeypatch.setattr(tsm, "get_state_machine", lambda: sm)
+    monkeypatch.setattr(patch._CONVERGENCE_LOCAL, "active", False, raising=False)
+
+    assert patch.converge_runtime_authority("test") is False
+    assert sm.commit_calls == 1
+    assert sm.transitions == []
+    assert sm.state == tsm.TradingState.OFF
+


### PR DESCRIPTION
## What changed

- add a thread-local reentrancy guard around runtime-authority convergence
- block import-hook convergence from recursively entering `commit_activation()` on the same thread
- remove the direct `transition_to(LIVE_ACTIVE)` fallback when the canonical activation commit returns false
- keep the normal activation commit and every existing safety gate authoritative
- add regression coverage for nested convergence and rejected activation commits

## Root cause

The runtime-authority import hook invokes `converge_runtime_authority()` when `trading_state_machine` is imported. Convergence calls `commit_activation()`; activation gate evaluation performs imports that can re-enter the hook and invoke convergence again. That cycle repeats until Python raises `maximum recursion depth exceeded`.

## Safety

A nested convergence attempt now returns false and leaves the outer activation attempt in control. A normal successful `commit_activation()` can still transition to `LIVE_ACTIVE`. A false result stays fail-closed and retries later instead of being converted into a direct state transition.

## Validation

- `python -m py_compile bot/runtime_authority_convergence_repair_patch.py bot/tests/test_runtime_authority_convergence_repair_patch.py`
- isolated regression passed: nested convergence does not call the inner convergence function
- isolated regression passed: rejected commit performs no `LIVE_ACTIVE` transition
- branch contains two intended files, is two commits ahead, and zero behind `main`
