### PR TITLE
Fix OKX reconnect and capital activation convergence

### DIFF
--- a/bot/activation_pending_commit_monitor_patch.py
+++ b/bot/activation_pending_commit_monitor_patch.py
@@ -614,7 +614,7 @@ def _commit_once(sm: Any, meta: dict[str, Any]) -> bool:
     return ok
 
 
-def _monitor() -> None:
+def _monitor(stop_event: threading.Event | None = None) -> None:
     interval = max(
         0.5,
         float(
@@ -649,7 +649,14 @@ def _monitor() -> None:
         interval,
         timeout_s,
     )
-    while time.monotonic() < deadline:
+    while stop_event is None or not stop_event.is_set():
+        now_monotonic = time.monotonic()
+        if now_monotonic >= deadline:
+            logger.warning(
+                "ACTIVATION_PENDING_COMMIT_MONITOR_STILL_WAITING timeout_s=%.1f continuing=true",
+                timeout_s,
+            )
+            deadline = now_monotonic + timeout_s
         try:
             if not _live_mode():
                 time.sleep(interval)
@@ -699,9 +706,7 @@ def _monitor() -> None:
                 "ACTIVATION_PENDING_COMMIT_MONITOR_ERROR err=%s", exc
             )
             time.sleep(interval)
-    logger.warning(
-        "ACTIVATION_PENDING_COMMIT_MONITOR_TIMEOUT timeout_s=%.1f", timeout_s
-    )
+    logger.info("ACTIVATION_PENDING_COMMIT_MONITOR_STOPPED requested=true")
 
 
 def install_import_hook() -> None:

--- a/bot/runtime_authority_convergence_repair_patch.py
+++ b/bot/runtime_authority_convergence_repair_patch.py
@@ -312,22 +312,33 @@ def _capital_authority_ready() -> tuple[bool, str, dict[str, Any]]:
             valid_brokers = max(valid_brokers, sum(1 for value in values.values() if _f(value) > 0.0))
     except Exception:
         pass
-    fresh = True
-    for method_name in ("is_fresh", "is_stale"):
-        method = getattr(ca, method_name, None)
-        if callable(method):
+    ttl_s = max(
+        30.0,
+        _f(
+            os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_CAPITAL_TTL_S"),
+            240.0,
+        ),
+    )
+    fresh = False
+    fresh_reader = getattr(ca, "is_fresh", None)
+    stale_reader = getattr(ca, "is_stale", None)
+    try:
+        if callable(fresh_reader):
             try:
