### PR TITLE
Make Coinbase connect reentry ownership chain-aware

### DIFF
--- a/runtime_auth_recursion_endpoint_repair_patch.py
+++ b/runtime_auth_recursion_endpoint_repair_patch.py
@@ -341,7 +341,20 @@ def _patch_coinbase_class(module: ModuleType) -> bool:
         changed = True
 
     original_connect = getattr(cls, "connect", None)
-    if callable(original_connect) and not getattr(original_connect, "_nija_coinbase_connect_reentry_guard_v1", False):
+    coinbase_guard_attr = "_nija_coinbase_connect_reentry_guard_v1"
+    has_coinbase_guard = bool(
+        callable(original_connect)
+        and _connect_chain_has_attr(original_connect, coinbase_guard_attr)
+    )
+    if has_coinbase_guard:
+        # A later compatibility wrapper may sit outside the canonical owner
+        # without copying its marker. Propagate ownership instead of adding a
+        # second guard whose nested call would be mistaken for recursion.
+        try:
+            setattr(original_connect, coinbase_guard_attr, True)
+        except Exception:
+            pass
+    elif callable(original_connect):
         @wraps(original_connect)
         def connect(self: Any, *args: Any, __original: Callable[..., Any] = original_connect, **kwargs: Any) -> Any:
             active = getattr(_LOCAL, "coinbase_connect_active", set())

--- a/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
+++ b/tests/test_runtime_auth_recursion_endpoint_repair_patch.py
@@ -173,6 +173,41 @@ def test_coinbase_recursive_connect_is_blocked(monkeypatch):
     assert os.environ["NIJA_COINBASE_ACTIVATION_STATE"] == "reconnect_pending"
 
 
+
+def test_coinbase_compatibility_wrapper_does_not_gain_second_reentry_guard():
+    class CoinbaseBroker:
+        def __init__(self):
+            self.connected = False
+            self._is_available = True
+            self.calls = 0
+
+        def connect(self):
+            self.calls += 1
+            self.connected = True
+            return True
+
+    module = ModuleType("bot.broker_manager")
+    module.CoinbaseBroker = CoinbaseBroker
+    assert repair._patch_coinbase_class(module) is True
+    canonical_guard = CoinbaseBroker.connect
+
+    # Reproduce a later compatibility wrapper that preserves __wrapped__ but
+    # does not copy the canonical reentry-owner marker.
+    def compatibility_connect(self, *args, **kwargs):
+        return canonical_guard(self, *args, **kwargs)
+
+    compatibility_connect.__wrapped__ = canonical_guard
+    CoinbaseBroker.connect = compatibility_connect
+
+    assert repair._patch_coinbase_class(module) is False
+    assert CoinbaseBroker.connect is compatibility_connect
+    assert CoinbaseBroker.connect._nija_coinbase_connect_reentry_guard_v1 is True
+
+    broker = CoinbaseBroker()
+    assert broker.connect() is True
+    assert broker.calls == 1
+    assert broker.connected is True
+
 def test_okx_recursive_connect_is_blocked(monkeypatch):
     class OKXBroker:
         def __init__(self):


### PR DESCRIPTION
## Problem
The current deployment hydrates Coinbase balance but disconnects it with `connect_recursion_blocked`, reducing the live capital snapshot from three brokers to two. The runtime endpoint watchdog checked only the outermost `connect` callable for its reentry marker. A later compatibility wrapper could hide the existing marker and cause a second guard to be installed. The inner guard then rejected the legitimate outer-to-inner delegation as recursion.

## Fix
- Search the complete acyclic `__wrapped__` chain for the Coinbase reentry-owner marker.
- Propagate ownership to a newer outer compatibility wrapper.
- Skip duplicate guard installation while preserving real same-thread recursion blocking.

## Validation
- Added a regression reproducing a later compatibility wrapper.
- Verifies repeated patching leaves one guard, one underlying connect call, and a successful connection.
- Full CI required before merge.

## Safety
Credential validation, authenticated private-account probing, and fail-closed behavior for genuine recursion are unchanged.