### PR TITLE
Fix Coinbase authenticated reconnect wrapper recursion

### DIFF
--- a/coinbase_authenticated_connect_recovery_patch.py
+++ b/coinbase_authenticated_connect_recovery_patch.py
@@ -48,6 +48,31 @@ def _wrapper_chain_has_patch(current: Any) -> bool:
     return False
 
 
+def _deepest_connect(current: Any) -> tuple[Any, int, bool]:
+    """Return the deepest acyclic connector exposed by a wrapper chain."""
+    seen: set[int] = set()
+    candidate = current
+    deepest = current
+    depth = 0
+    cycle = False
+    while callable(candidate):
+        identity = id(candidate)
+        if identity in seen:
+            cycle = True
+            break
+        seen.add(identity)
+        wrapped = getattr(candidate, "__wrapped__", None)
+        if not callable(wrapped):
+            break
+        if id(wrapped) in seen:
+            cycle = True
+            break
+        deepest = wrapped
+        candidate = wrapped
+        depth += 1
+    return deepest, depth, cycle
+
+
 def _same_thread_connect_guard(current: Any):
     """Stop a wrapper cycle from re-entering the same broker on one thread."""
 
@@ -583,6 +608,7 @@ def _patch_class(cls: type) -> bool:
     current = getattr(cls, "connect", None)
     if not callable(current) or _wrapper_chain_has_patch(current):
         return bool(callable(current) and _wrapper_chain_has_patch(current))
+    connect_target, wrapper_depth, wrapper_cycle = _deepest_connect(current)
 
     @_same_thread_connect_guard
     @wraps(current)
@@ -633,7 +659,7 @@ def _patch_class(cls: type) -> bool:
 
         first_error = ""
         try:
-            result = current(self, *args, **kwargs)
+            result = connect_target(self, *args, **kwargs)
         except Exception as exc:
             result = False
             first_error = f"{type(exc).__name__}:{str(exc)[:100]}"
@@ -683,7 +709,7 @@ def _patch_class(cls: type) -> bool:
             _apply_pair(self, source, key, secret)
             retry_error = ""
             try:
-                retry_result = current(self, *args, **kwargs)
+                retry_result = connect_target(self, *args, **kwargs)
             except Exception as exc:
                 retry_result = False
                 retry_error = f"{type(exc).__name__}:{str(exc)[:100]}"
@@ -749,8 +775,9 @@ def _patch_class(cls: type) -> bool:
     setattr(connect, _PATCH_ATTR, True)
     setattr(cls, "connect", connect)
     logger.warning(
-        "COINBASE_AUTHENTICATED_CONNECT_SURFACE_PATCHED marker=%s module=%s class=%s",
-        _MARKER, cls.__module__, cls.__name__,
+        "COINBASE_AUTHENTICATED_CONNECT_SURFACE_PATCHED marker=%s module=%s class=%s "
+        "wrapper_depth=%d wrapper_cycle=%s",
+        _MARKER, cls.__module__, cls.__name__, wrapper_depth, str(wrapper_cycle).lower(),
     )
     return True
 

--- a/tests/test_coinbase_authenticated_connect_wrapper_chain.py
+++ b/tests/test_coinbase_authenticated_connect_wrapper_chain.py
@@ -279,3 +279,70 @@ def test_transient_connect_failure_stays_retryable(monkeypatch):
     assert broker._is_available is False
     assert module.os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
     assert module.os.environ.get("NIJA_COINBASE_RECONNECT_DISABLED", "0") != "1"
+
+
+def test_recursive_outer_wrapper_uses_deepest_connector(monkeypatch):
+    module = _module()
+    calls = []
+
+    class Client:
+        def get_accounts(self):
+            return {"accounts": []}
+
+    def base_connect(self):
+        calls.append("base")
+        self.client = Client()
+        self.connected = True
+        return True
+
+    def recursive_wrapper(self):
+        calls.append("wrapper")
+        return self.connect()
+
+    recursive_wrapper.__wrapped__ = base_connect
+
+    class CoinbaseBroker:
+        connect = recursive_wrapper
+
+        def __init__(self):
+            self.client = None
+            self.connected = False
+            self._auth_failed = False
+            self._is_available = True
+            self._balance_fetch_errors = 0
+
+    monkeypatch.setenv("COINBASE_API_KEY", "organizations/test/apiKeys/key")
+    monkeypatch.setenv(
+        "COINBASE_API_SECRET",
+        "-----BEGIN EC PRIVATE KEY-----\nTEST\n-----END EC PRIVATE KEY-----",
+    )
+    monkeypatch.delenv("NIJA_COINBASE_CREDENTIALS_QUARANTINED", raising=False)
+    monkeypatch.setattr(module, "_measure_spendable", lambda broker: 100.0)
+
+    assert module._patch_class(CoinbaseBroker) is True
+    broker = CoinbaseBroker()
+
+    assert broker.connect() is True
+    assert calls == ["base"]
+    assert broker.client is not None
+    assert broker.connected is True
+    assert module.os.environ["NIJA_COINBASE_CONNECTED"] == "1"
+
+
+def test_deepest_connect_stops_at_wrapper_cycle():
+    module = _module()
+
+    def first(self):
+        return False
+
+    def second(self):
+        return False
+
+    first.__wrapped__ = second
+    second.__wrapped__ = first
+
+    target, depth, cycle = module._deepest_connect(first)
+
+    assert target is second
+    assert depth == 1
+    assert cycle is True


### PR DESCRIPTION
## Problem

Production commit `08aa114` reported:

```text
COINBASE_AUTHENTICATED_CONNECT_FAILED ... detail=private_account_method_unavailable;alternative_pairs_attempted=0;state=reconnect_pending
```

The PEM parsed correctly, but the authenticated recovery layer called the current stacked `connect()` wrapper. A recursive outer wrapper re-entered `self.connect()` before the base Coinbase connector could construct its REST client, so the fail-closed private account probe had no client method to call.

The Kraken product fallback occurred only 15 seconds into asynchronous startup and is not yet evidence of a persistent Kraken failure.

## Fix

- resolve the deepest acyclic connector from the `__wrapped__` chain
- call that connector once for the primary and alternate credential paths
- retain the same-thread recursion guard for genuinely recursive base connectors
- retain private `get_accounts()` verification, credential quarantine, and all fail-closed readiness behavior
- add regression tests for recursive outer wrappers and cyclic wrapper metadata

## Validation

- AST parsing passed for both changed Python files
- regression asserts the recursive outer wrapper is skipped, the base connector creates the client, and private authentication publishes connected state
- existing recursion, credential rebuild, transient failure, and authentication tests remain intact
