### PR TITLE
Fail closed on missing writer lock v48

### DIFF
--- a/bot/tests/test_writer_lost_epoch_v48.py
+++ b/bot/tests/test_writer_lost_epoch_v48.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "writer_lost_epoch_v48_patch.py"
+spec = importlib.util.spec_from_file_location("nija_test_writer_lost_epoch_v48", PATCH_PATH)
+assert spec is not None and spec.loader is not None
+v48 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(v48)
+
+
+class Redis:
+    def __init__(self, value="2036:owner"):
+        self.value = value
+        self.get_calls = []
+
+    def get(self, key):
+        self.get_calls.append(key)
+        return self.value
+
+
+class Runtime:
+    lost = False
+    _client = Redis()
+    _lock_key = "nija:writer_lock:process"
+    _lock_value = "2036:owner"
+    _generation = 3339
+    _token = "2036"
+
+
+def _module(original_result=(True, "")):
+    module = types.ModuleType("bot.entrypoint_writer_authority")
+
+    class Authority(Runtime):
+        calls = 0
+
+        def _heartbeat_tick(self):
+            type(self).calls += 1
+            return original_result
+
+    module.EntrypointWriterAuthority = Authority
+    return module, Authority
+
+
+def test_exact_owner_delegates_to_canonical_renewal(monkeypatch):
+    module, Authority = _module()
+    redis = Redis("2036:owner")
+    Authority._client = redis
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    result = Authority()._heartbeat_tick()
+    assert result == (True, "")
+    assert Authority.calls == 1
+
+
+def test_missing_lock_never_delegates_or_recreates(monkeypatch):
+    module, Authority = _module()
+    redis = Redis(None)
+    Authority._client = redis
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    ok, reason = Authority()._heartbeat_tick()
+    assert ok is False
+    assert reason == "lock_missing_and_fencing_token_mismatch"
+    assert Authority.calls == 0
+    assert redis.value is None
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_other_owner_is_nonrecoverable_and_never_delegates(monkeypatch):
+    module, Authority = _module()
+    Authority._client = Redis("9999:other")
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    ok, reason = Authority()._heartbeat_tick()
+    assert ok is False
+    assert reason == "lock_owned_by_different_writer"
+    assert Authority.calls == 0
+
+
+def test_redis_read_error_fails_closed(monkeypatch):
+    module, Authority = _module()
+
+    class BrokenRedis:
+        def get(self, _key):
+            raise RuntimeError("down")
+
+    Authority._client = BrokenRedis()
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    ok, reason = Authority()._heartbeat_tick()
+    assert ok is False
+    assert "redis_lock_read_error" in reason
+    assert Authority.calls == 0
+
+
+def test_already_lost_runtime_never_delegates(monkeypatch):
+    module, Authority = _module()
+    Authority.lost = True
+    Authority._client = Redis("2036:owner")
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    ok, reason = Authority()._heartbeat_tick()
+    assert ok is False
+    assert reason == "runtime_already_lost"
+    assert Authority.calls == 0
+
+
+def test_patch_is_idempotent():
+    module, Authority = _module()
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    first = Authority._heartbeat_tick
+    assert v48._patch_entrypoint_writer_authority(module) is True
+    assert Authority._heartbeat_tick is first

