### PR TITLE
[fix] Make Kraken activation readiness converge safely

### DIFF
--- a/bot/distributed_nonce_manager.py
+++ b/bot/distributed_nonce_manager.py
@@ -155,6 +155,7 @@ import logging
 import os
 import random
 import socket
+import sys
 import threading
 import time
 import uuid
@@ -175,6 +176,13 @@ except ImportError:
             return
 
 _logger = logging.getLogger(__name__)
+
+# Keep both supported import paths bound to one module so the process owns a
+# single nonce-manager singleton and one continuous lease-stability clock.
+if __name__ == "bot.distributed_nonce_manager":
+    sys.modules.setdefault("distributed_nonce_manager", sys.modules[__name__])
+elif __name__ == "distributed_nonce_manager":
+    sys.modules.setdefault("bot.distributed_nonce_manager", sys.modules[__name__])
 
 
 def _env_true(name: str, default: str = "0") -> bool:

--- a/bot/tests/test_nonce_lease_activation_gate.py
+++ b/bot/tests/test_nonce_lease_activation_gate.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bot import trading_state_machine as tsm
+
+
+class _MaturingLease:
+    def __init__(self, clock: list[float]) -> None:
+        self.clock = clock
+        self.fencing_token = ""
+
+    def ensure_writer_lock(self, _key_id: str) -> None:
+        return None
+
+    def get_writer_lease_status(self, _key_id: str) -> dict[str, object]:
+        return {
+            "enabled": True,
+            "token": 3074,
+            "owner_instance": "writer-a",
+            "stable_for_s": self.clock[0],
+            "error": "",
+        }
+
+
+def test_nonce_gate_waits_for_same_owner_lease_to_mature(monkeypatch) -> None:
+    clock = [28.2]
+    manager = _MaturingLease(clock)
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-key")
+    monkeypatch.setenv("NIJA_ENFORCE_NONCE_WRITER_LEASE", "true")
+    monkeypatch.setenv("NIJA_NONCE_LEASE_STABILITY_MAX_WAIT_S", "5")
+
+    def advance(seconds: float) -> None:
+        clock[0] += seconds
+
+    with patch.object(tsm, "_kraken_nonce_gates_required", return_value=True), patch.object(
+        tsm, "_nonce_lease_stability_requirement_s", return_value=30.0
+    ), patch(
+        "bot.distributed_nonce_manager.get_distributed_nonce_manager",
+        return_value=manager,
+    ), patch(
+        "bot.distributed_nonce_manager.make_api_key_id",
+        return_value="key-id",
+    ), patch(
+        "bot.execution_authority_context.assert_startup_write_authority",
+        return_value=None,
+    ), patch.object(
+        tsm.time, "monotonic", side_effect=lambda: clock[0]
+    ), patch.object(
+        tsm.time, "sleep", side_effect=advance
+    ):
+        ok, error = tsm._nonce_writer_lease_gate()
+
+    assert ok is True
+    assert error == ""
+    assert clock[0] >= 30.0
+    assert manager.fencing_token == "3074"
+
+
+def test_nonce_gate_remains_fail_closed_when_ownership_check_fails(monkeypatch) -> None:
+    manager = SimpleNamespace(
+        ensure_writer_lock=lambda _key_id: (_ for _ in ()).throw(
+            RuntimeError("foreign lease owner")
+        )
+    )
+    monkeypatch.setenv("KRAKEN_PLATFORM_API_KEY", "platform-key")
+    monkeypatch.setenv("NIJA_ENFORCE_NONCE_WRITER_LEASE", "true")
+    monkeypatch.setenv("NIJA_NONCE_LEASE_RETRIES", "2")
+    monkeypatch.setenv("NIJA_NONCE_LEASE_RETRY_DELAY_S", "0")
+    monkeypatch.setenv("NIJA_NONCE_LEASE_STABILITY_MAX_WAIT_S", "1")
+
+    with patch.object(tsm, "_kraken_nonce_gates_required", return_value=True), patch(
+        "bot.distributed_nonce_manager.get_distributed_nonce_manager",
+        return_value=manager,
+    ), patch(
+        "bot.distributed_nonce_manager.make_api_key_id",
+        return_value="key-id",
+    ), patch(
+        "bot.execution_authority_context.assert_startup_write_authority",
+        return_value=None,
+    ):
+        ok, error = tsm._nonce_writer_lease_gate()
+
+    assert ok is False
+    assert "foreign lease owner" in error
+    assert "LIVE_ACTIVE is permitted" in error

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -115,6 +115,7 @@ def test_one_ready_venue_enables_execution_independently(monkeypatch) -> None:
     assert result["ready_venues"] == ["kraken"]
     assert result["degraded_venues"] == ["coinbase", "okx"]
     assert result["venues"]["kraken"]["ready"] is True
