### PR TITLE
Fix OKX connect convergence and stalled writer bootstrap

### DIFF
--- a/bot/stalled_writer_release_guard_v22.py
+++ b/bot/stalled_writer_release_guard_v22.py
@@ -505,6 +505,98 @@ def _attempt_authority_convergence_retry(source: str) -> bool:
     return True
 
 
+def _attempt_bootstrap_progression(source: str) -> bool:
+    """Retry the normal validated capital-ready BootstrapFSM handoff.
+
+    Capital can become ready while ``MultiAccountBrokerManager.initialize`` is
+    still completing independent user-account work.  In that ordering, the
+    one-shot capital callback can miss the composite BootstrapFSM handoff and
+    leave it at ``LOCK_ACQUIRED``.  The old monitor then required
+    ``STARTUP_VALIDATED`` before it would retry authority, creating a circular
+    wait until it eventually released a healthy writer lease.
+
+    This recovery does not force a state.  It calls the canonical
+    ``advance_to_capital_ready`` helper only after the manager FSM, broker
+    registration, connection-attempt finalization, startup-validation
+    attestation, and real fresh capital have already been proven.  The helper
+    still enforces its I12 hydration barrier and legal FSM transitions.
+    """
+    manager = _manager_instance()
+    if manager is None or not bool(getattr(manager, "_fsm_initialized", False)):
+        return False
+
+    has_sources = getattr(manager, "has_registered_sources", None)
+    attempted = getattr(manager, "has_attempted_connections", None)
+    try:
+        if not callable(has_sources) or not bool(has_sources()):
+            return False
+        if not callable(attempted) or not bool(attempted()):
+            return False
+    except Exception:
+        return False
+
+    if not _truthy_env("NIJA_STARTUP_VALIDATED"):
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_BLOCKED "
+            "marker=%s source=%s reason=startup_validation_not_attested",
+            _MARKER,
+            source,
+        )
+        return False
+
+    module = sys.modules.get("bot.bootstrap_state_machine") or sys.modules.get(
+        "bootstrap_state_machine"
+    )
+    if module is None:
+        try:
+            from bot import bootstrap_state_machine as module
+        except Exception as exc:
+            logger.warning(
+                "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_FAILED "
+                "marker=%s source=%s err=%s",
+                _MARKER,
+                source,
+                exc,
+            )
+            return False
+
+    getter = getattr(module, "get_bootstrap_fsm", None)
+    if not callable(getter):
+        return False
+    try:
+        fsm = getter()
+        before = str(getattr(getattr(fsm, "state", None), "value", "") or "")
+        advance = getattr(fsm, "advance_to_capital_ready", None)
+        if not callable(advance):
+            return False
+        advanced = bool(
+            advance(reason=f"stalled_writer_ready_bootstrap_retry:{source}")
+        )
+        after = str(getattr(getattr(fsm, "state", None), "value", "") or "")
+    except Exception as exc:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_FAILED "
+            "marker=%s source=%s err=%s",
+            _MARKER,
+            source,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRIED "
+        "marker=%s source=%s before_state=%s after_state=%s advanced=%s "
+        "safety_gates_preserved=true",
+        _MARKER,
+        source,
+        before or "unknown",
+        after or "unknown",
+        advanced,
+    )
+    return advanced
+
+
 def _attempt_emergency_stop_recovery(source: str) -> int:
     """Clear only a safe stale emergency-stop latch, then rerun convergence."""
     try:
@@ -624,6 +716,7 @@ def _monitor() -> None:
     observed_generation = ""
     last_wait_log = 0.0
     last_ready_authority_retry = 0.0
+    last_bootstrap_progression_retry = 0.0
 
     while not _STOP.is_set():
         snapshot = _runtime_snapshot(bot_main)
@@ -639,6 +732,7 @@ def _monitor() -> None:
                 observed_token = snapshot.token
                 observed_generation = snapshot.generation
                 last_ready_authority_retry = 0.0
+                last_bootstrap_progression_retry = 0.0
                 logger.warning(
                     "STALLED_WRITER_RELEASE_GUARD_V22_LEASE_OBSERVED marker=%s token_prefix=%s generation=%s timeout_s=%.1f production_intent=%s state=%s",
                     _MARKER,
@@ -653,6 +747,7 @@ def _monitor() -> None:
             observed_token = ""
             observed_generation = ""
             last_ready_authority_retry = 0.0
+            last_bootstrap_progression_retry = 0.0
 
         if lease_seen_at is not None:
             elapsed_s = now - lease_seen_at
@@ -669,6 +764,20 @@ def _monitor() -> None:
                     snapshot.capital_ready,
                 )
                 last_wait_log = now
