### PR TITLE
Fix persistent strategy no-op and runtime log regressions

### DIFF
--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -3757,9 +3757,12 @@ class CoinbaseBroker(BaseBroker):
                 self._accounts_cache = resp
                 self._accounts_cache_time = time.time()
 
-            logging.info("BALANCE RESPONSE RAW: %s", str(resp)[:1200])
-
             accounts = getattr(resp, 'accounts', []) or (resp.get('accounts', []) if isinstance(resp, dict) else [])
+            logging.info(
+                "BALANCE RESPONSE SUMMARY: broker=coinbase type=%s accounts=%d",
+                type(resp).__name__,
+                len(accounts),
+            )
 
             # IMPROVEMENT #2: Validate API permissions
             if not accounts:
@@ -10208,7 +10211,6 @@ class KrakenBroker(BaseBroker):
                 self.account_identifier,
                 type(balance).__name__,
             )
-            logger.info("BALANCE RESPONSE RAW: %s", str(balance)[:1200])
 
             if balance and 'error' in balance and balance['error']:
                 error_msgs = ', '.join(balance['error'])
@@ -10297,7 +10299,12 @@ class KrakenBroker(BaseBroker):
                 # Use MONITORING category for balance checks (conservative rate limiting)
                 balance_category = KrakenAPICategory.MONITORING if KrakenAPICategory is not None else None
                 trade_balance = self._kraken_private_call('TradeBalance', {'asset': 'ZUSD'}, category=balance_category)
-                logger.info("BALANCE RESPONSE RAW: %s", str(trade_balance)[:1200])
+                logger.info(
+                    "[KrakenBalancePipeline] trade_balance_response account=%s type=%s has_error=%s",
+                    self.account_identifier,
+                    type(trade_balance).__name__,
+                    bool(isinstance(trade_balance, dict) and trade_balance.get("error")),
+                )
                 held_amount = 0.0
                 trade_balance_equity_usd = 0.0
 

--- a/bot/tests/test_runtime_log_regressions_20260801.py
+++ b/bot/tests/test_runtime_log_regressions_20260801.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from bot import trading_strategy as strategy_module
+from bot import universal_broker_exit_supervisor_patch as exit_supervisor
+
+
+def _strategy_shell() -> strategy_module.TradingStrategy:
+    strategy = strategy_module.TradingStrategy.__new__(strategy_module.TradingStrategy)
+    strategy.apex = None
+    strategy.nija_core_loop = None
+    strategy.execution_engine = None
+    strategy.broker = SimpleNamespace()
+    strategy._wiring_recovery_lock = threading.Lock()
+    strategy._wiring_recovery_last_attempt = 0.0
+    strategy._get_active_broker = lambda: strategy.broker
+    return strategy
+
+
+def test_missing_apex_recovers_and_attaches_core_loop(monkeypatch):
+    strategy = _strategy_shell()
+
+    class Apex:
+        def __init__(self, broker_client):
+            self.broker_client = broker_client
+            self.execution_engine = object()
+
+    loop = SimpleNamespace(apex=None)
+    monkeypatch.setattr(strategy_module, "NIJAApexStrategyV71", Apex)
+    monkeypatch.setattr(
+        strategy_module,
+        "get_nija_core_loop",
+        lambda *, apex_strategy, max_positions: loop,
+    )
+
+    strategy._ensure_nija_wiring()
+
+    assert isinstance(strategy.apex, Apex)
+    assert strategy.apex.broker_client is strategy.broker
+    assert strategy.execution_engine is strategy.apex.execution_engine
+    assert strategy.nija_core_loop is loop
+    assert loop.apex is strategy.apex
+
+
+def test_failed_apex_recovery_is_rate_limited(monkeypatch):
+    strategy = _strategy_shell()
+    attempts = 0
+
+    class BrokenApex:
+        def __init__(self, broker_client):
+            nonlocal attempts
+            attempts += 1
+            raise RuntimeError("startup dependency not ready")
+
+    monkeypatch.setenv("NIJA_STRATEGY_WIRING_RETRY_SECONDS", "60")
+    monkeypatch.setattr(strategy_module, "NIJAApexStrategyV71", BrokenApex)
+    monkeypatch.setattr(strategy_module, "get_nija_core_loop", None)
+
+    strategy._ensure_nija_wiring()
+    strategy._ensure_nija_wiring()
+
+    assert attempts == 1
+    assert strategy.apex is None
+
+
+def test_exit_registration_is_idempotent_and_replaces_stale_instance(monkeypatch):
+    class Broker:
+        venue = "kraken"
+        account_id = "platform"
+
+    first = Broker()
+    replacement = Broker()
+    monkeypatch.setattr(exit_supervisor, "_start", lambda: None)
+    monkeypatch.setattr(
+        exit_supervisor.auto_exit,
+        "_broker_label",
+        lambda broker: broker.venue,
+    )
+    exit_supervisor._BROKERS.clear()
+    exit_supervisor._STRONG_BROKERS.clear()
+
+    exit_supervisor._register_broker(first)
+    exit_supervisor._register_broker(first)
+    assert exit_supervisor._snapshot() == [first]
+
+    exit_supervisor._register_broker(replacement)
+    assert exit_supervisor._snapshot() == [replacement]
+
+
+def test_broker_manager_does_not_log_raw_balance_payloads():
+    source = Path(strategy_module.__file__).with_name("broker_manager.py").read_text(
+        encoding="utf-8"
+    )
+    assert "BALANCE RESPONSE RAW" not in source
+    assert "str(trade_balance)[:1200]" not in source

