### PR TITLE
Fix serial capital refresh timeouts and stale snapshot promotion

### DIFF
--- a/bot/capital_refresh_stall_guard_v35.py
+++ b/bot/capital_refresh_stall_guard_v35.py
@@ -1,10 +1,10 @@
 """Capital refresh stall guard v35.
 
-Bounds broker balance calls only inside CapitalRefreshCoordinator. A broker API
-call that stalls cannot leave the bootstrap FSM permanently in
-REFRESH_IN_FLIGHT. On timeout, an already-hydrated broker balance is reused;
-without a cached payload the coordinator records that venue as unavailable and
-continues fail-closed with the remaining venues.
+Bounds broker balance calls only inside CapitalRefreshCoordinator. All venue
+fetches begin together and share one deadline, so a stalled API cannot multiply
+the refresh timeout by the number of brokers. On timeout, an already-hydrated
+broker balance is reused; without a cached payload the coordinator records that
+venue as unavailable and continues fail-closed with the remaining venues.
 """
 from __future__ import annotations
 
@@ -18,10 +18,11 @@ from types import ModuleType
 from typing import Any, Dict
 
 LOGGER = logging.getLogger("nija.capital_refresh_stall_guard_v35")
-MARKER = "20260727-capital-refresh-stall-guard-v35"
+MARKER = "20260802-capital-refresh-shared-deadline-v36"
 _TARGETS = ("bot.capital_flow_state_machine", "capital_flow_state_machine")
 _LOCK = threading.RLock()
 _STARTED = False
+_REFRESH_CONTEXT = threading.local()
 
 
 def _timeout_seconds() -> float:
@@ -31,49 +32,48 @@ def _timeout_seconds() -> float:
         return 8.0
 
 
-class _BoundedBrokerProxy:
-    """Transparent broker proxy with a bounded get_account_balance call."""
+class _BalanceFetchBatch:
+    """Start all broker calls together and enforce one shared deadline."""
 
-    def __init__(self, broker_id: str, broker: Any) -> None:
-        object.__setattr__(self, "_broker_id", str(broker_id))
-        object.__setattr__(self, "_broker", broker)
+    def __init__(self, broker_map: Dict[str, Any]) -> None:
+        self._started_at = time.monotonic()
+        self._deadline = self._started_at + _timeout_seconds()
+        self._results: Dict[str, "queue.Queue[tuple[bool, Any]]"] = {}
+        for broker_id, broker in broker_map.items():
+            result_queue: "queue.Queue[tuple[bool, Any]]" = queue.Queue(maxsize=1)
+            self._results[broker_id] = result_queue
 
-    def __getattr__(self, name: str) -> Any:
-        return getattr(object.__getattribute__(self, "_broker"), name)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        setattr(object.__getattribute__(self, "_broker"), name, value)
-
-    def get_account_balance(self) -> Any:
-        broker = object.__getattribute__(self, "_broker")
-        broker_id = object.__getattribute__(self, "_broker_id")
-        result_queue: "queue.Queue[tuple[bool, Any]]" = queue.Queue(maxsize=1)
-
-        def _call() -> None:
-            try:
-                result_queue.put_nowait((True, broker.get_account_balance()))
-            except BaseException as exc:  # preserve broker exception semantics
+            def _call(
+                target: Any = broker,
+                output: "queue.Queue[tuple[bool, Any]]" = result_queue,
+            ) -> None:
                 try:
-                    result_queue.put_nowait((False, exc))
-                except queue.Full:
-                    pass
+                    output.put_nowait((True, target.get_account_balance()))
+                except BaseException as exc:  # preserve broker exception semantics
+                    try:
+                        output.put_nowait((False, exc))
+                    except queue.Full:
+                        pass
 
-        worker = threading.Thread(
-            target=_call,
-            name=f"capital-balance-fetch-{broker_id}",
-            daemon=True,
-        )
-        started_at = time.monotonic()
-        worker.start()
+            threading.Thread(
+                target=_call,
+                name=f"capital-balance-fetch-{broker_id}",
+                daemon=True,
+            ).start()
+
+    def result_for(self, broker_id: str, broker: Any) -> Any:
+        result_queue = self._results[broker_id]
+        remaining = max(0.0, self._deadline - time.monotonic())
         try:
