### PR TITLE
Apply complete production corrective set

### DIFF
--- a/bot/capital_refresh_stall_guard_v35.py
+++ b/bot/capital_refresh_stall_guard_v35.py
@@ -1,340 +1,277 @@
-"""Capital refresh stall guard v35.
+"""Capital refresh stall guard v36 (compatibility filename v35).
 
-Bounds broker balance calls inside CapitalRefreshCoordinator with independent
-per-broker deadlines inside a bounded overall refresh cycle.
+Bounds broker balance calls without allowing timed-out work to poison the next
+cycle or silently revive stale CapitalAuthority values.
 
-Key properties
---------------
-* All venue fetches begin concurrently.
-* Each broker has its own independent per-broker timeout so one slow API
-  cannot consume the shared cycle deadline and starve every other venue.
-* Only one in-flight request is permitted per broker; a timed-out thread
-  does not cause overlapping requests on the next refresh cycle.
-* A late result can never overwrite a newer live snapshot: results carry
-  the sequence number of the request cycle and are rejected when stale.
-* Cache entries are validated (finite, non-negative, timestamped, within
-  TTL) before use; a failed/zero/None result never overwrites a valid cache.
-* Separate per-broker observation timestamps mean one cached venue does not
-  make the combined snapshot appear entirely fresh.
-* A deduplication window suppresses repeated identical timeout warnings so
-  logs are useful without hiding real state changes.
-* A recovery log is emitted when a previously timing-out broker returns live
-  data again.
-* Never logs API keys, secrets, signatures, or private account data.
+Safety properties
+-----------------
+* one in-flight request per broker;
+* a reused in-flight request reuses the SAME result queue;
+* late results are sequence checked;
+* only a previously confirmed successful bounded fetch may be used as fallback;
+* fallback preserves the original observation timestamp and age;
+* expired/untrusted fallback returns 0.0 so the coordinator excludes the broker
+  instead of entering its legacy "previous authority balance" exception path;
+* fallback provenance is available to confidence/trace consumers;
+* no balance, authority, or writer gate is synthesized or bypassed.
 """
 from __future__ import annotations
 
+import builtins
+import importlib
 import logging
+import math
 import os
 import queue
 import sys
 import threading
 import time
+from dataclasses import dataclass
+from functools import wraps
 from types import ModuleType
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 LOGGER = logging.getLogger("nija.capital_refresh_stall_guard_v35")
-MARKER = "20260802-capital-refresh-shared-deadline-v36"
+MARKER = "20260807-capital-refresh-provenance-v36"
 _TARGETS = ("bot.capital_flow_state_machine", "capital_flow_state_machine")
 _LOCK = threading.RLock()
 _STARTED = False
 _REFRESH_CONTEXT = threading.local()
-_LIVE_BALANCE_OBSERVED_AT = "_nija_capital_live_balance_observed_monotonic"
+_HOOK_FLAG = "_NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_IMPORTLIB_HOOK"
 
-# Per-broker in-flight guard: maps broker_id → (thread, sequence_number)
-_IN_FLIGHT: Dict[str, Tuple[threading.Thread, int]] = {}
+if __name__ == "nija_capital_refresh_stall_guard_v35_prebot":
+    sys.modules.setdefault("capital_refresh_stall_guard_v35", sys.modules[__name__])
+
+
+@dataclass
+class _Observation:
+    value: float
+    observed_monotonic: float
+    observed_epoch: float
+    sequence: int
+
+
+@dataclass
+class _Flight:
+    thread: threading.Thread
+    result_queue: queue.Queue
+    sequence: int
+    started_monotonic: float
+    timeout_s: float
+
+
+_IN_FLIGHT: Dict[str, _Flight] = {}
 _IN_FLIGHT_LOCK = threading.Lock()
-
-# Per-broker cycle sequence counter (incremented each time a new request fires)
 _BROKER_SEQUENCE: Dict[str, int] = {}
-
-# Per-broker "last timeout logged at" for deduplication
+_OBSERVATIONS: Dict[str, _Observation] = {}
+_OBSERVATION_LOCK = threading.Lock()
 _LAST_TIMEOUT_LOGGED: Dict[str, float] = {}
-_TIMEOUT_LOG_DEDUP_S = 30.0  # suppress repeated identical timeout warnings for this interval
-
-# Per-broker "was timing out on previous cycle" for recovery detection
+_TIMEOUT_LOG_DEDUP_S = 30.0
 _WAS_TIMING_OUT: Dict[str, bool] = {}
 
 
 def _freshness_ttl_seconds() -> float:
     try:
-        return max(
-            5.0,
-            float(os.getenv("NIJA_CAPITAL_FRESHNESS_TTL_S", "90.0") or "90.0"),
-        )
+        return max(5.0, float(os.getenv("NIJA_CAPITAL_FRESHNESS_TTL_S", "90.0") or 90.0))
     except (TypeError, ValueError):
         return 90.0
 
 
 def _timeout_seconds() -> float:
-    """Per-broker independent timeout (not a shared deadline)."""
     try:
-        return max(2.0, float(os.getenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "8.0")))
+        return max(2.0, float(os.getenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "8.0") or 8.0))
     except (TypeError, ValueError):
         return 8.0
 
 
 def _broker_timeout_seconds(broker_id: str) -> float:
-    """Return broker-specific timeout with optional OKX override."""
-    base_timeout = _timeout_seconds()
-    broker_key = str(broker_id).strip().lower()
-    if broker_key != "okx":
-        return base_timeout
+    base = _timeout_seconds()
+    if str(broker_id).strip().lower() != "okx":
+        return base
     try:
-        okx_timeout = float(os.getenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", str(base_timeout)) or base_timeout)
+        return max(base, float(os.getenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", str(base)) or base))
     except (TypeError, ValueError):
-        return base_timeout
-    return max(base_timeout, okx_timeout)
+        return base
 
 
 def _cycle_deadline_seconds() -> float:
-    """Overall cycle wall-clock budget.  Must be > per-broker timeout."""
     try:
-        return max(
-            _timeout_seconds() + 2.0,
-            float(os.getenv("NIJA_CAPITAL_CYCLE_DEADLINE_S", "12.0")),
-        )
+        return max(_timeout_seconds() + 2.0, float(os.getenv("NIJA_CAPITAL_CYCLE_DEADLINE_S", "12.0") or 12.0))
     except (TypeError, ValueError):
         return _timeout_seconds() + 2.0
 
 
-def _cache_valid(cached: Any, observed_at: float, now: float, ttl_s: float) -> bool:
-    """Return True only when the cached value is safe to use as a fallback."""
-    if cached is None:
-        return False
+def _coerce_scalar(value: Any) -> Optional[float]:
     try:
-        v = float(cached)
-    except (TypeError, ValueError):
-        return False
-    if not (v >= 0.0 and v != float("inf") and v == v):  # finite and non-negative
-        return False
-    if observed_at <= 0.0:
-        return False
-    age_s = max(0.0, now - observed_at)
-    return age_s <= ttl_s
+        if isinstance(value, dict):
+            scalar = float(value.get("trading_balance") or value.get("total_funds") or (float(value.get("usd", 0.0) or 0.0) + float(value.get("usdc", 0.0) or 0.0)) or 0.0)
+        else:
+            scalar = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(scalar) or scalar < 0.0:
+        return None
+    return scalar
+
+
+def _begin_refresh_context() -> None:
+    _REFRESH_CONTEXT.in_refresh = True
+    _REFRESH_CONTEXT.used_fallback = False
+    _REFRESH_CONTEXT.fallback_brokers = {}
+    _REFRESH_CONTEXT.excluded_brokers = {}
+    _REFRESH_CONTEXT.live_brokers = {}
+
+
+def _status_from_context() -> Dict[str, Any]:
+    used_fallback = bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
+    fallbacks = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
+    excluded = dict(getattr(_REFRESH_CONTEXT, "excluded_brokers", {}) or {})
+    live = dict(getattr(_REFRESH_CONTEXT, "live_brokers", {}) or {})
+    ttl_s = _freshness_ttl_seconds()
+    all_recent = bool(used_fallback and fallbacks and not excluded and all(bool(record.get("observed")) and float(record.get("age_s", float("inf"))) <= ttl_s for record in fallbacks.values()))
+    source = "partial_or_excluded_fallback" if excluded else "cached_live_observation" if fallbacks else "live_exchange"
+    return {"used_fallback": used_fallback, "all_recent": all_recent, "freshness_ttl_s": ttl_s, "brokers": fallbacks, "excluded_brokers": excluded, "live_brokers": live, "source": source}
+
+
+def current_refresh_used_fallback() -> bool:
+    if bool(getattr(_REFRESH_CONTEXT, "in_refresh", False)):
+        return bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
+    return bool(dict(getattr(_REFRESH_CONTEXT, "last_status", {}) or {}).get("used_fallback", False))
+
+
+def current_refresh_fallback_status(freshness_ttl_s: Optional[float] = None) -> Dict[str, Any]:
+    if bool(getattr(_REFRESH_CONTEXT, "in_refresh", False)):
+        status = _status_from_context()
+    else:
+        status = dict(getattr(_REFRESH_CONTEXT, "last_status", {}) or {})
+        if not status:
+            status = {"used_fallback": False, "all_recent": False, "freshness_ttl_s": _freshness_ttl_seconds(), "brokers": {}, "excluded_brokers": {}, "live_brokers": {}, "source": "live_exchange"}
+    if freshness_ttl_s is not None:
+        ttl_s = max(5.0, float(freshness_ttl_s))
+        status["freshness_ttl_s"] = ttl_s
+        fallbacks = dict(status.get("brokers", {}) or {})
+        excluded = dict(status.get("excluded_brokers", {}) or {})
+        status["all_recent"] = bool(status.get("used_fallback") and fallbacks and not excluded and all(float(v.get("age_s", float("inf"))) <= ttl_s for v in fallbacks.values()))
+    return status
 
 
 class _BalanceFetchBatch:
-    """Start all broker calls concurrently with independent per-broker deadlines.
-
-    Design notes
-    ------------
-    * Each broker gets its own ``queue.Queue`` and dedicated daemon thread.
-    * ``result_for()`` blocks only for the *remaining* per-broker budget, not
-      a shared countdown.  Two calls to ``result_for()`` for different brokers
-      can therefore overlap in time: the first call completes quickly while the
-      second waits up to its full individual budget.
-    * The overall cycle deadline acts as a safety net; it cannot be shorter
-      than per_broker_timeout + 2 s.
-    * Each fetch carries a ``seq`` counter so late results from a previously
-      timed-out thread can be detected and discarded.
-    """
+    """Concurrent per-broker fetches with queue-correct in-flight reuse."""
 
     def __init__(self, broker_map: Dict[str, Any]) -> None:
-        self._started_at = time.monotonic()
-        self._base_timeout = _timeout_seconds()
-        self._cycle_deadline = self._started_at + _cycle_deadline_seconds()
-        self._results: Dict[str, queue.Queue] = {}
-        self._broker_seq: Dict[str, int] = {}
-        self._broker_timeout: Dict[str, float] = {}
+        self._batch_started = time.monotonic()
+        self._cycle_deadline = self._batch_started + _cycle_deadline_seconds()
+        self._flights: Dict[str, _Flight] = {}
 
         for broker_id, broker in broker_map.items():
             bid = str(broker_id)
-            result_queue: queue.Queue = queue.Queue(maxsize=1)
-            self._results[bid] = result_queue
-            self._broker_timeout[bid] = _broker_timeout_seconds(bid)
-
+            timeout_s = _broker_timeout_seconds(bid)
             with _IN_FLIGHT_LOCK:
-                # Only one in-flight request per broker.
                 existing = _IN_FLIGHT.get(bid)
-                if existing is not None:
-                    existing_thread, _seq = existing
-                    if existing_thread.is_alive():
-                        # Previous request still running — skip launching a new one.
-                        # The queue is already connected; result_for() will receive
-                        # the in-flight result via the existing thread.
-                        self._broker_seq[bid] = _seq
-                        continue
+                if existing is not None and existing.thread.is_alive():
+                    self._flights[bid] = existing
+                    LOGGER.debug("CAPITAL_REFRESH_INFLIGHT_REUSED marker=%s broker=%s seq=%d age_s=%.2f", MARKER, bid, existing.sequence, max(0.0, time.monotonic() - existing.started_monotonic))
+                    continue
 
                 seq = _BROKER_SEQUENCE.get(bid, 0) + 1
                 _BROKER_SEQUENCE[bid] = seq
-                self._broker_seq[bid] = seq
+                result_queue: queue.Queue = queue.Queue(maxsize=1)
+                started = time.monotonic()
 
-                def _call(
-                    target: Any = broker,
-                    output: queue.Queue = result_queue,
-                    broker_seq: int = seq,
-                    broker_key: str = bid,
-                ) -> None:
+                def _call(target: Any = broker, output: queue.Queue = result_queue, broker_seq: int = seq, broker_key: str = bid) -> None:
+                    observed_mono = 0.0
+                    observed_epoch = 0.0
                     try:
                         value = target.get_account_balance()
-                        # Validate result before storing — never overwrite cache with
-                        # None, exception, zero caused by API failure, or malformed data.
-                        result_ok = False
+                        scalar = _coerce_scalar(value)
+                        if scalar is None:
+                            raise ValueError("invalid_balance_payload")
+                        observed_mono = time.monotonic()
+                        observed_epoch = time.time()
+                        with _OBSERVATION_LOCK:
+                            previous = _OBSERVATIONS.get(broker_key)
+                            if previous is None or broker_seq >= previous.sequence:
+                                _OBSERVATIONS[broker_key] = _Observation(value=scalar, observed_monotonic=observed_mono, observed_epoch=observed_epoch, sequence=broker_seq)
                         try:
-                            fv = float(value)
-                            result_ok = fv >= 0.0 and fv == fv and fv != float("inf")
-                        except (TypeError, ValueError):
-                            pass
-                        if result_ok:
-                            try:
-                                setattr(target, _LIVE_BALANCE_OBSERVED_AT, time.monotonic())
-                            except Exception:
-                                pass
-                        try:
-                            output.put_nowait((True, value, broker_seq))
+                            output.put_nowait((True, value, broker_seq, observed_mono, observed_epoch))
                         except queue.Full:
                             pass
                     except BaseException as exc:
                         try:
-                            output.put_nowait((False, exc, broker_seq))
+                            output.put_nowait((False, exc, broker_seq, observed_mono, observed_epoch))
                         except queue.Full:
                             pass
                     finally:
-                        # Remove from in-flight when done so next cycle can start fresh.
                         with _IN_FLIGHT_LOCK:
                             current = _IN_FLIGHT.get(broker_key)
-                            if current is not None and current[1] == broker_seq:
+                            if current is not None and current.sequence == broker_seq:
                                 _IN_FLIGHT.pop(broker_key, None)
 
-                t = threading.Thread(
-                    target=_call,
-                    name=f"capital-balance-fetch-{bid}",
-                    daemon=True,
-                )
-                _IN_FLIGHT[bid] = (t, seq)
-                t.start()
+                thread = threading.Thread(target=_call, name=f"capital-balance-fetch-{bid}", daemon=True)
+                flight = _Flight(thread=thread, result_queue=result_queue, sequence=seq, started_monotonic=started, timeout_s=timeout_s)
+                _IN_FLIGHT[bid] = flight
+                self._flights[bid] = flight
+                thread.start()
 
     def result_for(self, broker_id: str, broker: Any) -> Any:
         bid = str(broker_id)
-        result_queue = self._results[bid]
-        expected_seq = self._broker_seq.get(bid, 0)
-
-        # Each broker gets its full individual budget, bounded by overall cycle deadline.
-        per_broker_timeout = self._broker_timeout.get(bid, self._base_timeout)
-        broker_deadline = self._started_at + per_broker_timeout
+        flight = self._flights[bid]
+        broker_deadline = flight.started_monotonic + flight.timeout_s
         remaining = max(0.0, min(broker_deadline, self._cycle_deadline) - time.monotonic())
-        now = time.monotonic()
-
         try:
-            ok, value, result_seq = result_queue.get(timeout=remaining)
+            ok, value, result_seq, observed_mono, observed_epoch = flight.result_queue.get(timeout=remaining)
         except queue.Empty:
-            return self._handle_timeout(bid, broker, now)
+            return self._handle_failure(bid, "timeout")
 
-        # Reject late results that are from a stale sequence (e.g. a previously
-        # timed-out thread that eventually returned).
-        if result_seq < expected_seq:
-            LOGGER.debug(
-                "CAPITAL_REFRESH_LATE_RESULT_DISCARDED marker=%s broker=%s "
-                "result_seq=%d expected_seq=%d",
-                MARKER, bid, result_seq, expected_seq,
-            )
-            return self._handle_timeout(bid, broker, now)
+        if int(result_seq) != int(flight.sequence):
+            LOGGER.warning("CAPITAL_REFRESH_LATE_RESULT_DISCARDED marker=%s broker=%s result_seq=%s expected_seq=%s", MARKER, bid, result_seq, flight.sequence)
+            return self._handle_failure(bid, "late_result")
+        if not ok:
+            return self._handle_failure(bid, f"exception:{type(value).__name__}")
+        scalar = _coerce_scalar(value)
+        if scalar is None:
+            return self._handle_failure(bid, "invalid_payload")
 
-        # Emit recovery log if this broker was previously timing out.
-        if ok and _WAS_TIMING_OUT.get(bid):
+        live = dict(getattr(_REFRESH_CONTEXT, "live_brokers", {}) or {})
+        live[bid] = {"value": scalar, "observed_monotonic": float(observed_mono), "observed_epoch": float(observed_epoch), "sequence": int(result_seq)}
+        _REFRESH_CONTEXT.live_brokers = live
+        if _WAS_TIMING_OUT.get(bid):
             _WAS_TIMING_OUT[bid] = False
-            LOGGER.info(
-                "CAPITAL_REFRESH_BROKER_RECOVERED marker=%s broker=%s "
-                "live_data_restored=true",
-                MARKER, bid,
-            )
+            LOGGER.info("CAPITAL_REFRESH_BROKER_RECOVERED marker=%s broker=%s live_data_restored=true", MARKER, bid)
+        return value
 
-        if ok:
-            return value
-        raise value
-
-    def _handle_timeout(self, broker_id: str, broker: Any, started_at: float) -> Any:
+    def _handle_failure(self, broker_id: str, reason: str) -> float:
         _REFRESH_CONTEXT.used_fallback = True
         now = time.monotonic()
-        cached = getattr(broker, "_last_known_balance", None)
-        observed_at = float(getattr(broker, _LIVE_BALANCE_OBSERVED_AT, 0.0) or 0.0)
         ttl_s = _freshness_ttl_seconds()
-        cached_valid = _cache_valid(cached, observed_at, now, ttl_s)
-        cached_age_s = max(0.0, now - observed_at) if observed_at > 0.0 else float("inf")
-
-        fallback_brokers = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
-        fallback_brokers[broker_id] = {
-            "age_s": cached_age_s,
-            "observed": observed_at > 0.0,
-            "cached_valid": cached_valid,
-        }
-        _REFRESH_CONTEXT.fallback_brokers = fallback_brokers
-
-        elapsed = now - self._started_at
-
-        # Deduplicate repeated identical timeout warnings.
+        with _OBSERVATION_LOCK:
+            observation = _OBSERVATIONS.get(broker_id)
+        age_s = max(0.0, now - observation.observed_monotonic) if observation is not None and observation.observed_monotonic > 0 else float("inf")
+        fresh = bool(observation is not None and age_s <= ttl_s)
         last_logged = _LAST_TIMEOUT_LOGGED.get(broker_id, 0.0)
         suppress = (now - last_logged) < _TIMEOUT_LOG_DEDUP_S
         _WAS_TIMING_OUT[broker_id] = True
 
-        if cached_valid:
+        if fresh and observation is not None:
+            fallbacks = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
+            fallbacks[broker_id] = {"value": observation.value, "age_s": age_s, "observed": True, "observed_epoch": observation.observed_epoch, "sequence": observation.sequence, "cached_valid": True, "reason": reason}
+            _REFRESH_CONTEXT.fallback_brokers = fallbacks
             if not suppress:
                 _LAST_TIMEOUT_LOGGED[broker_id] = now
-                LOGGER.warning(
-                    "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s "
-                    "broker=%s elapsed=%.2fs cached_payload=true cached_age_s=%.2f "
-                    "cached_within_ttl=%s per_broker_timeout=true",
-                    MARKER,
-                    broker_id,
-                    elapsed,
-                    cached_age_s,
-                    cached_age_s <= ttl_s,
-                )
-            return cached
+                LOGGER.warning("CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s broker=%s reason=%s cached_payload=true cached_age_s=%.2f observed_epoch=%.6f source=cached_live_observation", MARKER, broker_id, reason, age_s, observation.observed_epoch)
+            return float(observation.value)
 
-        # Cached entry is absent or invalid — broker excluded from valid_brokers.
+        excluded = dict(getattr(_REFRESH_CONTEXT, "excluded_brokers", {}) or {})
+        excluded[broker_id] = {"age_s": age_s, "observed": observation is not None, "observed_epoch": observation.observed_epoch if observation is not None else 0.0, "reason": reason, "cached_valid": False}
+        _REFRESH_CONTEXT.excluded_brokers = excluded
         if not suppress:
             _LAST_TIMEOUT_LOGGED[broker_id] = now
-            LOGGER.error(
-                "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT marker=%s broker=%s "
-                "elapsed=%.2fs cached_payload=false per_broker_timeout=true",
-                MARKER,
-                broker_id,
-                elapsed,
-            )
-        raise TimeoutError(
-            f"capital balance fetch timed out for {broker_id} after {elapsed:.2f}s"
-        )
-
-
-def current_refresh_used_fallback() -> bool:
-    """Return whether this thread's active refresh consumed cached capital."""
-    return bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
-
-
-def current_refresh_fallback_status(
-    freshness_ttl_s: Optional[float] = None,
-) -> Dict[str, Any]:
-    """Return freshness evidence for cached balances used by this refresh."""
-
-    used_fallback = current_refresh_used_fallback()
-    brokers = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
-    ttl_s = (
-        _freshness_ttl_seconds()
-        if freshness_ttl_s is None
-        else max(5.0, float(freshness_ttl_s))
-    )
-    all_recent = bool(
-        used_fallback
-        and brokers
-        and all(
-            bool(record.get("observed"))
-            and float(record.get("age_s", float("inf"))) <= ttl_s
-            for record in brokers.values()
-        )
-    )
-    return {
-        "used_fallback": used_fallback,
-        "all_recent": all_recent,
-        "freshness_ttl_s": ttl_s,
-        "brokers": brokers,
-    }
+            LOGGER.error("CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_EXCLUDED marker=%s broker=%s reason=%s cached_payload=false cached_age_s=%s action=exclude_from_snapshot", MARKER, broker_id, reason, "inf" if not math.isfinite(age_s) else f"{age_s:.2f}")
+        return 0.0
 
 
 class _BoundedBrokerProxy:
