### PR TITLE
[fix] Use current Kraken fetch for capital freshness

### DIFF
--- a/bot/capital_flow_state_machine.py
+++ b/bot/capital_flow_state_machine.py
@@ -115,6 +115,32 @@ def _resolve_bootstrap_fsm():
             continue
     return None, None
 
+def _current_refresh_requires_stale() -> bool:
+    """Return True when this refresh used unknown or expired cached capital."""
+
+    for module_name in (
+        "bot.capital_refresh_stall_guard_v35",
+        "capital_refresh_stall_guard_v35",
+    ):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        status_getter = getattr(module, "current_refresh_fallback_status", None)
+        if callable(status_getter):
+            try:
+                status = dict(status_getter(FRESHNESS_TTL_S))
+            except Exception:
+                return True
+            return bool(status.get("used_fallback") and not status.get("all_recent"))
+        fallback_checker = getattr(module, "current_refresh_used_fallback", None)
+        if callable(fallback_checker):
+            try:
+                return bool(fallback_checker())
+            except Exception:
+                return True
+    return False
+
+
 # Keep both import paths bound to the same module object.
 # This avoids duplicate process-wide singletons when callers mix
 # `bot.capital_flow_state_machine` and `capital_flow_state_machine`.
@@ -1090,6 +1116,8 @@ class CapitalRefreshCoordinator:
         # =================================================================
         raw_balances: Dict[str, float] = {}   # broker_id → fetched scalar
         balance_fetched_successfully = False
+        kraken_present = False
+        kraken_balance_fetched_successfully = False
         kraken_fetch_ts: Optional[float] = None
         kraken_response_age_s: float = FRESHNESS_TTL_S   # default = maximally stale
         assets_priced_success_pct: float = 1.0
@@ -1099,7 +1127,12 @@ class CapitalRefreshCoordinator:
             if broker is None:
                 continue
             broker_key = str(broker_id)
-            is_kraken = broker_key.lower() == "kraken"
+            broker_identity = str(getattr(broker_id, "value", broker_id) or "").strip().lower()
+            is_kraken = (
+                broker_identity == "kraken"
+                or broker_key.strip().lower().split(".")[-1] == "kraken"
+            )
+            kraken_present = kraken_present or is_kraken
 
             # Read Kraken diagnostics BEFORE the fetch so they reflect the
             # state that was current when this refresh was triggered.
@@ -1133,6 +1166,8 @@ class CapitalRefreshCoordinator:
                 raw = broker.get_account_balance()
                 if raw is not None:
                     balance_fetched_successfully = True
+                    if is_kraken:
+                        kraken_balance_fetched_successfully = True
                 if is_kraken and hasattr(broker, "get_balance_fetch_timestamp"):
                     # Use the broker's own timestamp for accuracy (it may have
                     # served a TTL-cached result rather than hitting the API).
@@ -1271,11 +1306,28 @@ class CapitalRefreshCoordinator:
             api_error_count=api_error_count,
         )
 
+        # Freshness belongs to the snapshot built by this refresh, not to the
+        # previously published authority snapshot. Preserve fail-closed behavior
+        # for an expired/unknown timeout fallback and for a configured Kraken
+        # venue whose current balance observation was not successful.
+        fallback_requires_stale = _current_refresh_requires_stale()
+        current_fetch_fresh = bool(
+            balance_fetched_successfully
+            and (
+                not kraken_present
+                or (
+                    kraken_balance_fetched_successfully
+                    and kraken_response_age_s < FRESHNESS_TTL_S
+                )
+            )
+        )
         is_fresh = (
             len(new_balances) >= broker_threshold
-            and prior_age_s <= FRESHNESS_TTL_S
+            and current_fetch_fresh
+            and not fallback_requires_stale
             and real > 0.0
         )
