### PR TITLE
Bound cached capital freshness to live observation TTL

### DIFF
--- a/bot/capital_refresh_stall_guard_v35.py
+++ b/bot/capital_refresh_stall_guard_v35.py
@@ -23,6 +23,17 @@ _TARGETS = ("bot.capital_flow_state_machine", "capital_flow_state_machine")
 _LOCK = threading.RLock()
 _STARTED = False
 _REFRESH_CONTEXT = threading.local()
+_LIVE_BALANCE_OBSERVED_AT = "_nija_capital_live_balance_observed_monotonic"
+
+
+def _freshness_ttl_seconds() -> float:
+    try:
+        return max(
+            5.0,
+            float(os.getenv("NIJA_CAPITAL_FRESHNESS_TTL_S", "90.0") or "90.0"),
+        )
+    except (TypeError, ValueError):
+        return 90.0
 
 
 def _timeout_seconds() -> float:
@@ -48,7 +59,12 @@ class _BalanceFetchBatch:
                 output: "queue.Queue[tuple[bool, Any]]" = result_queue,
             ) -> None:
                 try:
-                    output.put_nowait((True, target.get_account_balance()))
+                    value = target.get_account_balance()
+                    try:
+                        setattr(target, _LIVE_BALANCE_OBSERVED_AT, time.monotonic())
+                    except Exception:
+                        pass
+                    output.put_nowait((True, value))
                 except BaseException as exc:  # preserve broker exception semantics
                     try:
                         output.put_nowait((False, exc))
@@ -69,14 +85,34 @@ class _BalanceFetchBatch:
         except queue.Empty:
             _REFRESH_CONTEXT.used_fallback = True
             cached = getattr(broker, "_last_known_balance", None)
-            elapsed = time.monotonic() - self._started_at
+            now = time.monotonic()
+            observed_at = float(
+                getattr(broker, _LIVE_BALANCE_OBSERVED_AT, 0.0) or 0.0
+            )
+            cached_age_s = (
+                max(0.0, now - observed_at)
+                if observed_at > 0.0
+                else float("inf")
+            )
+            fallback_brokers = dict(
+                getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {}
+            )
+            fallback_brokers[str(broker_id)] = {
+                "age_s": cached_age_s,
+                "observed": observed_at > 0.0,
+            }
+            _REFRESH_CONTEXT.fallback_brokers = fallback_brokers
+            elapsed = now - self._started_at
             if cached is not None:
                 LOGGER.warning(
                     "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s "
-                    "broker=%s elapsed=%.2fs cached_payload=true shared_deadline=true",
+                    "broker=%s elapsed=%.2fs cached_payload=true cached_age_s=%.2f "
+                    "cached_within_ttl=%s shared_deadline=true",
                     MARKER,
                     broker_id,
                     elapsed,
+                    cached_age_s,
+                    cached_age_s <= _freshness_ttl_seconds(),
                 )
                 return cached
             LOGGER.error(
@@ -97,6 +133,35 @@ class _BalanceFetchBatch:
 def current_refresh_used_fallback() -> bool:
     """Return whether this thread's active refresh consumed cached capital."""
     return bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
+
+
+def current_refresh_fallback_status(
+    freshness_ttl_s: float | None = None,
+) -> Dict[str, Any]:
+    """Return freshness evidence for cached balances used by this refresh."""
+
+    used_fallback = current_refresh_used_fallback()
+    brokers = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
+    ttl_s = (
+        _freshness_ttl_seconds()
+        if freshness_ttl_s is None
+        else max(5.0, float(freshness_ttl_s))
+    )
+    all_recent = bool(
+        used_fallback
+        and brokers
+        and all(
+            bool(record.get("observed"))
+            and float(record.get("age_s", float("inf"))) <= ttl_s
+            for record in brokers.values()
+        )
+    )
+    return {
+        "used_fallback": used_fallback,
+        "all_recent": all_recent,
+        "freshness_ttl_s": ttl_s,
+        "brokers": brokers,
+    }
 
 
 class _BoundedBrokerProxy:
@@ -137,6 +202,7 @@ def _patch(module: ModuleType) -> bool:
         open_exposure_usd: float,
     ) -> Any:
         _REFRESH_CONTEXT.used_fallback = False
+        _REFRESH_CONTEXT.fallback_brokers = {}
         live_map = {
             str(broker_id): broker
             for broker_id, broker in broker_map.items()
@@ -156,6 +222,7 @@ def _patch(module: ModuleType) -> bool:
             )
         finally:
             _REFRESH_CONTEXT.used_fallback = False
+            _REFRESH_CONTEXT.fallback_brokers = {}
 
     _pipeline_with_bounded_brokers._nija_capital_refresh_stall_guard_v35 = True
     cls._pipeline = _pipeline_with_bounded_brokers