+
+            if (
+                not snapshot.manager_ready
+                and snapshot.sources_registered
+                and snapshot.attempts_finalized
+                and snapshot.capital_ready
+                and not snapshot.authority
+                and snapshot.state in {"OFF", "LIVE_PENDING_CONFIRMATION"}
+                and elapsed_s >= retry_after_s
+                and now - last_bootstrap_progression_retry >= retry_interval_s
+            ):
+                last_bootstrap_progression_retry = now
+                _attempt_bootstrap_progression("stalled_writer_monitor")
+                snapshot = _runtime_snapshot(bot_main)
 
             if (
                 snapshot.manager_ready
@@ -746,6 +855,7 @@ __all__ = [
     "_production_writer_intent",
     "_runtime_snapshot",
     "_should_release",
+    "_attempt_bootstrap_progression",
     "_attempt_authority_convergence_retry",
     "_attempt_emergency_stop_recovery",
     "_release_reason",

--- a/bot/tests/test_stalled_writer_release_guard_v22.py
+++ b/bot/tests/test_stalled_writer_release_guard_v22.py
@@ -258,6 +258,52 @@ def test_attempt_authority_convergence_retry_uses_ready_source(monkeypatch):
     assert calls == ["stalled_writer_ready_authority_retry:unit_test"]
 
 
+def test_bootstrap_progression_retries_only_validated_ready_manager(monkeypatch):
+    monkeypatch.setenv("NIJA_STARTUP_VALIDATED", "1")
+    manager = types.SimpleNamespace(
+        _fsm_initialized=True,
+        has_registered_sources=lambda: True,
+        has_attempted_connections=lambda: True,
+    )
+    state = types.SimpleNamespace(value="LOCK_ACQUIRED")
+    calls = []
+
+    def advance(*, reason):
+        calls.append(reason)
+        state.value = "CAPITAL_READY"
+        return True
+
+    bootstrap_fsm = types.SimpleNamespace(state=state, advance_to_capital_ready=advance)
+    bootstrap_module = types.SimpleNamespace(get_bootstrap_fsm=lambda: bootstrap_fsm)
+    monkeypatch.setattr(guard, "_manager_instance", lambda: manager)
+    monkeypatch.setitem(guard.sys.modules, "bot.bootstrap_state_machine", bootstrap_module)
+
+    assert guard._attempt_bootstrap_progression("unit_test") is True
+    assert calls == ["stalled_writer_ready_bootstrap_retry:unit_test"]
+    assert state.value == "CAPITAL_READY"
+
+
+def test_bootstrap_progression_refuses_unattested_startup(monkeypatch):
+    monkeypatch.delenv("NIJA_STARTUP_VALIDATED", raising=False)
+    manager = types.SimpleNamespace(
+        _fsm_initialized=True,
+        has_registered_sources=lambda: True,
+        has_attempted_connections=lambda: True,
+    )
+    state = types.SimpleNamespace(value="LOCK_ACQUIRED")
+    calls = []
+    bootstrap_fsm = types.SimpleNamespace(
+        state=state,
+        advance_to_capital_ready=lambda *, reason: calls.append(reason) or True,
+    )
+    bootstrap_module = types.SimpleNamespace(get_bootstrap_fsm=lambda: bootstrap_fsm)
+    monkeypatch.setattr(guard, "_manager_instance", lambda: manager)
+    monkeypatch.setitem(guard.sys.modules, "bot.bootstrap_state_machine", bootstrap_module)
+
+    assert guard._attempt_bootstrap_progression("unit_test") is False
+    assert calls == []
+
+
 def test_attempt_emergency_stop_recovery_clears_and_converges(monkeypatch):
     calls = []
 

--- a/bot/tests/test_writer_generation_scope_repair_patch.py
+++ b/bot/tests/test_writer_generation_scope_repair_patch.py
@@ -67,6 +67,31 @@ def test_platform_nonce_lease_publishes_platform_generation(monkeypatch):
     assert os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] == "303"
 
 
+def test_user_nonce_publisher_never_exposes_user_generation(monkeypatch):
+    patch = _load_patch()
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "101")
+    observed = []
+
+    module = ModuleType("fake_nonce")
+
+    class Backend:
+        def _publish_lock_acquired_state(self, lease_version):
+            os.environ["NIJA_WRITER_LEASE_GENERATION"] = str(lease_version)
+            observed.append(os.environ["NIJA_WRITER_LEASE_GENERATION"])
+
+        def _ensure_writer_lease(self, key_id):
+            self._publish_lock_acquired_state(202)
+            return 202
+
+    module._PerKeyRedisBackend = Backend
+    assert patch._patch_nonce_backend(module)
+
+    assert Backend()._ensure_writer_lease("user-key-id") == 202
+    assert observed == []
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "101"
+
+
 def test_tracker_reads_platform_per_key_version(monkeypatch):
     patch = _load_patch()
     monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-secret")

