### PR TITLE
Fix capital publication and Kraken connection convergence

### DIFF
--- a/bot/capital_publication_convergence_v43_patch.py
+++ b/bot/capital_publication_convergence_v43_patch.py
@@ -1,0 +1,484 @@
+"""NIJA capital publication convergence v43.
+
+Repairs a post-v42 capital-authority divergence observed during partial refreshes.
+A coordinator snapshot may contain only the broker that completed in the current
+bounded batch while the v37 sticky-success guard still holds fresh, independently
+observed balances for other platform brokers. The legacy live-total v2 property
+can then report the larger aggregate while CapitalAuthority.publish_snapshot()
+overwrites the canonical typed snapshot with the smaller one-broker picture.
+
+v43 restores one capital truth without inventing balances:
+
+* current-cycle snapshot values always win;
+* an omitted broker is added only when v37 has a fresh positive platform
+  observation for that exact broker and the canonical platform broker is
+  currently connected;
+* disconnected brokers, stale observations, invalid values, user accounts, and
+  unattributed aggregate totals are never promoted;
+* real/usable/risk capital and broker_count are recomputed from the exact merged
+  per-broker map before the authorized coordinator publish;
+* after a typed snapshot exists, total_capital reads that canonical snapshot
+  instead of max(snapshot, broker_sum, _last_updated_total), eliminating the
+  contradictory read-time aggregate;
+* the historical live-total v2 installer is wrapped so a later install cannot
+  reintroduce the divergent property.
+
+This patch does not connect brokers, fetch balances, force activation, clear any
+risk state, or bypass capital freshness/readiness gates.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+import time
+from dataclasses import is_dataclass, replace
+from functools import wraps
+from types import ModuleType
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+LOGGER = logging.getLogger("nija.capital_publication_convergence_v43")
+MARKER = "20260807-capital-publication-convergence-v43"
+
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_CAPITAL_PUBLICATION_CONVERGENCE_V43_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_CAPITAL_PUBLICATION_CONVERGENCE_V43_IMPORTLIB_HOOK"
+_CA_PATCH_ATTR = "_nija_capital_publication_convergence_v43_publish"
+_TOTAL_PATCH_ATTR = "_nija_capital_publication_convergence_v43_total"
+_LIVE_V2_PATCH_ATTR = "_nija_capital_publication_convergence_v43_live_v2"
+
+_CA_NAMES = ("bot.capital_authority", "capital_authority")
+_LIVE_V2_NAMES = (
+    "bot.capital_authority_live_total_v2_patch",
+    "capital_authority_live_total_v2_patch",
+)
+_GUARD_NAMES = (
+    "nija_capital_refresh_stall_guard_v35_prebot",
+    "bot.capital_refresh_stall_guard_v35",
+    "capital_refresh_stall_guard_v35",
+)
+_BROKER_MODULE_NAMES = ("bot.broker_manager", "broker_manager")
+_ALLOWED_BROKERS = ("coinbase", "okx", "kraken", "alpaca")
+
+
+def _num(value: Any) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    if not math.isfinite(result) or result < 0.0:
+        return 0.0
+    return result
+
+
+def _guard() -> Optional[ModuleType]:
+    for name in _GUARD_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    return None
+
+
+def _observation_ttl_s(guard: Optional[ModuleType]) -> float:
+    configured = 90.0
+    try:
+        configured = float(os.environ.get("NIJA_V43_CAPITAL_OBSERVATION_TTL_S", "90") or "90")
+    except (TypeError, ValueError):
+        configured = 90.0
+    configured = max(5.0, configured)
+    if guard is None:
+        return configured
+    getter = getattr(guard, "_freshness_ttl_seconds", None)
+    if callable(getter):
+        try:
+            return max(5.0, min(configured, float(getter())))
+        except Exception:
+            pass
+    return configured
+
+
+def _fresh_observation(broker_id: str) -> Tuple[bool, float, float, str]:
+    """Return (ok, value, age_s, reason) from the canonical v37 guard state."""
+    guard = _guard()
+    if guard is None:
+        return False, 0.0, float("inf"), "guard_unavailable"
+    observations = getattr(guard, "_OBSERVATIONS", None)
+    if not isinstance(observations, dict):
+        return False, 0.0, float("inf"), "observations_unavailable"
+    lock = getattr(guard, "_OBSERVATION_LOCK", None)
+    if lock is None:
+        observation = observations.get(broker_id)
+    else:
+        try:
+            with lock:
+                observation = observations.get(broker_id)
+        except Exception:
+            return False, 0.0, float("inf"), "observation_lock_failed"
+    if observation is None:
+        return False, 0.0, float("inf"), "observation_missing"
+
+    value = _num(getattr(observation, "value", 0.0))
+    observed_mono = _num(getattr(observation, "observed_monotonic", 0.0))
+    if value <= 0.0 or observed_mono <= 0.0:
+        return False, value, float("inf"), "observation_invalid"
+    age_s = max(0.0, time.monotonic() - observed_mono)
+    ttl_s = _observation_ttl_s(guard)
+    if age_s > ttl_s:
+        return False, value, age_s, f"observation_stale:{age_s:.3f}>{ttl_s:.3f}"
+    return True, value, age_s, "fresh_v37_observation"
+
+
+def _broker_name(instance: Any, key: Any = None) -> str:
+    candidates = (
+        getattr(getattr(instance, "broker_type", None), "value", None),
+        getattr(getattr(instance, "broker_type", None), "name", None),
+        getattr(instance, "name", None),
+        getattr(instance, "broker_name", None),
+        key,
+        instance.__class__.__name__ if instance is not None else None,
+    )
+    for candidate in candidates:
+        text = str(candidate or "").strip().lower()
+        for broker_id in _ALLOWED_BROKERS:
+            if broker_id in text:
+                return broker_id
+    return ""
+
+
+def _is_platform(instance: Any) -> bool:
+    account_type = getattr(instance, "account_type", None)
+    text = str(getattr(account_type, "value", account_type) or "").strip().lower()
+    return not text or "user" not in text
+
+
+def _is_connected(instance: Any) -> bool:
+    if instance is None or not _is_platform(instance):
+        return False
+    connected = getattr(instance, "connected", None)
+    if connected is True:
+        return True
+    probe = getattr(instance, "is_connected", None)
+    if callable(probe):
+        try:
+            return bool(probe())
+        except Exception:
+            return False
+    return False
+
+
+def _dict_instances(module: ModuleType) -> Iterable[Tuple[Any, Any]]:
+    for attr in ("_PLATFORM_BROKER_INSTANCES", "GLOBAL_PLATFORM_BROKERS"):
+        mapping = getattr(module, attr, None)
+        if isinstance(mapping, dict):
+            for key, value in list(mapping.items()):
+                if value is not None:
+                    yield key, value
+
+
+def _connected_platform_instance(broker_id: str) -> Optional[Any]:
+    seen: set[int] = set()
+    for name in _BROKER_MODULE_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        for key, instance in _dict_instances(module):
+            if id(instance) in seen:
+                continue
+            seen.add(id(instance))
+            if _broker_name(instance, key) == broker_id and _is_connected(instance):
+                return instance
+
+        getter = getattr(module, "get_platform_broker", None)
+        broker_type = getattr(module, "BrokerType", None)
+        if callable(getter) and broker_type is not None:
+            try:
+                members = list(broker_type)
+            except Exception:
+                members = []
+            for member in members:
+                member_name = str(getattr(member, "value", None) or getattr(member, "name", "")).lower()
+                if broker_id not in member_name:
+                    continue
+                try:
+                    instance = getter(member)
+                except Exception:
+                    continue
+                if instance is not None and _is_connected(instance):
+                    return instance
+    return None
+
+
+def _augment_snapshot(snapshot: Any) -> Tuple[Any, Dict[str, Dict[str, Any]]]:
+    """Return a canonicalized snapshot plus exact evidence for added brokers."""
+    if not is_dataclass(snapshot):
+        return snapshot, {}
+    raw_balances = getattr(snapshot, "broker_balances", None)
+    if not isinstance(raw_balances, dict):
+        return snapshot, {}
+
+    merged: Dict[str, float] = {
+        str(key).strip().lower(): _num(value)
+        for key, value in raw_balances.items()
+        if _num(value) > 0.0
+    }
+    additions: Dict[str, Dict[str, Any]] = {}
+    for broker_id in _ALLOWED_BROKERS:
+        if broker_id in merged:
+            continue
+        ok, value, age_s, reason = _fresh_observation(broker_id)
+        if not ok:
+            continue
+        instance = _connected_platform_instance(broker_id)
+        if instance is None:
+            LOGGER.info(
+                "CAPITAL_PUBLICATION_V43_OMITTED marker=%s broker=%s reason=not_connected observation_age_s=%.3f",
+                MARKER,
+                broker_id,
+                age_s,
+            )
+            continue
+        merged[broker_id] = value
+        additions[broker_id] = {
+            "value": value,
+            "age_s": age_s,
+            "reason": reason,
+            "class": instance.__class__.__name__,
+        }
+
+    if not additions:
+        return snapshot, {}
+
+    real = sum(merged.values())
+    reserve_pct = _num(getattr(snapshot, "reserve_pct", 0.0))
+    open_exposure = _num(getattr(snapshot, "open_exposure_usd", 0.0))
+    usable = real * max(0.0, 1.0 - reserve_pct)
+    risk = max(0.0, usable - open_exposure)
+    broker_count = sum(1 for value in merged.values() if value > 0.0)
+    try:
+        expected = max(int(getattr(snapshot, "expected_brokers", 0) or 0), broker_count)
+    except (TypeError, ValueError):
+        expected = broker_count
+
+    try:
+        repaired = replace(
+            snapshot,
+            real_capital=real,
+            usable_capital=usable,
+            risk_capital=risk,
+            broker_balances=dict(merged),
+            broker_count=broker_count,
+            expected_brokers=expected,
+        )
+    except Exception as exc:
+        LOGGER.warning(
+            "CAPITAL_PUBLICATION_V43_REPLACE_FAILED marker=%s err=%s",
+            MARKER,
+            exc,
+        )
+        return snapshot, {}
+
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_V43_AUGMENTED marker=%s original_total=%.2f repaired_total=%.2f original_brokers=%s repaired_brokers=%s additions=%s",
+        MARKER,
+        _num(getattr(snapshot, "real_capital", 0.0)),
+        real,
+        sorted(str(key) for key in raw_balances),
+        sorted(merged),
+        {key: round(row["value"], 8) for key, row in additions.items()},
+    )
+    return repaired, additions
+
+
+def _canonical_total_property(self: Any) -> float:
+    lock = getattr(self, "_lock", None)
+
+    def _read() -> float:
+        snapshot = getattr(self, "_last_typed_snapshot", None)
+        if snapshot is not None:
+            return _num(getattr(snapshot, "real_capital", 0.0))
+        if bool(getattr(self, "_hydrated", False)) or bool(getattr(self, "_warm_start", False)):
+            balances = getattr(self, "_broker_balances", {}) or {}
+            if isinstance(balances, dict):
+                return sum(_num(value) for value in balances.values())
+        return 0.0
+
+    if lock is None:
+        return _read()
+    try:
+        with lock:
+            return _read()
+    except Exception:
+        return _read()
+
+
+setattr(_canonical_total_property, _TOTAL_PATCH_ATTR, True)
+
+
+def _ensure_total_property(cls: type) -> None:
+    current = getattr(cls, "total_capital", None)
+    fget = getattr(current, "fget", current)
+    if getattr(fget, _TOTAL_PATCH_ATTR, False):
+        return
+    cls.total_capital = property(_canonical_total_property)
+    LOGGER.critical("CAPITAL_PUBLICATION_V43_TOTAL_CANONICALIZED marker=%s class=%s", MARKER, cls.__name__)
+
+
+def _patch_capital_authority(module: ModuleType) -> bool:
+    cls = getattr(module, "CapitalAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    _ensure_total_property(cls)
+    original = getattr(cls, "publish_snapshot", None)
+    if not callable(original):
+        return False
+    if getattr(original, _CA_PATCH_ATTR, False):
+        return True
+
+    @wraps(original)
+    def publish_snapshot(self: Any, snapshot: Any, writer_id: str) -> bool:
+        authorized = str(getattr(self, "_AUTHORIZED_WRITER_ID", "") or "")
+        candidate = snapshot
+        additions: Dict[str, Dict[str, Any]] = {}
+        if writer_id == authorized:
+            candidate, additions = _augment_snapshot(snapshot)
+        accepted = bool(original(self, candidate, writer_id=writer_id))
+        if accepted:
+            _ensure_total_property(self.__class__)
+            if additions:
+                candidate_ts = getattr(candidate, "computed_at", None)
+                lock = getattr(self, "_lock", None)
+                try:
+                    if lock is None:
+                        if getattr(self, "last_updated", None) == candidate_ts:
+                            self._last_updated_total = _num(getattr(candidate, "real_capital", 0.0))
+                    else:
+                        with lock:
+                            if getattr(self, "last_updated", None) == candidate_ts:
+                                self._last_updated_total = _num(getattr(candidate, "real_capital", 0.0))
+                except Exception:
+                    pass
+                LOGGER.critical(
+                    "CAPITAL_PUBLICATION_V43_COMMITTED marker=%s total=%.2f broker_count=%s additions=%s",
+                    MARKER,
+                    _num(getattr(candidate, "real_capital", 0.0)),
+                    getattr(candidate, "broker_count", "unknown"),
+                    sorted(additions),
+                )
+        return accepted
+
+    setattr(publish_snapshot, _CA_PATCH_ATTR, True)
+    cls.publish_snapshot = publish_snapshot
+    LOGGER.critical("CAPITAL_PUBLICATION_V43_CA_PATCHED marker=%s module=%s", MARKER, module.__name__)
+    return True
+
+
+def _patch_live_total_v2(module: ModuleType) -> bool:
+    original = getattr(module, "_patch_module", None)
+    if not callable(original):
+        return False
+    if getattr(original, _LIVE_V2_PATCH_ATTR, False):
+        return True
+
+    @wraps(original)
+    def patch_module(target: ModuleType) -> bool:
+        result = bool(original(target))
+        try:
+            _patch_capital_authority(target)
+        except Exception as exc:
+            LOGGER.warning(
+                "CAPITAL_PUBLICATION_V43_LIVE_V2_RECANONICALIZE_FAILED marker=%s err=%s",
+                MARKER,
+                exc,
+            )
+        return result
+
+    setattr(patch_module, _LIVE_V2_PATCH_ATTR, True)
+    module._patch_module = patch_module
+    LOGGER.critical("CAPITAL_PUBLICATION_V43_LIVE_V2_PATCHED marker=%s module=%s", MARKER, module.__name__)
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _CA_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_capital_authority(module) or changed
+    seen.clear()
+    for name in _LIVE_V2_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_live_total_v2(module) or changed
+    return changed
+
+
+def _interesting(name: str) -> bool:
+    text = str(name or "")
+    return any(
+        text.endswith(suffix)
+        for suffix in (
+            "capital_authority",
+            "capital_authority_live_total_v2_patch",
+            "capital_refresh_stall_guard_v35",
+            "broker_manager",
+        )
+    )
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: Optional[str] = None):
+                result = original_import_module(name, package)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        os.environ["NIJA_CAPITAL_PUBLICATION_CONVERGENCE_V43_INSTALLED"] = "1"
+        LOGGER.critical(
+            "CAPITAL_PUBLICATION_CONVERGENCE_V43_INSTALLED marker=%s fail_closed=true unattributed_total_promoted=false disconnected_brokers_promoted=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_augment_snapshot",
+    "_fresh_observation",
+    "_patch_capital_authority",
+    "_patch_live_total_v2",
+]

--- a/bot/kraken_connection_convergence_v44_patch.py
+++ b/bot/kraken_connection_convergence_v44_patch.py
@@ -1,0 +1,330 @@
+"""NIJA Kraken connection convergence v44.
+
+Production after v42 showed Kraken credentials present and historical capital
+available while the canonical platform broker remained ``connected=False``.
+The authenticated recovery in canonical_broker_startup_convergence_v24 already
+performs the correct real broker.connect()/supervisor path, but its one-shot
+``_KRAKEN_RECOVERY_STARTED`` guard remains latched after a successful recovery.
+A later disconnect can therefore leave Kraken permanently offline because every
+subsequent trigger sees recovery as already started.
+
+v44 adds a small writer-scoped watchdog around that existing recovery path.  It
+never marks Kraken connected and never fabricates authentication.  It rearms the
+canonical recovery only when all of these are true:
+
+* Kraken credentials are configured and not explicitly disabled;
+* verified writer lineage is present;
+* the canonical Kraken broker exists and is actually ``connected=False``;
+* the previous authenticated recovery had declared READY, proving the guard is
+  a stale success latch rather than an active in-flight attempt.
+
+If recovery is not currently started at all, the watchdog may invoke the
+canonical v24 recovery directly.  Permanent-auth failures remain latched by the
+existing reconnect supervisor and no execution/readiness gate is bypassed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.kraken_connection_convergence_v44")
+MARKER = "20260807-kraken-connection-convergence-v44"
+
+_LOCK = threading.RLock()
+_STOP = threading.Event()
+_WATCHDOG_STARTED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+_V24_NAMES = (
+    "nija_canonical_broker_startup_convergence_v24_prebot",
+    "bot.canonical_broker_startup_convergence_v24",
+    "canonical_broker_startup_convergence_v24",
+)
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _v24() -> Optional[ModuleType]:
+    for name in _V24_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    for name in ("bot.canonical_broker_startup_convergence_v24",):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(module, ModuleType):
+            return module
+    return None
+
+
+def _manager() -> Any:
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        getter = getattr(module, "get_multi_account_broker_manager", None) if module else None
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:
+                pass
+    try:
+        module = importlib.import_module("bot.multi_account_broker_manager")
+        getter = getattr(module, "get_multi_account_broker_manager", None)
+        if callable(getter):
+            return getter()
+    except Exception:
+        pass
+    return None
+
+
+def _canonical_kraken(manager: Any) -> Any:
+    if manager is None:
+        return None
+    try:
+        broker_module = importlib.import_module("bot.broker_manager")
+    except Exception:
+        return None
+    broker_type = getattr(getattr(broker_module, "BrokerType", None), "KRAKEN", None)
+    if broker_type is not None:
+        broker = getattr(manager, "_platform_brokers", {}).get(broker_type)
+        if broker is not None:
+            return broker
+    getter = getattr(broker_module, "get_platform_broker", None)
+    if callable(getter):
+        for key in ("kraken", broker_type):
+            if key is None:
+                continue
+            try:
+                broker = getter(key)
+            except Exception:
+                continue
+            if broker is not None:
+                return broker
+    return None
+
+
+def _lineage_ready(v24: ModuleType) -> tuple[bool, str]:
+    probe = getattr(v24, "_writer_lineage", None)
+    if not callable(probe):
+        return False, "writer_lineage_probe_unavailable"
+    try:
+        ready, reason = probe()
+        return bool(ready), str(reason or "")
+    except Exception as exc:
+        return False, f"writer_lineage_error:{type(exc).__name__}:{exc}"
+
+
+def _credentials_ready(v24: ModuleType) -> bool:
+    probe = getattr(v24, "_kraken_credentials_configured", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False
+
+
+def _permanent_failure_latched() -> bool:
+    for name in ("bot.kraken_reconnect_supervisor", "kraken_reconnect_supervisor"):
+        module = sys.modules.get(name)
+        probe = getattr(module, "is_permanent_failure_latched", None) if module else None
+        if callable(probe):
+            try:
+                return bool(probe())
+            except Exception:
+                return True
+    try:
+        module = importlib.import_module("bot.kraken_reconnect_supervisor")
+        probe = getattr(module, "is_permanent_failure_latched", None)
+        if callable(probe):
+            return bool(probe())
+    except ImportError:
+        return False
+    except Exception:
+        return True
+    return False
+
+
+def _rearm_if_stale_success(v24: ModuleType, broker: Any) -> bool:
+    """Clear only the stale post-success guard; never interrupt in-flight recovery."""
+    if broker is None or bool(getattr(broker, "connected", False)):
+        return False
+    if not bool(getattr(v24, "_KRAKEN_RECOVERY_STARTED", False)):
+        return False
+    if not _truthy("NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"):
+        return False
+    with _LOCK:
+        if bool(getattr(broker, "connected", False)):
+            return False
+        if not bool(getattr(v24, "_KRAKEN_RECOVERY_STARTED", False)):
+            return False
+        if not _truthy("NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"):
+            return False
+        setattr(v24, "_KRAKEN_RECOVERY_STARTED", False)
+        os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] = "0"
+    LOGGER.critical(
+        "KRAKEN_V44_STALE_SUCCESS_REARMED marker=%s connected=false previous_ready=true",
+        MARKER,
+    )
+    return True
+
+
+def reconcile_once() -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "ok": False,
+        "action": "none",
+        "reason": "uninitialized",
+        "connected": False,
+    }
+    v24 = _v24()
+    if v24 is None:
+        result["reason"] = "v24_unavailable"
+        return result
+    if not _credentials_ready(v24):
+        result["reason"] = "credentials_not_configured_or_disabled"
+        return result
+    lineage_ok, lineage_reason = _lineage_ready(v24)
+    if not lineage_ok:
+        result["reason"] = lineage_reason or "writer_lineage_not_ready"
+        return result
+    if _permanent_failure_latched():
+        result["reason"] = "permanent_auth_or_config_failure_latched"
+        return result
+
+    manager = _manager()
+    if manager is None:
+        result["reason"] = "canonical_manager_unavailable"
+        return result
+    broker = _canonical_kraken(manager)
+    if broker is None:
+        prepare = getattr(v24, "_prepare_canonical_manager", None)
+        if callable(prepare):
+            try:
+                manager = prepare()
+                broker = _canonical_kraken(manager)
+            except Exception as exc:
+                result["reason"] = f"canonical_prepare_failed:{type(exc).__name__}:{exc}"
+                return result
+    if broker is None:
+        result["reason"] = "canonical_kraken_unavailable"
+        return result
+
+    connected = bool(getattr(broker, "connected", False))
+    result["connected"] = connected
+    if connected:
+        result.update(ok=True, action="none", reason="already_connected")
+        return result
+
+    rearmed = _rearm_if_stale_success(v24, broker)
+    starter = getattr(v24, "_start_kraken_authenticated_recovery", None)
+    if not callable(starter):
+        result["reason"] = "authenticated_recovery_unavailable"
+        return result
+
+    already_started = bool(getattr(v24, "_KRAKEN_RECOVERY_STARTED", False))
+    if already_started and not rearmed:
+        result["reason"] = "authenticated_recovery_in_flight"
+        result["action"] = "observe"
+        return result
+
+    try:
+        started = bool(starter(manager))
+    except Exception as exc:
+        result["reason"] = f"authenticated_recovery_start_failed:{type(exc).__name__}:{exc}"
+        return result
+
+    if started:
+        result.update(
+            ok=True,
+            action="recovery_started",
+            reason="stale_success_rearmed" if rearmed else "disconnected_recovery_started",
+        )
+        LOGGER.warning(
+            "KRAKEN_V44_RECOVERY_STARTED marker=%s reason=%s writer_lineage=%s",
+            MARKER,
+            result["reason"],
+            lineage_reason,
+        )
+    else:
+        result["reason"] = "authenticated_recovery_not_started"
+    return result
+
+
+def _watchdog_loop() -> None:
+    try:
+        interval = max(
+            5.0,
+            float(os.environ.get("NIJA_KRAKEN_CONNECTION_WATCHDOG_INTERVAL_S", "15") or "15"),
+        )
+    except (TypeError, ValueError):
+        interval = 15.0
+    last_signature = ""
+    while not _STOP.wait(interval):
+        try:
+            state = reconcile_once()
+            signature = f"{state.get('action')}:{state.get('reason')}:{state.get('connected')}"
+            if signature != last_signature:
+                log = LOGGER.info if state.get("connected") else LOGGER.warning
+                log(
+                    "KRAKEN_V44_WATCHDOG marker=%s connected=%s action=%s reason=%s",
+                    MARKER,
+                    str(bool(state.get("connected"))).lower(),
+                    state.get("action"),
+                    state.get("reason"),
+                )
+                last_signature = signature
+        except Exception as exc:
+            LOGGER.warning(
+                "KRAKEN_V44_WATCHDOG_ERROR marker=%s error=%s:%s",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def install() -> bool:
+    global _WATCHDOG_STARTED
+    with _LOCK:
+        if _WATCHDOG_STARTED:
+            os.environ["NIJA_KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED"] = "1"
+            return True
+        _WATCHDOG_STARTED = True
+        os.environ["NIJA_KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED"] = "1"
+        thread = threading.Thread(
+            target=_watchdog_loop,
+            name="KrakenConnectionConvergenceV44",
+            daemon=True,
+        )
+        thread.start()
+    # Run one reconciliation immediately so startup does not wait one interval.
+    try:
+        reconcile_once()
+    except Exception:
+        LOGGER.exception("KRAKEN_V44_INITIAL_RECONCILE_FAILED marker=%s", MARKER)
+    LOGGER.critical(
+        "KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED marker=%s fail_closed=true fabricates_connected=false",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "reconcile_once",
+    "_rearm_if_stale_success",
+]

--- a/bot/tests/test_capital_publication_convergence_v43.py
+++ b/bot/tests/test_capital_publication_convergence_v43.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "capital_publication_convergence_v43_patch.py"
+
+
+def _load_patch():
+    name = "test_capital_publication_convergence_v43_patch"
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, PATCH_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    real_capital: float
+    usable_capital: float
+    risk_capital: float
+    open_exposure_usd: float
+    reserve_pct: float
+    broker_balances: dict[str, float]
+    broker_count: int
+    expected_brokers: int
+    computed_at: datetime
+
+
+class Observation:
+    def __init__(self, value: float, age_s: float = 0.0):
+        self.value = value
+        self.observed_monotonic = time.monotonic() - age_s
+
+
+class FakeCA:
+    _AUTHORIZED_WRITER_ID = "mabm_capital_refresh_coordinator"
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._last_typed_snapshot = None
+        self._broker_balances = {}
+        self._last_updated_total = 0.0
+        self.last_updated = None
+        self._hydrated = False
+        self._warm_start = False
+        self.accepted = None
+
+    def publish_snapshot(self, snapshot, writer_id: str):
+        if writer_id != self._AUTHORIZED_WRITER_ID:
+            return False
+        self._last_typed_snapshot = snapshot
+        self._broker_balances = dict(snapshot.broker_balances)
+        self.last_updated = snapshot.computed_at
+        self._hydrated = True
+        self.accepted = snapshot
+        return True
+
+
+
+def _snapshot() -> Snapshot:
+    return Snapshot(
+        real_capital=95.1159355748,
+        usable_capital=93.213616863304,
+        risk_capital=93.213616863304,
+        open_exposure_usd=0.0,
+        reserve_pct=0.02,
+        broker_balances={"coinbase": 95.1159355748},
+        broker_count=1,
+        expected_brokers=3,
+        computed_at=datetime.now(timezone.utc),
+    )
+
+
+def _install_guard(monkeypatch, *, okx_age=5.0, kraken_age=5.0):
+    guard = ModuleType("bot.capital_refresh_stall_guard_v35")
+    guard._OBSERVATIONS = {
+        "okx": Observation(144.96287318737, okx_age),
+        "kraken": Observation(228.17, kraken_age),
+    }
+    guard._OBSERVATION_LOCK = threading.Lock()
+    guard._freshness_ttl_seconds = lambda: 90.0
+    monkeypatch.setitem(sys.modules, "bot.capital_refresh_stall_guard_v35", guard)
+    monkeypatch.setitem(sys.modules, "capital_refresh_stall_guard_v35", guard)
+    return guard
+
+
+def _install_brokers(monkeypatch, *, okx_connected=True, kraken_connected=False):
+    broker_mod = ModuleType("bot.broker_manager")
+    okx = SimpleNamespace(connected=okx_connected, account_type="platform", name="okx")
+    kraken = SimpleNamespace(connected=kraken_connected, account_type="platform", name="kraken")
+    broker_mod._PLATFORM_BROKER_INSTANCES = {"okx": okx, "kraken": kraken}
+    broker_mod.GLOBAL_PLATFORM_BROKERS = broker_mod._PLATFORM_BROKER_INSTANCES
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", broker_mod)
+    monkeypatch.setitem(sys.modules, "broker_manager", broker_mod)
+    return broker_mod
+
+
+def test_augments_connected_fresh_okx_only(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    repaired, additions = patch._augment_snapshot(_snapshot())
+    assert set(repaired.broker_balances) == {"coinbase", "okx"}
+    assert abs(repaired.real_capital - 240.07880876217) < 1e-6
+    assert repaired.broker_count == 2
+    assert "okx" in additions
+    assert "kraken" not in additions
+
+
+def test_stale_okx_not_promoted(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch, okx_age=120.0)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    repaired, additions = patch._augment_snapshot(_snapshot())
+    assert repaired == _snapshot() or repaired.broker_balances == {"coinbase": 95.1159355748}
+    assert additions == {}
+
+
+def test_disconnected_okx_not_promoted(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch)
+    _install_brokers(monkeypatch, okx_connected=False, kraken_connected=False)
+    repaired, additions = patch._augment_snapshot(_snapshot())
+    assert repaired.broker_balances == {"coinbase": 95.1159355748}
+    assert additions == {}
+
+
+def test_current_snapshot_value_wins(monkeypatch):
+    patch = _load_patch()
+    guard = _install_guard(monkeypatch)
+    guard._OBSERVATIONS["coinbase"] = Observation(1.0, 1.0)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    repaired, _ = patch._augment_snapshot(_snapshot())
+    assert abs(repaired.broker_balances["coinbase"] - 95.1159355748) < 1e-9
+
+
+def test_recomputes_usable_and_risk(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    snap = Snapshot(**{**_snapshot().__dict__, "open_exposure_usd": 10.0})
+    repaired, _ = patch._augment_snapshot(snap)
+    assert abs(repaired.usable_capital - repaired.real_capital * 0.98) < 1e-9
+    assert abs(repaired.risk_capital - (repaired.usable_capital - 10.0)) < 1e-9
+
+
+def test_patch_publish_commits_canonical_snapshot(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    module = ModuleType("bot.capital_authority")
+    module.CapitalAuthority = FakeCA
+    assert patch._patch_capital_authority(module)
+    ca = FakeCA()
+    assert ca.publish_snapshot(_snapshot(), writer_id=ca._AUTHORIZED_WRITER_ID)
+    assert abs(ca.accepted.real_capital - 240.07880876217) < 1e-6
+    assert abs(ca.total_capital - ca.accepted.real_capital) < 1e-9
+    assert ca._last_updated_total == ca.accepted.real_capital
+
+
+def test_unauthorized_writer_not_augmented(monkeypatch):
+    patch = _load_patch()
+    _install_guard(monkeypatch)
+    _install_brokers(monkeypatch, okx_connected=True, kraken_connected=False)
+    module = ModuleType("bot.capital_authority")
+    module.CapitalAuthority = FakeCA
+    patch._patch_capital_authority(module)
+    ca = FakeCA()
+    assert ca.publish_snapshot(_snapshot(), writer_id="other_writer") is False
+    assert ca.accepted is None
+
+
+def test_total_capital_ignores_unattributed_updated_total(monkeypatch):
+    patch = _load_patch()
+    module = ModuleType("bot.capital_authority")
+    module.CapitalAuthority = FakeCA
+    patch._patch_capital_authority(module)
+    ca = FakeCA()
+    ca._last_typed_snapshot = _snapshot()
+    ca._broker_balances = {"coinbase": 95.1159355748, "okx": 144.96287318737}
+    ca._last_updated_total = 9999.0
+    assert abs(ca.total_capital - _snapshot().real_capital) < 1e-9
+
+
+def test_live_v2_late_patch_is_recanonicalized(monkeypatch):
+    patch = _load_patch()
+    ca_module = ModuleType("bot.capital_authority")
+    ca_module.CapitalAuthority = FakeCA
+    patch._patch_capital_authority(ca_module)
+
+    live = ModuleType("bot.capital_authority_live_total_v2_patch")
+    def legacy_patch(target):
+        def legacy_total(self):
+            return 9999.0
+        target.CapitalAuthority.total_capital = property(legacy_total)
+        return True
+    live._patch_module = legacy_patch
+    assert patch._patch_live_total_v2(live)
+    assert live._patch_module(ca_module)
+    ca = FakeCA()
+    ca._last_typed_snapshot = _snapshot()
+    assert abs(ca.total_capital - _snapshot().real_capital) < 1e-9

--- a/bot/tests/test_kraken_connection_convergence_v44.py
+++ b/bot/tests/test_kraken_connection_convergence_v44.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "kraken_connection_convergence_v44_patch.py"
+
+
+def _load_module(name: str = "test_kraken_connection_convergence_v44_patch"):
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_v24(*, started: bool, ready: bool = True):
+    calls = []
+    module = types.ModuleType("fake_v24")
+    module._KRAKEN_RECOVERY_STARTED = started
+    module._writer_lineage = lambda: (True, "lineage_ready generation=44")
+    module._kraken_credentials_configured = lambda: True
+
+    def _start(manager):
+        calls.append(manager)
+        module._KRAKEN_RECOVERY_STARTED = True
+        return True
+
+    module._start_kraken_authenticated_recovery = _start
+    if ready:
+        os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] = "1"
+    else:
+        os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] = "0"
+    return module, calls
+
+
+class _Broker:
+    def __init__(self, connected: bool):
+        self.connected = connected
+
+
+class TestKrakenConnectionConvergenceV44:
+    def teardown_method(self):
+        os.environ.pop("NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY", None)
+
+    def test_stale_success_latch_is_rearmed_only_when_disconnected(self):
+        module = _load_module("v44_test_rearm")
+        v24, _calls = _fake_v24(started=True, ready=True)
+        broker = _Broker(connected=False)
+
+        assert module._rearm_if_stale_success(v24, broker) is True
+        assert v24._KRAKEN_RECOVERY_STARTED is False
+        assert os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] == "0"
+
+    def test_connected_broker_never_rearms_recovery(self):
+        module = _load_module("v44_test_connected")
+        v24, _calls = _fake_v24(started=True, ready=True)
+        broker = _Broker(connected=True)
+
+        assert module._rearm_if_stale_success(v24, broker) is False
+        assert v24._KRAKEN_RECOVERY_STARTED is True
+        assert os.environ["NIJA_KRAKEN_AUTHENTICATED_RECOVERY_READY"] == "1"
+
+    def test_inflight_recovery_is_not_interrupted(self):
+        module = _load_module("v44_test_inflight")
+        v24, _calls = _fake_v24(started=True, ready=False)
+        broker = _Broker(connected=False)
+
+        assert module._rearm_if_stale_success(v24, broker) is False
+        assert v24._KRAKEN_RECOVERY_STARTED is True
+
+    def test_reconcile_starts_existing_authenticated_recovery(self, monkeypatch):
+        module = _load_module("v44_test_start")
+        v24, calls = _fake_v24(started=False, ready=False)
+        manager = object()
+        broker = _Broker(connected=False)
+
+        monkeypatch.setattr(module, "_v24", lambda: v24)
+        monkeypatch.setattr(module, "_manager", lambda: manager)
+        monkeypatch.setattr(module, "_canonical_kraken", lambda _manager: broker)
+        monkeypatch.setattr(module, "_permanent_failure_latched", lambda: False)
+
+        result = module.reconcile_once()
+
+        assert result["ok"] is True
+        assert result["action"] == "recovery_started"
+        assert result["connected"] is False
+        assert calls == [manager]
+        # v44 does not fabricate connection state; the existing recovery owns it.
+        assert broker.connected is False
+
+    def test_reconcile_rearms_stale_success_then_restarts(self, monkeypatch):
+        module = _load_module("v44_test_restart")
+        v24, calls = _fake_v24(started=True, ready=True)
+        manager = object()
+        broker = _Broker(connected=False)
+
+        monkeypatch.setattr(module, "_v24", lambda: v24)
+        monkeypatch.setattr(module, "_manager", lambda: manager)
+        monkeypatch.setattr(module, "_canonical_kraken", lambda _manager: broker)
+        monkeypatch.setattr(module, "_permanent_failure_latched", lambda: False)
+
+        result = module.reconcile_once()
+
+        assert result["ok"] is True
+        assert result["action"] == "recovery_started"
+        assert result["reason"] == "stale_success_rearmed"
+        assert calls == [manager]
+
+    def test_permanent_auth_failure_remains_fail_closed(self, monkeypatch):
+        module = _load_module("v44_test_perm")
+        v24, calls = _fake_v24(started=False, ready=False)
+
+        monkeypatch.setattr(module, "_v24", lambda: v24)
+        monkeypatch.setattr(module, "_permanent_failure_latched", lambda: True)
+
+        result = module.reconcile_once()
+
+        assert result["ok"] is False
+        assert result["action"] == "none"
+        assert result["reason"] == "permanent_auth_or_config_failure_latched"
+        assert calls == []
+
+    def test_missing_writer_lineage_never_starts_recovery(self, monkeypatch):
+        module = _load_module("v44_test_lineage")
+        v24, calls = _fake_v24(started=False, ready=False)
+        v24._writer_lineage = lambda: (False, "lease_not_acquired")
+
+        monkeypatch.setattr(module, "_v24", lambda: v24)
+        monkeypatch.setattr(module, "_permanent_failure_latched", lambda: False)
+
+        result = module.reconcile_once()
+
+        assert result["ok"] is False
+        assert result["reason"] == "lease_not_acquired"
+        assert calls == []
+
+    def test_already_connected_does_not_start_duplicate_recovery(self, monkeypatch):
+        module = _load_module("v44_test_no_duplicate")
+        v24, calls = _fake_v24(started=False, ready=False)
+        manager = object()
+        broker = _Broker(connected=True)
+
+        monkeypatch.setattr(module, "_v24", lambda: v24)
+        monkeypatch.setattr(module, "_manager", lambda: manager)
+        monkeypatch.setattr(module, "_canonical_kraken", lambda _manager: broker)
+        monkeypatch.setattr(module, "_permanent_failure_latched", lambda: False)
+
+        result = module.reconcile_once()
+
+        assert result["ok"] is True
+        assert result["reason"] == "already_connected"
+        assert result["connected"] is True
+        assert calls == []

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -22,7 +22,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
-MARKER = "20260807-canonical-runtime-launcher-v26-v42-v41-v40-v39-v38-v37-v18"
+MARKER = "20260807-canonical-runtime-launcher-v26-v44-v43-v42-v41-v40-v39-v38-v37-v18"
 ROOT = Path(__file__).resolve().parents[1]
 V24_PATH = ROOT / "bot" / "canonical_broker_startup_convergence_v24.py"
 V32_PATH = ROOT / "bot" / "runtime_execution_convergence_v32.py"
@@ -35,6 +35,8 @@ V39_PATH = ROOT / "bot" / "production_readiness_v39_patch.py"
 V40_PATH = ROOT / "bot" / "stale_renewal_recovery_v40_patch.py"
 V41_PATH = ROOT / "bot" / "activation_lifecycle_handoff_v41_patch.py"
 V42_PATH = ROOT / "bot" / "heartbeat_authority_reanchor_v42_patch.py"
+V43_PATH = ROOT / "bot" / "capital_publication_convergence_v43_patch.py"
+V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"
 V18_PATH = ROOT / "bot" / "production_corrective_set_v18_patch.py"
 V19_PATH = ROOT / "bot" / "entrypoint_writer_epoch_recovery_v19_patch.py"
 MAIN_PATH = ROOT / "main.py"
@@ -179,6 +181,30 @@ def _install_heartbeat_authority_reanchor_v42() -> ModuleType:
     return module
 
 
+def _install_capital_publication_convergence_v43() -> ModuleType:
+    if not V43_PATH.is_file():
+        raise RuntimeError(f"capital publication convergence v43 missing: {V43_PATH}")
+    module = _load_module_by_path("nija_capital_publication_convergence_v43_prebot", V43_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("capital publication convergence v43 installer failed")
+    if os.environ.get("NIJA_CAPITAL_PUBLICATION_CONVERGENCE_V43_INSTALLED") != "1":
+        raise RuntimeError("capital publication convergence v43 did not attest installed")
+    return module
+
+
+def _install_kraken_connection_convergence_v44() -> ModuleType:
+    if not V44_PATH.is_file():
+        raise RuntimeError(f"Kraken connection convergence v44 missing: {V44_PATH}")
+    module = _load_module_by_path("nija_kraken_connection_convergence_v44_prebot", V44_PATH)
+    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+    if not callable(installer) or not bool(installer()):
+        raise RuntimeError("Kraken connection convergence v44 installer failed")
+    if os.environ.get("NIJA_KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED") != "1":
+        raise RuntimeError("Kraken connection convergence v44 did not attest installed")
+    return module
+
+
 def _install_production_corrective_set() -> ModuleType:
     if not V18_PATH.is_file():
         raise RuntimeError(f"production corrective set missing: {V18_PATH}")
@@ -210,10 +236,12 @@ def install_canonical_startup_guard() -> ModuleType:
     _install_stale_renewal_recovery_v40()
     _install_activation_lifecycle_handoff_v41()
     _install_heartbeat_authority_reanchor_v42()
+    _install_capital_publication_convergence_v43()
+    _install_kraken_connection_convergence_v44()
     _install_production_corrective_set()
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY"] = "1"
     os.environ["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_MARKER"] = MARKER
-    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v38_installed=true v19_installed=true v39_installed=true v40_installed=true v41_installed=true v42_installed=true v18_installed=true", MARKER)
+    LOGGER.critical("CANONICAL_RUNTIME_LAUNCHER_V26_READY marker=%s bot_main_preloaded=false v24_installed=true v32_installed=true v33_installed=true v34_installed=true v36_installed=true v37_installed=true v38_installed=true v19_installed=true v39_installed=true v40_installed=true v41_installed=true v42_installed=true v43_installed=true v44_installed=true v18_installed=true", MARKER)
     return module
 
 
@@ -223,7 +251,7 @@ def main() -> int:
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
-    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v42-v41-v40-v39-v38-v37-v18 package_hook_fanout=deferred", flush=True)
+    print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v44-v43-v42-v41-v40-v39-v38-v37-v18 package_hook_fanout=deferred", flush=True)
     runpy.run_path(str(MAIN_PATH), run_name="__main__")
     return 0
 


### PR DESCRIPTION
## What changed

- Add v43 capital-publication convergence so fresh connected-broker balances preserved by the v37 sticky-success guard are merged into the canonical typed CapitalAuthority snapshot before publication.
- Keep current-cycle snapshot values authoritative; only add an omitted broker when its v37 observation is fresh, positive, platform-scoped, and the canonical platform broker is currently connected.
- Recompute real/usable/risk capital and broker_count from the exact merged broker map. Do not promote stale, disconnected, user-account, zero, or unattributed aggregate-only capital.
- Canonicalize `total_capital` back to the typed snapshot after publication so the legacy live-total v2 property cannot expose a different capital truth from downstream snapshot readers.
- Add v44 Kraken connection convergence. It watches the canonical Kraken broker and re-arms the existing authenticated recovery only when a previous successful-recovery latch is stale and the broker is actually disconnected.
- v44 never sets `broker.connected=True`, never fabricates authentication, and never bypasses the existing Kraken reconnect supervisor. Permanent auth/config failures remain fail-closed.
- Wire v43 and v44 into `canonical_runtime_launcher_v26.py` after v42 and before production corrective hooks.

## Why

Production showed Coinbase timing out safely to a cached `$95.12`, OKX independently funded at about `$144.96`, and the legacy live-total layer selecting about `$240.08`, while the canonical typed snapshot still published only `$95.12` / one broker. The same sample also showed Kraken configured but `kraken_connected=False`.

The capital problem was a publication-boundary divergence: a read-time aggregate could be newer than the typed snapshot consumed by readiness and capital CSM code. The Kraken problem was a restartability gap: the existing authenticated recovery guard stays latched after success, so a later disconnect can prevent a new recovery cycle from starting.

## Safety properties

- No force activation.
- No synthetic capital.
- No disconnected Kraken capital is counted.
- No stale observation is promoted.
- No user-account capital is aggregated unless already present in the authorized coordinator snapshot.
- No fabricated Kraken connection/authentication state.
- No bypass of Redis writer lineage, fencing, nonce, SEAK, kill-switch, risk, or readiness gates.
- Permanent Kraken authentication/configuration failures remain blocked by the existing reconnect supervisor.

## Validation

- Branch is based exactly on merged v42 commit `95aed5beece3b793479b35efe8f8ee359b141a68`.
- Diff is limited to 5 intended files: v43 patch/tests, v44 patch/tests, and canonical launcher wiring.
- Focused regression files are included for capital merge/exclusion behavior and Kraken stale-success rearm/reconnect behavior.
- Local container execution could not clone GitHub because this environment could not resolve `github.com`; GitHub Actions is the authoritative CI validation before merge.