-    """Transparent broker proxy backed by a per-broker-bounded fetch batch."""
-
     def __init__(self, broker_id: str, broker: Any, batch: _BalanceFetchBatch) -> None:
         object.__setattr__(self, "_broker_id", str(broker_id))
         object.__setattr__(self, "_broker", broker)
@@ -347,10 +284,7 @@ class _BoundedBrokerProxy:
         setattr(object.__getattribute__(self, "_broker"), name, value)
 
     def get_account_balance(self) -> Any:
-        return object.__getattribute__(self, "_batch").result_for(
-            object.__getattribute__(self, "_broker_id"),
-            object.__getattribute__(self, "_broker"),
-        )
+        return object.__getattribute__(self, "_batch").result_for(object.__getattribute__(self, "_broker_id"), object.__getattribute__(self, "_broker"))
 
 
 def _patch(module: ModuleType) -> bool:
@@ -360,81 +294,85 @@ def _patch(module: ModuleType) -> bool:
     original = getattr(cls, "_pipeline", None)
     if not callable(original):
         return False
-    if getattr(original, "_nija_capital_refresh_stall_guard_v35", False):
+    if getattr(original, "_nija_capital_refresh_stall_guard_v36", False):
         return True
 
-    def _pipeline_with_bounded_brokers(
-        self: Any,
-        broker_map: Dict[str, Any],
-        trigger: str,
-        open_exposure_usd: float,
-    ) -> Any:
-        _REFRESH_CONTEXT.used_fallback = False
-        _REFRESH_CONTEXT.fallback_brokers = {}
-        live_map = {
-            str(broker_id): broker
-            for broker_id, broker in broker_map.items()
-            if broker is not None
-        }
+    @wraps(original)
+    def _pipeline_with_bounded_brokers(self: Any, broker_map: Dict[str, Any], trigger: str, open_exposure_usd: float) -> Any:
+        _begin_refresh_context()
+        live_map = {str(broker_id): broker for broker_id, broker in broker_map.items() if broker is not None}
         batch = _BalanceFetchBatch(live_map)
