### PR TITLE
Include credential diagnostics in runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -104,6 +104,7 @@ test_state.json
 # Scripts not needed at runtime
 scripts/*
 !scripts/redis_connectivity_check.sh
+!scripts/credential_diagnostics.sh
 !scripts/debug_startup_safe_mode.sh
 !scripts/production_bootstrap.sh
 !scripts/three_venue_config_check.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN python -S /app/scripts/install_sitecustomize_defer_guard.py && \
     python -S /app/apply_bot_package_defer_fix.py && \
     python -S /app/scripts/apply_startup_handoff_fix.py && \
     bash -n /app/start.sh && \
+    bash -n /app/scripts/credential_diagnostics.sh && \
     bash -n /app/scripts/production_bootstrap.sh && \
     bash -n /app/scripts/render_entrypoint.sh
 RUN NIJA_DEFER_RUNTIME_SITE_HOOKS=1 python -S -m py_compile \
@@ -78,6 +79,7 @@ RUN python -S -c "import pathlib; required = [pathlib.Path('/app/apply_bot_packa
 RUN NIJA_DEFER_RUNTIME_SITE_HOOKS=1 GIT_BRANCH=build-attestation GIT_COMMIT=build-attestation DRY_RUN_MODE=true python -S /app/scripts/runtime_entrypoint_attestation.py
 
 RUN test -f /app/scripts/redis_connectivity_check.sh && \
+    test -f /app/scripts/credential_diagnostics.sh && \
     test -f /app/scripts/production_bootstrap.sh && \
     test -f /app/scripts/three_venue_config_check.py && \
     test -f /app/scripts/render_entrypoint.sh && \

--- a/tests/test_credential_diagnostics.py
+++ b/tests/test_credential_diagnostics.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "credential_diagnostics.sh"
+DOCKERIGNORE = ROOT / ".dockerignore"
+DOCKERFILE = ROOT / "Dockerfile"
 
 
 def _run(extra_env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -64,3 +66,12 @@ def test_partial_tania_credentials_are_reported_as_incomplete() -> None:
     assert result.returncode == 0
     assert "Incomplete configuration" in result.stdout
     assert "Secret: missing" in result.stdout
+
+
+def test_credential_helper_is_included_and_validated_in_runtime_image() -> None:
+    dockerignore = DOCKERIGNORE.read_text(encoding="utf-8")
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "!scripts/credential_diagnostics.sh" in dockerignore.splitlines()
+    assert "test -f /app/scripts/credential_diagnostics.sh" in dockerfile
+    assert "bash -n /app/scripts/credential_diagnostics.sh" in dockerfile


### PR DESCRIPTION
## Problem

The credential diagnostic helper merged in #2328 exists in the repository, but `.dockerignore` excludes `scripts/*` unless each runtime script is explicitly whitelisted. As a result, Render built an image containing the updated `start.sh` but not `/app/scripts/credential_diagnostics.sh`. With `set -e`, startup failed immediately at line 34 and the instance restarted.

## Fix

- whitelist `scripts/credential_diagnostics.sh` in `.dockerignore`
- require the helper to exist during the Docker build
- run `bash -n` on the helper during the Docker build
- add a regression test covering all three runtime-packaging requirements

## Validation

- `bash -n scripts/credential_diagnostics.sh`
- Python test module compiles
- existing full-name, mixed-alias, and incomplete-pair checks pass via direct invocation
- new packaging regression assertion passes
- branch contents verified after upload: helper whitelist present; Dockerfile presence and syntax guards present

This change does not alter credentials or print secret values.