+        current_snapshot_age_s = 0.0 if is_fresh else prior_age_s
 
         snapshot = CapitalSnapshot(
             real_capital=real,
@@ -1287,7 +1339,7 @@ class CapitalRefreshCoordinator:
             broker_count=len(new_balances),
             expected_brokers=expected,
             computed_at=now,
-            snapshot_age_s=prior_age_s,
+            snapshot_age_s=current_snapshot_age_s,
             kraken_response_age_s=kraken_response_age_s,
             assets_priced_success_pct=float(assets_priced_success_pct),
             api_error_count=int(api_error_count),

--- a/bot/tests/test_capital_flow_state_machine_guards.py
+++ b/bot/tests/test_capital_flow_state_machine_guards.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
+import time
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -61,6 +63,25 @@ class _PositiveBroker:
         return self._balance
 
 
+class _BrokerType(Enum):
+    KRAKEN = "kraken"
+
+
+class _TimestampedKrakenBroker(_PositiveBroker):
+    def __init__(self, balance: float) -> None:
+        super().__init__(balance)
+        self._fetched_at = time.time()
+
+    def get_balance_fetch_timestamp(self):
+        return self._fetched_at
+
+    def get_last_pricing_coverage(self):
+        return 1.0
+
+    def get_error_count(self):
+        return 0
+
+
 def _build_coordinator() -> tuple[CapitalRefreshCoordinator, CapitalRuntimeStateMachine]:
     bootstrap = get_capital_bootstrap_fsm()
     bootstrap.claim_bootstrap_ownership()
@@ -98,6 +119,48 @@ def check_zero_or_failed_fetch_never_reuses_stale_positive_balance() -> None:
     assert failed_snapshot.broker_balances == {}
 
 
+def check_enum_kraken_current_fetch_is_fresh_even_when_previous_snapshot_is_stale() -> None:
+    coordinator, _runtime = _build_coordinator()
+    authority = _StubAuthority(previous=0.0)
+    authority.last_updated = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+    with patch("capital_authority.get_capital_authority", return_value=authority):
+        snapshot = coordinator.execute_refresh(
+            broker_map={_BrokerType.KRAKEN: _TimestampedKrakenBroker(226.45)},
+            trigger="test_enum_kraken_freshness",
+            open_exposure_usd=0.0,
+        )
+
+    assert snapshot is not None
+    assert snapshot.real_capital == 226.45
+    assert snapshot.confidence.freshness_score > 0.90
+    assert snapshot.is_fresh is True
+    assert snapshot.is_stale is False
+    assert snapshot.snapshot_age_s == 0.0
+
+
+def check_expired_timeout_fallback_remains_stale() -> None:
+    coordinator, _runtime = _build_coordinator()
+    authority = _StubAuthority(previous=0.0)
+
+    with patch(
+        "capital_authority.get_capital_authority",
+        return_value=authority,
+    ), patch(
+        "capital_flow_state_machine._current_refresh_requires_stale",
+        return_value=True,
+    ):
+        snapshot = coordinator.execute_refresh(
+            broker_map={_BrokerType.KRAKEN: _TimestampedKrakenBroker(226.45)},
+            trigger="test_expired_fallback",
+            open_exposure_usd=0.0,
+        )
+
+    assert snapshot is not None
+    assert snapshot.is_fresh is False
+    assert snapshot.is_stale is True
+
+
 def check_runtime_refresh_does_not_mutate_terminal_bootstrap_state() -> None:
     coordinator, _runtime = _build_coordinator()
     bootstrap = get_capital_bootstrap_fsm()
@@ -117,5 +180,7 @@ def check_runtime_refresh_does_not_mutate_terminal_bootstrap_state() -> None:
 
 if __name__ == "__main__":
     check_zero_or_failed_fetch_never_reuses_stale_positive_balance()
+    check_enum_kraken_current_fetch_is_fresh_even_when_previous_snapshot_is_stale()
+    check_expired_timeout_fallback_remains_stale()
     check_runtime_refresh_does_not_mutate_terminal_bootstrap_state()
     print("✅ test_capital_flow_state_machine_guards passed")


### PR DESCRIPTION
## What changed

- Recognize Kraken when the broker map is keyed by `BrokerType.KRAKEN`, not only the literal string `kraken`.
- Compute freshness from the balances collected by the current refresh instead of inheriting the previous authority snapshot's age.
- Publish a zero snapshot age only when the current refresh is genuinely fresh.
- Keep unknown or expired timeout-cache fallbacks fail-closed.
- Add regression coverage for enum-valued Kraken keys and expired fallback data.

## Root cause

Production received a fresh Kraken balance, but the capital pipeline converted the enum key to `"BrokerType.KRAKEN"` and compared it only to `"kraken"`. Kraken diagnostics were therefore skipped, the freshness score remained `0.000`, and the new snapshot inherited the previous snapshot's stale age.

## Safety behavior

This does not bypass the freshness gate. A configured Kraken venue must have a successful current balance observation inside the 90-second TTL. Missing/failed observations and expired or unknown cached fallbacks still produce `is_stale=True`.

## Validation

- `python -m py_compile` passed for both changed files.
- `python bot/tests/test_capital_flow_state_machine_guards.py` passed, including the new fresh-current-fetch and expired-fallback cases.
