### PR TITLE
Make APEX imports canonical-runtime safe

### DIFF
--- a/bot/ai_intelligence_hub.py
+++ b/bot/ai_intelligence_hub.py
@@ -46,7 +46,7 @@ logger = logging.getLogger("nija.ai_hub")
 # ---------------------------------------------------------------------------
 
 try:
-    from market_regime_classification_ai import (
+    from bot.market_regime_classification_ai import (
         MarketRegimeClassificationAI,
         MarketRegimeType,
         StrategyType as RegimeStrategyType,
@@ -54,13 +54,22 @@ try:
     )
     REGIME_AI_AVAILABLE = True
 except ImportError:
-    REGIME_AI_AVAILABLE = False
-    MarketRegimeClassificationAI = None  # type: ignore
-    MarketRegimeType = None  # type: ignore
-    logger.warning("MarketRegimeClassificationAI not available – regime AI disabled")
+    try:
+        from market_regime_classification_ai import (
+            MarketRegimeClassificationAI,
+            MarketRegimeType,
+            StrategyType as RegimeStrategyType,
+            RegimeClassification,
+        )
+        REGIME_AI_AVAILABLE = True
+    except ImportError:
+        REGIME_AI_AVAILABLE = False
+        MarketRegimeClassificationAI = None  # type: ignore
+        MarketRegimeType = None  # type: ignore
+        logger.warning("MarketRegimeClassificationAI not available – regime AI disabled")
 
 try:
-    from portfolio_risk_engine import (
+    from bot.portfolio_risk_engine import (
         PortfolioRiskEngine,
         PositionExposure,
         get_portfolio_risk_engine,
@@ -68,23 +77,40 @@ try:
     )
     PORTFOLIO_RISK_AVAILABLE = True
 except ImportError:
-    PORTFOLIO_RISK_AVAILABLE = False
-    PortfolioRiskEngine = None  # type: ignore
-    PositionExposure = None  # type: ignore
-    get_portfolio_risk_engine = None  # type: ignore
-    logger.warning("PortfolioRiskEngine not available – portfolio risk control disabled")
+    try:
+        from portfolio_risk_engine import (
+            PortfolioRiskEngine,
+            PositionExposure,
+            get_portfolio_risk_engine,
+            PortfolioRiskMetrics,
+        )
+        PORTFOLIO_RISK_AVAILABLE = True
+    except ImportError:
+        PORTFOLIO_RISK_AVAILABLE = False
+        PortfolioRiskEngine = None  # type: ignore
+        PositionExposure = None  # type: ignore
+        get_portfolio_risk_engine = None  # type: ignore
+        logger.warning("PortfolioRiskEngine not available – portfolio risk control disabled")
 
 try:
-    from capital_allocation_brain import (
+    from bot.capital_allocation_brain import (
         CapitalAllocationBrain,
         AllocationMethod,
         AllocationPlan,
     )
     CAPITAL_BRAIN_AVAILABLE = True
 except ImportError:
-    CAPITAL_BRAIN_AVAILABLE = False
-    CapitalAllocationBrain = None  # type: ignore
-    logger.warning("CapitalAllocationBrain not available – capital allocation AI disabled")
+    try:
+        from capital_allocation_brain import (
+            CapitalAllocationBrain,
+            AllocationMethod,
+            AllocationPlan,
+        )
+        CAPITAL_BRAIN_AVAILABLE = True
+    except ImportError:
+        CAPITAL_BRAIN_AVAILABLE = False
+        CapitalAllocationBrain = None  # type: ignore
+        logger.warning("CapitalAllocationBrain not available – capital allocation AI disabled")
 
 try:
     from multi_account_broker_manager import get_broker_manager as _get_broker_manager
@@ -338,7 +364,10 @@ class AIIntelligenceHub:
         # Rule: NANO capital cannot influence global allocation decisions.
         if portfolio_value <= 0.0:
             try:
-                from capital_authority import get_capital_authority as _get_ca_hub
+                try:
+                    from bot.capital_authority import get_capital_authority as _get_ca_hub
+                except ImportError:
+                    from capital_authority import get_capital_authority as _get_ca_hub
                 _ca_hub = _get_ca_hub()
                 if _ca_hub.is_fresh():
                     # Primary capital = Kraken/authoritative only (NANO excluded).
@@ -823,7 +852,10 @@ class AIIntelligenceHub:
         if self.regime_ai is not None and regime and strategy:
             try:
                 regime_type = MarketRegimeType(regime)
-                from market_regime_classification_ai import StrategyType as ST
+                try:
+                    from bot.market_regime_classification_ai import StrategyType as ST
+                except ImportError:
+                    from market_regime_classification_ai import StrategyType as ST
                 strategy_type = ST(strategy)
                 self.regime_ai.update_performance(regime_type, strategy_type, pnl, is_win)
             except Exception as exc:

--- a/bot/execution_engine.py
+++ b/bot/execution_engine.py
@@ -429,15 +429,24 @@ def trade_is_economical(
 
 # Import fee-aware configuration for profit calculations
 try:
-    from fee_aware_config import MARKET_ORDER_ROUND_TRIP
+    from bot.fee_aware_config import MARKET_ORDER_ROUND_TRIP
     FEE_AWARE_MODE = True
     # Use market order fees as conservative estimate (worst case)
     DEFAULT_ROUND_TRIP_FEE = MARKET_ORDER_ROUND_TRIP  # 1.4%
     logger.info(f"✅ Fee-aware profit calculations enabled (round-trip fee: {DEFAULT_ROUND_TRIP_FEE*100:.1f}%)")
 except ImportError:
-    FEE_AWARE_MODE = False
-    DEFAULT_ROUND_TRIP_FEE = 0.014  # 1.4% default
-    logger.warning(f"⚠️ Fee-aware config not found - using default {DEFAULT_ROUND_TRIP_FEE*100:.1f}% round-trip fee")
+    try:
+        from fee_aware_config import MARKET_ORDER_ROUND_TRIP
+        FEE_AWARE_MODE = True
+        DEFAULT_ROUND_TRIP_FEE = MARKET_ORDER_ROUND_TRIP
+        logger.info(f"✅ Fee-aware profit calculations enabled (round-trip fee: {DEFAULT_ROUND_TRIP_FEE*100:.1f}%)")
+    except ImportError:
+        FEE_AWARE_MODE = False
+        DEFAULT_ROUND_TRIP_FEE = 0.014  # 1.4% default
+        logger.warning(
+            "⚠️ Fee-aware config not found - using default %.1f%% round-trip fee",
+            DEFAULT_ROUND_TRIP_FEE * 100,
+        )
 
 # Import trade ledger database
 try:

--- a/bot/nija_apex_strategy_v71.py
+++ b/bot/nija_apex_strategy_v71.py
@@ -20,51 +20,94 @@ from typing import Any, Dict, Optional, Tuple, List
 import logging
 import os
 
-from indicators import (
-    calculate_vwap, calculate_ema, calculate_rsi, calculate_macd,
-    calculate_atr, calculate_adx, calculate_bollinger_bands, scalar,
-    calculate_supertrend,
-)
-from risk_manager import RiskManager, EXTREME_VOLATILITY_ATR_PCT, _ATR_POSITION_SIZE_REFERENCE
-from execution_engine import ExecutionEngine
+try:
+    from bot.indicators import (
+        calculate_vwap, calculate_ema, calculate_rsi, calculate_macd,
+        calculate_atr, calculate_adx, calculate_bollinger_bands, scalar,
+        calculate_supertrend,
+    )
+    from bot.risk_manager import (
+        RiskManager,
+        EXTREME_VOLATILITY_ATR_PCT,
+        _ATR_POSITION_SIZE_REFERENCE,
+    )
+    from bot.execution_engine import ExecutionEngine
+except ImportError:
+    # Direct/script launches retain compatibility with the historical flat
+    # module layout.  Canonical package launches must not depend on /app/bot
+    # being injected into sys.path by the deferred runtime-hook fanout.
+    from indicators import (
+        calculate_vwap, calculate_ema, calculate_rsi, calculate_macd,
+        calculate_atr, calculate_adx, calculate_bollinger_bands, scalar,
+        calculate_supertrend,
+    )
+    from risk_manager import RiskManager, EXTREME_VOLATILITY_ATR_PCT, _ATR_POSITION_SIZE_REFERENCE
+    from execution_engine import ExecutionEngine
 
 # Import profitability assertion for configuration validation
 # Initialize logger before any imports that might use it
 logger = logging.getLogger("nija")
 
 try:
-    from profitability_assertion import assert_strategy_is_profitable, ProfitabilityAssertionError
+    from bot.profitability_assertion import assert_strategy_is_profitable, ProfitabilityAssertionError
     PROFITABILITY_ASSERTION_AVAILABLE = True
 except ImportError:
-    PROFITABILITY_ASSERTION_AVAILABLE = False
-    logger.warning("Profitability assertion module not available - configuration validation disabled")
+    try:
+        from profitability_assertion import assert_strategy_is_profitable, ProfitabilityAssertionError
+        PROFITABILITY_ASSERTION_AVAILABLE = True
+    except ImportError:
+        PROFITABILITY_ASSERTION_AVAILABLE = False
+        logger.warning("Profitability assertion module not available - configuration validation disabled")
 
 # Import exchange capabilities for SHORT entry validation and fee-aware profit targets
 try:
-    from exchange_capabilities import can_short, get_broker_capabilities, get_min_profit_target as _get_exchange_min_profit_target
+    from bot.exchange_capabilities import (
+        can_short,
+        get_broker_capabilities,
+        get_min_profit_target as _get_exchange_min_profit_target,
+    )
     EXCHANGE_CAPABILITIES_AVAILABLE = True
 except ImportError:
-    EXCHANGE_CAPABILITIES_AVAILABLE = False
-    logger.warning("Exchange capabilities module not available - SHORT validation and fee-aware targets disabled")
+    try:
+        from exchange_capabilities import (
+            can_short,
+            get_broker_capabilities,
+            get_min_profit_target as _get_exchange_min_profit_target,
+        )
+        EXCHANGE_CAPABILITIES_AVAILABLE = True
+    except ImportError:
+        EXCHANGE_CAPABILITIES_AVAILABLE = False
+        logger.warning("Exchange capabilities module not available - SHORT validation and fee-aware targets disabled")
 
 # Import position sizer for minimum position validation
 try:
-    from position_sizer import MIN_POSITION_USD, calculate_position_size as _calc_position_size
+    from bot.position_sizer import MIN_POSITION_USD, calculate_position_size as _calc_position_size
     _CALC_POSITION_SIZE_AVAILABLE = True
 except ImportError:
-    MIN_POSITION_USD = 10.0  # Default to $10 minimum for micro-cap / HF scalp mode (Apr 2026)
-    logger.warning("Could not import MIN_POSITION_USD from position_sizer, using default $10.00")
+    try:
+        from position_sizer import MIN_POSITION_USD, calculate_position_size as _calc_position_size
+        _CALC_POSITION_SIZE_AVAILABLE = True
+    except ImportError:
+        MIN_POSITION_USD = 10.0  # Default to $10 minimum for micro-cap / HF scalp mode (Apr 2026)
+        _CALC_POSITION_SIZE_AVAILABLE = False
+        logger.warning("Could not import MIN_POSITION_USD from position_sizer, using default $10.00")
 
 # Import small account constants from fee_aware_config
 try:
-    from fee_aware_config import (
+    from bot.fee_aware_config import (
         SMALL_ACCOUNT_THRESHOLD,
         SMALL_ACCOUNT_MAX_POSITION_PCT
     )
 except ImportError:
-    SMALL_ACCOUNT_THRESHOLD = 200.0  # Fallback — raised to cover $174 balance (Apr 2026)
-    SMALL_ACCOUNT_MAX_POSITION_PCT = 0.30  # Fallback — aligned with MAX_POSITION_SIZE hard limit
-    logger.warning("Could not import small account constants from fee_aware_config, using defaults")
+    try:
+        from fee_aware_config import (
+            SMALL_ACCOUNT_THRESHOLD,
+            SMALL_ACCOUNT_MAX_POSITION_PCT,
+        )
+    except ImportError:
+        SMALL_ACCOUNT_THRESHOLD = 200.0  # Fallback — raised to cover $174 balance (Apr 2026)
+        SMALL_ACCOUNT_MAX_POSITION_PCT = 0.30  # Fallback — aligned with MAX_POSITION_SIZE hard limit
+        logger.warning("Could not import small account constants from fee_aware_config, using defaults")
 
 # Broker-specific minimum position sizes (Jan 24, 2026)
 # Env-overridable via KRAKEN_MIN_NOTIONAL_USD for micro-cap / HF scalp mode.
@@ -215,20 +258,29 @@ except ImportError:
 
 # Import emergency liquidation for capital preservation (FIX 3)
 try:
-    from emergency_liquidation import EmergencyLiquidator
+    from bot.emergency_liquidation import EmergencyLiquidator
     EMERGENCY_LIQUIDATION_AVAILABLE = True
 except ImportError:
-    EMERGENCY_LIQUIDATION_AVAILABLE = False
-    logger.warning("Emergency liquidation module not available")
+    try:
+        from emergency_liquidation import EmergencyLiquidator
+        EMERGENCY_LIQUIDATION_AVAILABLE = True
+    except ImportError:
+        EMERGENCY_LIQUIDATION_AVAILABLE = False
+        logger.warning("Emergency liquidation module not available")
 
 # Import enhanced entry scoring and regime detection
 try:
-    from enhanced_entry_scoring import EnhancedEntryScorer
-    from market_regime_detector import RegimeDetector, MarketRegime
+    from bot.enhanced_entry_scoring import EnhancedEntryScorer
+    from bot.market_regime_detector import RegimeDetector, MarketRegime
     ENHANCED_SCORING_AVAILABLE = True
 except ImportError:
-    ENHANCED_SCORING_AVAILABLE = False
-    logger.warning("Enhanced scoring and regime detection modules not available - using basic scoring")
+    try:
+        from enhanced_entry_scoring import EnhancedEntryScorer
+        from market_regime_detector import RegimeDetector, MarketRegime
+        ENHANCED_SCORING_AVAILABLE = True
+    except ImportError:
+        ENHANCED_SCORING_AVAILABLE = False
+        logger.warning("Enhanced scoring and regime detection modules not available - using basic scoring")
 
 # Import entry optimizer (RSI divergence, Bollinger Band zone, volume pattern)
 try:
@@ -248,13 +300,17 @@ except ImportError:
 # Capital Allocation AI).  All three components are optional – the strategy degrades
 # gracefully when any of them is unavailable.
 try:
-    from ai_intelligence_hub import get_ai_intelligence_hub, AIIntelligenceHub
+    from bot.ai_intelligence_hub import get_ai_intelligence_hub, AIIntelligenceHub
     AI_HUB_AVAILABLE = True
 except ImportError:
-    AI_HUB_AVAILABLE = False
-    get_ai_intelligence_hub = None  # type: ignore
-    AIIntelligenceHub = None  # type: ignore
-    logger.warning("AI Intelligence Hub not available – running without AI regime / risk / allocation layer")
+    try:
+        from ai_intelligence_hub import get_ai_intelligence_hub, AIIntelligenceHub
+        AI_HUB_AVAILABLE = True
+    except ImportError:
+        AI_HUB_AVAILABLE = False
+        get_ai_intelligence_hub = None  # type: ignore
+        AIIntelligenceHub = None  # type: ignore
+        logger.warning("AI Intelligence Hub not available – running without AI regime / risk / allocation layer")
 
 # Import profit optimization stack (all three are optional – graceful degradation)
 # ProfitHarvestLayer: ratchet-tier profit locking + partial harvests

--- a/bot/risk_manager.py
+++ b/bot/risk_manager.py
@@ -38,17 +38,20 @@ except ImportError:
 
 # Import scalar helper for indicator conversions
 try:
-    from indicators import scalar
+    from bot.indicators import scalar
 except ImportError:
-    # Fallback if indicators.py is not available
-    def scalar(x):
-        if isinstance(x, (tuple, list)):
-            return float(x[0])
-        return float(x)
+    try:
+        from indicators import scalar
+    except ImportError:
+        # Fallback if indicators.py is not available
+        def scalar(x):
+            if isinstance(x, (tuple, list)):
+                return float(x[0])
+            return float(x)
 
 # Import fee-aware configuration
 try:
-    from fee_aware_config import (
+    from bot.fee_aware_config import (
         MIN_BALANCE_TO_TRADE,
         MICRO_ACCOUNT_THRESHOLD,
         get_position_size_pct,
@@ -60,10 +63,23 @@ try:
     FEE_AWARE_MODE = True
     logger.info("✅ Fee-aware configuration loaded - PROFITABILITY MODE ACTIVE")
 except ImportError:
-    FEE_AWARE_MODE = False
-    MIN_BALANCE_TO_TRADE = 10.0
-    MICRO_ACCOUNT_THRESHOLD = 5.0
-    logger.warning("⚠️ Fee-aware config not found - using legacy mode")
+    try:
+        from fee_aware_config import (
+            MIN_BALANCE_TO_TRADE,
+            MICRO_ACCOUNT_THRESHOLD,
+            get_position_size_pct,
+            get_min_profit_target,
+            should_trade,
+            get_fee_adjusted_targets,
+            MAX_TRADES_PER_DAY,
+        )
+        FEE_AWARE_MODE = True
+        logger.info("✅ Fee-aware configuration loaded - PROFITABILITY MODE ACTIVE")
+    except ImportError:
+        FEE_AWARE_MODE = False
+        MIN_BALANCE_TO_TRADE = 10.0
+        MICRO_ACCOUNT_THRESHOLD = 5.0
+        logger.warning("⚠️ Fee-aware config not found - using legacy mode")
 
 # Import tier configuration for tier-aware risk management
 try:
@@ -84,17 +100,24 @@ except ImportError:
 
 # Import small account constants from fee_aware_config
 try:
-    from fee_aware_config import (
+    from bot.fee_aware_config import (
         SMALL_ACCOUNT_THRESHOLD,
         SMALL_ACCOUNT_MAX_PCT_DIFF,
         STANDARD_MAX_PCT_DIFF
     )
 except ImportError:
-    # Fallback values if import fails
-    SMALL_ACCOUNT_THRESHOLD = 100.0
-    SMALL_ACCOUNT_MAX_PCT_DIFF = 10.0
-    STANDARD_MAX_PCT_DIFF = 5.0
-    logger.warning("Could not import small account constants from fee_aware_config, using defaults")
+    try:
+        from fee_aware_config import (
+            SMALL_ACCOUNT_THRESHOLD,
+            SMALL_ACCOUNT_MAX_PCT_DIFF,
+            STANDARD_MAX_PCT_DIFF,
+        )
+    except ImportError:
+        # Fallback values if import fails
+        SMALL_ACCOUNT_THRESHOLD = 100.0
+        SMALL_ACCOUNT_MAX_PCT_DIFF = 10.0
+        STANDARD_MAX_PCT_DIFF = 5.0
+        logger.warning("Could not import small account constants from fee_aware_config, using defaults")
 
 # ==============================================================================
 # HARD RISK LIMITS (non-negotiable — applied to every trade)

--- a/bot/tests/test_runtime_log_regressions_20260801.py
+++ b/bot/tests/test_runtime_log_regressions_20260801.py
@@ -1,11 +1,58 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
 
 from bot import trading_strategy as strategy_module
 from bot import universal_broker_exit_supervisor_patch as exit_supervisor
+
+
+def test_canonical_deferred_hooks_import_full_apex_stack():
+    """Canonical launches must not depend on /app/bot being on sys.path."""
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["NIJA_DEFER_RUNTIME_SITE_HOOKS"] = "1"
+    env.pop("PYTHONPATH", None)
+    probe = """
+import bot.ai_intelligence_hub as hub
+import bot.execution_engine as execution
+import bot.nija_apex_strategy_v71 as apex
+import bot.risk_manager as risk
+
+checks = (
+    apex.NIJAApexStrategyV71 is not None,
+    apex.PROFITABILITY_ASSERTION_AVAILABLE,
+    apex.EXCHANGE_CAPABILITIES_AVAILABLE,
+    apex._CALC_POSITION_SIZE_AVAILABLE,
+    apex.EMERGENCY_LIQUIDATION_AVAILABLE,
+    apex.ENHANCED_SCORING_AVAILABLE,
+    apex.AI_HUB_AVAILABLE,
+    hub.REGIME_AI_AVAILABLE,
+    hub.PORTFOLIO_RISK_AVAILABLE,
+    hub.CAPITAL_BRAIN_AVAILABLE,
+    risk.FEE_AWARE_MODE,
+    execution.FEE_AWARE_MODE,
+)
+assert all(checks), checks
+print("APEX_CANONICAL_IMPORT_OK")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=45,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "APEX_CANONICAL_IMPORT_OK" in result.stdout
 
 
 def _strategy_shell() -> strategy_module.TradingStrategy:


### PR DESCRIPTION
## What changed

- use `bot.*` package imports throughout the APEX strategy and its critical dependency chain
- retain flat-import fallbacks for direct and legacy launches
- keep fee-aware risk, execution, regime AI, portfolio risk, and capital allocation enabled under the canonical launcher
- add a subprocess regression that reproduces `NIJA_DEFER_RUNTIME_SITE_HOOKS=1` without `PYTHONPATH`

## Root cause

The canonical launcher deliberately defers package-wide site hooks. `bot.nija_apex_strategy_v71` still imported dependencies such as `indicators`, `risk_manager`, and `execution_engine` as top-level modules, so APEX import failed and every strategy cycle became a no-op.

## Validation

- canonical deferred-hook APEX stack probe: passed
- `bot.tests.test_apex_entry_gate_wiring`: 7 tests passed
- Python compile check: passed
- `git diff --check`: passed

Safety gates remain intact. This change does not force trades or bypass verified cost-basis requirements.