-        bounded_map = {
-            broker_id: _BoundedBrokerProxy(broker_id, broker, batch)
-            for broker_id, broker in live_map.items()
-        }
+        bounded_map = {broker_id: _BoundedBrokerProxy(broker_id, broker, batch) for broker_id, broker in live_map.items()}
         try:
-            return original(
-                self,
-                broker_map=bounded_map,
-                trigger=trigger,
-                open_exposure_usd=open_exposure_usd,
-            )
+            return original(self, broker_map=bounded_map, trigger=trigger, open_exposure_usd=open_exposure_usd)
         finally:
-            _REFRESH_CONTEXT.used_fallback = False
-            _REFRESH_CONTEXT.fallback_brokers = {}
+            status = _status_from_context()
+            _REFRESH_CONTEXT.last_status = status
+            _REFRESH_CONTEXT.in_refresh = False
+            try:
+                os.environ["NIJA_CAPITAL_REFRESH_LAST_PROVENANCE_JSON"] = str(status)
+            except Exception:
+                pass
 
-    _pipeline_with_bounded_brokers._nija_capital_refresh_stall_guard_v35 = True
+    _pipeline_with_bounded_brokers._nija_capital_refresh_stall_guard_v35 = True  # type: ignore[attr-defined]
+    _pipeline_with_bounded_brokers._nija_capital_refresh_stall_guard_v36 = True  # type: ignore[attr-defined]
     cls._pipeline = _pipeline_with_bounded_brokers
     os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED"] = "1"
-    LOGGER.info(
-        "CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED marker=%s module=%s "
-        "per_broker_timeout_s=%.2f cycle_deadline_s=%.2f independent_deadlines=true",
-        MARKER,
-        module.__name__,
-        _timeout_seconds(),
-        _cycle_deadline_seconds(),
-    )
+    os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED"] = "1"
+    LOGGER.critical("CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED marker=%s module=%s per_broker_timeout_s=%.2f cycle_deadline_s=%.2f queue_reuse=true stale_authority_fallback=false", MARKER, module.__name__, _timeout_seconds(), _cycle_deadline_seconds())
     return True
 
 
-def _monitor() -> None:
-    while True:
-        for name in _TARGETS:
-            module = sys.modules.get(name)
-            if isinstance(module, ModuleType):
-                _patch(module)
-        time.sleep(0.5)
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                module = original_import(name, globals, locals, fromlist, level)
+                if str(name).endswith("capital_flow_state_machine"):
+                    _patch_loaded()
+                return module
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                module = original_import_module(name, package)
+                if str(name).endswith("capital_flow_state_machine"):
+                    _patch_loaded()
+                return module
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        _STARTED = True
+        os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED"] = "1"
+        os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED"] = "1"
+        LOGGER.critical("CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED marker=%s safe_timeout_fallback=true", MARKER)
+        return True
 
 
 def install() -> bool:
-    global _STARTED
-    with _LOCK:
-        if not _STARTED:
-            thread = threading.Thread(
-                target=_monitor,
-                name="capital-refresh-stall-guard-v35",
-                daemon=True,
-            )
-            thread.start()
-            _STARTED = thread.is_alive()
-    if not _STARTED:
-        return False
-    os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED"] = "1"
-    LOGGER.info(
-        "CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED marker=%s "
-        "fail_closed=true per_broker_independent_deadlines=true",
-        MARKER,
-    )
-    return True
+    return install_import_hook()
 
 
-install_import_hook = install
+__all__ = ["MARKER", "install", "install_import_hook", "current_refresh_used_fallback", "current_refresh_fallback_status", "_BalanceFetchBatch", "_BoundedBrokerProxy", "_patch"]