-            ok, value = result_queue.get(timeout=_timeout_seconds())
+            ok, value = result_queue.get(timeout=remaining)
         except queue.Empty:
+            _REFRESH_CONTEXT.used_fallback = True
             cached = getattr(broker, "_last_known_balance", None)
-            elapsed = time.monotonic() - started_at
+            elapsed = time.monotonic() - self._started_at
             if cached is not None:
-                LOGGER.error(
+                LOGGER.warning(
                     "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s "
-                    "broker=%s elapsed=%.2fs cached_payload=true",
+                    "broker=%s elapsed=%.2fs cached_payload=true shared_deadline=true",
                     MARKER,
                     broker_id,
                     elapsed,
@@ -81,7 +81,7 @@ class _BoundedBrokerProxy:
                 return cached
             LOGGER.error(
                 "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT marker=%s broker=%s "
-                "elapsed=%.2fs cached_payload=false",
+                "elapsed=%.2fs cached_payload=false shared_deadline=true",
                 MARKER,
                 broker_id,
                 elapsed,
@@ -92,6 +92,32 @@ class _BoundedBrokerProxy:
         if ok:
             return value
         raise value
+
+
+def current_refresh_used_fallback() -> bool:
+    """Return whether this thread's active refresh consumed cached capital."""
+    return bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
+
+
+class _BoundedBrokerProxy:
+    """Transparent broker proxy backed by a shared balance-fetch batch."""
+
+    def __init__(self, broker_id: str, broker: Any, batch: _BalanceFetchBatch) -> None:
+        object.__setattr__(self, "_broker_id", str(broker_id))
+        object.__setattr__(self, "_broker", broker)
+        object.__setattr__(self, "_batch", batch)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_broker"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(object.__getattribute__(self, "_broker"), name, value)
+
+    def get_account_balance(self) -> Any:
+        return object.__getattribute__(self, "_batch").result_for(
+            object.__getattribute__(self, "_broker_id"),
+            object.__getattribute__(self, "_broker"),
+        )
 
 
 def _patch(module: ModuleType) -> bool:
@@ -110,23 +136,33 @@ def _patch(module: ModuleType) -> bool:
         trigger: str,
         open_exposure_usd: float,
     ) -> Any:
-        bounded_map = {
-            str(broker_id): _BoundedBrokerProxy(str(broker_id), broker)
+        _REFRESH_CONTEXT.used_fallback = False
+        live_map = {
+            str(broker_id): broker
             for broker_id, broker in broker_map.items()
             if broker is not None
         }
-        return original(
-            self,
-            broker_map=bounded_map,
-            trigger=trigger,
-            open_exposure_usd=open_exposure_usd,
-        )
+        batch = _BalanceFetchBatch(live_map)
+        bounded_map = {
+            broker_id: _BoundedBrokerProxy(broker_id, broker, batch)
+            for broker_id, broker in live_map.items()
+        }
+        try:
+            return original(
+                self,
+                broker_map=bounded_map,
+                trigger=trigger,
+                open_exposure_usd=open_exposure_usd,
+            )
+        finally:
+            _REFRESH_CONTEXT.used_fallback = False
 
     _pipeline_with_bounded_brokers._nija_capital_refresh_stall_guard_v35 = True
     cls._pipeline = _pipeline_with_bounded_brokers
     os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED"] = "1"
     LOGGER.critical(
-        "CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED marker=%s module=%s timeout_s=%.2f",
+        "CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED marker=%s module=%s "
+        "timeout_s=%.2f shared_deadline=true",
         MARKER,
         module.__name__,
         _timeout_seconds(),
@@ -158,7 +194,8 @@ def install() -> bool:
         return False
     os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED"] = "1"
     LOGGER.critical(
-        "CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED marker=%s fail_closed=true",
+        "CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED marker=%s "
+        "fail_closed=true shared_deadline=true",
         MARKER,
     )
     return True

--- a/bot/current_capital_snapshot_freshness_repair_patch.py
+++ b/bot/current_capital_snapshot_freshness_repair_patch.py
@@ -1,15 +1,10 @@
-"""Repair current live capital snapshots that inherit stale prior age.
+"""Repair freshness only for confirmed current live-broker snapshots.
 
-The coordinator builds a new ``CapitalSnapshot`` after fetching broker balances,
-but its ``is_fresh`` calculation historically used the age of the previous
-CapitalAuthority snapshot.  On first live refresh that previous age can be
-infinite, causing a brand-new live-exchange snapshot with positive capital and
-valid broker balances to carry ``is_stale=True``.
-
-This patch preserves the original ``CapitalSnapshot`` class identity and wraps
-only its constructor.  It clears the stale flag only for a newly constructed,
-positive, broker-backed, medium-or-better confidence snapshot.  It does not
-publish capital, grant writer authority, alter risk sizing, or submit orders.
+The coordinator historically derives a new snapshot's freshness from the prior
+authority snapshot age. This patch repairs that inherited stale flag only when
+the current refresh completed without a timeout fallback. If any venue supplied
+cached capital, the new snapshot remains explicitly stale and cannot be promoted
+to current live-exchange data.
 """
 from __future__ import annotations
 
@@ -17,12 +12,13 @@ from datetime import datetime, timezone
 import functools
 import logging
 import os
+import sys
 import threading
 from typing import Any
 
 logger = logging.getLogger("nija.current_capital_snapshot_freshness_repair")
 
-_MARKER = "20260731-current-capital-snapshot-freshness-v1"
+_MARKER = "20260802-current-capital-snapshot-freshness-v2"
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -59,12 +55,36 @@ def _broker_threshold(snapshot: Any) -> int:
         return 1
 
 
+def _current_refresh_used_fallback() -> bool:
+    for name in (
+        "bot.capital_refresh_stall_guard_v35",
+        "capital_refresh_stall_guard_v35",
+    ):
+        module = sys.modules.get(name)
+        checker = getattr(module, "current_refresh_used_fallback", None)
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:
+                return True
+    return False
+
+
 def _should_repair(snapshot: Any) -> bool:
+    if _current_refresh_used_fallback():
+        return False
     try:
         real_capital = float(getattr(snapshot, "real_capital", 0.0) or 0.0)
         broker_count = int(getattr(snapshot, "broker_count", 0) or 0)
         broker_balances = dict(getattr(snapshot, "broker_balances", {}) or {})
-        fresh_ttl_s = float(getattr(__import__("bot.capital_flow_state_machine", fromlist=["FRESHNESS_TTL_S"]), "FRESHNESS_TTL_S", 90.0) or 90.0)
+        fresh_ttl_s = float(
+            getattr(
+                __import__("bot.capital_flow_state_machine", fromlist=["FRESHNESS_TTL_S"]),
+                "FRESHNESS_TTL_S",
+                90.0,
+            )
+            or 90.0
+        )
     except Exception:
         return False
 
@@ -106,13 +126,25 @@ def install_import_hook() -> bool:
             @functools.wraps(current_init)
             def _init_with_current_freshness(self: Any, *args: Any, **kwargs: Any) -> None:
                 current_init(self, *args, **kwargs)
+                if _current_refresh_used_fallback():
+                    object.__setattr__(self, "is_fresh", False)
+                    object.__setattr__(self, "is_stale", True)
+                    logger.warning(
+                        "CURRENT_CAPITAL_SNAPSHOT_CACHE_FALLBACK_STALE marker=%s "
+                        "real=%.2f broker_count=%s",
+                        _MARKER,
+                        float(getattr(self, "real_capital", 0.0) or 0.0),
+                        getattr(self, "broker_count", "unknown"),
+                    )
+                    return
                 if not _should_repair(self):
                     return
                 object.__setattr__(self, "is_fresh", True)
                 object.__setattr__(self, "is_stale", False)
                 object.__setattr__(self, "snapshot_age_s", 0.0)
                 logger.warning(
-                    "CURRENT_CAPITAL_SNAPSHOT_FRESHNESS_REPAIRED marker=%s real=%.2f broker_count=%s confidence=%s",
+                    "CURRENT_CAPITAL_SNAPSHOT_FRESHNESS_REPAIRED marker=%s "
+                    "real=%.2f broker_count=%s confidence=%s",
                     _MARKER,
                     float(getattr(self, "real_capital", 0.0) or 0.0),
                     getattr(self, "broker_count", "unknown"),

--- a/bot/tests/test_capital_refresh_stall_guard_v35.py
+++ b/bot/tests/test_capital_refresh_stall_guard_v35.py
@@ -4,7 +4,7 @@ import types
 import unittest
 from unittest.mock import patch
 
-import capital_refresh_stall_guard_v35 as guard
+from bot import capital_refresh_stall_guard_v35 as guard
 
 
 class _Broker:

--- a/bot/tests/test_capital_refresh_stall_guard_v35.py
+++ b/bot/tests/test_capital_refresh_stall_guard_v35.py
@@ -1,0 +1,95 @@
+import threading
+import time
+import types
+import unittest
+from unittest.mock import patch
+
+import capital_refresh_stall_guard_v35 as guard
+
+
+class _Broker:
+    def __init__(self, value=None, release=None, error=None):
+        self._last_known_balance = value
+        self._release = release
+        self._error = error
+        self.started = threading.Event()
+
+    def get_account_balance(self):
+        self.started.set()
+        if self._release is not None:
+            self._release.wait(1.0)
+        if self._error is not None:
+            raise self._error
+        return self._last_known_balance
+
+
+class CapitalRefreshSharedDeadlineTests(unittest.TestCase):
+    def test_all_fetches_start_together_and_share_one_timeout(self):
+        release = threading.Event()
+        brokers = {
+            "coinbase": _Broker(10.0, release),
+            "kraken": _Broker(20.0, release),
+            "okx": _Broker(30.0, release),
+        }
+        with patch.object(guard, "_timeout_seconds", return_value=0.08):
+            batch = guard._BalanceFetchBatch(brokers)
+            started_at = time.monotonic()
+            values = [batch.result_for(name, broker) for name, broker in brokers.items()]
+            elapsed = time.monotonic() - started_at
+
+        self.assertTrue(all(broker.started.is_set() for broker in brokers.values()))
+        self.assertEqual(values, [10.0, 20.0, 30.0])
+        self.assertLess(elapsed, 0.16)
+        release.set()
+
+    def test_completed_result_and_exception_preserve_semantics(self):
+        error = RuntimeError("venue failed")
+        brokers = {"okx": _Broker(42.0), "coinbase": _Broker(error=error)}
+        batch = guard._BalanceFetchBatch(brokers)
+
+        self.assertEqual(batch.result_for("okx", brokers["okx"]), 42.0)
+        with self.assertRaisesRegex(RuntimeError, "venue failed"):
+            batch.result_for("coinbase", brokers["coinbase"])
+
+    def test_patch_prefetches_before_sequential_pipeline_reads(self):
+        release = threading.Event()
+        brokers = {"a": _Broker(1.0, release), "b": _Broker(2.0, release)}
+
+        class Coordinator:
+            def _pipeline(self, broker_map, trigger, open_exposure_usd):
+                self.all_started = all(broker.started.is_set() for broker in brokers.values())
+                release.set()
+                return [broker.get_account_balance() for broker in broker_map.values()]
+
+        module = types.ModuleType("test_capital_flow")
+        module.CapitalRefreshCoordinator = Coordinator
+        self.assertTrue(guard._patch(module))
+
+        coordinator = Coordinator()
+        result = coordinator._pipeline(brokers, "test", 0.0)
+        self.assertTrue(coordinator.all_started)
+        self.assertEqual(result, [1.0, 2.0])
+        self.assertFalse(guard.current_refresh_used_fallback())
+
+    def test_fallback_context_is_visible_during_pipeline_only(self):
+        release = threading.Event()
+        broker = _Broker(12.0, release)
+
+        class Coordinator:
+            def _pipeline(self, broker_map, trigger, open_exposure_usd):
+                value = next(iter(broker_map.values())).get_account_balance()
+                return value, guard.current_refresh_used_fallback()
+
+        module = types.ModuleType("test_fallback_context")
+        module.CapitalRefreshCoordinator = Coordinator
+        self.assertTrue(guard._patch(module))
+
+        with patch.object(guard, "_timeout_seconds", return_value=0.05):
+            result = Coordinator()._pipeline({"okx": broker}, "test", 0.0)
+        self.assertEqual(result, (12.0, True))
+        self.assertFalse(guard.current_refresh_used_fallback())
+        release.set()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
+++ b/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
@@ -1,0 +1,71 @@
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from bot import capital_refresh_stall_guard_v35 as guard
+from bot import current_capital_snapshot_freshness_repair_patch as repair
+
+
+class CurrentCapitalFreshnessRepairTests(unittest.TestCase):
+    def setUp(self):
+        self.original_bot = sys.modules.get("bot")
+        self.original_cfsm = sys.modules.get("bot.capital_flow_state_machine")
+        self.bot = types.ModuleType("bot")
+        self.cfsm = types.ModuleType("bot.capital_flow_state_machine")
+        self.cfsm.FRESHNESS_TTL_S = 90.0
+        self.bot.capital_flow_state_machine = self.cfsm
+        sys.modules["bot"] = self.bot
+        sys.modules["bot.capital_flow_state_machine"] = self.cfsm
+
+    def tearDown(self):
+        if self.original_bot is None:
+            sys.modules.pop("bot", None)
+        else:
+            sys.modules["bot"] = self.original_bot
+        if self.original_cfsm is None:
+            sys.modules.pop("bot.capital_flow_state_machine", None)
+        else:
+            sys.modules["bot.capital_flow_state_machine"] = self.original_cfsm
+        repair._INSTALLED = False
+        repair._ORIGINAL_INIT = None
+
+    def test_cache_fallback_blocks_freshness_repair(self):
+        snapshot = types.SimpleNamespace(
+            computed_at=datetime.now(timezone.utc),
+            confidence=types.SimpleNamespace(band="MEDIUM"),
+            real_capital=100.0,
+            broker_count=1,
+            expected_brokers=1,
+            broker_balances={"okx": 100.0},
+            is_fresh=False,
+            is_stale=True,
+        )
+        with patch.object(guard, "current_refresh_used_fallback", return_value=True):
+            self.assertFalse(repair._should_repair(snapshot))
+        with patch.object(guard, "current_refresh_used_fallback", return_value=False):
+            self.assertTrue(repair._should_repair(snapshot))
+
+    def test_constructor_forces_cache_backed_snapshot_stale(self):
+        class Snapshot:
+            def __init__(self):
+                self.computed_at = datetime.now(timezone.utc)
+                self.confidence = types.SimpleNamespace(band="MEDIUM")
+                self.real_capital = 100.0
+                self.broker_count = 1
+                self.expected_brokers = 1
+                self.broker_balances = {"okx": 100.0}
+                self.is_fresh = True
+                self.is_stale = False
+
+        self.cfsm.CapitalSnapshot = Snapshot
+        with patch.object(guard, "current_refresh_used_fallback", return_value=True):
+            self.assertTrue(repair.install_import_hook())
+            snapshot = Snapshot()
+        self.assertFalse(snapshot.is_fresh)
+        self.assertTrue(snapshot.is_stale)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Owner

- Primary owner: repository maintainer

## Purpose

Production logs show OKX, Coinbase, and Kraken balance probes timing out sequentially at roughly 8 seconds each, stretching one capital refresh to about 24 seconds. Cached timeout fallbacks can also be promoted to fresh `live_exchange` snapshots by the current freshness repair.

## Risk Assessment

- Risk level: medium
- Impacted areas: capital refresh timing and snapshot freshness classification
- Key failure mode addressed: stale cached capital presented as current live-exchange data

## Fix

- Start all broker balance calls together under one shared deadline.
- Preserve successful results, broker exceptions, cached fallback, and fail-closed cache-miss behavior.
- Track timeout fallback in thread-local refresh context.
- Force cache-backed capital snapshots stale and block freshness promotion.
- Log expected cached fallbacks at WARNING while retaining ERROR for cache-miss timeouts.

## Rollback Plan

- Revert the PR; no migrations, persistent state changes, or configuration changes are involved.

## Validation

- [x] 6 focused unit tests passed locally
- [ ] CI checks passed
- [x] Monitoring/observability impact reviewed

### NIJA Safety Checks

- [x] `python -m py_compile` clean on all changed `.py` files
- [x] No bypass flags committed
- [x] Authority-gate rejection behavior unchanged
- [x] No strategy or order-sizing logic changed

## Expected production evidence

- Timeout lines for one refresh occur within the same approximately 8-second window and include `shared_deadline=true`.
- Cache-backed refreshes emit `CURRENT_CAPITAL_SNAPSHOT_CACHE_FALLBACK_STALE` and remain stale.
- Fully live refreshes continue to publish normal fresh snapshots.