### PR TITLE
Fix heartbeat authority split and false Redis blocker

### DIFF
--- a/bot/heartbeat_authority_identity_v38_patch.py
+++ b/bot/heartbeat_authority_identity_v38_patch.py
@@ -1,0 +1,362 @@
+"""Canonical heartbeat/authority identity bridge v38.
+
+Repairs a startup-only authority split where ``bot.heartbeat_state`` and the
+legacy ``heartbeat_state`` import path can each create their own module-level
+singleton.  A writer heartbeat may therefore be successfully renewed and
+exported to the environment while an authority reader consults a different,
+uninitialised HeartbeatState and reports ``age=inf`` / ``authoritative=False``.
+
+The bridge is installed by the canonical launcher before any ``bot`` import.
+It does not acquire authority, refresh Redis, create fencing tokens, or bypass
+any gate.  It only makes all heartbeat readers/writers share one process-wide
+state object and makes recursive status checks consume that same canonical
+monotonic proof plus the already-established entrypoint lease-renewal proof.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Optional
+
+logger = logging.getLogger("nija.heartbeat_authority_identity_v38")
+MARKER = "20260807-heartbeat-authority-identity-v38"
+
+_LOCK = threading.RLock()
+_INSTALLED = False
+_HOOK_FLAG = "_NIJA_HEARTBEAT_AUTHORITY_IDENTITY_V38_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_HEARTBEAT_AUTHORITY_IDENTITY_V38_IMPORTLIB_HOOK"
+_STATE_KEY = "_NIJA_CANONICAL_HEARTBEAT_STATE_V38"
+_STATE_LOCK_KEY = "_NIJA_CANONICAL_HEARTBEAT_STATE_LOCK_V38"
+_HEARTBEAT_PATCHED = "_NIJA_HEARTBEAT_IDENTITY_V38_PATCHED"
+_RECURSION_PATCHED = "_NIJA_WRITER_REENTRY_CANONICAL_V38_PATCHED"
+
+_HEARTBEAT_NAMES = ("bot.heartbeat_state", "heartbeat_state")
+_RECURSION_NAMES = (
+    "bot.writer_authority_recursion_guard_patch",
+    "writer_authority_recursion_guard_patch",
+)
+_ENTRYPOINT_NAMES = ("bot.entrypoint_writer_authority", "entrypoint_writer_authority")
+_SINGLE_SOURCE_NAMES = (
+    "bot.heartbeat_authority_single_source_patch",
+    "heartbeat_authority_single_source_patch",
+)
+
+
+def _shared_lock() -> threading.RLock:
+    lock = getattr(builtins, _STATE_LOCK_KEY, None)
+    if lock is None:
+        with _LOCK:
+            lock = getattr(builtins, _STATE_LOCK_KEY, None)
+            if lock is None:
+                lock = threading.RLock()
+                setattr(builtins, _STATE_LOCK_KEY, lock)
+    return lock
+
+
+def _bind_aliases(module: ModuleType) -> None:
+    sys.modules["bot.heartbeat_state"] = module
+    sys.modules["heartbeat_state"] = module
+
+
+def _state_score(state: Any) -> tuple[int, float, int]:
+    if state is None:
+        return (0, 0.0, 0)
+    try:
+        snap = state.snapshot()
+        ts = float(getattr(snap, "timestamp", 0.0) or 0.0)
+        generation = int(getattr(snap, "generation", 0) or 0)
+        healthy = 1 if bool(getattr(snap, "healthy", False)) else 0
+        return (healthy, ts, generation)
+    except Exception:
+        return (0, 0.0, 0)
+
+
+def _patch_heartbeat_state(module: ModuleType) -> bool:
+    if getattr(module, _HEARTBEAT_PATCHED, False):
+        _bind_aliases(module)
+        return True
+
+    state_cls = getattr(module, "HeartbeatState", None)
+    if not isinstance(state_cls, type):
+        return False
+
+    existing_local = getattr(module, "_SINGLETON", None)
+    with _shared_lock():
+        shared = getattr(builtins, _STATE_KEY, None)
+        if shared is None or _state_score(existing_local) > _state_score(shared):
+            shared = existing_local if existing_local is not None else state_cls()
+            setattr(builtins, _STATE_KEY, shared)
+
+    def get_heartbeat_state() -> Any:
+        with _shared_lock():
+            state = getattr(builtins, _STATE_KEY, None)
+            if state is None:
+                state = state_cls()
+                setattr(builtins, _STATE_KEY, state)
+            module._SINGLETON = state
+            return state
+
+    def reset_heartbeat_state_for_testing() -> Any:
+        with _shared_lock():
+            state = state_cls()
+            setattr(builtins, _STATE_KEY, state)
+            module._SINGLETON = state
+            return state
+
+    module.get_heartbeat_state = get_heartbeat_state
+    module.reset_heartbeat_state_for_testing = reset_heartbeat_state_for_testing
+    module._SINGLETON = get_heartbeat_state()
+    setattr(module, _HEARTBEAT_PATCHED, True)
+    _bind_aliases(module)
+
+    logger.critical(
+        "HEARTBEAT_STATE_IDENTITY_V38_PATCHED marker=%s module=%s shared_state_id=%s aliases_same=true",
+        MARKER,
+        module.__name__,
+        hex(id(module._SINGLETON)),
+    )
+    return True
+
+
+def _canonical_heartbeat_proof(generation: int) -> dict[str, Any]:
+    max_age_s = 120.0
+    try:
+        max_age_s = max(
+            5.0,
+            float(os.environ.get("NIJA_WRITER_HEARTBEAT_MAX_AGE_S", "120") or 120.0),
+        )
+    except (TypeError, ValueError):
+        pass
+
+    for name in _SINGLE_SOURCE_NAMES:
+        module = sys.modules.get(name)
+        getter = getattr(module, "heartbeat_max_age_s", None) if isinstance(module, ModuleType) else None
+        if callable(getter):
+            try:
+                max_age_s = max(5.0, float(getter()))
+            except Exception:
+                pass
+            break
+
+    state_module = sys.modules.get("bot.heartbeat_state") or sys.modules.get("heartbeat_state")
+    getter = getattr(state_module, "get_heartbeat_state", None) if isinstance(state_module, ModuleType) else None
+    if not callable(getter):
+        return {
+            "healthy": False,
+            "authoritative": False,
+            "age_s": float("inf"),
+            "heartbeat_ts": 0.0,
+            "max_age_s": max_age_s,
+        }
+    try:
+        healthy, age_s, authoritative, heartbeat_ts = getter().health_for_generation(
+            expected_generation=int(generation or 0),
+            max_age_s=max_age_s,
+        )
+        return {
+            "healthy": bool(healthy),
+            "authoritative": bool(authoritative),
+            "age_s": float(age_s),
+            "heartbeat_ts": float(heartbeat_ts or 0.0),
+            "max_age_s": max_age_s,
+        }
+    except Exception as exc:
+        logger.warning("HEARTBEAT_STATE_IDENTITY_V38_READ_FAILED marker=%s error=%s", MARKER, exc)
+        return {
+            "healthy": False,
+            "authoritative": False,
+            "age_s": float("inf"),
+            "heartbeat_ts": 0.0,
+            "max_age_s": max_age_s,
+        }
+
+
+def _entrypoint_renewal_proof() -> dict[str, Any]:
+    for name in _ENTRYPOINT_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if not callable(getter):
+            continue
+        try:
+            runtime = getter()
+        except Exception as exc:
+            return {"ok": False, "reason": f"runtime_getter_error:{type(exc).__name__}:{exc}"}
+        if runtime is None:
+            return {"ok": False, "reason": "runtime_missing"}
+        if not bool(getattr(runtime, "acquired", False)):
+            return {"ok": False, "reason": "runtime_not_acquired"}
+        if bool(getattr(runtime, "lost", False)):
+            return {"ok": False, "reason": "runtime_lost"}
+        health = getattr(runtime, "_nija_lease_renewal_health", None)
+        if not callable(health):
+            return {"ok": False, "reason": "renewal_proof_unavailable"}
+        try:
+            ok, reason, age_s, max_age_s = health()
+            return {
+                "ok": bool(ok),
+                "reason": str(reason or ""),
+                "age_s": float(age_s),
+                "max_age_s": float(max_age_s),
+            }
+        except Exception as exc:
+            return {"ok": False, "reason": f"renewal_check_error:{type(exc).__name__}:{exc}"}
+    return {"ok": False, "reason": "entrypoint_writer_module_unavailable"}
+
+
+def _patch_recursion_guard(module: ModuleType) -> bool:
+    if getattr(module, _RECURSION_PATCHED, False):
+        return True
+    original = getattr(module, "_writer_reentry_proof", None)
+    if not callable(original):
+        return False
+
+    def _writer_reentry_proof() -> dict[str, Any]:
+        token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+        generation_text = str(
+            os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")
+            or os.environ.get("NIJA_WRITER_GENERATION", "")
+            or ""
+        ).strip()
+        try:
+            generation = int(generation_text or "0")
+        except (TypeError, ValueError):
+            generation = 0
+        heartbeat_active = str(os.environ.get("NIJA_WRITER_HEARTBEAT_ACTIVE", "") or "").strip().lower() in {
+            "1", "true", "yes", "on", "enabled", "y"
+        }
+        redis_configured = bool(
+            str(os.environ.get("NIJA_REDIS_URL", "") or "").strip()
+            or str(os.environ.get("REDIS_URL", "") or "").strip()
+        )
+        heartbeat = _canonical_heartbeat_proof(generation)
+        renewal = _entrypoint_renewal_proof()
+
+        proof_ok = bool(
+            redis_configured
+            and token
+            and generation > 0
+            and heartbeat_active
+            and heartbeat.get("healthy")
+            and heartbeat.get("authoritative")
+            and renewal.get("ok")
+        )
+        redis_reachable = bool(redis_configured and renewal.get("ok"))
+
+        logger.info(
+            "WRITER_AUTHORITY_REENTRY_CANONICAL_PROOF marker=%s ok=%s redis_reachable=%s generation=%s heartbeat_healthy=%s heartbeat_authoritative=%s heartbeat_age_s=%s renewal_ok=%s renewal_reason=%s",
+            MARKER,
+            proof_ok,
+            redis_reachable,
+            generation,
+            heartbeat.get("healthy"),
+            heartbeat.get("authoritative"),
+            heartbeat.get("age_s"),
+            renewal.get("ok"),
+            renewal.get("reason", ""),
+        )
+        return {
+            "ok": proof_ok,
+            "redis_configured": redis_configured,
+            "redis_reachable": redis_reachable,
+            "token_present": bool(token),
+            "token_prefix": token[:8],
+            "lease_generation": generation_text,
+            "heartbeat_active": heartbeat_active,
+            "heartbeat_age_s": float(heartbeat.get("age_s", float("inf"))),
+            "heartbeat_max_age_s": float(heartbeat.get("max_age_s", 120.0)),
+            "heartbeat_authoritative": bool(heartbeat.get("authoritative")),
+            "heartbeat_healthy": bool(heartbeat.get("healthy")),
+            "renewal_ok": bool(renewal.get("ok")),
+            "renewal_reason": str(renewal.get("reason", "")),
+        }
+
+    module._writer_reentry_proof = _writer_reentry_proof
+    setattr(module, _RECURSION_PATCHED, True)
+    logger.critical(
+        "WRITER_AUTHORITY_REENTRY_CANONICAL_V38_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _HEARTBEAT_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_heartbeat_state(module) or changed
+    seen.clear()
+    for name in _RECURSION_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_recursion_guard(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                module = original_import(name, globals, locals, fromlist, level)
+                text = str(name)
+                if text.endswith("heartbeat_state") or text.endswith("writer_authority_recursion_guard_patch"):
+                    _patch_loaded()
+                return module
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: Optional[str] = None):
+                module = original_import_module(name, package)
+                text = str(name)
+                if text.endswith("heartbeat_state") or text.endswith("writer_authority_recursion_guard_patch"):
+                    _patch_loaded()
+                return module
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        _INSTALLED = True
+        os.environ["NIJA_HEARTBEAT_AUTHORITY_IDENTITY_V38_INSTALLED"] = "1"
+        logger.critical(
+            "HEARTBEAT_AUTHORITY_IDENTITY_V38_INSTALLED marker=%s preboot=true fail_closed=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_patch_heartbeat_state",
+    "_patch_recursion_guard",
+    "_canonical_heartbeat_proof",
+    "_entrypoint_renewal_proof",
+]

--- a/bot/tests/test_heartbeat_authority_identity_v38.py
+++ b/bot/tests/test_heartbeat_authority_identity_v38.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+PATCH_PATH = BOT_DIR / "heartbeat_authority_identity_v38_patch.py"
+STATE_PATH = BOT_DIR / "heartbeat_state.py"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reset_shared_state(patch: ModuleType) -> None:
+    for key in (patch._STATE_KEY, patch._STATE_LOCK_KEY):
+        if hasattr(builtins, key):
+            delattr(builtins, key)
+
+
+def test_duplicate_heartbeat_imports_share_one_state(monkeypatch):
+    patch = _load("heartbeat_identity_v38_test", PATCH_PATH)
+    _reset_shared_state(patch)
+
+    first = _load("heartbeat_state_copy_a", STATE_PATH)
+    second = _load("heartbeat_state_copy_b", STATE_PATH)
+    assert first is not second
+
+    assert patch._patch_heartbeat_state(first) is True
+    state_a = first.get_heartbeat_state()
+    state_a.record_heartbeat(generation=77)
+
+    assert patch._patch_heartbeat_state(second) is True
+    state_b = second.get_heartbeat_state()
+
+    assert state_a is state_b
+    healthy, age_s, authoritative, _ts = state_b.health_for_generation(
+        expected_generation=77,
+        max_age_s=120.0,
+    )
+    assert authoritative is True
+    assert healthy is True
+    assert age_s < 1.0
+    assert sys.modules["bot.heartbeat_state"] is second
+    assert sys.modules["heartbeat_state"] is second
+
+
+def test_generation_reader_cannot_report_inf_after_shared_success(monkeypatch):
+    patch = _load("heartbeat_identity_v38_generation_test", PATCH_PATH)
+    _reset_shared_state(patch)
+    state_module = _load("heartbeat_state_generation_copy", STATE_PATH)
+    patch._patch_heartbeat_state(state_module)
+
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_MAX_AGE_S", "120")
+    state_module.get_heartbeat_state().record_heartbeat(generation=3)
+
+    proof = patch._canonical_heartbeat_proof(3)
+    assert proof["authoritative"] is True
+    assert proof["healthy"] is True
+    assert proof["age_s"] < 1.0
+
+
+def test_reentry_proof_uses_canonical_monotonic_heartbeat_not_stale_env(monkeypatch):
+    patch = _load("heartbeat_identity_v38_reentry_test", PATCH_PATH)
+    _reset_shared_state(patch)
+    state_module = _load("heartbeat_state_reentry_copy", STATE_PATH)
+    patch._patch_heartbeat_state(state_module)
+    state_module.get_heartbeat_state().record_heartbeat(generation=42)
+
+    monkeypatch.setenv("NIJA_REDIS_URL", "redis://configured")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "tok-42")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "42")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+    # This old wall-clock value reproduced the legacy recursion-guard failure.
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ALIVE_TS", str(time.time() - 999.0))
+
+    class Runtime:
+        acquired = True
+        lost = False
+
+        def _nija_lease_renewal_health(self):
+            return True, "renewal_healthy", 1.0, 60.0
+
+    entrypoint = ModuleType("bot.entrypoint_writer_authority")
+    entrypoint.get_entrypoint_writer_authority = lambda: Runtime()
+    sys.modules["bot.entrypoint_writer_authority"] = entrypoint
+
+    recursion = ModuleType("bot.writer_authority_recursion_guard_patch")
+    recursion._writer_reentry_proof = lambda: {"ok": False}
+    assert patch._patch_recursion_guard(recursion) is True
+
+    proof = recursion._writer_reentry_proof()
+    assert proof["ok"] is True
+    assert proof["redis_reachable"] is True
+    assert proof["heartbeat_authoritative"] is True
+    assert proof["heartbeat_healthy"] is True
+    assert proof["renewal_ok"] is True
+    assert proof["heartbeat_age_s"] < 1.0
+
+
+def test_reentry_proof_still_fails_closed_when_renewal_is_unhealthy(monkeypatch):
+    patch = _load("heartbeat_identity_v38_failclosed_test", PATCH_PATH)
+    _reset_shared_state(patch)
+    state_module = _load("heartbeat_state_failclosed_copy", STATE_PATH)
+    patch._patch_heartbeat_state(state_module)
+    state_module.get_heartbeat_state().record_heartbeat(generation=9)
+
+    monkeypatch.setenv("NIJA_REDIS_URL", "redis://configured")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "tok-9")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+
+    class Runtime:
+        acquired = True
+        lost = False
+
+        def _nija_lease_renewal_health(self):
+            return False, "renewal_stale", 90.0, 60.0
+
+    entrypoint = ModuleType("bot.entrypoint_writer_authority")
+    entrypoint.get_entrypoint_writer_authority = lambda: Runtime()
+    sys.modules["bot.entrypoint_writer_authority"] = entrypoint
+
+    recursion = ModuleType("bot.writer_authority_recursion_guard_patch")
+    recursion._writer_reentry_proof = lambda: {"ok": True}
+    patch._patch_recursion_guard(recursion)
+
+    proof = recursion._writer_reentry_proof()
+    assert proof["ok"] is False
+    assert proof["redis_reachable"] is False
+    assert proof["renewal_ok"] is False

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -22,7 +22,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
-MARKER = "20260807-canonical-runtime-launcher-v26-v37-v18"
+MARKER = "20260807-canonical-runtime-launcher-v26-v38-v37-v18"
 ROOT = Path(__file__).resolve().parents[1]
 V24_PATH = ROOT / "bot" / "canonical_broker_startup_convergence_v24.py"
 V32_PATH = ROOT / "bot" / "runtime_execution_convergence_v32.py"
@@ -30,6 +30,7 @@ V33_PATH = ROOT / "bot" / "runtime_execution_convergence_v33.py"
 V34_PATH = ROOT / "bot" / "capital_readiness_handoff_v34.py"
 V35_PATH = ROOT / "bot" / "capital_refresh_stall_guard_v35.py"
 V37_PATH = ROOT / "bot" / "capital_refresh_sticky_success_v37_patch.py"
+V38_PATH = ROOT / "bot" / "heartbeat_authority_identity_v38_patch.py"
 V18_PATH = ROOT / "bot" / "production_corrective_set_v18_patch.py"
 V19_PATH = ROOT / "bot" / "entrypoint_writer_epoch_recovery_v19_patch.py"
 MAIN_PATH = ROOT / "main.py"
@@ -102,6 +103,18 @@ def _install_capital_refresh_sticky_success() -> ModuleType:
     return module
 
 
+def _install_heartbeat_authority_identity() -> ModuleType:
+    if not V38_PATH.is_file():
+        raise RuntimeError(f"heartbeat authority identity v38 missing: {V38_PATH}")
+    module = _load_module_by_path("nija_heartbeat_authority_identity_v38_prebot", V38_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("heartbeat authority identity v38 installer failed")
+    if os.environ.get("NIJA_HEARTBEAT_AUTHORITY_IDENTITY_V38_INSTALLED") != "1":
+        raise RuntimeError("heartbeat authority identity v38 did not attest installed")
+    return module
+
+
 def _install_writer_epoch_recovery() -> ModuleType:
     if not V19_PATH.is_file():
         raise RuntimeError(f"writer epoch recovery missing: {V19_PATH}")
@@ -139,11 +152,12 @@ def install_canonical_startup_guard() -> ModuleType:
     _install_capital_readiness_handoff()
     _install_capital_refresh_stall_guard()
     _install_capital_refresh_sticky_success()
+    _install_heartbeat_authority_identity()
     _install_writer_epoch_recovery()
     _install_production_corrective_set()
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY"] = "1"
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_MARKER"] = MARKER
-    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v19_installed=true v18_installed=true", MARKER)
+    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v38_installed=true v19_installed=true v18_installed=true", MARKER)
     return module
 
 
@@ -153,7 +167,7 @@ def main() -> int:
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
-    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v37-v18 package_hook_fanout=deferred", flush=True)
+    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v38-v37-v18 package_hook_fanout=deferred", flush=True)
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
     return 0
 


### PR DESCRIPTION
## Runtime evidence

The post-capital-fix production logs show capital and broker readiness are now healthy, while activation is blocked by writer/heartbeat authority:

- `capital_ready=True`, `manager_ready=True`, all configured brokers connected.
- `HEARTBEAT_CHECK` has a real `heartbeat_ts` but returns `age=inf`, `healthy=False`, `authoritative=False`, generation 3.
- `finalize_boot` then reports `redis_reachable=False` and `authority_verified=False` even though the writer lease/fencing artifacts remain present.
- The recursion guard reports `writer_authority_status_reentry_guarded` and maps its failed heartbeat proof to `redis_reachable=False`.

## Root cause

Two authority readers can diverge from the writer that is actually renewing the lease:

1. `heartbeat_state.py` has a module-level singleton but does not enforce one object across `bot.heartbeat_state` and legacy `heartbeat_state` import identities. A successful writer heartbeat can therefore update one singleton while convergence reads another uninitialised singleton, producing `age=inf` for a nonzero heartbeat timestamp.
2. `writer_authority_recursion_guard_patch.py` independently rebuilds heartbeat freshness from the wall-clock environment timestamp and then equates a failed local proof with Redis being unreachable. That creates the exact false `redis_reachable=False` startup blocker seen in the logs.

## Fix

- Add a v38 preboot identity bridge installed before any `bot` import.
- Bind both heartbeat module aliases to one module and store the HeartbeatState object in a process-wide builtins-backed holder so even duplicate imports resolve to one state object.
- Preserve the freshest already-existing state if the bridge encounters an already-loaded module.
- Make recursive writer-authority proof consume the canonical monotonic heartbeat for the current lease generation.
- Require the existing EntrypointWriterAuthority lease-renewal health proof before recursive authority is accepted.
- Report Redis reachable in the recursion path only when the distributed entrypoint writer is actively renewing its lease; do not derive Redis reachability from an unrelated wall-clock heartbeat TTL.
- Preserve fail-closed behavior when generation, fencing token, canonical heartbeat, or renewal proof is missing/stale.
- Add telemetry `HEARTBEAT_STATE_IDENTITY_V38_PATCHED` and `WRITER_AUTHORITY_REENTRY_CANONICAL_PROOF`.

## Regression coverage added

- duplicate heartbeat module imports share exactly one state object;
- a successful current-generation heartbeat cannot later appear as `age=inf` through another import identity;
- stale `NIJA_WRITER_HEARTBEAT_ALIVE_TS` cannot override a fresh canonical monotonic heartbeat when the lease-renewal proof is healthy;
- unhealthy lease renewal still fails closed.

## Validation note

The branch diff is connector-verified and limited to the v38 preboot bridge, focused tests, and launcher wiring. The local test suite could not be executed in this environment because outbound Git/network access from the execution container is unavailable; no test-pass claim is being made here.