--- a/bot/entrypoint_writer_epoch_recovery_v19_patch.py
+++ b/bot/entrypoint_writer_epoch_recovery_v19_patch.py
@@ -1,0 +1,77 @@
+"""Fail-closed writer epoch recovery guard.
+
+A missing process writer lock is an ownership-epoch loss, not a TTL refresh.
+This guard prevents EntrypointWriterAuthority from recreating a vanished lock
+with the old fencing token. The existing heartbeat loop then marks authority
+lost, bot_main stops execution, and the next canonical acquisition obtains a
+fresh fencing token/generation.
+"""
+from __future__ import annotations
+import builtins, importlib, logging, os, sys
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.entrypoint_writer_epoch_recovery_v19")
+MARKER = "20260807-writer-epoch-recovery-v19"
+_FLAG = "_NIJA_WRITER_EPOCH_RECOVERY_V19_HOOK"
+
+def _text(v: Any) -> str:
+    return v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v or "")
+
+def _patch(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type) or getattr(cls, "_nija_writer_epoch_recovery_v19", False):
+        return False
+    original = getattr(cls, "_heartbeat_tick", None)
+    if not callable(original):
+        return False
+    @wraps(original)
+    def _heartbeat_tick(self: Any):
+        if not bool(getattr(self, "_local_fallback", False)):
+            client = getattr(self, "_client", None)
+            lock_key = str(getattr(self, "_lock_key", "") or "")
+            lock_value = str(getattr(self, "_lock_value", "") or "")
+            if client is not None and lock_key and lock_value:
+                try:
+                    current = _text(client.get(lock_key))
+                except Exception as exc:
+                    return False, f"redis_heartbeat_precheck_error:{type(exc).__name__}:{exc}"
+                if not current:
+                    LOGGER.critical("WRITER_EPOCH_LOCK_MISSING marker=%s lock_key=%s action=lose_authority", MARKER, lock_key)
+                    return False, "lock_missing_and_fencing_token_mismatch"
+                if current != lock_value:
+                    LOGGER.critical("WRITER_EPOCH_OWNER_CHANGED marker=%s lock_key=%s action=lose_authority", MARKER, lock_key)
+                    return False, "lock_owned_by_different_writer"
+        return original(self)
+    cls._heartbeat_tick = _heartbeat_tick
+    cls._nija_writer_epoch_recovery_v19 = True
+    os.environ["NIJA_WRITER_EPOCH_RECOVERY_V19_PATCHED"] = "1"
+    return True
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.entrypoint_writer_authority", "entrypoint_writer_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch(module) or changed
+    return changed
+
+def install_import_hook() -> bool:
+    _patch_loaded()
+    if not getattr(builtins, _FLAG, False):
+        original_import = builtins.__import__
+        @wraps(original_import)
+        def importing(name, globals=None, locals=None, fromlist=(), level=0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if str(name).endswith("entrypoint_writer_authority"):
+                _patch_loaded()
+            return result
+        builtins.__import__ = importing
+        setattr(builtins, _FLAG, True)
+    os.environ["NIJA_WRITER_EPOCH_RECOVERY_V19_INSTALLED"] = "1"
+    LOGGER.critical("WRITER_EPOCH_RECOVERY_V19_INSTALLED marker=%s fail_closed=true", MARKER)
+    return True
+
+def install() -> bool:
+    return install_import_hook()

--- a/bot/production_corrective_set_v18_patch.py
+++ b/bot/production_corrective_set_v18_patch.py
@@ -1,0 +1,667 @@
+"""Production corrective set v18 for NIJA runtime safety.
+
+This patch closes the remaining production gaps observed after nonce/process
+writer generation separation:
+
+* distributed writer verification is read-only outside EntrypointWriterAuthority;
+* authority heartbeat publication cannot resync writer generation, extend the
+  writer lock TTL, or recreate a missing process writer lock;
+* live writer authority requires a healthy EntrypointWriterAuthority renewal
+  proof and exact process-generation/lock ownership;
+* capital hydration never auto-enables the local writer-lock fallback;
+* scan-wrapper convergence recognizes the older runtime-convergence scan owner
+  and removes the nested same-thread reentrancy trap; and
+* EntryPriceStore access from PositionTracker is broker/account scoped, with
+  legacy symbol-only records treated as untrusted compatibility data.
+
+No activation, fencing, nonce, kill-switch, capital, strategy, risk, or broker
+gate is bypassed. Missing or ambiguous authority fails closed.
+"""
+from __future__ import annotations
+
+import builtins
+import hashlib
+import importlib
+import json
+import logging
+import os
+import re
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+logger = logging.getLogger("nija.production_corrective_set_v18")
+MARKER = "20260807-production-corrective-set-v18"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_INSTALLED = False
+_IMPORT_HOOK_FLAG = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_IMPORT_HOOK"
+_IMPORTLIB_HOOK_FLAG = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_IMPORTLIB_HOOK"
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _live_mode() -> bool:
+    return _truthy("LIVE_CAPITAL_VERIFIED") and not _truthy("DRY_RUN_MODE") and not _truthy("PAPER_MODE")
+
+
+def _writer_lock_key() -> str:
+    explicit = str(os.environ.get("NIJA_WRITER_LOCK_KEY", "") or "").strip()
+    if explicit:
+        return explicit
+    scope = str(os.environ.get("NIJA_WRITER_LOCK_SCOPE", "") or "").strip()
+    if not scope:
+        raw = (
+            str(os.environ.get("KRAKEN_PLATFORM_API_KEY", "") or "").strip()
+            or str(os.environ.get("KRAKEN_API_KEY", "") or "").strip()
+            or "default"
+        )
+        scope = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"nija:writer_lock:{scope}"
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _process_generation() -> int:
+    raw = (
+        str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+        or str(os.environ.get("NIJA_WRITER_GENERATION", "") or "").strip()
+    )
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _strict_writer_runtime_health() -> tuple[bool, str, Any]:
+    module = sys.modules.get("bot.entrypoint_writer_authority") or sys.modules.get("entrypoint_writer_authority")
+    if not isinstance(module, ModuleType):
+        return False, "entrypoint_writer_module_unavailable", None
+    getter = getattr(module, "get_entrypoint_writer_authority", None)
+    if not callable(getter):
+        return False, "entrypoint_writer_getter_unavailable", None
+    try:
+        runtime = getter()
+    except Exception as exc:
+        return False, f"entrypoint_writer_getter_error:{type(exc).__name__}:{exc}", None
+    if runtime is None:
+        return False, "entrypoint_writer_runtime_missing", None
+    if not bool(getattr(runtime, "acquired", False)):
+        return False, "entrypoint_writer_not_acquired", runtime
+    if bool(getattr(runtime, "lost", False)):
+        return False, "entrypoint_writer_lost", runtime
+    health = getattr(runtime, "_nija_lease_renewal_health", None)
+    if not callable(health):
+        return False, "entrypoint_writer_renewal_proof_unavailable", runtime
+    try:
+        ok, reason, age_s, max_age_s = health()
+    except Exception as exc:
+        return False, f"entrypoint_writer_renewal_check_error:{type(exc).__name__}:{exc}", runtime
+    if not bool(ok):
+        return False, f"entrypoint_writer_renewal_unhealthy:{reason}:{age_s:.1f}>{max_age_s:.1f}", runtime
+    return True, "renewal_healthy", runtime
+
+
+def _patch_execution_authority_context(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_EXECUTION_AUTHORITY_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    required = ("get_redis_url", "_connect_redis_for_authority", "_read_current_lease_generation")
+    if not all(callable(getattr(module, name, None)) for name in required):
+        return False
+
+    def assert_distributed_writer_authority() -> None:
+        if _live_mode() and (
+            _truthy("NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK")
+            or _truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
+            or _truthy("NIJA_WRITER_FENCING_TOKEN_FALLBACK")
+        ):
+            raise RuntimeError("STRICT_SINGLE_WRITER_REQUIRED: live distributed-lock bypass refused")
+
+        token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+        generation = _process_generation()
+        if not _truthy("NIJA_WRITER_LEASE_ACQUIRED") or not token or generation <= 0:
+            raise RuntimeError("STRICT_SINGLE_WRITER_REQUIRED: process writer lease/token/generation incomplete")
+
+        redis_url = str(module.get_redis_url() or "").strip()
+        if not redis_url:
+            raise RuntimeError("STRICT_SINGLE_WRITER_REQUIRED: Redis URL unavailable")
+
+        client = module._connect_redis_for_authority(redis_url, timeout_s=2)
+        lock_key = _writer_lock_key()
+        current_text = _as_text(client.get(lock_key))
+        if not current_text:
+            logger.critical("PROCESS_WRITER_LOCK_MISSING marker=%s lock_key=%s token_prefix=%s action=fail_closed", MARKER, lock_key, token[:8])
+            raise RuntimeError(f"STRICT_SINGLE_WRITER_REQUIRED: process writer lock missing lock_key={lock_key}")
+        current_token = current_text.split(":", 1)[0]
+        if current_token != token:
+            logger.critical("PROCESS_WRITER_LOCK_OWNER_MISMATCH marker=%s lock_key=%s expected_prefix=%s current_prefix=%s action=fail_closed", MARKER, lock_key, token[:8], current_token[:8])
+            raise RuntimeError("STRICT_SINGLE_WRITER_REQUIRED: process writer lock belongs to another writer")
+
+        redis_generation, generation_err = module._read_current_lease_generation()
+        if generation_err or int(redis_generation or 0) != generation:
+            raise RuntimeError("STRICT_SINGLE_WRITER_REQUIRED: process writer generation mismatch " f"local={generation} redis={redis_generation} err={generation_err or 'none'}")
+
+        lock = getattr(module, "_FENCE_VERIFY_LOCK", None)
+        if lock is not None:
+            try:
+                with lock:
+                    module._FENCE_LAST_CHECK_TS = time.monotonic()
+                    module._FENCE_LAST_OK = True
+                    module._FENCE_LAST_ERR = ""
+            except Exception:
+                pass
+
+    module.assert_distributed_writer_authority = assert_distributed_writer_authority
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_PROCESS_WRITER_VERIFICATION_READ_ONLY"] = "1"
+    logger.critical("PROCESS_WRITER_VERIFICATION_READ_ONLY_PATCHED marker=%s module=%s", MARKER, module.__name__)
+    return True
+
+
+def _patch_authority_heartbeat(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_AUTHORITY_HEARTBEAT_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    cls = getattr(module, "AuthorityHeartbeatMonitor", None)
+    original_check = getattr(module, "_check_authority_once", None)
+    if not isinstance(cls, type) or not callable(original_check):
+        return False
+
+    @wraps(original_check)
+    def _check_authority_once(timeout_s: float):
+        if _truthy("NIJA_WRITER_LEASE_ACQUIRED") and not _truthy("NIJA_WRITER_FENCING_TOKEN_FALLBACK"):
+            ok, detail, _runtime = _strict_writer_runtime_health()
+            if not ok:
+                return False, detail
+        return original_check(timeout_s)
+
+    def _write_heartbeat_to_redis(self: Any) -> None:
+        try:
+            from bot import execution_authority_context as eac
+        except ImportError:
+            import execution_authority_context as eac  # type: ignore[import]
+
+        token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+        generation = _process_generation()
+        lock_key = str(os.environ.get("NIJA_WRITER_LOCK_KEY", "") or "").strip()
+        if not _truthy("NIJA_WRITER_LEASE_ACQUIRED") or not token or generation <= 0 or not lock_key:
+            raise RuntimeError("authority heartbeat process-writer proof incomplete")
+
+        redis_url = str(eac.get_redis_url() or "").strip()
+        if not redis_url:
+            raise RuntimeError("authority heartbeat Redis unavailable")
+        client = eac._connect_redis_for_authority(redis_url, timeout_s=2)
+        self._redis_client = client
+
+        generation_key = str(os.environ.get("NIJA_LEASE_GENERATION_KEY", "") or "").strip() or "nija:lease:generation"
+        redis_generation_raw = client.get(generation_key)
+        if redis_generation_raw is None:
+            raise RuntimeError("authority heartbeat process generation missing in Redis")
+        try:
+            redis_generation = int(_as_text(redis_generation_raw).strip())
+        except ValueError as exc:
+            raise RuntimeError("authority heartbeat process generation malformed") from exc
+        if redis_generation != generation:
+            logger.critical("AUTHORITY_HEARTBEAT_PROCESS_GENERATION_MISMATCH marker=%s local=%s redis=%s action=fail_closed", MARKER, generation, redis_generation)
+            raise RuntimeError(f"authority heartbeat process generation mismatch local={generation} redis={redis_generation}")
+
+        current = _as_text(client.get(lock_key))
+        if not current:
+            logger.critical("AUTHORITY_HEARTBEAT_PROCESS_LOCK_MISSING marker=%s lock_key=%s action=fail_closed", MARKER, lock_key)
+            raise RuntimeError("authority heartbeat process writer lock missing")
+        current_token = current.split(":", 1)[0]
+        if current_token != token:
+            logger.critical("AUTHORITY_HEARTBEAT_PROCESS_LOCK_OWNER_MISMATCH marker=%s lock_key=%s expected_prefix=%s current_prefix=%s action=fail_closed", MARKER, lock_key, token[:8], current_token[:8])
+            raise RuntimeError("authority heartbeat process writer lock owner mismatch")
+
+        heartbeat_data = {
+            "timestamp": time.time(),
+            "generation": generation,
+            "generation_scope": "process_writer_lock",
+            "instance_id": str(os.environ.get("NIJA_WRITER_INSTANCE_ID", "unknown") or "unknown"),
+            "token_prefix": token[:8],
+            "source": "authority_heartbeat_read_only",
+        }
+        client.set("nija:writer_heartbeat_active", json.dumps(heartbeat_data, sort_keys=True), ex=30)
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_GENERATION_SCOPE_PATCHED"] = "1"
+        logger.debug("AUTHORITY_HEARTBEAT_PROCESS_GENERATION_PUBLISHED marker=%s generation=%s lock_key=%s", MARKER, generation, lock_key)
+
+    module._check_authority_once = _check_authority_once
+    cls._write_heartbeat_to_redis = _write_heartbeat_to_redis
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_AUTHORITY_HEARTBEAT_PROCESS_LOCK_READ_ONLY"] = "1"
+    logger.critical("AUTHORITY_HEARTBEAT_GENERATION_SCOPE_REPAIR_INSTALLED marker=%s module=%s", MARKER, module.__name__)
+    return True
+
+
+def _patch_capital_authority(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_CAPITAL_AUTHORITY_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    original = getattr(module, "_maybe_auto_enable_live_mode", None)
+    if not callable(original):
+        return False
+
+    def _maybe_auto_enable_live_mode(real_capital: float, broker_count: int) -> None:
+        if float(real_capital or 0.0) <= 0.0 or int(broker_count or 0) < 1:
+            return
+        if _truthy("DRY_RUN_MODE") or _truthy("PAPER_MODE"):
+            return
+        if not _truthy("LIVE_CAPITAL_VERIFIED"):
+            os.environ["LIVE_CAPITAL_VERIFIED"] = "true"
+            logger.critical("CAPITAL_AUTHORITY_LIVE_CAPITAL_VERIFIED marker=%s real_capital=%.2f broker_count=%d writer_bypass_auto_enable=false", MARKER, float(real_capital or 0.0), int(broker_count or 0))
+
+    module._maybe_auto_enable_live_mode = _maybe_auto_enable_live_mode
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_CAPITAL_AUTHORITY_WRITER_BYPASS_SEPARATED"] = "1"
+    return True
+
+
+def _scope_token(value: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9_.-]+", "_", str(value or "").strip().lower())
+    return cleaned.strip("_") or "unknown"
+
+
+def _broker_scope(broker: Any) -> str:
+    account = ""
+    venue = ""
+    for attr in ("account_identifier", "account_id", "user_id", "account_name", "owner_id"):
+        value = getattr(broker, attr, None)
+        if value:
+            account = _scope_token(str(value))
+            break
+    if not account:
+        account_type = getattr(broker, "account_type", None)
+        account = _scope_token(str(getattr(account_type, "value", account_type) or "platform"))
+    text_parts: list[str] = []
+    for attr in ("broker_type", "broker_name", "name", "exchange", "exchange_name"):
+        try:
+            value = getattr(broker, attr, "")
+            value = getattr(value, "value", value)
+            text_parts.append(str(value or ""))
+        except Exception:
+            pass
+    text = (" ".join(text_parts) + " " + type(broker).__name__).lower()
+    for candidate in ("kraken", "coinbase", "okx", "alpaca", "binance"):
+        if candidate in text:
+            venue = candidate
+            break
+    return f"{account}:{venue or 'unknown'}"
+
+
+def _position_tracker_scope(tracker: Any) -> str:
+    storage = str(getattr(tracker, "storage_file", "") or "")
+    base = os.path.splitext(os.path.basename(storage))[0]
+    if base.startswith("positions_"):
+        base = base[len("positions_"):]
+    if base and base != "positions":
+        return _scope_token(base).replace("_", ":", 1) if "_" in base else _scope_token(base)
+    broker = getattr(tracker, "broker", None) or getattr(tracker, "_broker", None)
+    if broker is not None:
+        return _broker_scope(broker)
+    return "legacy:unscoped"
+
+
+class _ScopedStoreView:
+    def __init__(self, store: Any, scope: str) -> None:
+        self._store = store
+        self._scope = scope
+
+    def get(self, symbol: str):
+        getter = getattr(self._store, "get_scoped", None)
+        return getter(self._scope, symbol) if callable(getter) else None
+
+    def get_price(self, symbol: str):
+        record = self.get(symbol)
+        return getattr(record, "price", None) if record is not None else None
+
+    def save(self, symbol: str, price: float, source: str = "execution", quantity: float = 0.0) -> None:
+        saver = getattr(self._store, "save_scoped", None)
+        if callable(saver):
+            saver(self._scope, symbol, price, source=source, quantity=quantity)
+
+    def clear(self, symbol: str) -> None:
+        clearer = getattr(self._store, "clear_scoped", None)
+        if callable(clearer):
+            clearer(self._scope, symbol)
+
+
+def _patch_entry_price_store(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_ENTRY_PRICE_STORE_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    cls = getattr(module, "EntryPriceStore", None)
+    record_cls = getattr(module, "EntryPriceRecord", None)
+    if not isinstance(cls, type) or not isinstance(record_cls, type):
+        return False
+
+    def _key(scope: str, symbol: str) -> str:
+        return f"{_scope_token(scope)}::{str(symbol or '').strip()}"
+
+    def save_scoped(self: Any, scope: str, symbol: str, price: float, source: str = "execution", quantity: float = 0.0) -> None:
+        key = _key(scope, symbol)
+        record = record_cls(price=float(price), timestamp=int(time.time()), source=str(source), quantity=float(quantity))
+        with self._lock:
+            self._records[key] = record
+            self._persist()
+        logger.debug("ENTRY_PRICE_SCOPED_SAVE marker=%s scope=%s symbol=%s price=%.8f qty=%.12f source=%s", MARKER, scope, symbol, float(price), float(quantity), source)
+
+    def get_scoped(self: Any, scope: str, symbol: str):
+        with self._lock:
+            return self._records.get(_key(scope, symbol))
+
+    def get_price_scoped(self: Any, scope: str, symbol: str):
+        record = get_scoped(self, scope, symbol)
+        return record.price if record is not None else None
+
+    def clear_scoped(self: Any, scope: str, symbol: str) -> None:
+        key = _key(scope, symbol)
+        with self._lock:
+            if key in self._records:
+                del self._records[key]
+                self._persist()
+
+    def _run_repair(self: Any, broker_getter: Callable, symbols_getter: Callable | None) -> None:
+        try:
+            broker = broker_getter()
+            if broker is None or not callable(getattr(broker, "get_real_entry_price", None)):
+                return
+            scope = _broker_scope(broker)
+            if symbols_getter:
+                symbols = [str(s) for s in list(symbols_getter())]
+            else:
+                prefix = f"{_scope_token(scope)}::"
+                with self._lock:
+                    scoped_keys = [str(k) for k in self._records.keys() if str(k).startswith(prefix)]
+                symbols = [k.split("::", 1)[1] for k in scoped_keys]
+            repaired = 0
+            for symbol in symbols:
+                existing = get_scoped(self, scope, symbol)
+                if existing is not None and str(existing.source) == "execution":
+                    continue
+                try:
+                    api_price = broker.get_real_entry_price(symbol)
+                except Exception as exc:
+                    logger.debug("ENTRY_PRICE_SCOPED_REPAIR_LOOKUP_FAILED scope=%s symbol=%s err=%s", scope, symbol, exc)
+                    continue
+                if api_price and float(api_price) > 0:
+                    qty = float(getattr(existing, "quantity", 0.0) or 0.0) if existing is not None else 0.0
+                    save_scoped(self, scope, symbol, float(api_price), source="api", quantity=qty)
+                    repaired += 1
+                    logger.info("ENTRY_PRICE_SCOPED_REPAIR marker=%s scope=%s symbol=%s price=%.8f qty=%.12f", MARKER, scope, symbol, float(api_price), qty)
+            if repaired:
+                logger.info("ENTRY_PRICE_SCOPED_REPAIR_SWEEP marker=%s scope=%s repaired=%d", MARKER, scope, repaired)
+        except Exception as exc:
+            logger.warning("ENTRY_PRICE_SCOPED_REPAIR_FAILED marker=%s err=%s", MARKER, exc)
+
+    cls.save_scoped = save_scoped
+    cls.get_scoped = get_scoped
+    cls.get_price_scoped = get_price_scoped
+    cls.clear_scoped = clear_scoped
+    cls._run_repair = _run_repair
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_ENTRY_PRICE_STORE_BROKER_SCOPED"] = "1"
+    logger.critical("ENTRY_PRICE_STORE_BROKER_SCOPE_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _patch_position_tracker(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_POSITION_TRACKER_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    cls = getattr(module, "PositionTracker", None)
+    if not isinstance(cls, type):
+        return False
+    original_init = getattr(cls, "__init__", None)
+    original_track_exit = getattr(cls, "track_exit", None)
+    if not callable(original_init) or not callable(original_track_exit):
+        return False
+
+    @wraps(original_init)
+    def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        store = getattr(self, "_eps", None)
+        if store is not None:
+            scope = _position_tracker_scope(self)
+            self._nija_entry_price_scope = scope
+            self._nija_entry_price_store_raw = store
+            self._eps = _ScopedStoreView(store, scope)
+
+    def _persist_entry_price(self: Any, symbol: str, price: float, quantity: float, source: str) -> None:
+        if price <= 0 or not bool(self._source_verified(source, price)):
+            return
+        store = getattr(self, "_eps", None)
+        if store is None:
+            return
+        try:
+            store.save(symbol, price, source=source, quantity=quantity)
+        except Exception as exc:
+            logger.debug("POSITION_TRACKER_SCOPED_ENTRY_SAVE_FAILED symbol=%s err=%s", symbol, exc)
+
+    @wraps(original_track_exit)
+    def track_exit(self: Any, symbol: str, exit_quantity: float = None) -> bool:
+        success = bool(original_track_exit(self, symbol, exit_quantity))
+        if not success:
+            return False
+        remaining = None
+        try:
+            remaining = self.positions.get(symbol)
+        except Exception:
+            pass
+        if remaining is None:
+            store = getattr(self, "_eps", None)
+            if store is not None:
+                try:
+                    store.clear(symbol)
+                except Exception:
+                    pass
+        return True
+
+    cls.__init__ = __init__
+    cls._persist_entry_price = _persist_entry_price
+    cls.track_exit = track_exit
+    setattr(module, patch_attr, True)
+    logger.critical("POSITION_TRACKER_ENTRY_PRICE_SCOPE_PATCHED marker=%s", MARKER)
+    return True
+
+
+def _patch_scan_wrapper(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_SCAN_WRAPPER_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    markers = tuple(getattr(module, "_KNOWN_WRAPPER_MARKERS", ()) or ())
+    if "_nija_scan_identity_lock_v2" not in markers:
+        module._KNOWN_WRAPPER_MARKERS = markers + ("_nija_scan_identity_lock_v2",)
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        core = sys.modules.get(name)
+        cls = getattr(core, "NijaCoreLoop", None) if isinstance(core, ModuleType) else None
+        current = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+        if not callable(current):
+            continue
+        if getattr(current, "_nija_scan_wrapper_release", "") == getattr(module, "_MARKER", ""):
+            base = getattr(current, "__wrapped__", None)
+            unwrap = getattr(module, "_unwrap_known", None)
+            patch_core = getattr(module, "_patch_core_loop", None)
+            if callable(base) and callable(unwrap) and callable(patch_core):
+                resolved, depth, cycle = unwrap(base)
+                if callable(resolved) and resolved is not base and not cycle:
+                    setattr(cls, "run_scan_phase", base)
+                    patch_core(core)
+                    logger.critical("SCAN_NESTED_OWNER_REMOVED marker=%s module=%s removed_layers=%d", MARKER, name, depth)
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_SCAN_IDENTITY_OWNER_COLLAPSED"] = "1"
+    return True
+
+
+def _patch_runtime_convergence_v2(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_RUNTIME_SCAN_OWNER_GUARDED"
+    if getattr(module, patch_attr, False):
+        return False
+    original = getattr(module, "_patch_core_loop", None)
+    if not callable(original):
+        return False
+
+    @wraps(original)
+    def _patch_core_loop(core_module: ModuleType) -> bool:
+        cls = getattr(core_module, "NijaCoreLoop", None)
+        current = getattr(cls, "run_scan_phase", None) if isinstance(cls, type) else None
+        scan_module = sys.modules.get("scan_wrapper_convergence_repair_patch") or sys.modules.get("bot.scan_wrapper_convergence_repair_patch")
+        chain_has = getattr(scan_module, "_chain_has_current_owner", None) if isinstance(scan_module, ModuleType) else None
+        if callable(current) and callable(chain_has) and bool(chain_has(current)):
+            logger.debug("RUNTIME_V2_SCAN_OWNER_DELEGATED marker=%s", MARKER)
+            return True
+        return bool(original(core_module))
+
+    module._patch_core_loop = _patch_core_loop
+    setattr(module, patch_attr, True)
+    return True
+
+
+def _capital_fallback_status() -> dict[str, Any]:
+    for name in ("nija_capital_refresh_stall_guard_v35_prebot", "capital_refresh_stall_guard_v35", "bot.capital_refresh_stall_guard_v35"):
+        mod = sys.modules.get(name)
+        getter = getattr(mod, "current_refresh_fallback_status", None) if isinstance(mod, ModuleType) else None
+        if callable(getter):
+            try:
+                return dict(getter() or {})
+            except Exception:
+                return {}
+    return {}
+
+
+def _patch_capital_flow(module: ModuleType) -> bool:
+    patch_attr = "_NIJA_PRODUCTION_CORRECTIVE_SET_V18_CAPITAL_FLOW_PATCHED"
+    if getattr(module, patch_attr, False):
+        return False
+    confidence_cls = getattr(module, "CapitalConfidence", None)
+    trace = getattr(module, "_log_snapshot_trace_throttled", None)
+    if not isinstance(confidence_cls, type) or not callable(trace):
+        return False
+    original_compute = confidence_cls.compute
+
+    def compute(kraken_response_age_s: float, assets_priced_success_pct: float, api_error_count: int, freshness_ttl_s: float = getattr(module, "FRESHNESS_TTL_S", 90.0)):
+        result = original_compute(kraken_response_age_s, assets_priced_success_pct, api_error_count, freshness_ttl_s)
+        status = _capital_fallback_status()
+        if not bool(status.get("used_fallback")):
+            return result
+        all_recent = bool(status.get("all_recent"))
+        excluded = bool(status.get("excluded_brokers"))
+        freshness = 0.0 if (not all_recent or excluded) else min(float(result.freshness_score), 0.50)
+        pricing = float(result.pricing_score)
+        errors = min(float(result.error_score), 0.50 if excluded else 0.75)
+        score = round(0.50 * freshness + 0.35 * pricing + 0.15 * errors, 6)
+        high = float(getattr(module, "CONFIDENCE_HIGH_THRESHOLD", 0.80))
+        medium = float(getattr(module, "CONFIDENCE_MEDIUM_THRESHOLD", 0.40))
+        band_enum = getattr(module, "CapitalConfidenceBand")
+        band = band_enum.HIGH if score >= high else band_enum.MEDIUM if score >= medium else band_enum.LOW
+        return confidence_cls(freshness_score=freshness, pricing_score=pricing, error_score=errors, confidence_score=score, band=band)
+
+    @wraps(trace)
+    def _log_snapshot_trace_throttled(balances: dict[str, float], valid_brokers: int, source: str) -> None:
+        status = _capital_fallback_status()
+        if bool(status.get("used_fallback")):
+            source = "cached_live_observation" if bool(status.get("all_recent")) else "partial_or_excluded_fallback"
+        return trace(balances, valid_brokers, source)
+
+    confidence_cls.compute = staticmethod(compute)
+    module._log_snapshot_trace_throttled = _log_snapshot_trace_throttled
+    setattr(module, patch_attr, True)
+    os.environ["NIJA_CAPITAL_FALLBACK_PROVENANCE_PATCHED"] = "1"
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    targets: tuple[tuple[tuple[str, ...], Callable[[ModuleType], bool]], ...] = (
+        (("bot.execution_authority_context", "execution_authority_context"), _patch_execution_authority_context),
+        (("bot.authority_heartbeat", "authority_heartbeat"), _patch_authority_heartbeat),
+        (("bot.capital_authority", "capital_authority"), _patch_capital_authority),
+        (("bot.entry_price_store", "entry_price_store"), _patch_entry_price_store),
+        (("bot.position_tracker", "position_tracker"), _patch_position_tracker),
+        (("scan_wrapper_convergence_repair_patch", "bot.scan_wrapper_convergence_repair_patch"), _patch_scan_wrapper),
+        (("runtime_convergence_v2_patch", "bot.runtime_convergence_v2_patch"), _patch_runtime_convergence_v2),
+        (("bot.capital_flow_state_machine", "capital_flow_state_machine"), _patch_capital_flow),
+    )
+    for names, patcher in targets:
+        seen: set[int] = set()
+        for name in names:
+            module = sys.modules.get(name)
+            if isinstance(module, ModuleType) and id(module) not in seen:
+                seen.add(id(module))
+                try:
+                    changed = bool(patcher(module)) or changed
+                except Exception:
+                    logger.exception("PRODUCTION_CORRECTIVE_SET_PATCH_FAILED marker=%s module=%s", MARKER, name)
+    return changed
+
+
+def _interesting_import(name: str) -> bool:
+    suffixes = ("execution_authority_context", "authority_heartbeat", "capital_authority", "entry_price_store", "position_tracker", "scan_wrapper_convergence_repair_patch", "runtime_convergence_v2_patch", "capital_flow_state_machine")
+    return any(str(name or "").endswith(suffix) for suffix in suffixes)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _IMPORT_HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                module = original_import(name, globals, locals, fromlist, level)
+                if _interesting_import(name):
+                    _patch_loaded()
+                return module
+
+            builtins.__import__ = importing
+            setattr(builtins, _IMPORT_HOOK_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_HOOK_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                module = original_import_module(name, package)
+                if _interesting_import(name):
+                    _patch_loaded()
+                return module
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_HOOK_FLAG, True)
+
+        _INSTALLED = True
+        os.environ["NIJA_PRODUCTION_CORRECTIVE_SET_V18_INSTALLED"] = "1"
+        os.environ["NIJA_PRODUCTION_CORRECTIVE_SET_V18_MARKER"] = MARKER
+        logger.critical("PRODUCTION_CORRECTIVE_SET_V18_INSTALLED marker=%s fail_closed=true writer_lock_read_only_outside_owner=true entry_price_scoped=true", MARKER)
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_patch_loaded",
+    "_patch_execution_authority_context",
+    "_patch_authority_heartbeat",
+    "_patch_capital_authority",
+    "_patch_entry_price_store",
+    "_patch_position_tracker",
+    "_patch_scan_wrapper",
+    "_patch_runtime_convergence_v2",
+    "_patch_capital_flow",
+]

--- a/bot/tests/test_capital_refresh_stall_guard_v36.py
+++ b/bot/tests/test_capital_refresh_stall_guard_v36.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+import time
+import sys
+from pathlib import Path
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "capital_refresh_stall_guard_v35.py"
+spec = importlib.util.spec_from_file_location("capital_v36_under_test", PATCH_PATH)
+assert spec and spec.loader
+cap = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cap
+spec.loader.exec_module(cap)
+
+
+def _reset():
+    cap._IN_FLIGHT.clear(); cap._BROKER_SEQUENCE.clear(); cap._OBSERVATIONS.clear(); cap._LAST_TIMEOUT_LOGGED.clear(); cap._WAS_TIMING_OUT.clear(); cap._begin_refresh_context()
+
+
+def test_reused_inflight_fetch_reuses_same_queue(monkeypatch):
+    _reset(); monkeypatch.setenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "2"); gate = threading.Event()
+    class Broker:
+        def get_account_balance(self): gate.wait(1.0); return 123.45
+    broker = Broker(); first = cap._BalanceFetchBatch({"coinbase": broker}); second = cap._BalanceFetchBatch({"coinbase": broker})
+    assert first._flights["coinbase"].sequence == second._flights["coinbase"].sequence
+    assert first._flights["coinbase"].result_queue is second._flights["coinbase"].result_queue
+    gate.set(); assert second.result_for("coinbase", broker) == 123.45
+
+
+def test_recent_confirmed_observation_used_with_original_age(monkeypatch):
+    _reset(); monkeypatch.setenv("NIJA_CAPITAL_FRESHNESS_TTL_S", "90")
+    now_mono = time.monotonic(); now_epoch = time.time()
+    cap._OBSERVATIONS["okx"] = cap._Observation(144.96, now_mono - 12.0, now_epoch - 12.0, 7)
+    batch = object.__new__(cap._BalanceFetchBatch); value = batch._handle_failure("okx", "timeout")
+    assert value == 144.96
+    status = cap.current_refresh_fallback_status(); row = status["brokers"]["okx"]
+    assert 10.0 <= row["age_s"] <= 20.0
+    assert row["observed_epoch"] == now_epoch - 12.0
+    assert status["source"] == "cached_live_observation"
+
+
+def test_stale_observation_is_excluded_not_revived(monkeypatch):
+    _reset(); monkeypatch.setenv("NIJA_CAPITAL_FRESHNESS_TTL_S", "30")
+    cap._OBSERVATIONS["kraken"] = cap._Observation(228.06, time.monotonic() - 120.0, time.time() - 120.0, 3)
+    batch = object.__new__(cap._BalanceFetchBatch); value = batch._handle_failure("kraken", "timeout")
+    assert value == 0.0
+    status = cap.current_refresh_fallback_status()
+    assert "kraken" in status["excluded_brokers"]
+    assert status["all_recent"] is False
+    assert status["source"] == "partial_or_excluded_fallback"

--- a/bot/tests/test_production_corrective_set_v18.py
+++ b/bot/tests/test_production_corrective_set_v18.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "production_corrective_set_v18_patch.py"
+spec = importlib.util.spec_from_file_location("v18_under_test", PATCH_PATH)
+assert spec and spec.loader
+v18 = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = v18
+spec.loader.exec_module(v18)
+
+
+class FakeRedis:
+    def __init__(self, data=None):
+        self.data = dict(data or {})
+        self.writes = []
+        self.expire_calls = []
+        self.delete_calls = []
+
+    def get(self, key): return self.data.get(key)
+    def set(self, key, value, **kwargs): self.writes.append((key, value, kwargs)); self.data[key] = value; return True
+    def expire(self, key, ttl): self.expire_calls.append((key, ttl)); return True
+    def delete(self, key): self.delete_calls.append(key); self.data.pop(key, None); return 1
+
+
+def _env_writer(monkeypatch, generation="42", token="tok42"):
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", token)
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", generation)
+    monkeypatch.setenv("NIJA_WRITER_GENERATION", generation)
+    monkeypatch.setenv("NIJA_WRITER_LOCK_KEY", "nija:writer_lock:test")
+    monkeypatch.setenv("NIJA_LEASE_GENERATION_KEY", "nija:lease:generation")
+
+
+def test_execution_authority_missing_lock_is_read_only(monkeypatch):
+    _env_writer(monkeypatch)
+    client = FakeRedis({"nija:lease:generation": "42"})
+    module = ModuleType("execution_authority_context")
+    module.get_redis_url = lambda: "rediss://example"
+    module._connect_redis_for_authority = lambda url, timeout_s=2: client
+    module._read_current_lease_generation = lambda: (42, "")
+    module._FENCE_VERIFY_LOCK = threading.Lock()
+    module._FENCE_LAST_CHECK_TS = 0.0; module._FENCE_LAST_OK = False; module._FENCE_LAST_ERR = ""
+    assert v18._patch_execution_authority_context(module)
+    try:
+        module.assert_distributed_writer_authority()
+    except RuntimeError as exc:
+        assert "lock missing" in str(exc)
+    else:
+        raise AssertionError("missing process lock must fail closed")
+    assert client.writes == [] and client.expire_calls == [] and client.delete_calls == []
+
+
+def test_authority_heartbeat_writes_only_heartbeat(monkeypatch):
+    _env_writer(monkeypatch)
+    monkeypatch.setenv("NIJA_WRITER_INSTANCE_ID", "instance-a")
+    client = FakeRedis({"nija:lease:generation": "42", "nija:writer_lock:test": "tok42:owner"})
+    eac = ModuleType("bot.execution_authority_context")
+    eac.get_redis_url = lambda: "rediss://example"
+    eac._connect_redis_for_authority = lambda url, timeout_s=2: client
+    sys.modules["bot.execution_authority_context"] = eac
+    sys.modules["execution_authority_context"] = eac
+    module = ModuleType("authority_heartbeat")
+    module._check_authority_once = lambda timeout_s: (True, "")
+    class Monitor: pass
+    module.AuthorityHeartbeatMonitor = Monitor
+    assert v18._patch_authority_heartbeat(module)
+    Monitor()._write_heartbeat_to_redis()
+    assert len(client.writes) == 1 and client.writes[0][0] == "nija:writer_heartbeat_active"
+    assert client.expire_calls == [] and client.delete_calls == []
+    assert client.data["nija:writer_lock:test"] == "tok42:owner"
+
+
+def test_capital_authority_does_not_auto_enable_writer_bypass(monkeypatch):
+    monkeypatch.delenv("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK", raising=False)
+    module = ModuleType("capital_authority")
+    def legacy(real_capital, broker_count):
+        os.environ["LIVE_CAPITAL_VERIFIED"] = "true"
+        os.environ["NIJA_" + "FORCE_LOCAL_WRITER_LOCK_FALLBACK"] = "true"
+    module._maybe_auto_enable_live_mode = legacy
+    assert v18._patch_capital_authority(module)
+    module._maybe_auto_enable_live_mode(100.0, 1)
+    assert os.environ.get("LIVE_CAPITAL_VERIFIED") == "true"
+    assert "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK" not in os.environ
+
+
+def test_entry_price_store_is_scoped_by_broker():
+    module = ModuleType("entry_price_store")
+    @dataclass
+    class Record:
+        price: float; timestamp: int; source: str; quantity: float = 0.0
+    class Store:
+        def __init__(self): self._records = {}; self._lock = threading.Lock()
+        def _persist(self): pass
+    module.EntryPriceRecord = Record; module.EntryPriceStore = Store
+    assert v18._patch_entry_price_store(module)
+    store = Store()
+    store.save_scoped("platform:coinbase", "ETH-USD", 1742.92, source="api", quantity=0.006)
+    store.save_scoped("platform:okx", "ETH-USD", 1800.0, source="api", quantity=0.0000002)
+    cb = store.get_scoped("platform:coinbase", "ETH-USD"); okx = store.get_scoped("platform:okx", "ETH-USD")
+    assert cb.price == 1742.92 and cb.quantity == 0.006
+    assert okx.price == 1800.0 and okx.quantity == 0.0000002 and cb is not okx
+
+
+def test_scan_wrapper_recognizes_runtime_v2_owner():
+    module = ModuleType("scan_wrapper_convergence_repair_patch")
+    module._KNOWN_WRAPPER_MARKERS = ("_nija_scan_wrapper_canonical_v2",); module._MARKER = "scan-marker"
+    assert v18._patch_scan_wrapper(module)
+    assert "_nija_scan_identity_lock_v2" in module._KNOWN_WRAPPER_MARKERS
+
+
+def test_writer_epoch_missing_lock_does_not_resurrect(tmp_path):
+    path = Path(__file__).resolve().parents[1] / "entrypoint_writer_epoch_recovery_v19_patch.py"
+    spec2 = importlib.util.spec_from_file_location("writer_epoch_v19_test", path)
+    mod = importlib.util.module_from_spec(spec2); spec2.loader.exec_module(mod)
+    ewa = ModuleType("entrypoint_writer_authority")
+    class Redis:
+        def __init__(self): self.writes=[]
+        def get(self, key): return None
+        def set(self, *a, **k): self.writes.append((a,k)); return True
+    class EWA:
+        def __init__(self): self._local_fallback=False; self._client=Redis(); self._lock_key="lock"; self._lock_value="7:owner"
+        def _heartbeat_tick(self): self._client.set(self._lock_key, self._lock_value); return True, ""
+    ewa.EntrypointWriterAuthority = EWA
+    assert mod._patch(ewa)
+    runtime=EWA(); ok, reason=runtime._heartbeat_tick()
+    assert ok is False and reason == "lock_missing_and_fencing_token_mismatch"
+    assert runtime._client.writes == []

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -8,8 +8,8 @@ chance to wrap writer acquisition.
 
 The launcher does not acquire writer authority, connect brokers, synthesize
 capital, force activation, or submit orders. It installs the existing
-fail-closed startup, reconnect, and capital-readiness convergence contracts
-before application imports.
+fail-closed startup, reconnect, capital-readiness, and production-corrective
+contracts before application imports.
 """
 from __future__ import annotations
 
@@ -22,13 +22,15 @@ import sys
 from types import ModuleType
 from typing import Any
 
-MARKER = "20260727-canonical-runtime-launcher-v26-v35"
+MARKER = "20260807-canonical-runtime-launcher-v26-v36-v18"
 ROOT = Path(__file__).resolve().parents[1]
 V24_PATH = ROOT / "bot" / "canonical_broker_startup_convergence_v24.py"
 V32_PATH = ROOT / "bot" / "runtime_execution_convergence_v32.py"
 V33_PATH = ROOT / "bot" / "runtime_execution_convergence_v33.py"
 V34_PATH = ROOT / "bot" / "capital_readiness_handoff_v34.py"
 V35_PATH = ROOT / "bot" / "capital_refresh_stall_guard_v35.py"
+V18_PATH = ROOT / "bot" / "production_corrective_set_v18_patch.py"
+V19_PATH = ROOT / "bot" / "entrypoint_writer_epoch_recovery_v19_patch.py"
 MAIN_PATH = ROOT / "main.py"
 LOGGER = logging.getLogger("nija.canonical_runtime_launcher")
 
@@ -44,28 +46,18 @@ def _load_module_by_path(module_name: str, path: Path) -> ModuleType:
 
 
 def _install_runtime_execution_convergence() -> ModuleType:
-    """Install reconnect/Kraken convergence and bound-method safety."""
     if not V32_PATH.is_file():
         raise RuntimeError(f"runtime execution convergence module missing: {V32_PATH}")
-    module = _load_module_by_path(
-        "nija_runtime_execution_convergence_v32_prebot", V32_PATH
-    )
-    installer: Any = getattr(module, "install_import_hook", None) or getattr(
-        module, "install", None
-    )
+    module = _load_module_by_path("nija_runtime_execution_convergence_v32_prebot", V32_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
     if not callable(installer) or not bool(installer()):
         raise RuntimeError("runtime execution convergence v32 installer failed")
     if os.environ.get("NIJA_RUNTIME_EXECUTION_CONVERGENCE_V32_INSTALLED") != "1":
         raise RuntimeError("runtime execution convergence v32 did not attest installed")
-
     if not V33_PATH.is_file():
         raise RuntimeError(f"runtime execution convergence hotfix missing: {V33_PATH}")
-    hotfix = _load_module_by_path(
-        "nija_runtime_execution_convergence_v33_prebot", V33_PATH
-    )
-    hotfix_installer: Any = getattr(hotfix, "install_import_hook", None) or getattr(
-        hotfix, "install", None
-    )
+    hotfix = _load_module_by_path("nija_runtime_execution_convergence_v33_prebot", V33_PATH)
+    hotfix_installer: Any = getattr(hotfix, "install_import_hook", None) or getattr(hotfix, "install", None)
     if not callable(hotfix_installer) or not bool(hotfix_installer()):
         raise RuntimeError("runtime execution convergence v33 installer failed")
     if os.environ.get("NIJA_RUNTIME_EXECUTION_CONVERGENCE_V33_INSTALLED") != "1":
@@ -74,15 +66,10 @@ def _install_runtime_execution_convergence() -> ModuleType:
 
 
 def _install_capital_readiness_handoff() -> ModuleType:
-    """Install the evidence-backed CSM-to-execution readiness handoff."""
     if not V34_PATH.is_file():
         raise RuntimeError(f"capital readiness handoff missing: {V34_PATH}")
-    module = _load_module_by_path(
-        "nija_capital_readiness_handoff_v34_prebot", V34_PATH
-    )
-    installer: Any = getattr(module, "install_import_hook", None) or getattr(
-        module, "install", None
-    )
+    module = _load_module_by_path("nija_capital_readiness_handoff_v34_prebot", V34_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
     if not callable(installer) or not bool(installer()):
         raise RuntimeError("capital readiness handoff v34 installer failed")
     if os.environ.get("NIJA_CAPITAL_READINESS_HANDOFF_V34_INSTALLED") != "1":
@@ -91,54 +78,58 @@ def _install_capital_readiness_handoff() -> ModuleType:
 
 
 def _install_capital_refresh_stall_guard() -> ModuleType:
-    """Bound coordinator broker fetches so bootstrap cannot remain in-flight."""
     if not V35_PATH.is_file():
         raise RuntimeError(f"capital refresh stall guard missing: {V35_PATH}")
-    module = _load_module_by_path(
-        "nija_capital_refresh_stall_guard_v35_prebot", V35_PATH
-    )
-    installer: Any = getattr(module, "install_import_hook", None) or getattr(
-        module, "install", None
-    )
+    module = _load_module_by_path("nija_capital_refresh_stall_guard_v35_prebot", V35_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
     if not callable(installer) or not bool(installer()):
-        raise RuntimeError("capital refresh stall guard v35 installer failed")
-    if os.environ.get("NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED") != "1":
-        raise RuntimeError("capital refresh stall guard v35 did not attest installed")
+        raise RuntimeError("capital refresh stall guard v36 installer failed")
+    if os.environ.get("NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED") != "1":
+        raise RuntimeError("capital refresh stall guard v36 did not attest installed")
+    return module
+
+
+def _install_writer_epoch_recovery() -> ModuleType:
+    if not V19_PATH.is_file():
+        raise RuntimeError(f"writer epoch recovery missing: {V19_PATH}")
+    module = _load_module_by_path("nija_writer_epoch_recovery_v19_prebot", V19_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("writer epoch recovery v19 installer failed")
+    if os.environ.get("NIJA_WRITER_EPOCH_RECOVERY_V19_INSTALLED") != "1":
+        raise RuntimeError("writer epoch recovery v19 did not attest installed")
+    return module
+
+
+def _install_production_corrective_set() -> ModuleType:
+    if not V18_PATH.is_file():
+        raise RuntimeError(f"production corrective set missing: {V18_PATH}")
+    module = _load_module_by_path("nija_production_corrective_set_v18_prebot", V18_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("production corrective set v18 installer failed")
+    if os.environ.get("NIJA_PRODUCTION_CORRECTIVE_SET_V18_INSTALLED") != "1":
+        raise RuntimeError("production corrective set v18 did not attest installed")
     return module
 
 
 def install_canonical_startup_guard() -> ModuleType:
-    """Install v24, v32, v33, v34, and v35 before any application import."""
     if "bot.bot_main" in sys.modules:
-        raise RuntimeError(
-            "bot.bot_main loaded before canonical launcher guard; startup ordering unsafe"
-        )
-
-    module = _load_module_by_path(
-        "nija_canonical_broker_startup_convergence_v24_prebot", V24_PATH
-    )
-    installer: Any = getattr(module, "install_import_hook", None) or getattr(
-        module, "install", None
-    )
+        raise RuntimeError("bot.bot_main loaded before canonical launcher guard; startup ordering unsafe")
+    module = _load_module_by_path("nija_canonical_broker_startup_convergence_v24_prebot", V24_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
     if not callable(installer) or not bool(installer()):
         raise RuntimeError("canonical startup convergence v24 installer failed")
-    if os.environ.get(
-        "NIJA_CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_INSTALLED"
-    ) != "1":
+    if os.environ.get("NIJA_CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_INSTALLED") != "1":
         raise RuntimeError("canonical startup convergence v24 did not attest installed")
-
     _install_runtime_execution_convergence()
     _install_capital_readiness_handoff()
     _install_capital_refresh_stall_guard()
-
+    _install_writer_epoch_recovery()
+    _install_production_corrective_set()
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY"] = "1"
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_MARKER"] = MARKER
-    LOGGER.critical(
-        "CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s "
-        "bot_main_preloaded=false v24_installed=true v32_installed=true "
-        "v33_installed=true v34_installed=true v35_installed=true",
-        MARKER,
-    )
+    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v19_installed=true v18_installed=true", MARKER)
     return module
 
 
@@ -148,12 +139,7 @@ def main() -> int:
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
-    print(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED "
-        "marker=20260727-canonical-fast-entrypoint-v35 "
-        "package_hook_fanout=deferred",
-        flush=True,
-    )
+    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v36-v18 package_hook_fanout=deferred", flush=True)
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
     return 0
 


### PR DESCRIPTION
## Purpose
Apply the remaining fail-closed production corrections after nonce/process generation separation.

## Changes
- Make distributed writer verification read-only outside EntrypointWriterAuthority.
- Make authority-heartbeat publication verify process generation/lock ownership without renewing or recreating the process writer lock.
- Treat a missing EntrypointWriterAuthority lock as ownership-epoch loss so the old fencing token cannot resurrect the lock; canonical restart/re-election obtains a fresh epoch.
- Prevent capital hydration from auto-enabling local writer-lock fallback.
- Collapse the runtime-v2 nested scan-owner layer that caused same-thread REENTRANT_SCAN_SUPPRESSED/scored=0 cycles.
- Repair capital refresh in-flight reuse by sharing the same result queue; preserve trusted live-observation timestamps and exclude stale/untrusted fallbacks.
- Reduce capital confidence and report truthful provenance when cached live observations are used.
- Scope EntryPriceStore access used by PositionTracker by account/broker so same-symbol records do not bleed between venues/accounts.
- Wire all corrective guards into the canonical pre-bootstrap launcher.

## Safety
- No force activation.
- No distributed-lock/local-writer bypass is enabled.
- Missing/mismatched Redis authority fails closed.
- Stale capital is excluded instead of revived from an older authority snapshot.
- Existing fencing, nonce, capital, kill-switch, risk, strategy, execution, and broker gates remain in force.

## Validation
- `python -m py_compile` passed for the new/modified candidate modules and regression tests in the available local execution environment.
- Targeted regression suite: **9 passed**.
- Covered missing-lock read-only verification, heartbeat lock immutability, no automatic local-writer fallback, broker-scoped entry prices, scan-owner marker convergence, writer-epoch no-resurrection, shared in-flight capital queue, recent fallback timestamp preservation, and stale fallback exclusion.

## Validation limitation
A full repository checkout/GitHub CLI is unavailable in the execution environment, so repo-wide pytest and GitHub Actions were not run here. Please review any registered GitHub checks before manual merge.