### PR TITLE
Make supervised activation proof publication atomic

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -275,9 +275,9 @@ def _publish_supervised_thread_evidence() -> bool:
             if worker is not threading.current_thread() and worker.is_alive()
         )
         worker_count = max(1, live_workers)
-        coordinator.record_threads_launched(worker_count)
-        coordinator.record_threads_confirmed_running(
-            bootstrap_state="RUNNING_SUPERVISED"
+        coordinator.record_threads_supervised(
+            worker_count,
+            bootstrap_state="RUNNING_SUPERVISED",
         )
         logger.critical(
             "SUPERVISED_THREAD_EVIDENCE_PUBLISHED "

--- a/bot/startup_coordinator.py
+++ b/bot/startup_coordinator.py
@@ -720,16 +720,17 @@ class StartupCoordinator:
 
             count_changed = self._runtime.threads_launched != normalized_count
             self._runtime.threads_launched = normalized_count
-            self._runtime.bootstrap_state = bootstrap_state
-            self._runtime.threads_confirmed_running = True
-            self._runtime.coordinator_state = StartupCoordinatorState.SUPERVISED_RUNNING
-            self._runtime._last_bootstrap_state_published = bootstrap_state
-
             if count_changed:
+                self._runtime.coordinator_state = StartupCoordinatorState.THREADS_PENDING
                 self._publish_locked(
                     StartupEvent.THREADS_LAUNCHED,
                     {"count": normalized_count, "atomic_supervision": True},
                 )
+
+            self._runtime.bootstrap_state = bootstrap_state
+            self._runtime.threads_confirmed_running = True
+            self._runtime.coordinator_state = StartupCoordinatorState.SUPERVISED_RUNNING
+            self._runtime._last_bootstrap_state_published = bootstrap_state
             return self._publish_locked(
                 StartupEvent.THREADS_CONFIRMED_RUNNING,
                 {

--- a/bot/startup_coordinator.py
+++ b/bot/startup_coordinator.py
@@ -695,6 +695,50 @@ class StartupCoordinator:
                 {"bootstrap_state": self._runtime.bootstrap_state},
             )
 
+    def record_threads_supervised(
+        self,
+        count: int,
+        *,
+        bootstrap_state: str = "RUNNING_SUPERVISED",
+    ) -> int:
+        """Atomically publish launched and supervised thread readiness evidence."""
+
+        normalized_count = max(0, int(count or 0))
+        if normalized_count <= 0:
+            raise ValueError("supervised thread count must be positive")
+
+        with self._lock:
+            already_supervised = bool(
+                self._runtime.threads_launched == normalized_count
+                and self._runtime.threads_confirmed_running
+                and self._runtime.bootstrap_state == bootstrap_state
+                and self._runtime.coordinator_state
+                == StartupCoordinatorState.SUPERVISED_RUNNING
+            )
+            if already_supervised:
+                return self._runtime.event_version
+
+            count_changed = self._runtime.threads_launched != normalized_count
+            self._runtime.threads_launched = normalized_count
+            self._runtime.bootstrap_state = bootstrap_state
+            self._runtime.threads_confirmed_running = True
+            self._runtime.coordinator_state = StartupCoordinatorState.SUPERVISED_RUNNING
+            self._runtime._last_bootstrap_state_published = bootstrap_state
+
+            if count_changed:
+                self._publish_locked(
+                    StartupEvent.THREADS_LAUNCHED,
+                    {"count": normalized_count, "atomic_supervision": True},
+                )
+            return self._publish_locked(
+                StartupEvent.THREADS_CONFIRMED_RUNNING,
+                {
+                    "bootstrap_state": bootstrap_state,
+                    "count": normalized_count,
+                    "atomic_supervision": True,
+                },
+            )
+
     def record_activation_requested(self, *, requested: bool = True, source: str = "") -> int:
         with self._lock:
             self._runtime.activation_requested = bool(requested)

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -298,6 +298,7 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
         from bot.startup_coordinator import (
             StartupCoordinator,
             StartupCoordinatorState,
+            StartupEvent,
         )
 
         coordinator = StartupCoordinator()
@@ -318,6 +319,30 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
                 coordinator._runtime.coordinator_state,
                 StartupCoordinatorState.SUPERVISED_RUNNING,
             )
+            history = list(coordinator._history)
+
+        self.assertEqual(
+            [entry["event"] for entry in history],
+            [
+                StartupEvent.THREADS_LAUNCHED.value,
+                StartupEvent.THREADS_CONFIRMED_RUNNING.value,
+            ],
+        )
+        self.assertEqual(
+            [entry["state"] for entry in history],
+            [
+                StartupCoordinatorState.THREADS_PENDING.value,
+                StartupCoordinatorState.SUPERVISED_RUNNING.value,
+            ],
+        )
+
+        repeated_version = coordinator.record_threads_supervised(
+            2,
+            bootstrap_state="RUNNING_SUPERVISED",
+        )
+        self.assertEqual(repeated_version, version)
+        with coordinator._lock:
+            self.assertEqual(list(coordinator._history), history)
 
     def test_running_supervised_handoff_publishes_thread_evidence(self):
         from bot.bootstrap_state_machine import BootstrapState

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -270,9 +270,9 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
         ):
             self.assertTrue(self.bot_main._publish_supervised_thread_evidence())
 
-        coordinator.record_threads_launched.assert_called_once_with(1)
-        coordinator.record_threads_confirmed_running.assert_called_once_with(
-            bootstrap_state="RUNNING_SUPERVISED"
+        coordinator.record_threads_supervised.assert_called_once_with(
+            1,
+            bootstrap_state="RUNNING_SUPERVISED",
         )
 
     def test_supervised_thread_evidence_blocks_without_live_heartbeat(self):
@@ -292,8 +292,76 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
         ):
             self.assertFalse(self.bot_main._publish_supervised_thread_evidence())
 
-        coordinator.record_threads_launched.assert_not_called()
-        coordinator.record_threads_confirmed_running.assert_not_called()
+        coordinator.record_threads_supervised.assert_not_called()
+
+    def test_atomic_supervised_thread_record_sets_complete_proof(self):
+        from bot.startup_coordinator import (
+            StartupCoordinator,
+            StartupCoordinatorState,
+        )
+
+        coordinator = StartupCoordinator()
+        version = coordinator.record_threads_supervised(
+            2,
+            bootstrap_state="RUNNING_SUPERVISED",
+        )
+
+        self.assertGreater(version, 0)
+        with coordinator._lock:
+            self.assertEqual(coordinator._runtime.threads_launched, 2)
+            self.assertTrue(coordinator._runtime.threads_confirmed_running)
+            self.assertEqual(
+                coordinator._runtime.bootstrap_state,
+                "RUNNING_SUPERVISED",
+            )
+            self.assertEqual(
+                coordinator._runtime.coordinator_state,
+                StartupCoordinatorState.SUPERVISED_RUNNING,
+            )
+
+    def test_running_supervised_handoff_publishes_thread_evidence(self):
+        from bot.bootstrap_state_machine import BootstrapState
+
+        fsm = types.SimpleNamespace(state=BootstrapState.RUNNING_SUPERVISED)
+        with (
+            patch(
+                "bot.bootstrap_state_machine.get_bootstrap_fsm",
+                return_value=fsm,
+            ),
+            patch.object(self.bot_main, "_apply_bootstrap_i12_repair_direct"),
+            patch.object(
+                self.bot_main,
+                "_publish_supervised_thread_evidence",
+                return_value=True,
+            ) as publish,
+        ):
+            self.assertTrue(
+                self.bot_main._advance_bootstrap_fsm_to_running_supervised()
+            )
+
+        publish.assert_called_once_with()
+
+    def test_running_supervised_handoff_fails_closed_without_thread_evidence(self):
+        from bot.bootstrap_state_machine import BootstrapState
+
+        fsm = types.SimpleNamespace(state=BootstrapState.RUNNING_SUPERVISED)
+        with (
+            patch(
+                "bot.bootstrap_state_machine.get_bootstrap_fsm",
+                return_value=fsm,
+            ),
+            patch.object(self.bot_main, "_apply_bootstrap_i12_repair_direct"),
+            patch.object(
+                self.bot_main,
+                "_publish_supervised_thread_evidence",
+                return_value=False,
+            ) as publish,
+        ):
+            self.assertFalse(
+                self.bot_main._advance_bootstrap_fsm_to_running_supervised()
+            )
+
+        publish.assert_called_once_with()
 
     def test_bootstrap_is_not_called_when_writer_authority_is_missing(self):
         with (


### PR DESCRIPTION
## Problem
PR #2347 supplies the previously missing supervised-worker evidence, but it publishes `threads_launched` and `threads_confirmed_running` through two independently locked calls. A concurrent readiness evaluation can briefly observe an incomplete thread proof and deny activation.

## Fix
- Add `StartupCoordinator.record_threads_supervised()` to publish the complete worker proof under one coordinator lock.
- Keep the operation fail closed for zero worker counts.
- Make repeated identical publications idempotent.
- Switch the canonical writer-heartbeat handoff to the atomic API.
- Add direct tests for atomic state, successful handoff, and missing-evidence failure.

## Risk and rollback
- Risk: low and isolated to startup evidence publication.
- Failure remains fail closed: missing writer heartbeat or invalid worker count leaves activation pending.
- Rollback: revert this PR to restore the two-call publication path.

## Safety
No activation gate is bypassed. Writer acquisition, live writer heartbeat, capital, broker, nonce, dispatch health, kill switch, strategy, and epoch checks remain authoritative.

## Validation
- [x] Focused unit coverage added
- [x] No bypass flags introduced
- [ ] Full CI passed
- [ ] Review threads resolved