+    assert result["venues"]["kraken"]["activation_state"] == "ready"
     assert result["venues"]["coinbase"]["ready"] is False
     assert result["venues"]["okx"]["ready"] is False
 
@@ -267,6 +268,54 @@ def test_publish_sets_independent_compatibility_flags(monkeypatch) -> None:
     assert os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] == "1"
     assert os.environ["NIJA_EXECUTION_READY_VENUES"] == "kraken"
     assert os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] == "coinbase,okx"
+    assert os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] == "ready"
+    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "1"
+    assert os.environ["NIJA_KRAKEN_ACTIVATED"] == "1"
+
+
+def test_kraken_activation_flags_clear_when_any_stage_fails(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "evaluate_all",
+        lambda: {
+            "marker": module.MARKER,
+            "timestamp": 1.0,
+            "pid": 1,
+            "writer_ready": True,
+            "capital_ready": True,
+            "any_venue_ready": False,
+            "all_venues_ready": False,
+            "execution_ready": False,
+            "three_venue_execution_ready": False,
+            "ready_venues": [],
+            "degraded_venues": ["kraken", "coinbase", "okx"],
+            "venues": {
+                venue: {
+                    "credentials_loaded": True,
+                    "authentication_succeeded": venue != "kraken",
+                    "balance_fetched": True,
+                    "market_metadata_loaded": True,
+                    "order_adapter_initialized": True,
+                    "venue_marked_ready": venue != "kraken",
+                    "eligible_for_execution": False,
+                    "spendable_quote": 0.0,
+                    "activation_state": "not_ready",
+                    "reason": "not_execution_eligible",
+                    "ready": False,
+                }
+                for venue in module.VENUES
+            },
+        },
+    )
+    monkeypatch.setattr(module, "_write_state", lambda payload: None)
+    monkeypatch.setattr(module, "_LAST_SIGNATURE", "")
+
+    module.publish_once(force=True)
+
+    assert os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] == "not_ready"
+    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "0"
+    assert os.environ["NIJA_KRAKEN_ACTIVATED"] == "0"
 
 
 def test_source_bootstrap_installs_definitive_verifier() -> None:

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -495,10 +495,11 @@ def _distributed_writer_authority_gate() -> tuple[bool, str]:
 
 
 def _nonce_writer_lease_gate() -> tuple[bool, str]:
-    """Verify nonce writer lease ownership for the platform Kraken key.
+    """Verify and, when safe, wait for the platform Kraken nonce lease.
 