--- a/bot/writer_lost_epoch_v48_patch.py
+++ b/bot/writer_lost_epoch_v48_patch.py
@@ -1,0 +1,191 @@
+"""NIJA writer lost-epoch convergence v48.
+
+Production after v47 showed the process writer lock disappear while the runtime
+still held the same fencing token/generation. The canonical heartbeat renewal
+Lua path treated a missing lock plus matching fencing counter as recoverable and
+recreated the missing lock with the stale epoch. That delayed the intended v40
+-> v39 fresh-epoch recovery and allowed the recreated lock to expire again.
+
+v48 makes missing-lock handling strictly fail-closed:
+* exact current lock value -> delegate to the canonical renewal path;
+* missing lock -> return lock_missing_and_fencing_token_mismatch so the existing
+  heartbeat loop marks the runtime LOST and v39 performs fresh re-election;
+* different lock value -> return lock_owned_by_different_writer;
+* Redis read error -> fail closed without inferring ownership.
+
+This patch never creates, extends, deletes, or steals a Redis writer lock. It
+never changes broker, capital, SEAK, emergency-stop, readiness, risk, or
+execution-dispatch gates.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_lost_epoch_v48")
+MARKER = "20260808-writer-lost-epoch-v48"
+
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_writer_lost_epoch_v48"
+_INSTALL_FLAG = "_NIJA_WRITER_LOST_EPOCH_V48_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_WRITER_LOST_EPOCH_V48_IMPORTLIB_HOOK"
+_TARGETS = {"bot.entrypoint_writer_authority", "entrypoint_writer_authority"}
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _classify_current_lock(runtime: Any) -> tuple[str, str]:
+    client = getattr(runtime, "_client", None)
+    lock_key = str(getattr(runtime, "_lock_key", "") or "").strip()
+    expected = str(getattr(runtime, "_lock_value", "") or "").strip()
+    if client is None:
+        return "error", "redis_client_missing"
+    if not lock_key:
+        return "error", "lock_key_missing"
+    if not expected:
+        return "error", "lock_value_missing"
+    try:
+        current = _text(client.get(lock_key)).strip()
+    except Exception as exc:
+        return "error", f"redis_lock_read_error:{type(exc).__name__}:{exc}"
+    if not current:
+        return "missing", f"lock_missing key={lock_key}"
+    if current == expected:
+        return "owned", f"lock_owned_exact key={lock_key}"
+    return "other", f"lock_owned_by_other key={lock_key}"
+
+
+def _patch_entrypoint_writer_authority(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_heartbeat_tick", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def heartbeat_tick(self: Any) -> tuple[bool, str]:
+        # A runtime already marked LOST must never be allowed to mutate or renew
+        # writer state from a stale heartbeat worker.
+        if bool(getattr(self, "lost", False)):
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            return False, "runtime_already_lost"
+
+        state, detail = _classify_current_lock(self)
+        if state == "missing":
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            LOGGER.critical(
+                "WRITER_LOST_EPOCH_V48_MISSING marker=%s generation=%s token_prefix=%s detail=%s action=fresh_epoch_reelection",
+                MARKER,
+                getattr(self, "_generation", 0),
+                str(getattr(self, "_token", "") or "")[:8],
+                detail,
+            )
+            return False, "lock_missing_and_fencing_token_mismatch"
+        if state == "other":
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            LOGGER.critical(
+                "WRITER_LOST_EPOCH_V48_OWNER_CHANGED marker=%s generation=%s detail=%s action=nonrecoverable_loss",
+                MARKER,
+                getattr(self, "_generation", 0),
+                detail,
+            )
+            return False, "lock_owned_by_different_writer"
+        if state == "error":
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            return False, detail
+
+        # Only an exact current lock value may reach the legacy renewal Lua.
+        return original(self)
+
+    setattr(heartbeat_tick, _PATCH_ATTR, True)
+    setattr(heartbeat_tick, "__wrapped__", original)
+    cls._heartbeat_tick = heartbeat_tick
+    os.environ["NIJA_WRITER_LOST_EPOCH_V48_PATCHED"] = "1"
+    LOGGER.critical(
+        "WRITER_LOST_EPOCH_V48_PATCHED marker=%s module=%s missing_lock_recreate=false exact_owner_required=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen: set[int] = set()
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        patched = _patch_entrypoint_writer_authority(module) or patched
+    return patched
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _INSTALL_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if str(name or "") in _TARGETS:
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _INSTALL_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if str(name or "") in _TARGETS:
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        os.environ["NIJA_WRITER_LOST_EPOCH_V48_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_LOST_EPOCH_V48_INSTALLED marker=%s fail_closed=true stale_epoch_recreate=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_classify_current_lock",
+    "_patch_entrypoint_writer_authority",
+]

--- a/scripts/apply_writer_generation_handoff_v45.py
+++ b/scripts/apply_writer_generation_handoff_v45.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Idempotently wire writer-generation handoff v45 and idempotence v47 into launcher v26."""
+"""Idempotently wire writer-generation v45/v47/v48 into canonical launcher v26."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -8,7 +8,8 @@ import py_compile
 ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
 V47 = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"
-MARKER = "20260808-writer-generation-idempotence-v47"
+V48 = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"
+MARKER = "20260808-writer-lost-epoch-v48"
 
 
 def _replace_once(text: str, old: str, new: str, label: str) -> str:
@@ -20,9 +21,10 @@ def _replace_once(text: str, old: str, new: str, label: str) -> str:
 
 
 def apply() -> bool:
-    if not V47.is_file():
-        raise RuntimeError(f"v47 runtime patch missing: {V47}")
-    py_compile.compile(str(V47), doraise=True)
+    for label, path in (("v47", V47), ("v48", V48)):
+        if not path.is_file():
+            raise RuntimeError(f"{label} runtime patch missing: {path}")
+        py_compile.compile(str(path), doraise=True)
 
     text = LAUNCHER.read_text(encoding="utf-8")
     original = text
@@ -30,39 +32,39 @@ def apply() -> bool:
     text = _replace_once(
         text,
         'MARKER = "20260807-canonical-runtime-launcher-v26-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
-        'MARKER = "20260808-canonical-runtime-launcher-v26-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
+        'MARKER = "20260808-canonical-runtime-launcher-v26-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
         "launcher marker",
     )
     text = _replace_once(
         text,
         'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV18_PATH',
-        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"\nV18_PATH',
-        "v45/v47 paths",
+        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"\nV48_PATH = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"\nV18_PATH',
+        "v45/v47/v48 paths",
     )
 
-    functions = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n\n\ndef _install_writer_generation_idempotence_v47() -> ModuleType:\n    if not V47_PATH.is_file():\n        raise RuntimeError(f"writer generation idempotence v47 missing: {V47_PATH}")\n    module = _load_module_by_path("nija_writer_generation_idempotence_v47_prebot", V47_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation idempotence v47 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED") != "1":\n        raise RuntimeError("writer generation idempotence v47 did not attest installed")\n    return module\n'''
+    functions = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n\n\ndef _install_writer_generation_idempotence_v47() -> ModuleType:\n    if not V47_PATH.is_file():\n        raise RuntimeError(f"writer generation idempotence v47 missing: {V47_PATH}")\n    module = _load_module_by_path("nija_writer_generation_idempotence_v47_prebot", V47_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation idempotence v47 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED") != "1":\n        raise RuntimeError("writer generation idempotence v47 did not attest installed")\n    return module\n\n\ndef _install_writer_lost_epoch_v48() -> ModuleType:\n    if not V48_PATH.is_file():\n        raise RuntimeError(f"writer lost epoch v48 missing: {V48_PATH}")\n    module = _load_module_by_path("nija_writer_lost_epoch_v48_prebot", V48_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer lost epoch v48 installer failed")\n    if os.environ.get("NIJA_WRITER_LOST_EPOCH_V48_INSTALLED") != "1":\n        raise RuntimeError("writer lost epoch v48 did not attest installed")\n    return module\n'''
     text = _replace_once(
         text,
         '\n\ndef _install_production_corrective_set() -> ModuleType:',
         functions + '\n\ndef _install_production_corrective_set() -> ModuleType:',
-        "v45/v47 installer functions",
+        "v45/v47/v48 installer functions",
     )
     text = _replace_once(
         text,
         '    _install_runtime_execution_convergence()\n',
-        '    _install_writer_generation_handoff_v45()\n    _install_writer_generation_idempotence_v47()\n    _install_runtime_execution_convergence()\n',
-        "v45/v47 install order",
+        '    _install_writer_generation_handoff_v45()\n    _install_writer_generation_idempotence_v47()\n    _install_writer_lost_epoch_v48()\n    _install_runtime_execution_convergence()\n',
+        "v45/v47/v48 install order",
     )
     text = _replace_once(
         text,
         'v43_installed=true v44_installed=true v18_installed=true',
-        'v43_installed=true v44_installed=true v45_installed=true v47_installed=true v18_installed=true',
+        'v43_installed=true v44_installed=true v45_installed=true v47_installed=true v48_installed=true v18_installed=true',
         "ready attestation",
     )
     text = _replace_once(
         text,
         'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v44-v43-v42-v41-v40-v39-v38-v37-v18',
-        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260808-canonical-fast-entrypoint-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
+        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260808-canonical-fast-entrypoint-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
         "fast marker",
     )
 
@@ -71,14 +73,16 @@ def apply() -> bool:
     required = (
         'V45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"',
         'V47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"',
+        'V48_PATH = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"',
         '_install_writer_generation_handoff_v45()',
         '_install_writer_generation_idempotence_v47()',
+        '_install_writer_lost_epoch_v48()',
     )
     missing = [item for item in required if item not in text]
     if missing:
         raise RuntimeError("writer generation launcher attestation missing: " + ", ".join(missing))
     print(
-        f"WRITER_GENERATION_HANDOFF_V45_V47_LAUNCHER_PATCHED marker={MARKER} v45=true v47=true",
+        f"WRITER_GENERATION_V45_V47_V48_LAUNCHER_PATCHED marker={MARKER} v45=true v47=true v48=true",
         flush=True,
     )
     return True


### PR DESCRIPTION
## What changed

- Add `writer_lost_epoch_v48_patch.py` to harden `EntrypointWriterAuthority._heartbeat_tick` before the legacy renewal Lua executes.
- Require the current Redis process-writer lock value to exactly match the runtime's `_lock_value` before canonical renewal is allowed.
- Treat a missing lock as `lock_missing_and_fencing_token_mismatch`, which hands control to the existing v40 -> v39 fresh token/generation re-election path instead of recreating the missing lock from the old fencing epoch.
- Treat a different current lock as `lock_owned_by_different_writer` and remain nonrecoverably fail-closed.
- Treat Redis inspection errors as fail-closed with no ownership inference.
- Prevent an already-LOST runtime from delegating to a stale heartbeat worker.
- Wire v48 into the existing v45/v47 canonical launcher patcher; the patcher compiles and attests v48 before canonical runtime launch.

## Why

Production on merged v47 commit `2ff727ee3e14a34b0bbfc473b784a55860e76f8e` showed generation `3339` become ACTIVE after `WRITER_LOCK_RENEWED`, but the same tick also emitted `WRITER_LOCK_REFRESHED_FROM_FENCING`. That message can only occur when the process lock is already missing and the old heartbeat Lua recreates it using the existing fencing token. Roughly one TTL later, v18 observed `PROCESS_WRITER_LOCK_MISSING`; the runtime then remained `LIVE_PENDING_CONFIRMATION` and heartbeat renewal became stale.

All three brokers were connected throughout the failure, including Kraken, so this is a writer-lease lifecycle defect rather than a broker-connectivity defect.

## Safety

- No writer lock is created, recreated, deleted, stolen, or force-extended by v48.
- No stale fencing token is reused to resurrect a missing lock.
- Fresh recovery continues to use the existing v39 bounded re-election path, which acquires a new fencing token and generation through canonical `acquire_once()`.
- Other-writer ownership remains nonrecoverable and fail-closed.
- Redis ambiguity remains fail-closed.
- No Kraken, Coinbase, OKX, capital, SEAK, emergency-stop, kill-switch, terminal-risk, readiness, strategy, risk, or dispatch-health bypass is introduced.

## Validation

- Branch starts exactly from current production/main `2ff727ee3e14a34b0bbfc473b784a55860e76f8e`.
- Diff is limited to 3 intended files: v48 patch, focused v48 tests, and existing canonical launcher patcher wiring.
- Branch is 3 commits ahead and 0 behind base.
- Focused tests cover exact-owner delegation, missing-lock fail-closed behavior, other-owner rejection, Redis read failure, already-lost runtime rejection, and patch idempotence.
- CI should validate the exact PR head before merge.