### PR TITLE
Fix live activation convergence and stalled bootstrap recovery

### DIFF
--- a/bot/stalled_writer_release_guard_v22.py
+++ b/bot/stalled_writer_release_guard_v22.py
@@ -221,6 +221,20 @@ def _manager_valid_broker_count(manager: Any) -> int:
     return _connected_platform_broker_count(manager)
 
 
+def _bootstrap_state_value() -> str:
+    module = sys.modules.get("bot.bootstrap_state_machine") or sys.modules.get(
+        "bootstrap_state_machine"
+    )
+    getter = getattr(module, "get_bootstrap_fsm", None) if module is not None else None
+    if not callable(getter):
+        return "UNKNOWN"
+    try:
+        state = getter().state
+        return str(getattr(state, "value", state) or "UNKNOWN").strip().upper()
+    except Exception:
+        return "UNKNOWN"
+
+
 def _manager_snapshot() -> tuple[bool, bool, bool]:
     manager = _manager_instance()
     if manager is None:
@@ -736,6 +750,27 @@ def _attempt_bootstrap_progression(source: str) -> bool:
             advance(reason=f"stalled_writer_ready_bootstrap_retry:{source}")
         )
         after = str(getattr(getattr(fsm, "state", None), "value", "") or "")
+        supervised = after == "RUNNING_SUPERVISED"
+        if not supervised:
+            bot_main = sys.modules.get("bot.bot_main")
+            handoff = getattr(
+                bot_main,
+                "_advance_bootstrap_fsm_to_running_supervised",
+                None,
+            ) if bot_main is not None else None
+            if not callable(handoff):
+                logger.warning(
+                    "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_BLOCKED "
+                    "marker=%s source=%s reason=canonical_supervised_handoff_unavailable "
+                    "state=%s",
+                    _MARKER,
+                    source,
+                    after or "unknown",
+                )
+                return False
+            supervised = bool(handoff())
+            after = str(getattr(getattr(fsm, "state", None), "value", "") or "")
+            supervised = bool(supervised and after == "RUNNING_SUPERVISED")
     except Exception as exc:
         logger.warning(
             "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRY_FAILED "
@@ -750,14 +785,15 @@ def _attempt_bootstrap_progression(source: str) -> bool:
     logger.critical(
         "STALLED_WRITER_RELEASE_GUARD_V22_BOOTSTRAP_RETRIED "
         "marker=%s source=%s before_state=%s after_state=%s advanced=%s "
-        "safety_gates_preserved=true",
+        "supervised=%s safety_gates_preserved=true",
         _MARKER,
         source,
         before or "unknown",
         after or "unknown",
         advanced,
+        supervised,
     )
-    return advanced
+    return supervised
 
 
 def _attempt_emergency_stop_recovery(source: str) -> int:
@@ -929,7 +965,7 @@ def _monitor() -> None:
                 last_wait_log = now
 
             if (
-                not snapshot.manager_ready
+                _bootstrap_state_value() != "RUNNING_SUPERVISED"
                 and snapshot.sources_registered
                 and snapshot.attempts_finalized
                 and snapshot.capital_ready

--- a/bot/tests/test_live_activation_convergence_fix.py
+++ b/bot/tests/test_live_activation_convergence_fix.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+
+
+def test_preactivation_bootstrap_ready_requires_running_supervised(monkeypatch):
+    patch = importlib.import_module("preactivation_readiness_convergence_v16_patch")
+    state = SimpleNamespace(value="CAPITAL_READY")
+    bootstrap = types.ModuleType("bot.bootstrap_state_machine")
+    bootstrap.get_bootstrap_fsm = lambda: SimpleNamespace(state=state)
+    monkeypatch.setitem(sys.modules, "bot.bootstrap_state_machine", bootstrap)
+
+    for name in (
+        "NIJA_RUNTIME_MODULE_IDENTITY_READY",
+        "NIJA_SCAN_WRAPPER_DEPTH_READY",
+        "NIJA_ZERO_SIGNAL_STREAK_STATE_READY",
+        "NIJA_PRE_DISPATCH_RISK_SIZING_READY",
+    ):
+        monkeypatch.setenv(name, "1")
+
+    ready, missing = patch._bootstrap_ready()
+    assert ready is False
+    assert "bootstrap_supervised" in missing
+    assert "bootstrap_state:CAPITAL_READY" in missing
+
+    state.value = "RUNNING_SUPERVISED"
+    ready, missing = patch._bootstrap_ready()
+    assert ready is True
+    assert missing == []
+
+
+def test_stalled_writer_completes_canonical_supervised_handoff(monkeypatch):
+    guard = importlib.import_module("bot.stalled_writer_release_guard_v22")
+    state = SimpleNamespace(value="CAPITAL_READY")
+    fsm = SimpleNamespace(
+        state=state,
+        advance_to_capital_ready=lambda *, reason: True,
+    )
+    bootstrap = types.ModuleType("bot.bootstrap_state_machine")
+    bootstrap.get_bootstrap_fsm = lambda: fsm
+    monkeypatch.setitem(sys.modules, "bot.bootstrap_state_machine", bootstrap)
+
+    manager = SimpleNamespace(
+        _fsm_initialized=True,
+        has_registered_sources=lambda: True,
+        has_attempted_connections=lambda: True,
+    )
+    monkeypatch.setattr(guard, "_manager_instance", lambda: manager)
+    monkeypatch.setattr(
+        guard,
+        "_ingest_authority_snapshot_into_csm",
+        lambda source: True,
+    )
+    monkeypatch.setenv("NIJA_STARTUP_VALIDATED", "1")
+
+    bot_main = types.ModuleType("bot.bot_main")
+
+    def handoff():
+        state.value = "RUNNING_SUPERVISED"
+        return True
+
+    bot_main._advance_bootstrap_fsm_to_running_supervised = handoff
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+
+    assert guard._attempt_bootstrap_progression("unit_test") is True
+    assert state.value == "RUNNING_SUPERVISED"
+
+
+def test_activation_commit_callers_are_serialized():
+    module = importlib.import_module("bot.trading_state_machine")
+    machine = module.TradingStateMachine.__new__(module.TradingStateMachine)
+    machine._activation_commit_lock = threading.RLock()
+
+    state_lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def fake_commit(self, cycle_capital=None):
+        nonlocal active, maximum_active
+        with state_lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        time.sleep(0.03)
+        with state_lock:
+            active -= 1
+        return True
+
+    machine._commit_activation_unlocked = types.MethodType(fake_commit, machine)
+    threads = [
+        threading.Thread(target=machine.commit_activation)
+        for _ in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert maximum_active == 1

--- a/bot/tests/test_stalled_writer_release_guard_v22.py
+++ b/bot/tests/test_stalled_writer_release_guard_v22.py
@@ -283,9 +283,22 @@ def test_bootstrap_progression_retries_only_validated_ready_manager(monkeypatch)
     )
     monkeypatch.setitem(guard.sys.modules, "bot.bootstrap_state_machine", bootstrap_module)
 
+    handoff_calls = []
+
+    def complete_supervised_handoff():
+        handoff_calls.append(True)
+        state.value = "RUNNING_SUPERVISED"
+        return True
+
+    bot_main = types.SimpleNamespace(
+        _advance_bootstrap_fsm_to_running_supervised=complete_supervised_handoff
+    )
+    monkeypatch.setitem(guard.sys.modules, "bot.bot_main", bot_main)
+
     assert guard._attempt_bootstrap_progression("unit_test") is True
     assert calls == ["stalled_writer_ready_bootstrap_retry:unit_test"]
-    assert state.value == "CAPITAL_READY"
+    assert handoff_calls == [True]
+    assert state.value == "RUNNING_SUPERVISED"
 
 
 def test_missed_authority_snapshot_is_ingested_into_canonical_csm(monkeypatch):

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -2932,7 +2932,7 @@ class TradingStateMachine:
                         rolled_back = True
                 if rolled_back:
                     try:
-                        self._save_state()
+                        self._persist_state()
                     except Exception:
                         logger.exception(
                             "ACTIVATION_ROLLBACK_PERSIST_FAILED trading_remains_fail_closed=true"

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -1258,6 +1258,10 @@ class TradingStateMachine:
         # All supervisor paths MUST check this flag and call commit_activation()
         # as the sole authority for the OFF → LIVE_ACTIVE transition.
         self._activation_committed: bool = False
+        # Serialize the complete activation transaction. Individual state reads use
+        # _lock, but gate evaluation and coordinator finalization must not race
+        # across the activation monitor, preactivation monitor, and supervisor.
+        self._activation_commit_lock = threading.RLock()
 
         # Timestamp (monotonic) when the FSM first entered LIVE_PENDING_CONFIRMATION.
         # Used by the 5-minute stalled-state diagnostic and the 30-second monitoring
@@ -2077,6 +2081,14 @@ class TradingStateMachine:
         self,
         cycle_capital: Optional[Dict[str, Any]] = None,
     ) -> bool:
+        """Serialize and execute the canonical activation transaction."""
+        with self._activation_commit_lock:
+            return self._commit_activation_unlocked(cycle_capital=cycle_capital)
+
+    def _commit_activation_unlocked(
+        self,
+        cycle_capital: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Single atomic activation commit — the ONE source of truth for OFF → LIVE_ACTIVE.
 
         This is the FINAL AUTHORITY for the activation transition.  All callers
@@ -2876,6 +2888,7 @@ class TradingStateMachine:
             )
             return False
 
+        _coordinator_committed = False
         try:
             self._first_snap_accepted = True
             logger.critical("🚀 ACTIVATING TRADING ENGINE")
@@ -2891,6 +2904,7 @@ class TradingStateMachine:
                 f"FSM state must be LIVE_ACTIVE after activation, got {self._current_state}"
             )
             _coordinator.finalize_activation_commit(_frozen_snapshot)
+            _coordinator_committed = True
             logger.critical("STATE AFTER ACTIVATION = %s", self._current_state)
             logger.critical("ACTIVATION_COMMITTED — LIVE_ACTIVE confirmed")
             logger.critical(
@@ -2900,7 +2914,38 @@ class TradingStateMachine:
             )
             return True
         except Exception as exc:
-            logger.critical("[AUTO_ACTIVATE BLOCKED] reason=COMMIT_TRANSITION_FAILED error=%s", exc)
+            if not _coordinator_committed:
+                rolled_back = False
+                with self._lock:
+                    if self._current_state == TradingState.LIVE_ACTIVE:
+                        self._current_state = TradingState.LIVE_PENDING_CONFIRMATION
+                        self._activation_committed = False
+                        self._execution_authority = False
+                        self._core_loop_owns_execution = True
+                        self._can_dispatch_trades = False
+                        self._pending_confirmation_since = time.monotonic()
+                        self._last_pending_log_time = None
+                        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+                        os.environ["NIJA_RUNTIME_TRADING_STATE"] = (
+                            TradingState.LIVE_PENDING_CONFIRMATION.value
+                        )
+                        rolled_back = True
+                if rolled_back:
+                    try:
+                        self._save_state()
+                    except Exception:
+                        logger.exception(
+                            "ACTIVATION_ROLLBACK_PERSIST_FAILED trading_remains_fail_closed=true"
+                        )
+                    logger.error(
+                        "ACTIVATION_ROLLED_BACK reason=coordinator_commit_failed "
+                        "state=LIVE_PENDING_CONFIRMATION execution_authority=false"
+                    )
+            logger.error(
+                "[AUTO_ACTIVATE BLOCKED] reason=COMMIT_TRANSITION_FAILED error=%s",
+                exc,
+                exc_info=True,
+            )
             return False
 
     def get_activation_committed(self) -> bool:

--- a/preactivation_readiness_convergence_v16_patch.py
+++ b/preactivation_readiness_convergence_v16_patch.py
@@ -201,13 +201,28 @@ def _strict_authority_ready() -> tuple[bool, str]:
 
 
 def _bootstrap_ready() -> tuple[bool, list[str]]:
+    state_value = "UNAVAILABLE"
+    try:
+        try:
+            module = importlib.import_module("bot.bootstrap_state_machine")
+        except Exception:
+            module = importlib.import_module("bootstrap_state_machine")
+        fsm = module.get_bootstrap_fsm()
+        state = getattr(fsm, "state", None)
+        state_value = str(getattr(state, "value", state) or "UNKNOWN").strip().upper()
+    except Exception:
+        state_value = "UNAVAILABLE"
+
     required = {
+        "bootstrap_supervised": state_value == "RUNNING_SUPERVISED",
         "module_identity": _truthy("NIJA_RUNTIME_MODULE_IDENTITY_READY"),
         "scan_wrapper_depth": _truthy("NIJA_SCAN_WRAPPER_DEPTH_READY"),
         "zero_signal_state": _truthy("NIJA_ZERO_SIGNAL_STREAK_STATE_READY"),
         "pre_dispatch_risk": _truthy("NIJA_PRE_DISPATCH_RISK_SIZING_READY"),
     }
     missing = [name for name, ready in required.items() if not ready]
+    if state_value != "RUNNING_SUPERVISED":
+        missing.append(f"bootstrap_state:{state_value}")
     return not missing, missing
 
 


### PR DESCRIPTION
## Problem

Production reached `LIVE_PENDING_CONFIRMATION` with funded, connected brokers and a 9/9 readiness table, but the startup coordinator remained at `commit_version=0`. The readiness reconstruction treated environment guards as bootstrap completion while the coordinator correctly required `RUNNING_SUPERVISED` plus supervised thread evidence. The stalled-writer recovery then skipped bootstrap progression because `CAPITAL_READY` was classified as manager-ready.

Concurrent activation monitors could also enter the full activation operation simultaneously, and a coordinator finalization failure after the FSM transition could leave `LIVE_ACTIVE` without a committed dispatch version.

## Changes

- Require the canonical BootstrapFSM to reach `RUNNING_SUPERVISED` before reconstructed bootstrap readiness passes.
- Make the stalled-writer guard distinguish manager readiness from supervised bootstrap completion.
- Complete the legal canonical handoff through `bot_main._advance_bootstrap_fsm_to_running_supervised()` when recovery starts at `CAPITAL_READY`.
- Serialize the complete activation transaction with a reentrant activation lock.
- Roll back the trading FSM, dispatch latches, environment authority, and persisted state if coordinator finalization fails.
- Log activation rollback as an error instead of leaving an inconsistent live state.
- Add regression coverage for the production stall, truthful readiness semantics, and concurrent activation callers.

## Safety

No broker order path, sizing threshold, strategy signal, kill switch, nonce gate, writer lease validation, or capital requirement is bypassed. Recovery uses the existing legal BootstrapFSM handoff and remains fail-closed when the canonical helper is unavailable.

## Validation

- Python AST parsing passed for all modified Python files.
- Added `bot/tests/test_live_activation_convergence_fix.py`.
- Full repository test execution is delegated to PR CI because the connected environment cannot clone the repository directly.

## Follow-up

Runtime execution still carries a very deep historical wrapper chain. Consolidating legacy runtime patch installers should be handled separately after this activation fix, with dedicated dispatch equivalence and broker-routing coverage.