### PR TITLE
Fix false missing status for Tania Kraken credentials

### DIFF
--- a/scripts/credential_diagnostics.sh
+++ b/scripts/credential_diagnostics.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Credential-presence diagnostics shared by start.sh. Values are never printed.
+
+nija_first_nonempty_env_name() {
+    local name
+    local value
+    for name in "$@"; do
+        value="${!name-}"
+        if [ -n "${value//[[:space:]]/}" ]; then
+            printf '%s' "$name"
+            return 0
+        fi
+    done
+    return 1
+}
+
+nija_print_kraken_user_credential_status() {
+    local label="$1"
+    local short_prefix="$2"
+    local full_prefix="$3"
+    local key_name=""
+    local secret_name=""
+    local key_value=""
+    local secret_value=""
+
+    key_name=$(nija_first_nonempty_env_name \
+        "KRAKEN_USER_${short_prefix}_API_KEY" \
+        "KRAKEN_USER_${full_prefix}_API_KEY" || true)
+    secret_name=$(nija_first_nonempty_env_name \
+        "KRAKEN_USER_${short_prefix}_API_SECRET" \
+        "KRAKEN_USER_${full_prefix}_API_SECRET" || true)
+
+    echo "   👤 KRAKEN (${label}):"
+    if [ -n "$key_name" ] && [ -n "$secret_name" ]; then
+        key_value="${!key_name}"
+        secret_value="${!secret_name}"
+        echo "      ✅ Configured (Key: ${#key_value} chars via ${key_name}, Secret: ${#secret_value} chars via ${secret_name})"
+        return 0
+    fi
+
+    echo "      ❌ Incomplete configuration (Key: ${key_name:-missing}, Secret: ${secret_name:-missing})"
+    # Diagnostics are informational; an optional user account must not abort start.sh.
+    return 0
+}

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,7 @@ echo ""
 # ─────────────────────────────────────────────────────────────────────────────
 _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 _PID_FILE="${_SCRIPT_DIR}/data/nija.pid"
+source "${_SCRIPT_DIR}/scripts/credential_diagnostics.sh"
 
 # Seconds to wait for a graceful shutdown before escalating to SIGKILL.
 _GRACE_PERIOD_SECONDS=10
@@ -1275,20 +1276,10 @@ else
 fi
 
 # Kraken - User #1 (Daivon)
-echo "   👤 KRAKEN (User #1: Daivon):"
-if [ -n "${KRAKEN_USER_DAIVON_API_KEY}" ] && [ -n "${KRAKEN_USER_DAIVON_API_SECRET}" ]; then
-    echo "      ✅ Configured (Key: ${#KRAKEN_USER_DAIVON_API_KEY} chars, Secret: ${#KRAKEN_USER_DAIVON_API_SECRET} chars)"
-else
-    echo "      ❌ Not configured"
-fi
+nija_print_kraken_user_credential_status "User #1: Daivon" "DAIVON" "DAIVON_FRAZIER"
 
 # Kraken - User #2 (Tania)
-echo "   👤 KRAKEN (User #2: Tania):"
-if [ -n "${KRAKEN_USER_TANIA_API_KEY}" ] && [ -n "${KRAKEN_USER_TANIA_API_SECRET}" ]; then
-    echo "      ✅ Configured (Key: ${#KRAKEN_USER_TANIA_API_KEY} chars, Secret: ${#KRAKEN_USER_TANIA_API_SECRET} chars)"
-else
-    echo "      ❌ Not configured"
-fi
+nija_print_kraken_user_credential_status "User #2: Tania" "TANIA" "TANIA_GILBERT"
 
 # OKX
 echo "   📊 OKX (Master):"

--- a/tests/test_credential_diagnostics.py
+++ b/tests/test_credential_diagnostics.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "credential_diagnostics.sh"
+
+
+def _run(extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("KRAKEN_USER_TANIA")
+    }
+    env.update(extra_env)
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{HELPER}"; '
+            'nija_print_kraken_user_credential_status "User #2: Tania" "TANIA" "TANIA_GILBERT"',
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_full_name_tania_credentials_are_detected() -> None:
+    result = _run(
+        {
+            "KRAKEN_USER_TANIA_GILBERT_API_KEY": "full-key",
+            "KRAKEN_USER_TANIA_GILBERT_API_SECRET": "full-secret",
+        }
+    )
+
+    assert result.returncode == 0
+    assert "✅ Configured" in result.stdout
+    assert "KRAKEN_USER_TANIA_GILBERT_API_KEY" in result.stdout
+    assert "full-key" not in result.stdout
+    assert "full-secret" not in result.stdout
+
+
+def test_mixed_short_and_full_aliases_match_broker_resolution() -> None:
+    result = _run(
+        {
+            "KRAKEN_USER_TANIA_API_KEY": "short-key",
+            "KRAKEN_USER_TANIA_GILBERT_API_SECRET": "full-secret",
+        }
+    )
+
+    assert result.returncode == 0
+    assert "KRAKEN_USER_TANIA_API_KEY" in result.stdout
+    assert "KRAKEN_USER_TANIA_GILBERT_API_SECRET" in result.stdout
+
+
+def test_partial_tania_credentials_are_reported_as_incomplete() -> None:
+    result = _run({"KRAKEN_USER_TANIA_GILBERT_API_KEY": "full-key"})
+
+    assert result.returncode == 0
+    assert "Incomplete configuration" in result.stdout
+    assert "Secret: missing" in result.stdout


### PR DESCRIPTION
## Problem

`start.sh` only checked `KRAKEN_USER_TANIA_API_KEY` and `KRAKEN_USER_TANIA_API_SECRET`. The canonical `KrakenBroker` resolver also accepts the full user-id aliases `KRAKEN_USER_TANIA_GILBERT_API_KEY` and `KRAKEN_USER_TANIA_GILBERT_API_SECRET`, so correctly configured credentials could be reported as missing during startup.

## Fix

- share a shell credential-presence diagnostic helper from `start.sh`
- resolve short-name and full-name key/secret aliases independently, matching broker behavior
- report the selected variable names and value lengths without printing credential values
- classify partial pairs as incomplete while keeping optional-account diagnostics non-fatal
- apply the same resolver to Daivon for consistency

## Validation

- `bash -n` passed for `start.sh` and the helper
- Python test module compiles
- full-name Tania pair detected
- mixed short/full aliases detected
- incomplete pair reported without aborting `set -e` startup
- output checked to ensure test credential values are not exposed