### PR TITLE
Make Coinbase capital guard installation process-wide

### DIFF
--- a/bot/coinbase_capital_consistency_patch.py
+++ b/bot/coinbase_capital_consistency_patch.py
@@ -1,6 +1,7 @@
 """Keep Coinbase valuation caches separate from execution readiness."""
 from __future__ import annotations
 
+import builtins
 import logging
 import os
 import sys
@@ -11,10 +12,21 @@ from types import ModuleType
 from typing import Any, Iterator, Mapping
 
 logger = logging.getLogger("nija.coinbase_capital_consistency")
-_MARKER = "20260726-coinbase-capital-auth-fail-closed-v2"
+_MARKER = "20260802-coinbase-capital-install-idempotency-v3"
 _PATCH_ATTR = "_nija_coinbase_capital_consistency_v2"
-_LOCK = threading.RLock()
-_STARTED = False
+_STATE_KEY = "_NIJA_COINBASE_CAPITAL_CONSISTENCY_SHARED_STATE_V3"
+if not hasattr(builtins, _STATE_KEY):
+    setattr(
+        builtins,
+        _STATE_KEY,
+        {
+            "lock": threading.RLock(),
+            "monitor_started": False,
+            "install_attested": False,
+        },
+    )
+_STATE: dict[str, Any] = getattr(builtins, _STATE_KEY)
+_LOCK: threading.RLock = _STATE["lock"]
 
 
 def _number(value: Any) -> float:
@@ -296,21 +308,23 @@ def _monitor() -> None:
 
 
 def install() -> bool:
-    global _STARTED
+    """Install once even when compatibility loaders import this file by alias."""
     with _LOCK:
         _patch_loaded()
-        if not _STARTED:
-            _STARTED = True
+        if not bool(_STATE["monitor_started"]):
+            _STATE["monitor_started"] = True
             threading.Thread(
                 target=_monitor,
-                name="CoinbaseCapitalConsistencyV2",
+                name="CoinbaseCapitalConsistencyV3",
                 daemon=True,
             ).start()
         os.environ["NIJA_COINBASE_CAPITAL_CONSISTENCY_INSTALLED"] = "1"
-        logger.critical(
-            "COINBASE_CAPITAL_CONSISTENCY_INSTALLED marker=%s",
-            _MARKER,
-        )
+        if not bool(_STATE["install_attested"]):
+            _STATE["install_attested"] = True
+            logger.critical(
+                "COINBASE_CAPITAL_CONSISTENCY_INSTALLED marker=%s",
+                _MARKER,
+            )
         return True
 
 

--- a/tests/test_coinbase_capital_consistency_auth_fail_closed.py
+++ b/tests/test_coinbase_capital_consistency_auth_fail_closed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 
 
 def _module():
@@ -102,7 +103,6 @@ def test_capital_wrapper_patch_is_chain_aware():
     assert Broker.get_account_balance is first_balance
 
 
-
 def test_install_is_process_wide_idempotent_across_module_aliases(
     monkeypatch, caplog
 ):
@@ -132,7 +132,7 @@ def test_install_is_process_wide_idempotent_across_module_aliases(
         assert spec is not None
         assert spec.loader is not None
         alias = importlib.util.module_from_spec(spec)
-        importlib.sys.modules[alias_name] = alias
+        sys.modules[alias_name] = alias
         spec.loader.exec_module(alias)
 
         assert module.install() is True
@@ -146,6 +146,6 @@ def test_install_is_process_wide_idempotent_across_module_aliases(
         assert state["monitor_started"] is True
         assert state["install_attested"] is True
     finally:
-        importlib.sys.modules.pop(alias_name, None)
+        sys.modules.pop(alias_name, None)
         state["monitor_started"] = original_started
         state["install_attested"] = original_attested

--- a/tests/test_coinbase_capital_consistency_auth_fail_closed.py
+++ b/tests/test_coinbase_capital_consistency_auth_fail_closed.py
@@ -100,3 +100,52 @@ def test_capital_wrapper_patch_is_chain_aware():
     assert module._patch_class(Broker) is False
     assert Broker.connect is first_connect
     assert Broker.get_account_balance is first_balance
+
+
+
+def test_install_is_process_wide_idempotent_across_module_aliases(
+    monkeypatch, caplog
+):
+    module = _module()
+    state = module._STATE
+    original_started = state["monitor_started"]
+    original_attested = state["install_attested"]
+    started = []
+
+    class FakeThread:
+        def __init__(self, **kwargs):
+            started.append(kwargs)
+
+        def start(self):
+            return None
+
+    alias_name = "nija_test_coinbase_capital_consistency_alias"
+    try:
+        state["monitor_started"] = False
+        state["install_attested"] = False
+        monkeypatch.setattr(module.threading, "Thread", FakeThread)
+        monkeypatch.setattr(module, "_patch_loaded", lambda: False)
+        caplog.clear()
+        caplog.set_level(module.logging.CRITICAL)
+
+        spec = importlib.util.spec_from_file_location(alias_name, module.__file__)
+        assert spec is not None
+        assert spec.loader is not None
+        alias = importlib.util.module_from_spec(spec)
+        importlib.sys.modules[alias_name] = alias
+        spec.loader.exec_module(alias)
+
+        assert module.install() is True
+        records = [
+            record
+            for record in caplog.records
+            if "COINBASE_CAPITAL_CONSISTENCY_INSTALLED" in record.getMessage()
+        ]
+        assert len(started) == 1
+        assert len(records) == 1
+        assert state["monitor_started"] is True
+        assert state["install_attested"] is True
+    finally:
+        importlib.sys.modules.pop(alias_name, None)
+        state["monitor_started"] = original_started
+        state["install_attested"] = original_attested


### PR DESCRIPTION
## Problem
The deployed canonical startup imports the Coinbase capital consistency guard through compatibility and package module names. Each module copy owned its own `_STARTED` flag and every `install()` call emitted an installation attestation, producing three critical installation messages and potentially starting duplicate monitor threads.

## Fix
- Move monitor ownership and install attestation state to a process-wide, lock-protected shared state.
- Keep repeated installer calls successful and continue patching newly loaded broker classes.
- Emit the critical installation attestation only on the first process-wide install.
- Add a regression test that loads the same guard through a second module alias and verifies exactly one monitor and one attestation.

## Risk
Narrow startup/idempotency change. Coinbase auth fail-closed and balance publication behavior are unchanged.

## Validation
- Added focused alias-import idempotency regression coverage.
- Full repository CI required before merge.