-    This prevents LIVE activation when a stale/foreign process still owns the
-    Redis nonce lease for the same API key (split-brain protection).
+    A lease owned by this process is allowed to mature for a bounded interval.
+    Ownership errors, missing Redis state, and exhausted wait budgets remain
+    fail-closed; no activation gate is bypassed.
     """
     if not _env_truthy("NIJA_ENFORCE_NONCE_WRITER_LEASE", "true"):
         return True, ""
@@ -508,7 +509,6 @@ def _nonce_writer_lease_gate() -> tuple[bool, str]:
         or os.environ.get("KRAKEN_API_KEY", "").strip()
     )
     if not platform_key:
-        # No Kraken platform key configured in this process; nothing to verify.
         return True, ""
     if not _kraken_nonce_gates_required():
         logger.info(
@@ -517,10 +517,20 @@ def _nonce_writer_lease_gate() -> tuple[bool, str]:
         return True, ""
 
     retries = max(1, int(os.environ.get("NIJA_NONCE_LEASE_RETRIES", "3") or "3"))
-    retry_delay_s = max(0.0, float(os.environ.get("NIJA_NONCE_LEASE_RETRY_DELAY_S", "0.20") or "0.20"))
+    retry_delay_s = max(
+        0.0,
+        float(os.environ.get("NIJA_NONCE_LEASE_RETRY_DELAY_S", "0.20") or "0.20"),
+    )
+    max_wait_s = max(
+        0.0,
+        float(os.environ.get("NIJA_NONCE_LEASE_STABILITY_MAX_WAIT_S", "35") or "35"),
+    )
+    started = time.monotonic()
     last_err = ""
+    unstable_err = ""
+    failures = 0
 
-    for attempt in range(retries):
+    while True:
         try:
             try:
                 from bot.distributed_nonce_manager import (
@@ -540,49 +550,79 @@ def _nonce_writer_lease_gate() -> tuple[bool, str]:
             manager = get_distributed_nonce_manager()
             manager.ensure_writer_lock(key_id)
             status_fn = getattr(manager, "get_writer_lease_status", None)
-            if callable(status_fn):
-                status = status_fn(key_id)
-                if isinstance(status, dict):
-                    token = status.get("token")
-                    if token is not None and str(token).strip():
-                        setattr(manager, "fencing_token", str(token).strip())
+            status = status_fn(key_id) if callable(status_fn) else None
+            if not isinstance(status, dict):
+                raise RuntimeError("nonce lease stability status unavailable")
+
+            status_error = str(status.get("error") or "").strip()
+            if status_error:
+                raise RuntimeError(f"nonce lease status error: {status_error}")
+            if status.get("enabled") is False:
+                return True, ""
+
+            token = status.get("token")
+            if token is not None and str(token).strip():
+                setattr(manager, "fencing_token", str(token).strip())
+
             stability_required_s = _nonce_lease_stability_requirement_s()
-            if stability_required_s > 0:
-                status = None
-                status_fn = getattr(manager, "get_writer_lease_status", None)
-                if callable(status_fn):
-                    status = status_fn(key_id)
-                if not isinstance(status, dict):
-                    raise RuntimeError("nonce lease stability status unavailable")
-                if status.get("enabled") is False:
-                    return True, ""
-                stable_for = status.get("stable_for_s")
-                if not isinstance(stable_for, (int, float)):
-                    stable_for = 0.0
-                if stable_for < stability_required_s:
-                    token = status.get("token")
-                    owner = status.get("owner_instance") or status.get("owner_id") or "<unknown>"
-                    raise RuntimeError(
-                        "nonce lease unstable "
-                        f"(stable_for={stable_for:.1f}s required={stability_required_s:.1f}s "
-                        f"token={token} owner={owner})"
-                    )
-            return True, ""
+            stable_for = status.get("stable_for_s")
+            if stability_required_s <= 0:
+                return True, ""
+            if not isinstance(stable_for, (int, float)):
+                stable_for = 0.0
+            if float(stable_for) >= stability_required_s:
+                return True, ""
+
+            owner = status.get("owner_instance") or status.get("owner_id") or "<unknown>"
+            remaining_s = max(0.0, stability_required_s - float(stable_for))
+            unstable_err = (
+                "nonce lease unstable "
+                f"(stable_for={float(stable_for):.1f}s required={stability_required_s:.1f}s "
+                f"token={token} owner={owner})"
+            )
+            wait_budget_s = max(0.0, max_wait_s - (time.monotonic() - started))
+            if wait_budget_s <= 0:
+                last_err = unstable_err
+                break
+
+            sleep_s = min(
+                max(retry_delay_s, remaining_s + 0.10),
+                5.0,
+                wait_budget_s,
+            )
+            logger.warning(
+                "[NONCE LEASE WAITING] activation deferred while same-owner Redis "
+                "nonce lease matures stable_for=%.1fs required=%.1fs remaining=%.1fs "
+                "token=%s owner=%s sleep=%.2fs budget_remaining=%.2fs",
+                float(stable_for),
+                stability_required_s,
+                remaining_s,
+                token,
+                owner,
+                sleep_s,
+                wait_budget_s,
+            )
+            time.sleep(sleep_s)
         except Exception as exc:
+            failures += 1
             last_err = str(exc)
-            if attempt < retries - 1 and retry_delay_s > 0:
-                time.sleep(retry_delay_s)
+            if failures >= retries:
+                break
+            wait_budget_s = max(0.0, max_wait_s - (time.monotonic() - started))
+            if wait_budget_s <= 0:
+                break
+            time.sleep(min(retry_delay_s, wait_budget_s))
 
-    # Hard fail — no fail-open for transient Redis errors.
-    # Nonce lease is a mandatory safety gate; Redis unavailability blocks activation.
     err = (
-        f"LIVE TRADING BLOCKED: nonce writer lease verification failed "
-        f"after {retries} attempt(s). Redis nonce lease is required before "
-        f"LIVE_ACTIVE is permitted. last_error={last_err}"
+        "LIVE TRADING BLOCKED: nonce writer lease verification deferred/failed "
+        f"after {failures} failure(s). Redis nonce lease is required before "
+        f"LIVE_ACTIVE is permitted. last_error={last_err or unstable_err}"
     )
-    logger.critical("[NONCE LEASE HARD FAIL] %s", err)
+    if "nonce lease unstable" in (last_err or unstable_err):
+        logger.warning("[NONCE LEASE WAITING] %s", err)
+    else:
+        logger.critical("[NONCE LEASE HARD FAIL] %s", err)
     return False, err
-
 
 def _nonce_lease_stability_requirement_s() -> float:
     """Return required lease stability window in seconds (0 disables)."""

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -443,6 +443,12 @@ def evaluate_venue(
         and _manager_marks_eligible(manager, broker_module, venue, broker)
     )
 
+    # Kraken is the primary venue and has no secondary-activation handshake.
+    # Its activation state is therefore derived from the same complete,
+    # fail-closed stage contract used to determine execution eligibility.
+    if venue == "kraken":
+        activation = "ready" if eligible else "not_ready"
+
     reasons = [
         reason
         for reason in (
@@ -546,6 +552,10 @@ def publish_once(*, force: bool = False) -> dict[str, Any]:
     os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] = "1" if enabled else "0"
     os.environ["NIJA_EXECUTION_READY_VENUES"] = ready_csv
     os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] = degraded_csv
+    kraken_ready = bool(payload["venues"]["kraken"]["ready"])
+    os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] = "ready" if kraken_ready else "not_ready"
+    os.environ["NIJA_KRAKEN_TRADING_READY"] = "1" if kraken_ready else "0"
+    os.environ["NIJA_KRAKEN_ACTIVATED"] = "1" if kraken_ready else "0"
     os.environ["NIJA_THREE_VENUE_STAGE_VERIFIER_MARKER"] = MARKER
     _write_state(payload)
 


### PR DESCRIPTION
## What changed

- Derive Kraken's activation state from the complete canonical venue-readiness contract.
- Publish and clear Kraken activation/trading-ready flags together with each readiness snapshot.
- Move bounded same-owner nonce-lease maturation into the canonical trading state machine.
- Bind both distributed nonce-manager import paths to one process singleton.
- Add focused ready/not-ready, lease-maturation, and foreign-owner tests.

## Root cause

Kraken does not use the Coinbase/OKX secondary activation handshake, so it could satisfy every execution stage while still reporting `activation=unknown`. The canonical nonce gate also retried an immature 30-second lease for only a fraction of a second; a runtime patch made the outcome depend on import order.

## Safety behavior

No gate is bypassed. Kraken reaches `ready` only after the complete existing eligibility contract passes. Redis errors, ownership failures, and exhausted bounded wait budgets still block `LIVE_ACTIVE`.

## Validation

- Python compilation passed for all five changed files.
- Runtime repair regression tests, import smoke tests, and preflight/lint passed on the identical head SHA in the superseded draft PR.
- Full checks are running on this policy-compliant branch.
