### PR TITLE
Repair capital CSM bootstrap handoff

### DIFF
--- a/bot/multi_account_broker_manager.py
+++ b/bot/multi_account_broker_manager.py
@@ -1376,6 +1376,59 @@ class MultiAccountBrokerManager:
         )
         return snapshot
 
+    def _ingest_canonical_csm_snapshot(self, snapshot: Any, source: str) -> bool:
+        """Hydrate the canonical CSM-v2 from an accepted capital snapshot.
+
+        CapitalAuthority publication and CapitalCSMv2 ingestion are separate
+        write paths.  The bootstrap seed used to perform the CSM handoff only
+        when the capital bootstrap FSM was already wired.  During a valid
+        startup ordering the authority could therefore accept fresh capital
+        while CSM-v2 remained ``INITIALIZING``, causing the I12 hydration
+        barrier to block the otherwise-ready bootstrap indefinitely.
+
+        This helper does not synthesize capital or mutate CSM state directly;
+        it calls the canonical ``ingest_snapshot`` single-writer API with the
+        exact snapshot already accepted by CapitalAuthority.
+        """
+        try:
+            module = importlib.import_module("bot.capital_csm_v2")
+            getter = getattr(module, "get_csm_v2", None)
+            if not callable(getter):
+                raise RuntimeError("bot.capital_csm_v2.get_csm_v2 unavailable")
+            csm = getter()
+            state = csm.ingest_snapshot(snapshot)
+            hydrated_raw = getattr(csm, "is_hydrated", False)
+            hydrated = bool(
+                hydrated_raw() if callable(hydrated_raw) else hydrated_raw
+            )
+            state_value = str(getattr(state, "value", state) or "unknown")
+            if hydrated:
+                logger.info(
+                    "[MABM] canonical CSM-v2 snapshot handoff complete "
+                    "source=%s state=%s capital=$%.2f brokers=%d",
+                    source,
+                    state_value,
+                    float(getattr(snapshot, "real_capital", 0.0) or 0.0),
+                    int(getattr(snapshot, "broker_count", 0) or 0),
+                )
+            else:
+                logger.warning(
+                    "[MABM] canonical CSM-v2 snapshot handoff remained unhydrated "
+                    "source=%s state=%s",
+                    source,
+                    state_value,
+                )
+            return hydrated
+        except Exception as exc:
+            logger.warning(
+                "[MABM] canonical CSM-v2 snapshot handoff failed "
+                "source=%s err=%s",
+                source,
+                exc,
+                exc_info=True,
+            )
+            return False
+
     def _advance_seed_capital_bootstrap_ready(self) -> bool:
         """Legally converge the capital bootstrap FSM after a seed publish."""
         boot_fsm = self._capital_bootstrap_fsm
@@ -2119,23 +2172,17 @@ class MultiAccountBrokerManager:
                                     sorted(_seed_snapshot.broker_balances.keys()),
                                 )
                                 self.finalize_broker_registration()
+                                # CSM-v2 hydration is an independent safety
+                                # contract and must not depend on whether the
+                                # capital bootstrap FSM has finished wiring.
+                                # Feed it immediately after the registration
+                                # gate opens, using the exact CA-accepted seed.
+                                self._ingest_canonical_csm_snapshot(
+                                    _seed_snapshot,
+                                    "bootstrap_seed",
+                                )
                                 _seed_handoff_ready = False
                                 if _CAPITAL_FSM_AVAILABLE and self._capital_bootstrap_fsm is not None:
-                                    # ── Notify CSM-v2 BEFORE the READY transition ────────────────
-                                    # The READY transition fires _on_capital_bootstrap_ready
-                                    # synchronously; that callback calls advance_to_capital_ready()
-                                    # which runs the I12 hydration barrier.  Feed CSM-v2 the seed
-                                    # snapshot here so it is already hydrated when I12 fires.
-                                    try:
-                                        from bot.capital_csm_v2 import get_csm_v2 as _csmv2  # noqa: PLC0415
-                                        _csmv2().ingest_snapshot(_seed_snapshot)
-                                    except ImportError:
-                                        pass
-                                    except Exception as _csm_seed_exc:
-                                        logger.warning(
-                                            "[MABM] bootstrap seed CSM-v2 ingest failed (non-fatal): %s",
-                                            _csm_seed_exc,
-                                        )
                                     if self._capital_event_bus is not None:
                                         self._capital_event_bus.emit(CapitalEvent(
                                             event_type=CapitalEventType.CAPITAL_READY,

--- a/bot/multi_account_broker_manager.py
+++ b/bot/multi_account_broker_manager.py
@@ -2177,12 +2177,16 @@ class MultiAccountBrokerManager:
                                 # capital bootstrap FSM has finished wiring.
                                 # Feed it immediately after the registration
                                 # gate opens, using the exact CA-accepted seed.
-                                self._ingest_canonical_csm_snapshot(
+                                _seed_csm_hydrated = self._ingest_canonical_csm_snapshot(
                                     _seed_snapshot,
                                     "bootstrap_seed",
                                 )
                                 _seed_handoff_ready = False
-                                if _CAPITAL_FSM_AVAILABLE and self._capital_bootstrap_fsm is not None:
+                                if (
+                                    _seed_csm_hydrated
+                                    and _CAPITAL_FSM_AVAILABLE
+                                    and self._capital_bootstrap_fsm is not None
+                                ):
                                     if self._capital_event_bus is not None:
                                         self._capital_event_bus.emit(CapitalEvent(
                                             event_type=CapitalEventType.CAPITAL_READY,
@@ -2212,8 +2216,10 @@ class MultiAccountBrokerManager:
                                     }
                                 logger.warning(
                                     "[MABM] bootstrap seed accepted but readiness handoff is pending "
-                                    "(capital_fsm_ready=%s startup_lock_released=%s); "
+                                    "(csm_hydrated=%s capital_fsm_ready=%s "
+                                    "startup_lock_released=%s); "
                                     "falling through to normal pipeline",
+                                    _seed_csm_hydrated,
                                     _seed_handoff_ready,
                                     _startup_released,
                                 )

--- a/bot/stalled_writer_release_guard_v22.py
+++ b/bot/stalled_writer_release_guard_v22.py
@@ -505,6 +505,160 @@ def _attempt_authority_convergence_retry(source: str) -> bool:
     return True
 
 
+def _ingest_authority_snapshot_into_csm(source: str) -> bool:
+    """Close a missed CapitalAuthority -> CapitalCSMv2 bootstrap handoff.
+
+    The authority and CSM intentionally have separate single-writer APIs.  A
+    seed snapshot can be accepted by CapitalAuthority while the producer's
+    capital FSM is still wiring, leaving the canonical CSM in
+    ``INITIALIZING``.  Re-ingest only the exact, fresh, positive snapshot that
+    CapitalAuthority already accepted.  No capital is synthesized and no CSM
+    fields are assigned directly.
+    """
+    csm_module = sys.modules.get("bot.capital_csm_v2") or sys.modules.get(
+        "capital_csm_v2"
+    )
+    if csm_module is None:
+        try:
+            from bot import capital_csm_v2 as csm_module
+        except Exception as exc:
+            logger.warning(
+                "STALLED_WRITER_RELEASE_GUARD_V22_CSM_HANDOFF_FAILED "
+                "marker=%s source=%s reason=csm_import err=%s",
+                _MARKER,
+                source,
+                exc,
+            )
+            return False
+
+    csm_getter = getattr(csm_module, "get_csm_v2", None)
+    if not callable(csm_getter):
+        return False
+    try:
+        csm = csm_getter()
+    except Exception:
+        return False
+
+    hydrated_raw = getattr(csm, "is_hydrated", False)
+    try:
+        already_hydrated = bool(
+            hydrated_raw() if callable(hydrated_raw) else hydrated_raw
+        )
+    except Exception:
+        already_hydrated = False
+    if already_hydrated:
+        return True
+
+    authority_module = sys.modules.get("bot.capital_authority") or sys.modules.get(
+        "capital_authority"
+    )
+    if authority_module is None:
+        try:
+            from bot import capital_authority as authority_module
+        except Exception:
+            return False
+    authority_getter = getattr(authority_module, "get_capital_authority", None)
+    if not callable(authority_getter):
+        return False
+    try:
+        authority = authority_getter()
+        authority_hydrated_raw = getattr(authority, "is_hydrated", False)
+        authority_hydrated = bool(
+            authority_hydrated_raw()
+            if callable(authority_hydrated_raw)
+            else authority_hydrated_raw
+        )
+        accepted = bool(
+            getattr(authority, "first_snap_accepted", False)
+            or getattr(authority, "_first_snap_accepted", False)
+        )
+        typed_getter = getattr(authority, "get_typed_snapshot", None)
+        snapshot = (
+            typed_getter()
+            if callable(typed_getter)
+            else getattr(authority, "_last_typed_snapshot", None)
+        )
+    except Exception:
+        return False
+
+    if not authority_hydrated or not accepted or snapshot is None:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_CSM_HANDOFF_BLOCKED "
+            "marker=%s source=%s authority_hydrated=%s accepted=%s snapshot=%s",
+            _MARKER,
+            source,
+            authority_hydrated,
+            accepted,
+            snapshot is not None,
+        )
+        return False
+
+    try:
+        capital = float(getattr(snapshot, "real_capital", 0.0) or 0.0)
+        broker_count = int(getattr(snapshot, "broker_count", 0) or 0)
+        try:
+            stale = bool(
+                authority.is_stale(
+                    ttl_s=max(
+                        30.0,
+                        _float_env(
+                            "NIJA_RUNTIME_AUTHORITY_CONVERGENCE_CAPITAL_TTL_S",
+                            240.0,
+                        ),
+                    )
+                )
+            )
+        except TypeError:
+            stale = bool(authority.is_stale())
+    except Exception:
+        return False
+
+    if capital <= 0.0 or broker_count <= 0 or stale:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_CSM_HANDOFF_BLOCKED "
+            "marker=%s source=%s capital=%.2f broker_count=%d stale=%s",
+            _MARKER,
+            source,
+            capital,
+            broker_count,
+            stale,
+        )
+        return False
+
+    ingest = getattr(csm, "ingest_snapshot", None)
+    if not callable(ingest):
+        return False
+    try:
+        state = ingest(snapshot)
+        hydrated_raw = getattr(csm, "is_hydrated", False)
+        hydrated = bool(
+            hydrated_raw() if callable(hydrated_raw) else hydrated_raw
+        )
+    except Exception as exc:
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_CSM_HANDOFF_FAILED "
+            "marker=%s source=%s reason=ingest err=%s",
+            _MARKER,
+            source,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+    logger.critical(
+        "STALLED_WRITER_RELEASE_GUARD_V22_CSM_HANDOFF_RETRIED "
+        "marker=%s source=%s state=%s hydrated=%s capital=%.2f broker_count=%d "
+        "accepted_authority_snapshot=true",
+        _MARKER,
+        source,
+        str(getattr(state, "value", state) or "unknown"),
+        hydrated,
+        capital,
+        broker_count,
+    )
+    return hydrated
+
+
 def _attempt_bootstrap_progression(source: str) -> bool:
     """Retry the normal validated capital-ready BootstrapFSM handoff.
 
@@ -539,6 +693,15 @@ def _attempt_bootstrap_progression(source: str) -> bool:
         logger.warning(
             "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_BLOCKED "
             "marker=%s source=%s reason=startup_validation_not_attested",
+            _MARKER,
+            source,
+        )
+        return False
+
+    if not _ingest_authority_snapshot_into_csm(source):
+        logger.warning(
+            "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_BLOCKED "
+            "marker=%s source=%s reason=canonical_csm_not_hydrated",
             _MARKER,
             source,
         )
@@ -855,6 +1018,7 @@ __all__ = [
     "_production_writer_intent",
     "_runtime_snapshot",
     "_should_release",
+    "_ingest_authority_snapshot_into_csm",
     "_attempt_bootstrap_progression",
     "_attempt_authority_convergence_retry",
     "_attempt_emergency_stop_recovery",

--- a/bot/tests/test_multi_account_bootstrap_csm_handoff.py
+++ b/bot/tests/test_multi_account_bootstrap_csm_handoff.py
@@ -123,3 +123,48 @@ def test_real_bootstrap_seed_path_hydrates_authority_and_csm(monkeypatch, tmp_pa
         reset_broker_manager_singleton()
         reset_csm_v2_singleton()
         reset_capital_authority_singleton(clear_disk_cache=True)
+
+
+def test_seed_path_does_not_advance_when_csm_handoff_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("NIJA_LOCK_ACQUIRED", "true")
+    monkeypatch.setattr(capital_authority_module, "_STATE_DIR", tmp_path)
+    monkeypatch.setattr(
+        capital_authority_module,
+        "_STATE_FILE",
+        tmp_path / "capital_authority_state.json",
+    )
+
+    reset_capital_authority_singleton(clear_disk_cache=True)
+    reset_csm_v2_singleton()
+    reset_broker_manager_singleton()
+    try:
+        manager = get_broker_manager()
+        manager.register_platform_broker_instance(
+            BrokerType.COINBASE,
+            _ReadyBroker(),
+            mark_connected_state=False,
+        )
+        manager._capital_bootstrap_fsm = types.SimpleNamespace(state="TEST_READY")
+        advance_calls = []
+        monkeypatch.setattr(
+            manager,
+            "_ingest_canonical_csm_snapshot",
+            lambda snapshot, source: False,
+        )
+        monkeypatch.setattr(
+            manager,
+            "_advance_seed_capital_bootstrap_ready",
+            lambda: advance_calls.append(True) or True,
+        )
+
+        manager.refresh_capital_authority(
+            trigger="platform_connect:coinbase:attempt_1"
+        )
+
+        assert get_capital_authority().first_snap_accepted is True
+        assert advance_calls == []
+    finally:
+        reset_broker_manager_singleton()
+        reset_csm_v2_singleton()
+        reset_capital_authority_singleton(clear_disk_cache=True)

--- a/bot/tests/test_multi_account_bootstrap_csm_handoff.py
+++ b/bot/tests/test_multi_account_bootstrap_csm_handoff.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import bot.capital_authority as capital_authority_module
+from bot.broker_manager import AccountType, BaseBroker, BrokerType
+from bot.capital_authority import (
+    get_capital_authority,
+    reset_capital_authority_singleton,
+)
+from bot.capital_csm_v2 import get_csm_v2, reset_csm_v2_singleton
+from bot.multi_account_broker_manager import (
+    MultiAccountBrokerManager,
+    get_broker_manager,
+    reset_broker_manager_singleton,
+)
+
+
+class _ReadyBroker(BaseBroker):
+    def __init__(self) -> None:
+        super().__init__(BrokerType.COINBASE, AccountType.PLATFORM)
+        self.connected = True
+        self._last_known_balance = 100.0
+
+    def connect(self):
+        self.connected = True
+        return True
+
+    def get_account_balance(self):
+        return 100.0
+
+    def has_balance_payload_for_capital(self):
+        return True
+
+    def is_ready_for_capital(self):
+        return True
+
+    def get_positions(self):
+        return []
+
+    def get_available_markets(self):
+        return ["BTC-USD"]
+
+    def place_market_order(self, symbol, side, quantity, **kwargs):
+        return {
+            "status": "filled",
+            "symbol": symbol,
+            "side": side,
+            "quantity": quantity,
+        }
+
+
+def test_seed_handoff_hydrates_csm_even_without_capital_fsm(monkeypatch):
+    snapshot = types.SimpleNamespace(real_capital=371.07, broker_count=2)
+    calls = []
+    csm = types.SimpleNamespace(is_hydrated=False)
+
+    def ingest(received):
+        calls.append(received)
+        csm.is_hydrated = True
+        return types.SimpleNamespace(value="READY")
+
+    csm.ingest_snapshot = ingest
+    module = types.SimpleNamespace(get_csm_v2=lambda: csm)
+    monkeypatch.setitem(sys.modules, "bot.capital_csm_v2", module)
+
+    manager = object.__new__(MultiAccountBrokerManager)
+
+    assert manager._ingest_canonical_csm_snapshot(snapshot, "unit_test") is True
+    assert calls == [snapshot]
+
+
+def test_seed_handoff_fails_closed_when_csm_rejects_snapshot(monkeypatch):
+    snapshot = types.SimpleNamespace(real_capital=371.07, broker_count=2)
+
+    def reject(_received):
+        raise RuntimeError("snapshot rejected")
+
+    csm = types.SimpleNamespace(is_hydrated=False, ingest_snapshot=reject)
+    module = types.SimpleNamespace(get_csm_v2=lambda: csm)
+    monkeypatch.setitem(sys.modules, "bot.capital_csm_v2", module)
+
+    manager = object.__new__(MultiAccountBrokerManager)
+
+    assert manager._ingest_canonical_csm_snapshot(snapshot, "unit_test") is False
+
+
+def test_real_bootstrap_seed_path_hydrates_authority_and_csm(monkeypatch, tmp_path):
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("NIJA_LOCK_ACQUIRED", "true")
+    monkeypatch.setattr(capital_authority_module, "_STATE_DIR", tmp_path)
+    monkeypatch.setattr(
+        capital_authority_module,
+        "_STATE_FILE",
+        tmp_path / "capital_authority_state.json",
+    )
+
+    reset_capital_authority_singleton(clear_disk_cache=True)
+    reset_csm_v2_singleton()
+    reset_broker_manager_singleton()
+    try:
+        manager = get_broker_manager()
+        manager.register_platform_broker_instance(
+            BrokerType.COINBASE,
+            _ReadyBroker(),
+            mark_connected_state=False,
+        )
+
+        result = manager.refresh_capital_authority(
+            trigger="platform_connect:coinbase:attempt_1"
+        )
+        authority = get_capital_authority()
+        csm = get_csm_v2()
+
+        assert result["ready"] == 1.0
+        assert authority.is_hydrated is True
+        assert authority.first_snap_accepted is True
+        assert csm.is_hydrated is True
+        assert csm.first_snap_accepted is True
+        assert csm.state.value == "READY"
+    finally:
+        reset_broker_manager_singleton()
+        reset_csm_v2_singleton()
+        reset_capital_authority_singleton(clear_disk_cache=True)

--- a/bot/tests/test_stalled_writer_release_guard_v22.py
+++ b/bot/tests/test_stalled_writer_release_guard_v22.py
@@ -276,11 +276,75 @@ def test_bootstrap_progression_retries_only_validated_ready_manager(monkeypatch)
     bootstrap_fsm = types.SimpleNamespace(state=state, advance_to_capital_ready=advance)
     bootstrap_module = types.SimpleNamespace(get_bootstrap_fsm=lambda: bootstrap_fsm)
     monkeypatch.setattr(guard, "_manager_instance", lambda: manager)
+    monkeypatch.setattr(
+        guard,
+        "_ingest_authority_snapshot_into_csm",
+        lambda source: source == "unit_test",
+    )
     monkeypatch.setitem(guard.sys.modules, "bot.bootstrap_state_machine", bootstrap_module)
 
     assert guard._attempt_bootstrap_progression("unit_test") is True
     assert calls == ["stalled_writer_ready_bootstrap_retry:unit_test"]
     assert state.value == "CAPITAL_READY"
+
+
+def test_missed_authority_snapshot_is_ingested_into_canonical_csm(monkeypatch):
+    snapshot = types.SimpleNamespace(real_capital=371.07, broker_count=2)
+    authority = types.SimpleNamespace(
+        is_hydrated=True,
+        first_snap_accepted=True,
+        get_typed_snapshot=lambda: snapshot,
+        is_stale=lambda ttl_s: False,
+    )
+    authority_module = types.SimpleNamespace(
+        get_capital_authority=lambda: authority
+    )
+
+    calls = []
+    csm = types.SimpleNamespace(is_hydrated=False)
+
+    def ingest(received):
+        calls.append(received)
+        csm.is_hydrated = True
+        return types.SimpleNamespace(value="READY")
+
+    csm.ingest_snapshot = ingest
+    csm_module = types.SimpleNamespace(get_csm_v2=lambda: csm)
+
+    monkeypatch.setitem(guard.sys.modules, "bot.capital_authority", authority_module)
+    monkeypatch.setitem(guard.sys.modules, "capital_authority", authority_module)
+    monkeypatch.setitem(guard.sys.modules, "bot.capital_csm_v2", csm_module)
+    monkeypatch.setitem(guard.sys.modules, "capital_csm_v2", csm_module)
+
+    assert guard._ingest_authority_snapshot_into_csm("unit_test") is True
+    assert calls == [snapshot]
+
+
+def test_stale_authority_snapshot_is_not_replayed_into_csm(monkeypatch):
+    snapshot = types.SimpleNamespace(real_capital=371.07, broker_count=2)
+    authority = types.SimpleNamespace(
+        is_hydrated=True,
+        first_snap_accepted=True,
+        get_typed_snapshot=lambda: snapshot,
+        is_stale=lambda ttl_s: True,
+    )
+    authority_module = types.SimpleNamespace(
+        get_capital_authority=lambda: authority
+    )
+    calls = []
+    csm = types.SimpleNamespace(
+        is_hydrated=False,
+        ingest_snapshot=lambda received: calls.append(received),
+    )
+    csm_module = types.SimpleNamespace(get_csm_v2=lambda: csm)
+
+    monkeypatch.setitem(guard.sys.modules, "bot.capital_authority", authority_module)
+    monkeypatch.setitem(guard.sys.modules, "capital_authority", authority_module)
+    monkeypatch.setitem(guard.sys.modules, "bot.capital_csm_v2", csm_module)
+    monkeypatch.setitem(guard.sys.modules, "capital_csm_v2", csm_module)
+
+    assert guard._ingest_authority_snapshot_into_csm("unit_test") is False
+    assert calls == []
 
 
 def test_bootstrap_progression_refuses_unattested_startup(monkeypatch):


### PR DESCRIPTION
## Summary

- hydrate the canonical CapitalCSMv2 immediately from an accepted bootstrap seed, independently of capital-FSM wiring order
- let the stalled-writer recovery replay only the exact fresh, positive snapshot already accepted by CapitalAuthority before retrying the legal bootstrap transition
- keep recovery fail-closed for stale, missing, zero-capital, unaccepted, or unattested state
- add focused and real seed-path regression coverage

## Validation

- compiled all Python under `bot/`, `scripts/`, and `main.py`
- passed all 17 stalled-writer guard behavioral tests
- passed seven focused handoff tests, including the real bootstrap seed path
- `git diff --check`

No forced activation or safety-gate bypass is introduced.