### PR TITLE
Fix stale writer renewal recovery v40

### DIFF
--- a/bot/stale_renewal_recovery_v40_patch.py
+++ b/bot/stale_renewal_recovery_v40_patch.py
@@ -1,0 +1,312 @@
+"""NIJA stale writer-renewal recovery v40.
+
+Production after v39 exposed one remaining writer lifecycle gap: the entrypoint
+heartbeat thread can remain alive while its last successful Redis lease renewal
+becomes stale. In that state the process-local writer object still reports
+ACTIVE/acquired, but the Redis process writer lock can expire. Because the
+runtime never transitions to LOST, v39's bounded fresh-epoch re-election callback
+is never triggered.
+
+v40 adds a fail-closed watchdog around the canonical EntrypointWriterAuthority.
+It does not renew, recreate, or extend the existing writer lock. When renewal
+proof becomes stale it reads the actual Redis lock:
+
+* lock still owned by this writer -> wait; do not create a second heartbeat
+  worker and do not mutate the lease;
+* lock missing -> transition the runtime to LOST with the canonical
+  ``lock_missing_and_fencing_token_mismatch`` reason so v39 can perform bounded
+  fresh-epoch re-election;
+* lock owned by another writer -> transition to LOST with
+  ``lock_owned_by_different_writer`` so the existing non-recoverable shutdown
+  path remains authoritative;
+* Redis inspection error -> remain fail closed and retry; never infer ownership.
+
+No capital, broker, SEAK, nonce, risk, or fencing bypass is introduced.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.stale_renewal_recovery_v40")
+MARKER = "20260807-stale-renewal-recovery-v40"
+
+_INSTALL_FLAG = "_NIJA_STALE_RENEWAL_RECOVERY_V40_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_STALE_RENEWAL_RECOVERY_V40_IMPORTLIB_HOOK"
+_PATCH_ATTR = "_nija_stale_renewal_recovery_v40"
+_WATCHDOG_ATTR = "_nija_stale_renewal_watchdog_v40"
+_WATCHDOG_STOP_ATTR = "_nija_stale_renewal_watchdog_stop_v40"
+_PATCH_LOCK = threading.RLock()
+
+
+def _cfg_float(name: str, default: float, minimum: float) -> float:
+    try:
+        return max(minimum, float(os.environ.get(name, str(default)) or default))
+    except (TypeError, ValueError):
+        return max(minimum, default)
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _runtime_health(runtime: Any) -> tuple[bool, str, float, float]:
+    health = getattr(runtime, "_nija_lease_renewal_health", None)
+    if not callable(health):
+        return False, "renewal_health_unavailable", float("inf"), 0.0
+    try:
+        ok, reason, age_s, max_age_s = health()
+        return bool(ok), str(reason or ""), float(age_s), float(max_age_s)
+    except Exception as exc:
+        return False, f"renewal_health_error:{type(exc).__name__}:{exc}", float("inf"), 0.0
+
+
+def _inspect_lock(runtime: Any) -> tuple[str, str]:
+    """Return (state, detail): owned, missing, other, or error."""
+    client = getattr(runtime, "_client", None)
+    lock_key = str(getattr(runtime, "_lock_key", "") or os.environ.get("NIJA_WRITER_LOCK_KEY", "") or "").strip()
+    expected = str(getattr(runtime, "_lock_value", "") or "").strip()
+    token = str(getattr(runtime, "_token", "") or os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    if client is None or not lock_key:
+        return "error", "redis_client_or_lock_key_missing"
+    try:
+        current = _as_text(client.get(lock_key)).strip()
+    except Exception as exc:
+        return "error", f"redis_lock_read_error:{type(exc).__name__}:{exc}"
+    if not current:
+        return "missing", f"lock_missing key={lock_key}"
+    if expected and current == expected:
+        return "owned", f"lock_owned_exact key={lock_key}"
+    current_token = current.split(":", 1)[0]
+    if token and current_token == token:
+        return "owned", f"lock_owned_token key={lock_key}"
+    return "other", f"lock_owned_by_other key={lock_key} current_prefix={current_token[:8]} expected_prefix={token[:8]}"
+
+
+def _mark_runtime_lost(runtime: Any, reason: str) -> bool:
+    marker = getattr(runtime, "_mark_lost", None)
+    if not callable(marker):
+        LOGGER.critical(
+            "STALE_RENEWAL_V40_MARK_LOST_UNAVAILABLE marker=%s reason=%s action=fail_closed",
+            MARKER,
+            reason,
+        )
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+        return False
+    if bool(getattr(runtime, "lost", False)):
+        return True
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+    LOGGER.critical(
+        "STALE_RENEWAL_V40_TRANSITION_LOST marker=%s generation=%s reason=%s trading_fail_closed=true",
+        MARKER,
+        getattr(runtime, "_generation", 0),
+        reason,
+    )
+    marker(reason)
+    return True
+
+
+def _watchdog_loop(runtime: Any, stop_event: threading.Event) -> None:
+    poll_s = _cfg_float("NIJA_STALE_RENEWAL_WATCHDOG_POLL_S", 2.0, 0.25)
+    stale_confirmations = max(1, int(_cfg_float("NIJA_STALE_RENEWAL_CONFIRMATIONS", 2.0, 1.0)))
+    stale_seen = 0
+    last_log = 0.0
+
+    LOGGER.critical(
+        "STALE_RENEWAL_V40_WATCHDOG_STARTED marker=%s generation=%s poll_s=%.2f confirmations=%d",
+        MARKER,
+        getattr(runtime, "_generation", 0),
+        poll_s,
+        stale_confirmations,
+    )
+
+    while not stop_event.is_set():
+        if bool(getattr(runtime, "lost", False)):
+            return
+        if not bool(getattr(runtime, "acquired", False)):
+            stale_seen = 0
+            stop_event.wait(poll_s)
+            continue
+
+        ok, reason, age_s, max_age_s = _runtime_health(runtime)
+        if ok:
+            stale_seen = 0
+            stop_event.wait(poll_s)
+            continue
+
+        if reason != "renewal_success_stale":
+            stale_seen = 0
+            stop_event.wait(poll_s)
+            continue
+
+        stale_seen += 1
+        state, detail = _inspect_lock(runtime)
+        now = time.monotonic()
+        if now - last_log >= 5.0:
+            last_log = now
+            LOGGER.critical(
+                "STALE_RENEWAL_V40_PROBE marker=%s generation=%s age_s=%.1f max_age_s=%.1f confirmations=%d/%d lock_state=%s detail=%s",
+                MARKER,
+                getattr(runtime, "_generation", 0),
+                age_s,
+                max_age_s,
+                stale_seen,
+                stale_confirmations,
+                state,
+                detail,
+            )
+
+        if stale_seen < stale_confirmations:
+            stop_event.wait(poll_s)
+            continue
+
+        if state == "missing":
+            _mark_runtime_lost(runtime, "lock_missing_and_fencing_token_mismatch")
+            return
+        if state == "other":
+            _mark_runtime_lost(runtime, "lock_owned_by_different_writer")
+            return
+        if state == "owned":
+            # The old epoch still exists. Never start a second renewal worker or
+            # mutate the lock from this watchdog. Continue fail-closed observation
+            # until the canonical heartbeat succeeds again or Redis ownership
+            # actually changes/expires.
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+        # state=error is also fail-closed: no ownership inference is permitted.
+        stop_event.wait(poll_s)
+
+
+def _start_watchdog(runtime: Any) -> bool:
+    existing = getattr(runtime, _WATCHDOG_ATTR, None)
+    if existing is not None and callable(getattr(existing, "is_alive", None)) and existing.is_alive():
+        return True
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_watchdog_loop,
+        args=(runtime, stop_event),
+        name="writer-stale-renewal-watchdog-v40",
+        daemon=True,
+    )
+    setattr(runtime, _WATCHDOG_STOP_ATTR, stop_event)
+    setattr(runtime, _WATCHDOG_ATTR, thread)
+    thread.start()
+    return True
+
+
+def _patch_entrypoint_writer_authority(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type) or getattr(cls, _PATCH_ATTR, False):
+        return False
+
+    original_activate = getattr(cls, "_activate_distributed_authority", None)
+    if callable(original_activate):
+        @wraps(original_activate)
+        def _activate_distributed_authority(self: Any, *args: Any, **kwargs: Any):
+            result = original_activate(self, *args, **kwargs)
+            _start_watchdog(self)
+            return result
+        cls._activate_distributed_authority = _activate_distributed_authority
+
+    original_release = getattr(cls, "release", None)
+    if callable(original_release):
+        @wraps(original_release)
+        def release(self: Any, *args: Any, **kwargs: Any):
+            stop = getattr(self, _WATCHDOG_STOP_ATTR, None)
+            if stop is not None and callable(getattr(stop, "set", None)):
+                stop.set()
+            return original_release(self, *args, **kwargs)
+        cls.release = release
+
+    # If the singleton already acquired before this class patch landed, arm its
+    # watchdog immediately instead of waiting for a future re-election.
+    getter = getattr(module, "get_entrypoint_writer_authority", None)
+    if callable(getter):
+        try:
+            runtime = getter()
+            if runtime is not None and bool(getattr(runtime, "acquired", False)):
+                _start_watchdog(runtime)
+        except Exception:
+            pass
+
+    setattr(cls, _PATCH_ATTR, True)
+    LOGGER.critical(
+        "STALE_RENEWAL_V40_ENTRYPOINT_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _interesting_module(name: str) -> bool:
+    return str(name or "") in {"bot.entrypoint_writer_authority", "entrypoint_writer_authority"}
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name, module in list(sys.modules.items()):
+        if not isinstance(module, ModuleType) or not _interesting_module(name):
+            continue
+        try:
+            changed = _patch_entrypoint_writer_authority(module) or changed
+        except Exception as exc:
+            LOGGER.warning(
+                "STALE_RENEWAL_V40_PATCH_FAILED marker=%s module=%s err=%s",
+                MARKER,
+                name,
+                exc,
+            )
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _PATCH_LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _INSTALL_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if _interesting_module(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _INSTALL_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if _interesting_module(name):
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        os.environ["NIJA_STALE_RENEWAL_RECOVERY_V40_INSTALLED"] = "1"
+        LOGGER.critical(
+            "STALE_RENEWAL_RECOVERY_V40_INSTALLED marker=%s fail_closed=true lock_mutation=false fresh_epoch_via_v39=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()

--- a/bot/tests/test_stale_renewal_recovery_v40.py
+++ b/bot/tests/test_stale_renewal_recovery_v40.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib
+import os
+import threading
+import types
+
+
+MODULE = "bot.stale_renewal_recovery_v40_patch"
+
+
+def _load():
+    return importlib.import_module(MODULE)
+
+
+class _Client:
+    def __init__(self, value=None, error: Exception | None = None):
+        self.value = value
+        self.error = error
+        self.calls = 0
+
+    def get(self, _key):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+class _Runtime:
+    def __init__(self, lock_value: str = "77:owner", redis_value=None):
+        self._client = _Client(redis_value)
+        self._lock_key = "nija:writer_lock:process"
+        self._lock_value = lock_value
+        self._token = "77"
+        self._generation = 5
+        self.acquired = True
+        self.lost = False
+        self.marked = []
+
+    def _mark_lost(self, reason: str):
+        self.marked.append(reason)
+        self.lost = True
+
+
+def test_lock_inspection_owned_exact():
+    mod = _load()
+    runtime = _Runtime(redis_value="77:owner")
+    state, detail = mod._inspect_lock(runtime)
+    assert state == "owned"
+    assert "lock_owned_exact" in detail
+
+
+def test_lock_inspection_missing():
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    state, detail = mod._inspect_lock(runtime)
+    assert state == "missing"
+    assert "lock_missing" in detail
+
+
+def test_lock_inspection_other_writer():
+    mod = _load()
+    runtime = _Runtime(redis_value="88:other")
+    state, detail = mod._inspect_lock(runtime)
+    assert state == "other"
+    assert "current_prefix=88" in detail
+
+
+def test_lock_inspection_error_never_infers_loss():
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    runtime._client = _Client(error=TimeoutError("redis timeout"))
+    state, detail = mod._inspect_lock(runtime)
+    assert state == "error"
+    assert "redis_lock_read_error" in detail
+
+
+def test_mark_runtime_lost_forces_execution_fail_closed(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    assert mod._mark_runtime_lost(runtime, "lock_missing_and_fencing_token_mismatch") is True
+    assert runtime.marked == ["lock_missing_and_fencing_token_mismatch"]
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_watchdog_stale_missing_triggers_recoverable_loss(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    stop = threading.Event()
+
+    monkeypatch.setattr(mod, "_cfg_float", lambda name, default, minimum: 1.0)
+    monkeypatch.setattr(
+        mod,
+        "_runtime_health",
+        lambda _runtime: (False, "renewal_success_stale", 30.0, 10.0),
+    )
+    monkeypatch.setattr(mod, "_inspect_lock", lambda _runtime: ("missing", "lock_missing"))
+
+    mod._watchdog_loop(runtime, stop)
+
+    assert runtime.marked == ["lock_missing_and_fencing_token_mismatch"]
+    assert runtime.lost is True
+
+
+def test_watchdog_stale_other_writer_is_nonrecoverable(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value="88:other")
+    stop = threading.Event()
+
+    monkeypatch.setattr(mod, "_cfg_float", lambda name, default, minimum: 1.0)
+    monkeypatch.setattr(
+        mod,
+        "_runtime_health",
+        lambda _runtime: (False, "renewal_success_stale", 30.0, 10.0),
+    )
+    monkeypatch.setattr(mod, "_inspect_lock", lambda _runtime: ("other", "other writer"))
+
+    mod._watchdog_loop(runtime, stop)
+
+    assert runtime.marked == ["lock_owned_by_different_writer"]
+    assert runtime.lost is True
+
+
+def test_watchdog_stale_but_owned_does_not_create_false_loss(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value="77:owner")
+    stop = threading.Event()
+    calls = {"health": 0}
+
+    monkeypatch.setattr(mod, "_cfg_float", lambda name, default, minimum: 0.01 if "POLL" in name else 1.0)
+
+    def _health(_runtime):
+        calls["health"] += 1
+        if calls["health"] == 1:
+            return False, "renewal_success_stale", 30.0, 10.0
+        stop.set()
+        return True, "renewal_healthy", 0.0, 10.0
+
+    monkeypatch.setattr(mod, "_runtime_health", _health)
+    monkeypatch.setattr(mod, "_inspect_lock", lambda _runtime: ("owned", "owned"))
+
+    mod._watchdog_loop(runtime, stop)
+
+    assert runtime.marked == []
+    assert runtime.lost is False
+
+
+def test_watchdog_redis_error_does_not_infer_ownership_loss(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    stop = threading.Event()
+    calls = {"health": 0}
+
+    monkeypatch.setattr(mod, "_cfg_float", lambda name, default, minimum: 0.01 if "POLL" in name else 1.0)
+
+    def _health(_runtime):
+        calls["health"] += 1
+        if calls["health"] == 1:
+            return False, "renewal_success_stale", 30.0, 10.0
+        stop.set()
+        return True, "renewal_healthy", 0.0, 10.0
+
+    monkeypatch.setattr(mod, "_runtime_health", _health)
+    monkeypatch.setattr(mod, "_inspect_lock", lambda _runtime: ("error", "redis timeout"))
+
+    mod._watchdog_loop(runtime, stop)
+
+    assert runtime.marked == []
+    assert runtime.lost is False
+
+
+def test_entrypoint_activation_arms_watchdog(monkeypatch):
+    mod = _load()
+    starts = []
+
+    class _Authority:
+        acquired = False
+
+        def _activate_distributed_authority(self, *args, **kwargs):
+            self.acquired = True
+            return types.SimpleNamespace(acquired=True)
+
+        def release(self):
+            return True
+
+    module = types.ModuleType("bot.entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = _Authority
+    module.get_entrypoint_writer_authority = lambda: _Authority()
+
+    monkeypatch.setattr(mod, "_start_watchdog", lambda runtime: starts.append(runtime) or True)
+    assert mod._patch_entrypoint_writer_authority(module) is True
+
+    runtime = _Authority()
+    result = runtime._activate_distributed_authority()
+    assert result.acquired is True
+    assert starts == [runtime]

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -22,7 +22,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
-MARKER = "20260807-canonical-runtime-launcher-v26-v39-v38-v37-v18"
+MARKER = "20260807-canonical-runtime-launcher-v26-v40-v39-v38-v37-v18"
 ROOT = Path(__file__).resolve().parents[1]
 V24_PATH = ROOT / "bot" / "canonical_broker_startup_convergence_v24.py"
 V32_PATH = ROOT / "bot" / "runtime_execution_convergence_v32.py"
@@ -32,6 +32,7 @@ V35_PATH = ROOT / "bot" / "capital_refresh_stall_guard_v35.py"
 V37_PATH = ROOT / "bot" / "capital_refresh_sticky_success_v37_patch.py"
 V38_PATH = ROOT / "bot" / "heartbeat_authority_identity_v38_patch.py"
 V39_PATH = ROOT / "bot" / "production_readiness_v39_patch.py"
+V40_PATH = ROOT / "bot" / "stale_renewal_recovery_v40_patch.py"
 V18_PATH = ROOT / "bot" / "production_corrective_set_v18_patch.py"
 V19_PATH = ROOT / "bot" / "entrypoint_writer_epoch_recovery_v19_patch.py"
 MAIN_PATH = ROOT / "main.py"
@@ -140,6 +141,18 @@ def _install_production_readiness_v39() -> ModuleType:
     return module
 
 
+def _install_stale_renewal_recovery_v40() -> ModuleType:
+    if not V40_PATH.is_file():
+        raise RuntimeError(f"stale renewal recovery v40 missing: {V40_PATH}")
+    module = _load_module_by_path("nija_stale_renewal_recovery_v40_prebot", V40_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("stale renewal recovery v40 installer failed")
+    if os.environ.get("NIJA_STALE_RENEWAL_RECOVERY_V40_INSTALLED") != "1":
+        raise RuntimeError("stale renewal recovery v40 did not attest installed")
+    return module
+
+
 def _install_production_corrective_set() -> ModuleType:
     if not V18_PATH.is_file():
         raise RuntimeError(f"production corrective set missing: {V18_PATH}")
@@ -168,10 +181,11 @@ def install_canonical_startup_guard() -> ModuleType:
     _install_heartbeat_authority_identity()
     _install_writer_epoch_recovery()
     _install_production_readiness_v39()
+    _install_stale_renewal_recovery_v40()
     _install_production_corrective_set()
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY"] = "1"
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_MARKER"] = MARKER
-    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v38_installed=true v19_installed=true v39_installed=true v18_installed=true", MARKER)
+    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v38_installed=true v19_installed=true v39_installed=true v40_installed=true v18_installed=true", MARKER)
     return module
 
 
@@ -181,7 +195,7 @@ def main() -> int:
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
-    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v39-v38-v37-v18 package_hook_fanout=deferred", flush=True)
+    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v40-v39-v38-v37-v18 package_hook_fanout=deferred", flush=True)
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
     return 0
 


### PR DESCRIPTION
## What changed

- Add a fail-closed stale-renewal watchdog around `EntrypointWriterAuthority`.
- Detect the production state where the heartbeat thread is still alive but its last successful Redis lease renewal is stale.
- Read the actual Redis process writer lock before taking recovery action.
- If the lock is missing, transition the runtime to `LOST` with `lock_missing_and_fencing_token_mismatch`, allowing the existing v39 bounded fresh-epoch re-election flow to acquire a new token/generation.
- If the lock belongs to another writer, transition to `LOST` with `lock_owned_by_different_writer`, preserving the existing non-recoverable shutdown path.
- If the old lock is still owned by this writer, do not create a second heartbeat worker and do not mutate/extend the lease; remain fail closed and continue observing.
- If Redis inspection fails, do not infer ownership and do not attempt unsafe recovery.
- Install v40 from the canonical preboot launcher after v39.
- Add regression coverage for owned, missing, other-writer, Redis-error, fail-closed transition, and watchdog activation behavior.

## Why

Production on merged v39 commit `d2ac1a8abb58252ef6dcf5a4a523c310d359a433` showed all three brokers connected and live capital around $468, but writer authority remained stuck in an inconsistent state: the local runtime still reported `ACTIVE/acquired` while canonical renewal health reported `renewal_success_stale`, heartbeat authority was non-authoritative, and the strict writer verifier later confirmed the Redis process lock was missing.

Because `runtime.lost` stayed false, v39's writer-loss callback never fired and fresh-epoch re-election never started. v40 closes that exact lifecycle gap.

## Safety properties

- No stale fencing token is reused.
- No missing writer lock is recreated by the watchdog.
- No second heartbeat renewal worker is started for a still-owned stale epoch.
- No ownership is inferred when Redis cannot be read.
- A lock owned by another writer never enters auto-re-election; it follows the existing shutdown path.
- Execution remains fail closed throughout stale-renewal detection and recovery.
- v39 remains responsible for bounded fresh-epoch acquisition and synchronous distributed-authority verification.

## Validation

- Branch diff is limited to three files: the v40 patch, its focused tests, and canonical launcher wiring.
- Full GitHub Actions CI should be treated as authoritative before merge; no full-suite pass is claimed yet.