--- a/bot/current_capital_snapshot_freshness_repair_patch.py
+++ b/bot/current_capital_snapshot_freshness_repair_patch.py
@@ -1,10 +1,10 @@
 """Repair freshness only for confirmed current live-broker snapshots.
 
 The coordinator historically derives a new snapshot's freshness from the prior
-authority snapshot age. This patch repairs that inherited stale flag only when
-the current refresh completed without a timeout fallback. If any venue supplied
-cached capital, the new snapshot remains explicitly stale and cannot be promoted
-to current live-exchange data.
+authority snapshot age. This patch repairs that inherited stale flag when the
+current refresh uses live values or a cached value backed by a successful live
+observation inside the configured freshness TTL. Unknown or expired cached
+capital remains explicitly stale and cannot be promoted.
 """
 from __future__ import annotations
 

--- a/bot/current_capital_snapshot_freshness_repair_patch.py
+++ b/bot/current_capital_snapshot_freshness_repair_patch.py
@@ -55,6 +55,17 @@ def _broker_threshold(snapshot: Any) -> int:
         return 1
 
 
+def _capital_freshness_ttl_s() -> float:
+    try:
+        module = __import__(
+            "bot.capital_flow_state_machine",
+            fromlist=["FRESHNESS_TTL_S"],
+        )
+        return max(5.0, float(getattr(module, "FRESHNESS_TTL_S", 90.0) or 90.0))
+    except Exception:
+        return 90.0
+
+
 def _current_refresh_fallback_status() -> dict[str, Any]:
     for name in (
         "bot.capital_refresh_stall_guard_v35",
@@ -64,7 +75,7 @@ def _current_refresh_fallback_status() -> dict[str, Any]:
         status_getter = getattr(module, "current_refresh_fallback_status", None)
         if callable(status_getter):
             try:
-                return dict(status_getter())
+                return dict(status_getter(_capital_freshness_ttl_s()))
             except Exception:
                 return {
                     "used_fallback": True,
@@ -101,14 +112,7 @@ def _should_repair(snapshot: Any) -> bool:
         real_capital = float(getattr(snapshot, "real_capital", 0.0) or 0.0)
         broker_count = int(getattr(snapshot, "broker_count", 0) or 0)
         broker_balances = dict(getattr(snapshot, "broker_balances", {}) or {})
-        fresh_ttl_s = float(
-            getattr(
-                __import__("bot.capital_flow_state_machine", fromlist=["FRESHNESS_TTL_S"]),
-                "FRESHNESS_TTL_S",
-                90.0,
-            )
-            or 90.0
-        )
+        fresh_ttl_s = _capital_freshness_ttl_s()
     except Exception:
         return False
 

--- a/bot/current_capital_snapshot_freshness_repair_patch.py
+++ b/bot/current_capital_snapshot_freshness_repair_patch.py
@@ -18,7 +18,7 @@ from typing import Any
 
 logger = logging.getLogger("nija.current_capital_snapshot_freshness_repair")
 
-_MARKER = "20260802-current-capital-snapshot-freshness-v2"
+_MARKER = "20260802-current-capital-snapshot-freshness-v3"
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -55,23 +55,47 @@ def _broker_threshold(snapshot: Any) -> int:
         return 1
 
 
-def _current_refresh_used_fallback() -> bool:
+def _current_refresh_fallback_status() -> dict[str, Any]:
     for name in (
         "bot.capital_refresh_stall_guard_v35",
         "capital_refresh_stall_guard_v35",
     ):
         module = sys.modules.get(name)
+        status_getter = getattr(module, "current_refresh_fallback_status", None)
+        if callable(status_getter):
+            try:
+                return dict(status_getter())
+            except Exception:
+                return {
+                    "used_fallback": True,
+                    "all_recent": False,
+                    "brokers": {},
+                }
         checker = getattr(module, "current_refresh_used_fallback", None)
         if callable(checker):
             try:
-                return bool(checker())
+                used = bool(checker())
             except Exception:
-                return True
-    return False
+                used = True
+            return {
+                "used_fallback": used,
+                "all_recent": False,
+                "brokers": {},
+            }
+    return {
+        "used_fallback": False,
+        "all_recent": True,
+        "brokers": {},
+    }
+
+
+def _current_refresh_requires_stale() -> bool:
+    status = _current_refresh_fallback_status()
+    return bool(status.get("used_fallback") and not status.get("all_recent"))
 
 
 def _should_repair(snapshot: Any) -> bool:
-    if _current_refresh_used_fallback():
+    if _current_refresh_requires_stale():
         return False
     try:
         real_capital = float(getattr(snapshot, "real_capital", 0.0) or 0.0)
@@ -126,15 +150,20 @@ def install_import_hook() -> bool:
             @functools.wraps(current_init)
             def _init_with_current_freshness(self: Any, *args: Any, **kwargs: Any) -> None:
                 current_init(self, *args, **kwargs)
-                if _current_refresh_used_fallback():
+                fallback_status = _current_refresh_fallback_status()
+                if bool(
+                    fallback_status.get("used_fallback")
+                    and not fallback_status.get("all_recent")
+                ):
                     object.__setattr__(self, "is_fresh", False)
                     object.__setattr__(self, "is_stale", True)
                     logger.warning(
                         "CURRENT_CAPITAL_SNAPSHOT_CACHE_FALLBACK_STALE marker=%s "
-                        "real=%.2f broker_count=%s",
+                        "real=%.2f broker_count=%s fallback_brokers=%s",
                         _MARKER,
                         float(getattr(self, "real_capital", 0.0) or 0.0),
                         getattr(self, "broker_count", "unknown"),
+                        fallback_status.get("brokers", {}),
                     )
                     return
                 if not _should_repair(self):
@@ -144,11 +173,12 @@ def install_import_hook() -> bool:
                 object.__setattr__(self, "snapshot_age_s", 0.0)
                 logger.warning(
                     "CURRENT_CAPITAL_SNAPSHOT_FRESHNESS_REPAIRED marker=%s "
-                    "real=%.2f broker_count=%s confidence=%s",
+                    "real=%.2f broker_count=%s confidence=%s fallback_recent=%s",
                     _MARKER,
                     float(getattr(self, "real_capital", 0.0) or 0.0),
                     getattr(self, "broker_count", "unknown"),
                     getattr(getattr(self, "confidence", None), "band", "unknown"),
+                    bool(fallback_status.get("used_fallback")),
                 )
 
             setattr(_init_with_current_freshness, "_nija_current_snapshot_freshness_repair", True)

--- a/bot/tests/test_capital_refresh_stall_guard_v35.py
+++ b/bot/tests/test_capital_refresh_stall_guard_v35.py
@@ -99,6 +99,57 @@ class CapitalRefreshSharedDeadlineTests(unittest.TestCase):
         self.assertEqual(result, (12.0, True))
         self.assertFalse(guard.current_refresh_used_fallback())
 
+    def test_recent_live_balance_fallback_remains_within_freshness_ttl(self):
+        broker = _Broker(12.0)
+        live_batch = guard._BalanceFetchBatch({"okx": broker})
+        self.assertEqual(live_batch.result_for("okx", broker), 12.0)
+        self.assertGreater(
+            getattr(broker, guard._LIVE_BALANCE_OBSERVED_AT, 0.0),
+            0.0,
+        )
+
+        release = threading.Event()
+        broker._release = release
+        try:
+            guard._REFRESH_CONTEXT.used_fallback = False
+            guard._REFRESH_CONTEXT.fallback_brokers = {}
+            with patch.object(guard, "_timeout_seconds", return_value=0.05):
+                cached_batch = guard._BalanceFetchBatch({"okx": broker})
+                self.assertEqual(cached_batch.result_for("okx", broker), 12.0)
+            status = guard.current_refresh_fallback_status(90.0)
+        finally:
+            release.set()
+            guard._REFRESH_CONTEXT.used_fallback = False
+            guard._REFRESH_CONTEXT.fallback_brokers = {}
+
+        self.assertTrue(status["used_fallback"])
+        self.assertTrue(status["all_recent"])
+        self.assertIn("okx", status["brokers"])
+
+    def test_expired_live_balance_fallback_remains_fail_closed(self):
+        release = threading.Event()
+        broker = _Broker(12.0, release)
+        setattr(
+            broker,
+            guard._LIVE_BALANCE_OBSERVED_AT,
+            time.monotonic() - 120.0,
+        )
+        try:
+            guard._REFRESH_CONTEXT.used_fallback = False
+            guard._REFRESH_CONTEXT.fallback_brokers = {}
+            with patch.object(guard, "_timeout_seconds", return_value=0.05):
+                batch = guard._BalanceFetchBatch({"okx": broker})
+                self.assertEqual(batch.result_for("okx", broker), 12.0)
+            status = guard.current_refresh_fallback_status(90.0)
+        finally:
+            release.set()
+            guard._REFRESH_CONTEXT.used_fallback = False
+            guard._REFRESH_CONTEXT.fallback_brokers = {}
+
+        self.assertTrue(status["used_fallback"])
+        self.assertFalse(status["all_recent"])
+        self.assertGreater(status["brokers"]["okx"]["age_s"], 90.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
+++ b/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
@@ -63,6 +63,22 @@ class CurrentCapitalFreshnessRepairTests(unittest.TestCase):
         ):
             self.assertTrue(repair._should_repair(snapshot))
 
+    def test_fallback_status_uses_canonical_capital_ttl(self):
+        expected = {
+            "used_fallback": True,
+            "all_recent": True,
+            "brokers": {"okx": {"age_s": 10.0, "observed": True}},
+        }
+        with patch.object(
+            guard,
+            "current_refresh_fallback_status",
+            return_value=expected,
+        ) as status_getter:
+            status = repair._current_refresh_fallback_status()
+
+        self.assertEqual(status, expected)
+        status_getter.assert_called_once_with(90.0)
+
     def test_constructor_forces_cache_backed_snapshot_stale(self):
         class Snapshot:
             def __init__(self):

--- a/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
+++ b/bot/tests/test_current_capital_snapshot_freshness_repair_v2.py
@@ -42,9 +42,25 @@ class CurrentCapitalFreshnessRepairTests(unittest.TestCase):
             is_fresh=False,
             is_stale=True,
         )
-        with patch.object(guard, "current_refresh_used_fallback", return_value=True):
+        with patch.object(
+            repair,
+            "_current_refresh_fallback_status",
+            return_value={
+                "used_fallback": True,
+                "all_recent": False,
+                "brokers": {"okx": {"age_s": 120.0, "observed": True}},
+            },
+        ):
             self.assertFalse(repair._should_repair(snapshot))
-        with patch.object(guard, "current_refresh_used_fallback", return_value=False):
+        with patch.object(
+            repair,
+            "_current_refresh_fallback_status",
+            return_value={
+                "used_fallback": True,
+                "all_recent": True,
+                "brokers": {"okx": {"age_s": 10.0, "observed": True}},
+            },
+        ):
             self.assertTrue(repair._should_repair(snapshot))
 
     def test_constructor_forces_cache_backed_snapshot_stale(self):
@@ -60,11 +76,49 @@ class CurrentCapitalFreshnessRepairTests(unittest.TestCase):
                 self.is_stale = False
 
         self.cfsm.CapitalSnapshot = Snapshot
-        with patch.object(guard, "current_refresh_used_fallback", return_value=True):
+        with patch.object(
+            repair,
+            "_current_refresh_fallback_status",
+            return_value={
+                "used_fallback": True,
+                "all_recent": False,
+                "brokers": {"okx": {"age_s": 120.0, "observed": True}},
+            },
+        ):
             self.assertTrue(repair.install_import_hook())
             snapshot = Snapshot()
         self.assertFalse(snapshot.is_fresh)
         self.assertTrue(snapshot.is_stale)
+
+    def test_constructor_repairs_recent_cache_backed_snapshot(self):
+        class Snapshot:
+            def __init__(self):
+                self.computed_at = datetime.now(timezone.utc)
+                self.confidence = types.SimpleNamespace(band="MEDIUM")
+                self.real_capital = 100.0
+                self.broker_count = 1
+                self.expected_brokers = 1
+                self.broker_balances = {"okx": 100.0}
+                self.snapshot_age_s = 120.0
+                self.is_fresh = False
+                self.is_stale = True
+
+        self.cfsm.CapitalSnapshot = Snapshot
+        with patch.object(
+            repair,
+            "_current_refresh_fallback_status",
+            return_value={
+                "used_fallback": True,
+                "all_recent": True,
+                "brokers": {"okx": {"age_s": 10.0, "observed": True}},
+            },
+        ):
+            self.assertTrue(repair.install_import_hook())
+            snapshot = Snapshot()
+
+        self.assertTrue(snapshot.is_fresh)
+        self.assertFalse(snapshot.is_stale)
+        self.assertEqual(snapshot.snapshot_age_s, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
A broker fetch timeout makes the current capital snapshot stale even when the cached balance came from a successful live exchange response moments earlier. That can repeatedly push CapitalCSMv2 to DEGRADED and block the normal activation proof despite a complete, recently observed three-broker capital map.

## Fix
- Record a per-broker monotonic timestamp whenever a live balance call succeeds, including late completions after the shared deadline.
- Record which brokers used cached values during the active refresh and their live-observation age.
- Permit freshness repair only when every fallback value is backed by a live observation inside the configured capital freshness TTL.
- Keep unknown or expired cached balances fail closed and explicitly stale.
- Add regression tests for recent fallback acceptance, expired fallback rejection, constructor behavior, and context cleanup.

## Safety
This does not bypass the capital gate or extend its configured TTL. It applies the existing 90-second freshness policy to the actual age of each fallback balance. Missing timestamps, expired observations, zero capital, insufficient brokers, low confidence, and timeout-without-cache remain blocked.

## Validation
- [x] Focused regression coverage added
- [x] No activation or writer bypass flags introduced
- [ ] Full CI passed
- [ ] Review threads resolved