-                if method_name == "is_fresh":
-                    fresh = bool(method(ttl_s=max(30.0, _f(os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_CAPITAL_TTL_S"), 240.0))))
-                else:
-                    fresh = not bool(method())
+                fresh = bool(fresh_reader(ttl_s=ttl_s))
             except TypeError:
-                try:
-                    fresh = bool(method()) if method_name == "is_fresh" else not bool(method())
-                except Exception:
-                    pass
-            except Exception:
-                pass
+                fresh = bool(fresh_reader())
+        elif fresh_reader is not None:
+            fresh = bool(fresh_reader)
+        elif callable(stale_reader):
+            try:
+                fresh = not bool(stale_reader(ttl_s=ttl_s))
+            except TypeError:
+                fresh = not bool(stale_reader())
+        elif stale_reader is not None:
+            fresh = not bool(stale_reader)
+    except Exception:
+        fresh = False
     min_capital = max(1.0, _f(os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_CAPITAL_USD"), 10.0))
     min_brokers = max(1, _i(os.environ.get("NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS"), 2))
     if handoff_ready and hydrated and real >= min_capital and valid_brokers >= min_brokers:

--- a/bot/tests/test_activation_pending_startup_order.py
+++ b/bot/tests/test_activation_pending_startup_order.py
@@ -100,3 +100,23 @@ def test_startup_repairs_wait_for_broker_manager(monkeypatch) -> None:
 
     assert module.ensure_startup_execution_repairs_ready(timeout_s=0.0) is False
     assert called == []
+
+
+def test_activation_monitor_continues_after_diagnostic_deadline(
+    monkeypatch, caplog
+) -> None:
+    module = importlib.import_module("bot.activation_pending_commit_monitor_patch")
+    stop_event = threading.Event()
+    monotonic_values = iter((0.0, 31.0))
+
+    monkeypatch.setenv("NIJA_ACTIVATION_PENDING_COMMIT_MONITOR_TIMEOUT_S", "30")
+    monkeypatch.setattr(module, "_live_mode", lambda: False)
+    monkeypatch.setattr(module.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: stop_event.set())
+
+    with caplog.at_level(logging.WARNING):
+        module._monitor(stop_event=stop_event)
+
+    assert stop_event.is_set()
+    assert "ACTIVATION_PENDING_COMMIT_MONITOR_STILL_WAITING" in caplog.text
+    assert "continuing=true" in caplog.text

--- a/bot/tests/test_runtime_authority_convergence_repair_patch.py
+++ b/bot/tests/test_runtime_authority_convergence_repair_patch.py
@@ -41,6 +41,18 @@ class HandoffOnlyCapitalAuthority:
         return True
 
 
+class ConflictingFreshnessCapitalAuthority(FakeCapitalAuthority):
+    def __init__(self):
+        self.freshness_ttls = []
+
+    def is_fresh(self, ttl_s=240.0):
+        self.freshness_ttls.append(ttl_s)
+        return True
+
+    def is_stale(self, ttl_s=60.0):
+        raise AssertionError("is_stale must not overwrite canonical is_fresh")
+
+
 class FakeKillSwitch:
     def __init__(self, active=False):
         self._active = active
@@ -89,6 +101,22 @@ def test_capital_authority_accepts_handoff_ready_snapshot_without_usable_field(m
     assert detail["usable"] == 466.62
     assert detail["valid_brokers"] == 3
     assert detail["fresh"] is True
+
+
+def test_capital_freshness_uses_one_consistent_ttl(monkeypatch):
+    _live_env(monkeypatch)
+    monkeypatch.setenv(
+        "NIJA_RUNTIME_AUTHORITY_CONVERGENCE_CAPITAL_TTL_S", "240"
+    )
+    authority = ConflictingFreshnessCapitalAuthority()
+    import bot.capital_authority as ca_mod
+    monkeypatch.setattr(ca_mod, "get_capital_authority", lambda: authority)
+
+    ready, _reason, detail = patch._capital_authority_ready()
+
+    assert ready is True
+    assert detail["fresh"] is True
+    assert authority.freshness_ttls == [240.0]
 
 
 def test_heartbeat_ready_requires_token_generation_and_fresh_alive(monkeypatch):

--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -66,6 +66,8 @@ def _reset_okx_connection_state(instance: Any, reason: str, error: BaseException
         ("_authentication_failed", False),
         ("_is_available", False),
         ("client", None),
+        ("_client", None),
+        ("rest_client", None),
         ("account_api", None),
         ("market_api", None),
         ("trade_api", None),
@@ -157,10 +159,49 @@ def _okx_attempt_is_current(instance: Any, token: int) -> bool:
 
 
 def _mark_okx_attempt_success(instance: Any, token: int) -> None:
+    """Publish a completed authenticated connection and clear retry state."""
     with _OKX_CONNECT_STATE_LOCK:
         active = getattr(instance, "_nija_okx_connect_attempt", None)
         if isinstance(active, dict) and active.get("token") == token:
             active["successful"] = True
+    for attr, value in (
+        ("connected", True),
+        ("_is_available", True),
+        ("_connecting", False),
+        ("_connection_in_progress", False),
+        ("_connect_in_progress", False),
+        ("_auth_failed", False),
+        ("auth_failed", False),
+        ("_authentication_failed", False),
+    ):
+        if hasattr(instance, attr):
+            try:
+                setattr(instance, attr, value)
+            except Exception:
+                pass
+    try:
+        instance._nija_okx_last_connect_error = None
+        instance._nija_okx_last_connect_reason = "authenticated"
+    except Exception:
+        pass
+    os.environ["NIJA_OKX_CONNECTED"] = "1"
+    activation_state = str(
+        os.environ.get("NIJA_OKX_ACTIVATION_STATE", "") or ""
+    ).strip().lower()
+    if activation_state not in {
+        "ready",
+        "connected_unfunded",
+        "market_discovery_pending",
+    }:
+        os.environ["NIJA_OKX_ACTIVATION_STATE"] = "authenticated"
+    if str(os.environ.get("NIJA_OKX_FUNDING_STATUS", "") or "").strip().lower() != "funded":
+        os.environ["NIJA_OKX_FUNDING_STATUS"] = "authenticated"
+    logger.warning(
+        "OKX_CONNECT_AUTHENTICATED marker=%s class=%s token=%s reconnect_state_cleared=true",
+        _OKX_MARKER,
+        type(instance).__name__,
+        token,
+    )
 
 
 def _restore_latest_okx_success(instance: Any) -> bool:
@@ -339,7 +380,11 @@ def _patch_okx_class(module: ModuleType) -> bool:
             reason = str((blocked or {}).get("reason", "connection_in_progress"))
             error = (blocked or {}).get("error")
             if reason == "same_thread_recursion":
-                _reset_okx_connection_state(self, "connect_recursion_blocked", error)
+                try:
+                    self._nija_okx_last_connect_reason = "connect_recursion_blocked"
+                    self._nija_okx_last_connect_error = error
+                except Exception:
+                    pass
             logger.error(
                 "OKX_CONNECT_REENTRY_BLOCKED marker=%s class=%s reason=%s age_s=%.3f timeout_s=%.3f "
                 "original_error=%s action=fail_closed_retryable",
@@ -383,16 +428,13 @@ def _patch_okx_class(module: ModuleType) -> bool:
             configured_after = str(os.environ.get("OKX_BASE_URL", "") or "").strip().rstrip("/")
             if configured_after and configured_after != configured:
                 _set_okx_endpoint(self, configured_after)
-            if not result:
+            connected = bool(result or getattr(self, "connected", False))
+            if not connected:
                 failure_reason = getattr(self, "_nija_okx_last_connect_reason", None) or "connect_failed_retryable"
                 _reset_okx_connection_state(self, failure_reason)
             else:
                 _mark_okx_attempt_success(self, token)
-                try:
-                    self._nija_okx_last_connect_error = None
-                except Exception:
-                    pass
-            return result
+            return connected
         except Exception as exc:
             if not _okx_attempt_is_current(self, token):
                 logger.warning(

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -213,6 +213,39 @@ def test_okx_endpoint_is_applied_without_recursion(monkeypatch):
     assert broker.connect() is True
     assert broker.connected is True
     assert broker.base_url == "https://us.okx.com"
+    assert os.environ["NIJA_OKX_CONNECTED"] == "1"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "authenticated"
+    assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "authenticated"
+
+
+def test_okx_nested_probe_does_not_clear_successful_owner(monkeypatch):
+    class OKXBroker:
+        def __init__(self):
+            self.connected = False
+            self._is_available = False
+            self.account_api = None
+            self.calls = 0
+
+        def connect(self):
+            self.calls += 1
+            assert self.connect() is False
+            self.account_api = object()
+            self.connected = True
+            self._is_available = True
+            return True
+
+    module = ModuleType("bot.broker_manager")
+    module.OKXBroker = OKXBroker
+    assert repair._patch_okx_class(module) is True
+    broker = OKXBroker()
+
+    assert broker.connect() is True
+    assert broker.calls == 1
+    assert broker.account_api is not None
+    assert broker.connected is True
+    assert broker._is_available is True
+    assert os.environ["NIJA_OKX_CONNECTED"] == "1"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "authenticated"
 
 
 def test_okx_failed_initialization_releases_guard_and_allows_retry(monkeypatch):
@@ -242,6 +275,8 @@ def test_okx_failed_initialization_releases_guard_and_allows_retry(monkeypatch):
     assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "reconnect_pending"
     assert broker.connect() is True
     assert broker.calls == 2
+    assert os.environ["NIJA_OKX_CONNECTED"] == "1"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "authenticated"
 
 
 def test_okx_live_attempt_blocks_concurrent_connect_without_mutating_owner(monkeypatch):


### PR DESCRIPTION
## Problem

Production remained fail-closed in two places after infrastructure and broker credentials were healthy:

1. The OKX runtime guard reset the active owner when a same-thread reconnect probe re-entered `connect()`. That cleared client handles and wrote `reconnect_pending` while authentication was still running. A later successful return marked only an internal attempt flag and did not publish `NIJA_OKX_CONNECTED=1`.
2. Runtime capital convergence evaluated `is_fresh()` with the configured 240-second TTL and then overwrote that result with `is_stale()` using its 60-second default. The pending-activation monitor also terminated permanently after its diagnostic timeout, so late capital acceptance could no longer invoke the normal activation commit.

## Fix

- keep same-thread OKX reentry fail-closed without mutating the owning attempt
- clear all known client handles after a real failed initialization
- publish connected, available, authentication, and environment state after successful OKX authentication
- preserve an already-funded or ready OKX state instead of downgrading it
- use one canonical freshness evaluation and one configured TTL
- keep the pending activation monitor alive after each diagnostic deadline
- retain the distributed writer lease and every normal activation/risk gate

## Validation

- Python compilation passed for all six changed modules/tests
- direct OKX regression passed: nested reentry is blocked while the owner completes successfully and publishes connected state
- direct capital regression passed: `is_fresh(ttl_s=240)` is authoritative and is not overwritten by a shorter stale check
- direct monitor regression passed: timeout emits a continuing diagnostic and monitoring remains active
- added focused pytest coverage for all three behaviors

No force-trade flags, writer-lock bypasses, fabricated capital, or order submission paths are introduced.