--- a/bot/trading_strategy.py
+++ b/bot/trading_strategy.py
@@ -396,6 +396,8 @@ class TradingStrategy:
             float(_SYMBOL_UNIVERSE_REFRESH_INTERVAL_S),
         )
         self._last_symbol_refresh_ts: float = 0.0
+        self._wiring_recovery_lock = threading.Lock()
+        self._wiring_recovery_last_attempt = 0.0
 
         # Heartbeat trade state
         self._heartbeat_trade_enabled: bool = (
@@ -1738,36 +1740,87 @@ class TradingStrategy:
     # -----------------------------------------------------------------------
 
     def _ensure_nija_wiring(self) -> None:
-        """Ensure APEX and NijaCoreLoop references are correctly wired.
-
-        This self-heals runtime ordering issues where TradingStrategy is
-        constructed before all optional modules are fully ready.
-        """
+        """Recover and align APEX/CoreLoop wiring after transient startup failures."""
         if self.apex is None:
-            return
+            cooldown = max(
+                1.0,
+                _env_float("NIJA_STRATEGY_WIRING_RETRY_SECONDS", default=30.0),
+            )
+            now = time.monotonic()
+            if now - self._wiring_recovery_last_attempt < cooldown:
+                return
+            if not self._wiring_recovery_lock.acquire(blocking=False):
+                return
+            try:
+                if self.apex is None:
+                    now = time.monotonic()
+                    if now - self._wiring_recovery_last_attempt < cooldown:
+                        return
+                    self._wiring_recovery_last_attempt = now
+                    strategy_cls = NIJAApexStrategyV71
+                    if strategy_cls is None:
+                        try:
+                            from bot.nija_apex_strategy_v71 import NIJAApexStrategyV71 as strategy_cls
+                        except ImportError:
+                            try:
+                                from nija_apex_strategy_v71 import NIJAApexStrategyV71 as strategy_cls  # type: ignore[import,no-redef]
+                            except ImportError:
+                                strategy_cls = None
+                    if strategy_cls is None:
+                        logger.error("APEX_WIRING_RECOVERY_DEFERRED reason=strategy_class_unavailable")
+                        return
+                    try:
+                        broker = self.broker or self._get_active_broker()
+                        self.apex = strategy_cls(broker_client=broker)
+                        self.execution_engine = getattr(self.apex, "execution_engine", None)
+                        logger.critical(
+                            "APEX_WIRING_RECOVERED strategy=%s broker=%s",
+                            type(self.apex).__name__,
+                            type(broker).__name__ if broker is not None else "None",
+                        )
+                    except Exception as exc:
+                        self.apex = None
+                        self.execution_engine = None
+                        logger.error(
+                            "APEX_WIRING_RECOVERY_FAILED error_type=%s error=%s retry_in_s=%.1f",
+                            type(exc).__name__,
+                            str(exc)[:240],
+                            cooldown,
+                        )
+                        return
+            finally:
+                self._wiring_recovery_lock.release()
 
         if self.execution_engine is None:
             self.execution_engine = getattr(self.apex, "execution_engine", None)
 
-        if not _CORE_LOOP_AVAILABLE or get_nija_core_loop is None:
+        loop_factory = get_nija_core_loop
+        if loop_factory is None:
+            try:
+                from bot.nija_core_loop import get_nija_core_loop as loop_factory
+            except ImportError:
+                try:
+                    from nija_core_loop import get_nija_core_loop as loop_factory  # type: ignore[import,no-redef]
+                except ImportError:
+                    loop_factory = None
+        if loop_factory is None:
             return
 
         if self.nija_core_loop is None:
             try:
-                _max_positions = int(os.environ.get("NIJA_MAX_POSITIONS", "5") or 5)
-                self.nija_core_loop = get_nija_core_loop(
+                max_positions = int(os.environ.get("NIJA_MAX_POSITIONS", "5") or 5)
+                self.nija_core_loop = loop_factory(
                     apex_strategy=self.apex,
-                    max_positions=max(1, _max_positions),
+                    max_positions=max(1, max_positions),
                 )
-                logger.info("✅ NijaCoreLoop lazily attached during run_cycle")
-            except Exception as _wire_err:
-                logger.warning("⚠️ NijaCoreLoop lazy attach failed: %s", _wire_err)
+                logger.info("NijaCoreLoop lazily attached during run_cycle")
+            except Exception as exc:
+                logger.warning("NijaCoreLoop lazy attach failed: %s", exc)
                 return
 
-        # Keep singleton core loop aligned with the active APEX instance.
         if getattr(self.nija_core_loop, "apex", None) is not self.apex:
             self.nija_core_loop.apex = self.apex
-            logger.info("🔗 NijaCoreLoop apex reference re-synchronized")
+            logger.info("NijaCoreLoop apex reference re-synchronized")
 
     def run_cycle(self, broker: Optional[Any] = None, user_mode: bool = False) -> int:
         """Execute one trading cycle and return the recommended next interval in seconds.
@@ -1792,9 +1845,9 @@ class TradingStrategy:
             f"nija_core_loop={type(self.nija_core_loop).__name__ if self.nija_core_loop is not None else 'None'}",
             flush=True,
         )
+        self._ensure_nija_wiring()
         if self.apex is not None:
             try:
-                self._ensure_nija_wiring()
                 print(
                     f"[NIJA-PRINT] after _ensure_nija_wiring | "
                     f"nija_core_loop={type(self.nija_core_loop).__name__ if self.nija_core_loop is not None else 'None'} "

--- a/bot/universal_broker_exit_supervisor_patch.py
+++ b/bot/universal_broker_exit_supervisor_patch.py
@@ -198,28 +198,70 @@ def _scan_broker(broker: Any) -> int:
     return closed
 
 
+def _logical_identity(broker: Any) -> tuple[str, str]:
+    return (
+        str(auto_exit._broker_label(broker) or "unknown").strip().lower(),
+        str(_account_label(broker) or "platform").strip().lower(),
+    )
+
+
+def _registered_values() -> list[Any]:
+    return list(_BROKERS) + list(_STRONG_BROKERS)
+
+
+def _discard_broker(broker: Any) -> None:
+    try:
+        _BROKERS.discard(broker)
+    except TypeError:
+        pass
+    while broker in _STRONG_BROKERS:
+        _STRONG_BROKERS.remove(broker)
+
+
 def _register_broker(broker: Any) -> None:
     if broker is None:
         return
+    identity = _logical_identity(broker)
+    replaced = None
     with _LOCK:
+        for existing in _registered_values():
+            if existing is broker:
+                _start()
+                return
+            if _logical_identity(existing) == identity:
+                replaced = existing
+                _discard_broker(existing)
         try:
             _BROKERS.add(broker)
         except TypeError:
-            if broker not in _STRONG_BROKERS:
-                _STRONG_BROKERS.append(broker)
-    logger.info("UNIVERSAL_BROKER_EXIT_REGISTERED marker=%s venue=%s account=%s class=%s", _MARKER, auto_exit._broker_label(broker), _account_label(broker), type(broker).__name__)
+            _STRONG_BROKERS.append(broker)
+    if replaced is not None:
+        logger.warning(
+            "UNIVERSAL_BROKER_EXIT_REPLACED marker=%s venue=%s account=%s old_class=%s new_class=%s",
+            _MARKER,
+            identity[0],
+            identity[1],
+            type(replaced).__name__,
+            type(broker).__name__,
+        )
+    else:
+        logger.info(
+            "UNIVERSAL_BROKER_EXIT_REGISTERED marker=%s venue=%s account=%s class=%s",
+            _MARKER,
+            identity[0],
+            identity[1],
+            type(broker).__name__,
+        )
     _start()
 
 
 def _snapshot() -> list[Any]:
-    values = list(_BROKERS) + list(_STRONG_BROKERS)
-    out: list[Any] = []
-    seen: set[int] = set()
+    values = _registered_values()
+    latest: dict[tuple[str, str], Any] = {}
     for broker in values:
-        if broker is not None and id(broker) not in seen:
-            seen.add(id(broker))
-            out.append(broker)
-    return out
+        if broker is not None:
+            latest[_logical_identity(broker)] = broker
+    return list(latest.values())
 
 
 def _start() -> None:


### PR DESCRIPTION
## Summary

- recover APEX and NijaCoreLoop wiring after transient startup failures instead of leaving every later trading cycle as a permanent no-op
- serialize and rate-limit recovery attempts while keeping failed initialization fail-closed
- register one universal exit supervisor per logical venue/account and replace stale reconnect-created broker objects
- remove raw Coinbase and Kraken account-balance payloads from production logs
- add focused regression coverage for recovery, cooldown, identity replacement, and log redaction

## Evidence

The supplied Render logs showed:

- `TradingStrategy.run_cycle(): apex=None` followed by a permanent no-op
- repeated `UNIVERSAL_BROKER_EXIT_REGISTERED` events for the same venue/account
- full Kraken balance dictionaries emitted by `BALANCE RESPONSE RAW`
- transient Coinbase connect reentry that recovered four seconds later; that fail-closed guard is intentionally unchanged

Earlier OKX, capital-freshness, and activation issues in the uploaded log sequence were already fixed by merged PRs or recovered in later lines, so this PR does not duplicate those repairs.

## Safety

- no execution, writer-authority, capital, risk, or order-admission gate is bypassed
- APEX recovery stays fail-closed and retries no more often than `NIJA_STRATEGY_WIRING_RETRY_SECONDS` (default 30 seconds)
- broker replacement is scoped to the same normalized venue/account identity
- no credentials or raw private broker payloads are logged

## Validation

- AST parsing passed for all four changed Python files
- branch is 4 commits ahead and 0 behind `main`
- focused pytest coverage added in `bot/tests/test_runtime_log_regressions_20260801.py`
- full repository test execution is delegated to GitHub Actions because the workspace network cannot clone the repository
