### PR TITLE
Fix v45 writer generation patch idempotence

### DIFF
--- a/bot/tests/test_writer_generation_idempotence_v47.py
+++ b/bot/tests/test_writer_generation_idempotence_v47.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "writer_generation_idempotence_v47_patch.py"
+spec = importlib.util.spec_from_file_location("nija_test_writer_generation_idempotence_v47", PATCH_PATH)
+assert spec is not None and spec.loader is not None
+v47 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(v47)
+
+
+def fake_v45(generation=3337, proof_ok=True):
+    module = types.ModuleType("nija_writer_generation_handoff_v45_prebot")
+    module._HEARTBEAT_PATCH = "_v45_hb"
+    module._prove_process_writer = lambda: ({"generation": generation}, "") if proof_ok else (None, "no_proof")
+
+    def patch_hb(target):
+        cls = target.AuthorityHeartbeatMonitor
+
+        def hb(self):
+            return None
+
+        hb._v45_hb = True
+        cls._write_heartbeat_to_redis = hb
+        return True
+
+    module._patch_heartbeat_module = patch_hb
+    module._patch_scope_module = lambda _scope: True
+    return module
+
+
+def fake_scope(counter):
+    module = types.ModuleType("authority_heartbeat_generation_scope_patch")
+    module._platform_generation = lambda: (10, "")
+
+    def legacy(target):
+        counter[0] += 1
+
+        def legacy_hb(self):
+            return None
+
+        target.AuthorityHeartbeatMonitor._write_heartbeat_to_redis = legacy_hb
+        return True
+
+    module._patch_module = legacy
+    return module
+
+
+def fake_target():
+    module = types.ModuleType("bot.authority_heartbeat")
+
+    class Monitor:
+        def _write_heartbeat_to_redis(self):
+            return None
+
+    module.AuthorityHeartbeatMonitor = Monitor
+    return module
+
+
+def test_scope_wrapper_stops_legacy_ping_pong():
+    count = [0]
+    v45 = fake_v45()
+    scope = fake_scope(count)
+    target = fake_target()
+    assert v47._converge_scope_module(v45, scope)
+    assert scope._patch_module(target)
+    first = target.AuthorityHeartbeatMonitor._write_heartbeat_to_redis
+    assert getattr(first, "_v45_hb", False)
+    assert count[0] == 1
+    assert scope._patch_module(target)
+    assert target.AuthorityHeartbeatMonitor._write_heartbeat_to_redis is first
+    assert count[0] == 1
+
+
+def test_converge_scope_is_idempotent():
+    count = [0]
+    v45 = fake_v45()
+    scope = fake_scope(count)
+    assert v47._converge_scope_module(v45, scope)
+    generation_fn = scope._platform_generation
+    patch_fn = scope._patch_module
+    assert v47._converge_scope_module(v45, scope)
+    assert scope._platform_generation is generation_fn
+    assert scope._patch_module is patch_fn
+
+
+def test_stable_v45_scope_patcher_does_not_recreate_wrappers():
+    count = [0]
+    v45 = fake_v45()
+    scope = fake_scope(count)
+    assert v47._patch_v45_module(v45)
+    patcher = v45._patch_scope_module
+    assert patcher(scope)
+    generation_fn = scope._platform_generation
+    scope_patch = scope._patch_module
+    assert patcher(scope)
+    assert v45._patch_scope_module is patcher
+    assert scope._platform_generation is generation_fn
+    assert scope._patch_module is scope_patch
+
+
+def test_generation_uses_v45_process_writer_proof():
+    v45 = fake_v45(4444)
+    assert v47._process_generation(v45) == (4444, "")
+
+
+def test_generation_fails_closed_without_proof():
+    v45 = fake_v45(proof_ok=False)
+    assert v47._process_generation(v45) == (0, "no_proof")
+
+
+def test_reconcile_patches_loaded_aliases(monkeypatch):
+    count = [0]
+    v45 = fake_v45()
+    scope = fake_scope(count)
+    monkeypatch.setitem(sys.modules, "nija_writer_generation_handoff_v45_prebot", v45)
+    monkeypatch.setitem(sys.modules, "authority_heartbeat_generation_scope_patch", scope)
+    state = v47.reconcile_once()
+    assert state["ready"] is True
+    assert getattr(v45._patch_scope_module, v47._V45_PATCHER_MARK, False)
+    assert getattr(scope._patch_module, v47._SCOPE_WRAPPER_MARK, False)

