### PR TITLE
Quiesce writer heartbeat before releasing Redis lease

### DIFF
--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -11,6 +11,8 @@ Safety properties
 * The process remains fail-closed in standby while Redis/lock authority is
   unavailable.
 * Heartbeat renewal verifies exact lock ownership before extending the TTL.
+* Release joins the renewal thread before compare-and-delete, so shutdown cannot
+  recreate a countdown-only lease after deletion.
 * Release is compare-and-delete; a process can never delete another writer's
   lock.
 * Local fallback is available only through the explicit operator flags
@@ -670,10 +672,28 @@ class EntrypointWriterAuthority:
             )
 
     def release(self) -> bool:
-        """Stop heartbeat and compare-and-delete only this process's lock."""
+        """Quiesce heartbeat, then compare-delete only this process's lock."""
+
+        self._stop.set()
+        heartbeat = self._heartbeat_thread
+        if heartbeat is not None and heartbeat is not threading.current_thread():
+            if heartbeat.is_alive():
+                heartbeat.join(
+                    timeout=_cfg_float(
+                        "NIJA_WRITER_RELEASE_HEARTBEAT_JOIN_S",
+                        2.0,
+                        minimum=0.1,
+                    )
+                )
+            if heartbeat.is_alive():
+                logger.error(
+                    "ENTRYPOINT_WRITER_AUTHORITY_RELEASE_DEFERRED marker=%s "
+                    "reason=heartbeat_thread_still_alive lock_delete_skipped=true",
+                    _MARKER,
+                )
+                return False
 
         with self._state_lock:
-            self._stop.set()
             released = False
             if self._client is not None and self._lock_key and self._lock_value:
                 script = """
@@ -703,13 +723,15 @@ class EntrypointWriterAuthority:
                         exc,
                     )
 
+            self._heartbeat_thread = None
             os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
             os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "0"
             os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = "0"
             os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
             os.environ.pop("NIJA_WRITER_FENCING_TOKEN_FALLBACK", None)
             logger.info(
-                "ENTRYPOINT_WRITER_AUTHORITY_RELEASED marker=%s released=%s local_fallback=%s",
+                "ENTRYPOINT_WRITER_AUTHORITY_RELEASED marker=%s released=%s "
+                "local_fallback=%s heartbeat_quiesced=true",
                 _MARKER,
                 released,
                 self._local_fallback,

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -29,6 +29,7 @@ _ENV_KEYS = (
     "NIJA_WRITER_HEARTBEAT_LAST_TS",
     "NIJA_WRITER_HEARTBEAT_ALIVE_TS",
     "NIJA_ENTRYPOINT_WRITER_LOCK_WAIT_S",
+    "NIJA_WRITER_RELEASE_HEARTBEAT_JOIN_S",
     "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK",
     "NIJA_CONFIRM_BYPASS_RISKS",
     "NIJA_WRITER_FENCING_TOKEN_FALLBACK",
@@ -110,6 +111,59 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
         self.assertEqual(result.error, "active_writer_lock_held")
         self.assertEqual(result.holder, "9:other-instance")
         client.delete.assert_not_called()
+
+    def test_release_joins_heartbeat_before_deleting_owned_lease(self):
+        order = []
+        client = MagicMock()
+
+        def delete_owned_lease(*_args):
+            order.append("delete")
+            return 1
+
+        client.eval.side_effect = delete_owned_lease
+
+        class Heartbeat:
+            alive = True
+
+            def is_alive(self):
+                return self.alive
+
+            def join(self, timeout):
+                self.assert_timeout = timeout
+                order.append("join")
+                self.alive = False
+
+        runtime = EntrypointWriterAuthority()
+        runtime._client = client
+        runtime._lock_key = "nija:writer_lock:test"
+        runtime._meta_key = "nija:writer_lock_meta:test"
+        runtime._lock_value = "17:local-owner"
+        runtime._heartbeat_thread = Heartbeat()
+
+        self.assertTrue(runtime.release())
+        self.assertEqual(order, ["join", "delete"])
+        self.assertIsNone(runtime._heartbeat_thread)
+        self.assertEqual(os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"], "0")
+
+    def test_release_keeps_lease_when_heartbeat_cannot_quiesce(self):
+        client = MagicMock()
+
+        class StuckHeartbeat:
+            def is_alive(self):
+                return True
+
+            def join(self, timeout):
+                self.assert_timeout = timeout
+
+        runtime = EntrypointWriterAuthority()
+        runtime._client = client
+        runtime._lock_key = "nija:writer_lock:test"
+        runtime._meta_key = "nija:writer_lock_meta:test"
+        runtime._lock_value = "17:local-owner"
+        runtime._heartbeat_thread = StuckHeartbeat()
+
+        self.assertFalse(runtime.release())
+        client.eval.assert_not_called()
 
     def test_redis_unavailable_remains_fail_closed_without_explicit_fallback(self):
         runtime = EntrypointWriterAuthority()


### PR DESCRIPTION
## Problem
During Render rolling shutdown, `EntrypointWriterAuthority.release()` set the stop event and immediately compare-deleted the Redis lease without joining the renewal thread. An already-running heartbeat could observe the deletion, execute its lost-key recovery branch, and recreate the old writer lease once. That leaves a countdown-only lock and makes the replacement wait for the full TTL, matching the observed stable TTL followed by a countdown.

## Fix
- Stop and join the canonical renewal thread before compare-and-delete.
- Delete only after the thread is proven quiescent.
- Fail closed and preserve the TTL when the heartbeat cannot stop within the bounded join timeout.
- Clear the heartbeat reference after a completed release.

## Validation
- Added a regression test proving join occurs before Redis deletion.
- Added a regression test proving Redis is not touched when the heartbeat remains alive.
- Full CI required before merge.

## Safety
Exact-value compare-and-delete and fencing behavior are unchanged. This change cannot steal another instance's lease.