--- a/critical_runtime_repairs_v10.py
+++ b/critical_runtime_repairs_v10.py
@@ -47,6 +47,7 @@ _OKX_COMPAT_ATTRS = (
     "_nija_final_okx_endpoint_e",
     "_nija_okx_connect_canonical_20260713b",
     "_nija_endpoint_instance_repair_v2",
+    "_nija_endpoint_instance_repair_v3",
     "_nija_runtime_convergence_auth_e",
     "_nija_final_auth_safe",
     "_nija_runtime_convergence_auth_safe_v2",

--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -54,6 +54,27 @@ def _okx_error_text(error: Any) -> str:
     return f"{type(error).__name__}: {error}"[:240]
 
 
+def _connect_chain_has_attr(connect: Any, attr: str, *, limit: int = 128) -> bool:
+    """Return whether a linked connect wrapper already has an ownership marker.
+
+    Later compatibility installers may wrap the canonical OKX connect owner
+    without copying all of its marker attributes.  Looking only at the outer
+    callable then causes this watchdog to install a second runtime attempt
+    guard.  The nested guard sees the same instance and thread and correctly
+    rejects the call as recursion, leaving OKX permanently disconnected.
+    """
+    current = connect
+    seen: set[int] = set()
+    for _ in range(limit):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, attr, False)):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
 def _reset_okx_connection_state(instance: Any, reason: str, error: BaseException | None = None) -> None:
     """Return a failed OKX initialization to a clean, retryable state."""
     for attr, value in (
@@ -370,7 +391,16 @@ def _patch_okx_class(module: ModuleType) -> bool:
     if not isinstance(cls, type):
         return False
     original = getattr(cls, "connect", None)
-    if not callable(original) or getattr(original, "_nija_endpoint_instance_repair_v3", False):
+    if not callable(original):
+        return False
+    if _connect_chain_has_attr(original, "_nija_endpoint_instance_repair_v3"):
+        # Propagate ownership to the outer compatibility wrapper so repeated
+        # watchdog scans stay constant-time and cannot add a second guard.
+        try:
+            original._nija_endpoint_instance_repair_v2 = True  # type: ignore[attr-defined]
+            original._nija_endpoint_instance_repair_v3 = True  # type: ignore[attr-defined]
+        except Exception:
+            pass
         return False
 
     @wraps(original)

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -8,6 +8,7 @@ import weakref
 from types import ModuleType
 
 import coinbase_authenticated_connect_recovery_patch as recovery
+import critical_runtime_repairs_v10 as critical_repairs
 import runtime_auth_recursion_endpoint_repair_patch as repair
 
 
@@ -216,6 +217,48 @@ def test_okx_endpoint_is_applied_without_recursion(monkeypatch):
     assert os.environ["NIJA_OKX_CONNECTED"] == "1"
     assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "authenticated"
     assert os.environ["NIJA_OKX_FUNDING_STATUS"] == "authenticated"
+
+
+def test_okx_compatibility_wrapper_does_not_gain_a_second_attempt_guard(monkeypatch):
+    monkeypatch.setenv("OKX_BASE_URL", "https://us.okx.com")
+
+    class OKXBroker:
+        def __init__(self):
+            self.connected = False
+            self.base_url = ""
+            self.calls = 0
+
+        def connect(self):
+            self.calls += 1
+            self.connected = True
+            return True
+
+    module = ModuleType("bot.broker_manager")
+    module.OKXBroker = OKXBroker
+    assert repair._patch_okx_class(module) is True
+    canonical_guard = OKXBroker.connect
+
+    # Reproduce a later compatibility installer that preserves __wrapped__ but
+    # does not copy the current endpoint-owner marker to its outer callable.
+    def compatibility_connect(self, *args, **kwargs):
+        return canonical_guard(self, *args, **kwargs)
+
+    compatibility_connect.__wrapped__ = canonical_guard
+    compatibility_connect._nija_endpoint_instance_repair_v2 = True
+    OKXBroker.connect = compatibility_connect
+
+    assert repair._patch_okx_class(module) is False
+    assert OKXBroker.connect is compatibility_connect
+    assert OKXBroker.connect._nija_endpoint_instance_repair_v3 is True
+
+    broker = OKXBroker()
+    assert broker.connect() is True
+    assert broker.calls == 1
+    assert broker.connected is True
+
+
+def test_critical_okx_owner_preserves_current_endpoint_guard_marker():
+    assert "_nija_endpoint_instance_repair_v3" in critical_repairs._OKX_COMPAT_ATTRS
 
 
 def test_okx_nested_probe_does_not_clear_successful_owner(monkeypatch):

--- a/writer_generation_scope_repair_patch.py
+++ b/writer_generation_scope_repair_patch.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 logger = logging.getLogger("nija.writer_generation_scope_repair")
 MARKER = "20260712f"
 _LOCK = threading.RLock()
+_LEASE_SCOPE = threading.local()
 _INSTALLED = False
 _LAST_PLATFORM_GENERATION: int | None = None
 
@@ -64,12 +65,58 @@ def _patch_nonce_backend(module: ModuleType) -> bool:
     if not callable(original) or getattr(original, "_nija_platform_generation_scoped", False):
         return False
 
+    # The legacy repair restored process-wide generation variables only after
+    # ``_ensure_writer_lease`` returned.  The underlying method publishes its
+    # lease version before returning, so other threads could observe a user
+    # account's nonce-lease generation during that window and revoke platform
+    # execution authority.  Scope the publisher itself with thread-local key
+    # identity so a user lease never mutates platform lineage, even transiently.
+    publish_original = getattr(backend, "_publish_lock_acquired_state", None)
+    if callable(publish_original) and not getattr(
+        publish_original,
+        "_nija_platform_generation_scoped",
+        False,
+    ):
+        def _publish_lock_acquired_state(
+            self: Any,
+            lease_version: int,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            key_id = str(getattr(_LEASE_SCOPE, "key_id", "") or "")
+            platform_id = _platform_key_id()
+            if key_id and platform_id and key_id != platform_id:
+                logger.debug(
+                    "USER_NONCE_LEASE_GLOBAL_PUBLICATION_SUPPRESSED "
+                    "marker=%s key_id=%s lease_version=%d",
+                    MARKER,
+                    key_id,
+                    lease_version,
+                )
+                return None
+            return publish_original(self, lease_version, *args, **kwargs)
+
+        _publish_lock_acquired_state._nija_platform_generation_scoped = True  # type: ignore[attr-defined]
+        _publish_lock_acquired_state.__wrapped__ = publish_original  # type: ignore[attr-defined]
+        setattr(backend, "_publish_lock_acquired_state", _publish_lock_acquired_state)
+
     def _ensure_writer_lease(self: Any, key_id: str, *args: Any, **kwargs: Any) -> int:
         global _LAST_PLATFORM_GENERATION
         platform_id = _platform_key_id()
         is_platform = bool(platform_id and str(key_id) == platform_id)
         before = _snapshot_generation_env()
-        version = int(original(self, key_id, *args, **kwargs))
+        previous_key_id = getattr(_LEASE_SCOPE, "key_id", None)
+        _LEASE_SCOPE.key_id = str(key_id)
+        try:
+            version = int(original(self, key_id, *args, **kwargs))
+        finally:
+            if previous_key_id is None:
+                try:
+                    delattr(_LEASE_SCOPE, "key_id")
+                except AttributeError:
+                    pass
+            else:
+                _LEASE_SCOPE.key_id = previous_key_id
         if is_platform:
             os.environ["NIJA_WRITER_LEASE_GENERATION"] = str(version)
             os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = str(version)


### PR DESCRIPTION
## Summary
- preserve the canonical OKX endpoint/connect guard marker so compatibility installers cannot create a recursive connect wrapper
- scope writer lease generations to the platform key and prevent per-user nonce leases from corrupting process-wide writer authority
- let the stalled-writer guard advance the canonical BootstrapFSM after registration and fresh capital are genuinely ready, without bypassing attestation or hydration invariants
- add focused regression coverage for all three failure modes

## Validation
- Python compilation passed for changed modules
- diff whitespace validation passed
- OKX installer-sequence regression passed
- writer-generation race regression passed
- stalled-writer bootstrap progression regression passed
- unattested startup remains fail-closed