--- a/bot/writer_generation_idempotence_v47_patch.py
+++ b/bot/writer_generation_idempotence_v47_patch.py
@@ -1,0 +1,228 @@
+"""NIJA v47 convergence guard for v45 heartbeat-generation patching.
+
+v45 correctly moved process-writer generation back under EntrypointWriterAuthority,
+but the legacy authority-heartbeat generation-scope watchdog can repeatedly
+reinstall its writer. v45 then immediately replaces it again, producing a
+high-frequency patch ping-pong and CRITICAL log storm.
+
+v47 makes that boundary idempotent. Once the v45 heartbeat writer owns the
+AuthorityHeartbeatMonitor method, subsequent legacy scope-patch attempts become
+no-ops. It also replaces v45's scope patch helper with a stable implementation
+that does not recreate wrapper functions on every watchdog pass.
+
+No writer authority is granted here. No Redis lock is created, extended,
+deleted, or stolen. No Kraken, capital, SEAK, readiness, risk, or dispatch gate
+is changed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_generation_idempotence_v47")
+MARKER = "20260808-writer-generation-idempotence-v47"
+
+_LOCK = threading.RLock()
+_INSTALLED = False
+_WATCHDOG_STARTED = False
+_SCOPE_WRAPPER_MARK = "_nija_writer_generation_idempotence_v47_scope_wrapper"
+_SCOPE_GENERATION_MARK = "_nija_writer_generation_idempotence_v47_generation"
+_V45_PATCHER_MARK = "_nija_writer_generation_idempotence_v47_v45_patcher"
+_MODULE_MARK = "_nija_writer_generation_idempotence_v47_converged"
+
+_V45_NAMES = (
+    "nija_writer_generation_handoff_v45_prebot",
+    "bot.writer_generation_handoff_v45_patch",
+    "writer_generation_handoff_v45_patch",
+)
+_SCOPE_NAMES = ("authority_heartbeat_generation_scope_patch",)
+
+
+def _modules(names: tuple[str, ...]) -> list[ModuleType]:
+    found: list[ModuleType] = []
+    seen: set[int] = set()
+    for name in names:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            found.append(module)
+    return found
+
+
+def _heartbeat_writer(target: ModuleType) -> Any:
+    cls = getattr(target, "AuthorityHeartbeatMonitor", None)
+    return getattr(cls, "_write_heartbeat_to_redis", None) if isinstance(cls, type) else None
+
+
+def _is_v45_heartbeat(target: ModuleType, v45: ModuleType) -> bool:
+    marker = str(
+        getattr(v45, "_HEARTBEAT_PATCH", "_nija_writer_generation_handoff_v45_heartbeat")
+        or "_nija_writer_generation_handoff_v45_heartbeat"
+    )
+    return bool(getattr(_heartbeat_writer(target), marker, False))
+
+
+def _process_generation(v45: ModuleType) -> tuple[int, str]:
+    proof_fn = getattr(v45, "_prove_process_writer", None)
+    if not callable(proof_fn):
+        return 0, "v45_process_writer_proof_unavailable"
+    try:
+        proof, reason = proof_fn()
+    except Exception as exc:
+        return 0, f"v45_process_writer_proof_error:{type(exc).__name__}:{exc}"
+    if proof is None:
+        return 0, str(reason or "process_writer_proof_failed")
+    try:
+        generation = int(proof.get("generation", 0) or 0)
+    except Exception:
+        generation = 0
+    if generation <= 0:
+        return 0, "process_writer_generation_invalid"
+    return generation, ""
+
+
+def _converge_scope_module(v45: ModuleType, scope: ModuleType) -> bool:
+    changed = False
+
+    generation_fn = getattr(scope, "_platform_generation", None)
+    if not getattr(generation_fn, _SCOPE_GENERATION_MARK, False):
+        def process_generation() -> tuple[int, str]:
+            return _process_generation(v45)
+
+        setattr(process_generation, _SCOPE_GENERATION_MARK, True)
+        scope._platform_generation = process_generation
+        changed = True
+
+    current = getattr(scope, "_patch_module", None)
+    if not getattr(current, _SCOPE_WRAPPER_MARK, False):
+        legacy = current
+
+        @wraps(legacy if callable(legacy) else (lambda _target: False))
+        def patch_module(target: ModuleType) -> bool:
+            # Once v45 owns the heartbeat method, do not call the legacy scope
+            # patcher again. It would overwrite v45 and restart the ping-pong.
+            if _is_v45_heartbeat(target, v45):
+                return True
+            result = False
+            if callable(legacy):
+                result = bool(legacy(target))
+            patch_v45 = getattr(v45, "_patch_heartbeat_module", None)
+            if callable(patch_v45):
+                result = bool(patch_v45(target)) or result
+            return result
+
+        setattr(patch_module, _SCOPE_WRAPPER_MARK, True)
+        if callable(legacy):
+            setattr(patch_module, "__wrapped__", legacy)
+        scope._patch_module = patch_module
+        changed = True
+
+    if not bool(getattr(scope, _MODULE_MARK, False)):
+        setattr(scope, _MODULE_MARK, True)
+        changed = True
+
+    if changed:
+        LOGGER.critical(
+            "WRITER_GENERATION_V47_SCOPE_CONVERGED marker=%s module=%s legacy_repatch_suppressed=true",
+            MARKER,
+            scope.__name__,
+        )
+    return True
+
+
+def _patch_v45_module(v45: ModuleType) -> bool:
+    current = getattr(v45, "_patch_scope_module", None)
+    if getattr(current, _V45_PATCHER_MARK, False):
+        return True
+
+    def stable_scope_patcher(scope: ModuleType) -> bool:
+        return _converge_scope_module(v45, scope)
+
+    setattr(stable_scope_patcher, _V45_PATCHER_MARK, True)
+    if callable(current):
+        setattr(stable_scope_patcher, "__wrapped__", current)
+    v45._patch_scope_module = stable_scope_patcher
+    LOGGER.critical(
+        "WRITER_GENERATION_V47_V45_PATCHER_CONVERGED marker=%s module=%s stable=true",
+        MARKER,
+        v45.__name__,
+    )
+    return True
+
+
+def reconcile_once() -> dict[str, Any]:
+    v45_modules = _modules(_V45_NAMES)
+    scope_modules = _modules(_SCOPE_NAMES)
+    patched_v45 = 0
+    patched_scope = 0
+
+    for v45 in v45_modules:
+        if _patch_v45_module(v45):
+            patched_v45 += 1
+        for scope in scope_modules:
+            if _converge_scope_module(v45, scope):
+                patched_scope += 1
+
+    return {
+        "v45_modules": len(v45_modules),
+        "scope_modules": len(scope_modules),
+        "patched_v45": patched_v45,
+        "patched_scope": patched_scope,
+        "ready": bool(v45_modules),
+    }
+
+
+def _watchdog() -> None:
+    # v45 already owns the import hooks. This quiet watchdog only catches a
+    # later alias/module load and never emits per-pass success logs.
+    deadline = time.monotonic() + max(
+        120.0,
+        float(os.environ.get("NIJA_WRITER_GENERATION_V47_WATCHDOG_S", "900") or 900),
+    )
+    while time.monotonic() < deadline:
+        try:
+            reconcile_once()
+        except Exception:
+            LOGGER.debug("WRITER_GENERATION_V47_RECONCILE_DEFERRED", exc_info=True)
+        time.sleep(1.0)
+
+
+def install() -> bool:
+    global _INSTALLED, _WATCHDOG_STARTED
+    with _LOCK:
+        reconcile_once()
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="WriterGenerationIdempotenceV47",
+                daemon=True,
+            ).start()
+        _INSTALLED = True
+        os.environ["NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED marker=%s legacy_repatch_suppressed=true fail_closed=true",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "reconcile_once",
+    "_converge_scope_module",
+    "_patch_v45_module",
+    "_process_generation",
+]

--- a/scripts/apply_writer_generation_handoff_v45.py
+++ b/scripts/apply_writer_generation_handoff_v45.py
@@ -1,72 +1,86 @@
 #!/usr/bin/env python3
-"""Idempotently wire writer-generation handoff v45 into canonical launcher v26."""
+"""Idempotently wire writer-generation handoff v45 and idempotence v47 into launcher v26."""
 from __future__ import annotations
 
 from pathlib import Path
+import py_compile
 
 ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
-MARKER = "20260807-writer-generation-handoff-v45"
+V47 = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"
+MARKER = "20260808-writer-generation-idempotence-v47"
 
 
 def _replace_once(text: str, old: str, new: str, label: str) -> str:
     if new in text:
         return text
     if old not in text:
-        raise RuntimeError(f"v45 launcher patch anchor missing: {label}")
+        raise RuntimeError(f"writer generation launcher patch anchor missing: {label}")
     return text.replace(old, new, 1)
 
 
 def apply() -> bool:
+    if not V47.is_file():
+        raise RuntimeError(f"v47 runtime patch missing: {V47}")
+    py_compile.compile(str(V47), doraise=True)
+
     text = LAUNCHER.read_text(encoding="utf-8")
     original = text
 
     text = _replace_once(
         text,
         'MARKER = "20260807-canonical-runtime-launcher-v26-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
-        'MARKER = "20260807-canonical-runtime-launcher-v26-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
+        'MARKER = "20260808-canonical-runtime-launcher-v26-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
         "launcher marker",
     )
     text = _replace_once(
         text,
         'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV18_PATH',
-        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV18_PATH',
-        "v45 path",
+        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"\nV18_PATH',
+        "v45/v47 paths",
     )
 
-    function = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n'''
+    functions = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n\n\ndef _install_writer_generation_idempotence_v47() -> ModuleType:\n    if not V47_PATH.is_file():\n        raise RuntimeError(f"writer generation idempotence v47 missing: {V47_PATH}")\n    module = _load_module_by_path("nija_writer_generation_idempotence_v47_prebot", V47_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation idempotence v47 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED") != "1":\n        raise RuntimeError("writer generation idempotence v47 did not attest installed")\n    return module\n'''
     text = _replace_once(
         text,
         '\n\ndef _install_production_corrective_set() -> ModuleType:',
-        function + '\n\ndef _install_production_corrective_set() -> ModuleType:',
-        "v45 installer function",
+        functions + '\n\ndef _install_production_corrective_set() -> ModuleType:',
+        "v45/v47 installer functions",
     )
     text = _replace_once(
         text,
         '    _install_runtime_execution_convergence()\n',
-        '    _install_writer_generation_handoff_v45()\n    _install_runtime_execution_convergence()\n',
-        "v45 install order",
+        '    _install_writer_generation_handoff_v45()\n    _install_writer_generation_idempotence_v47()\n    _install_runtime_execution_convergence()\n',
+        "v45/v47 install order",
     )
     text = _replace_once(
         text,
         'v43_installed=true v44_installed=true v18_installed=true',
-        'v43_installed=true v44_installed=true v45_installed=true v18_installed=true',
+        'v43_installed=true v44_installed=true v45_installed=true v47_installed=true v18_installed=true',
         "ready attestation",
     )
     text = _replace_once(
         text,
         'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v44-v43-v42-v41-v40-v39-v38-v37-v18',
-        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
+        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260808-canonical-fast-entrypoint-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
         "fast marker",
     )
 
     if text != original:
         LAUNCHER.write_text(text, encoding="utf-8")
-    if 'V45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"' not in text:
-        raise RuntimeError("v45 path attestation missing after patch")
-    if '_install_writer_generation_handoff_v45()' not in text:
-        raise RuntimeError("v45 install call missing after patch")
-    print(f"WRITER_GENERATION_HANDOFF_V45_LAUNCHER_PATCHED marker={MARKER}", flush=True)
+    required = (
+        'V45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"',
+        'V47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"',
+        '_install_writer_generation_handoff_v45()',
+        '_install_writer_generation_idempotence_v47()',
+    )
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise RuntimeError("writer generation launcher attestation missing: " + ", ".join(missing))
+    print(
+        f"WRITER_GENERATION_HANDOFF_V45_V47_LAUNCHER_PATCHED marker={MARKER} v45=true v47=true",
+        flush=True,
+    )
     return True
 
 


### PR DESCRIPTION
## What changed

- Add v47 writer-generation idempotence convergence around the v45/legacy heartbeat-scope boundary.
- Once v45 owns `AuthorityHeartbeatMonitor._write_heartbeat_to_redis`, subsequent legacy scope-patch attempts become no-ops instead of overwriting v45 and triggering another v45 repatch.
- Replace v45's scope patch helper with a stable implementation that reuses the same generation and patch wrapper functions rather than recreating them every watchdog pass.
- Keep generation resolution sourced only from v45's exact process-writer proof; missing proof remains fail-closed.
- Extend the existing `apply_writer_generation_handoff_v45.py` launcher patcher to compile, attest, and install v47 immediately after v45 in canonical preboot. No new runtime script is added, avoiding another Docker allowlist dependency.

## Why

Production on commit `cbbb68abd3844d44fe74fbefe96f42afb027df39` showed repeated `AUTHORITY_HEARTBEAT_GENERATION_SCOPE_PATCHED`, `WRITER_GENERATION_V45_HEARTBEAT_PATCHED`, and `WRITER_GENERATION_V45_SCOPE_PATCHED` messages every few hundred milliseconds. Module identity remained clean, so this was not duplicate-module loading; the legacy scope watchdog and v45 watchdog were repeatedly replacing the same method with each other's wrapper.

The same sample showed a single `kraken_connected=False` connectivity snapshot. v44 already has writer-scoped authenticated reconnect and a 15-second watchdog / 30-second recovery cadence, so this PR does not fabricate or force Kraken connectivity from one transient sample. It removes the critical log storm so v44 recovery telemetry remains visible.

## Safety

- No writer authority is granted or synthesized.
- No Redis lock is created, recreated, deleted, stolen, or force-extended by v47.
- No nonce lease is promoted into process-writer lineage.
- No Kraken connection state is fabricated.
- No SEAK, emergency-stop, kill-switch, terminal-risk, readiness, capital, risk, or dispatch-health gate is bypassed.
- Missing v45 process-writer proof returns generation 0/error and remains fail-closed.

## Validation

- Branch starts exactly from current production/main `cbbb68abd3844d44fe74fbefe96f42afb027df39`.
- Focused v47 regression suite: `6 passed` locally.
- Tests prove legacy scope patch runs at most once after convergence, repeated v47 convergence preserves wrapper identity, v45 remains the final heartbeat writer, generation comes from exact v45 proof, and missing proof fails closed.
- Diff is limited to 3 intended files: v47 patch, v47 tests, and existing v45 launcher patcher wiring.
- Branch is 3 commits ahead and 0 behind base.