### PR TITLE
Clean up failed writer recovery monitor v49

### DIFF
--- a/bot/tests/test_writer_recovery_monitor_cleanup_v49.py
+++ b/bot/tests/test_writer_recovery_monitor_cleanup_v49.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "writer_recovery_monitor_cleanup_v49_patch.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Monitor:
+    def __init__(self):
+        self.stop_calls = 0
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def _bot_main(monitor):
+    mod = types.ModuleType("bot.bot_main")
+    mod._authority_heartbeat_monitor = monitor
+    return mod
+
+
+def _v39(result=True):
+    mod = types.ModuleType("nija_production_readiness_v39_prebot")
+    mod._assert_writer_authority = lambda: result
+    return mod
+
+
+def teardown_function(_fn):
+    for name in ("bot.bot_main", "bot_main", "nija_production_readiness_v39_prebot"):
+        sys.modules.pop(name, None)
+    os.environ.pop("NIJA_RUNTIME_EXECUTION_AUTHORITY", None)
+    os.environ.pop("NIJA_EXECUTION_ACTIVE", None)
+
+
+def test_failed_verify_stops_and_clears_recovery_monitor():
+    patch = _load("v49_test_failed")
+    monitor = Monitor()
+    bot_main = _bot_main(monitor)
+    v39 = _v39(False)
+    sys.modules["bot.bot_main"] = bot_main
+    assert patch._patch_v39(v39) is True
+
+    assert v39._assert_writer_authority() is False
+    assert monitor.stop_calls == 1
+    assert bot_main._authority_heartbeat_monitor is None
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_successful_verify_leaves_monitor_running():
+    patch = _load("v49_test_success")
+    monitor = Monitor()
+    bot_main = _bot_main(monitor)
+    v39 = _v39(True)
+    sys.modules["bot.bot_main"] = bot_main
+    assert patch._patch_v39(v39) is True
+
+    assert v39._assert_writer_authority() is True
+    assert monitor.stop_calls == 0
+    assert bot_main._authority_heartbeat_monitor is monitor
+
+
+def test_patch_is_idempotent():
+    patch = _load("v49_test_idempotent")
+    v39 = _v39(False)
+    assert patch._patch_v39(v39) is True
+    first = v39._assert_writer_authority
+    assert patch._patch_v39(v39) is True
+    assert v39._assert_writer_authority is first
+
+
+def test_failed_verify_without_monitor_remains_fail_closed():
+    patch = _load("v49_test_no_monitor")
+    bot_main = _bot_main(None)
+    v39 = _v39(False)
+    sys.modules["bot.bot_main"] = bot_main
+    assert patch._patch_v39(v39) is True
+
+    assert v39._assert_writer_authority() is False
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"

--- a/bot/writer_recovery_monitor_cleanup_v49_patch.py
+++ b/bot/writer_recovery_monitor_cleanup_v49_patch.py
@@ -1,0 +1,182 @@
+"""NIJA writer recovery monitor cleanup v49.
+
+During v39 fresh-epoch writer recovery each successful Redis acquisition restarts
+AuthorityHeartbeatMonitor before synchronous distributed-authority verification.
+If that verification fails, v39 releases the attempted writer epoch and retries,
+but the newly restarted monitor is left running. That orphan monitor can reach
+its independent failure threshold and force an authority lockdown while the
+bounded writer re-election loop is still legitimately retrying.
+
+v49 does not weaken any authority check. It only stops the just-restarted
+heartbeat monitor when v39's existing synchronous authority verification returns
+False, before v39 releases that failed recovery attempt. Successful verification
+leaves the monitor untouched.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_recovery_monitor_cleanup_v49")
+MARKER = "20260808-writer-recovery-monitor-cleanup-v49"
+
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_writer_recovery_monitor_cleanup_v49"
+_INSTALL_FLAG = "_NIJA_WRITER_RECOVERY_MONITOR_CLEANUP_V49_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_WRITER_RECOVERY_MONITOR_CLEANUP_V49_IMPORTLIB_HOOK"
+_V39_TARGETS = {
+    "nija_production_readiness_v39_prebot",
+    "bot.production_readiness_v39_patch",
+    "production_readiness_v39_patch",
+}
+_BOT_MAIN_TARGETS = ("bot.bot_main", "bot_main")
+
+
+def _stop_recovery_monitor(reason: str) -> bool:
+    """Stop only the monitor currently published by bot_main, if any."""
+    stopped = False
+    seen: set[int] = set()
+    for name in _BOT_MAIN_TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        monitor = getattr(module, "_authority_heartbeat_monitor", None)
+        if monitor is None:
+            continue
+        stop = getattr(monitor, "stop", None)
+        if not callable(stop):
+            continue
+        try:
+            stop()
+            stopped = True
+            if getattr(module, "_authority_heartbeat_monitor", None) is monitor:
+                setattr(module, "_authority_heartbeat_monitor", None)
+            LOGGER.warning(
+                "WRITER_RECOVERY_V49_MONITOR_STOPPED marker=%s module=%s reason=%s",
+                MARKER,
+                name,
+                reason,
+            )
+        except Exception as exc:
+            LOGGER.error(
+                "WRITER_RECOVERY_V49_MONITOR_STOP_FAILED marker=%s module=%s reason=%s err=%s:%s",
+                MARKER,
+                name,
+                reason,
+                type(exc).__name__,
+                exc,
+            )
+    return stopped
+
+
+def _patch_v39(module: ModuleType) -> bool:
+    current = getattr(module, "_assert_writer_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def _assert_writer_authority() -> bool:
+        try:
+            ok = bool(original())
+        except Exception as exc:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            _stop_recovery_monitor(f"authority_verify_exception:{type(exc).__name__}")
+            raise
+
+        if ok:
+            return True
+
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+        _stop_recovery_monitor("post_acquire_authority_verify_failed")
+        LOGGER.critical(
+            "WRITER_RECOVERY_V49_VERIFY_FAILED_CLEAN marker=%s action=v39_release_then_retry fail_closed=true",
+            MARKER,
+        )
+        return False
+
+    setattr(_assert_writer_authority, _PATCH_ATTR, True)
+    setattr(_assert_writer_authority, "__wrapped__", original)
+    module._assert_writer_authority = _assert_writer_authority
+    os.environ["NIJA_WRITER_RECOVERY_MONITOR_CLEANUP_V49_PATCHED"] = "1"
+    LOGGER.critical(
+        "WRITER_RECOVERY_MONITOR_CLEANUP_V49_PATCHED marker=%s module=%s authority_checks_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen: set[int] = set()
+    for name in _V39_TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        patched = _patch_v39(module) or patched
+    return patched
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _INSTALL_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if str(name or "") in _V39_TARGETS:
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _INSTALL_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if str(name or "") in _V39_TARGETS:
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        os.environ["NIJA_WRITER_RECOVERY_MONITOR_CLEANUP_V49_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_RECOVERY_MONITOR_CLEANUP_V49_INSTALLED marker=%s fail_closed=true recovery_criteria_unchanged=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_patch_v39",
+    "_stop_recovery_monitor",
+]

--- a/scripts/apply_writer_generation_handoff_v45.py
+++ b/scripts/apply_writer_generation_handoff_v45.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Idempotently wire writer-generation v45/v47/v48 into canonical launcher v26."""
+"""Idempotently wire writer-generation v45/v47/v48/v49 into canonical launcher v26."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,7 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
 V47 = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"
 V48 = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"
-MARKER = "20260808-writer-lost-epoch-v48"
+V49 = ROOT / "bot" / "writer_recovery_monitor_cleanup_v49_patch.py"
+MARKER = "20260808-writer-recovery-monitor-cleanup-v49"
 
 
 def _replace_once(text: str, old: str, new: str, label: str) -> str:
@@ -21,7 +22,7 @@ def _replace_once(text: str, old: str, new: str, label: str) -> str:
 
 
 def apply() -> bool:
-    for label, path in (("v47", V47), ("v48", V48)):
+    for label, path in (("v47", V47), ("v48", V48), ("v49", V49)):
         if not path.is_file():
             raise RuntimeError(f"{label} runtime patch missing: {path}")
         py_compile.compile(str(path), doraise=True)
@@ -32,39 +33,39 @@ def apply() -> bool:
     text = _replace_once(
         text,
         'MARKER = "20260807-canonical-runtime-launcher-v26-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
-        'MARKER = "20260808-canonical-runtime-launcher-v26-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
+        'MARKER = "20260808-canonical-runtime-launcher-v26-v49-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18"',
         "launcher marker",
     )
     text = _replace_once(
         text,
         'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV18_PATH',
-        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"\nV48_PATH = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"\nV18_PATH',
-        "v45/v47/v48 paths",
+        'V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"\nV45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"\nV47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"\nV48_PATH = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"\nV49_PATH = ROOT / "bot" / "writer_recovery_monitor_cleanup_v49_patch.py"\nV18_PATH',
+        "v45/v47/v48/v49 paths",
     )
 
-    functions = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n\n\ndef _install_writer_generation_idempotence_v47() -> ModuleType:\n    if not V47_PATH.is_file():\n        raise RuntimeError(f"writer generation idempotence v47 missing: {V47_PATH}")\n    module = _load_module_by_path("nija_writer_generation_idempotence_v47_prebot", V47_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation idempotence v47 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED") != "1":\n        raise RuntimeError("writer generation idempotence v47 did not attest installed")\n    return module\n\n\ndef _install_writer_lost_epoch_v48() -> ModuleType:\n    if not V48_PATH.is_file():\n        raise RuntimeError(f"writer lost epoch v48 missing: {V48_PATH}")\n    module = _load_module_by_path("nija_writer_lost_epoch_v48_prebot", V48_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer lost epoch v48 installer failed")\n    if os.environ.get("NIJA_WRITER_LOST_EPOCH_V48_INSTALLED") != "1":\n        raise RuntimeError("writer lost epoch v48 did not attest installed")\n    return module\n'''
+    functions = '''\n\ndef _install_writer_generation_handoff_v45() -> ModuleType:\n    if not V45_PATH.is_file():\n        raise RuntimeError(f"writer generation handoff v45 missing: {V45_PATH}")\n    module = _load_module_by_path("nija_writer_generation_handoff_v45_prebot", V45_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation handoff v45 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_HANDOFF_V45_INSTALLED") != "1":\n        raise RuntimeError("writer generation handoff v45 did not attest installed")\n    return module\n\n\ndef _install_writer_generation_idempotence_v47() -> ModuleType:\n    if not V47_PATH.is_file():\n        raise RuntimeError(f"writer generation idempotence v47 missing: {V47_PATH}")\n    module = _load_module_by_path("nija_writer_generation_idempotence_v47_prebot", V47_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer generation idempotence v47 installer failed")\n    if os.environ.get("NIJA_WRITER_GENERATION_IDEMPOTENCE_V47_INSTALLED") != "1":\n        raise RuntimeError("writer generation idempotence v47 did not attest installed")\n    return module\n\n\ndef _install_writer_lost_epoch_v48() -> ModuleType:\n    if not V48_PATH.is_file():\n        raise RuntimeError(f"writer lost epoch v48 missing: {V48_PATH}")\n    module = _load_module_by_path("nija_writer_lost_epoch_v48_prebot", V48_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer lost epoch v48 installer failed")\n    if os.environ.get("NIJA_WRITER_LOST_EPOCH_V48_INSTALLED") != "1":\n        raise RuntimeError("writer lost epoch v48 did not attest installed")\n    return module\n\n\ndef _install_writer_recovery_monitor_cleanup_v49() -> ModuleType:\n    if not V49_PATH.is_file():\n        raise RuntimeError(f"writer recovery monitor cleanup v49 missing: {V49_PATH}")\n    module = _load_module_by_path("nija_writer_recovery_monitor_cleanup_v49_prebot", V49_PATH)\n    installer: Any = getattr(module, "install_import_hook", None) or getattr(module, "install", None)\n    if not callable(installer) or not bool(installer()):\n        raise RuntimeError("writer recovery monitor cleanup v49 installer failed")\n    if os.environ.get("NIJA_WRITER_RECOVERY_MONITOR_CLEANUP_V49_INSTALLED") != "1":\n        raise RuntimeError("writer recovery monitor cleanup v49 did not attest installed")\n    return module\n'''
     text = _replace_once(
         text,
         '\n\ndef _install_production_corrective_set() -> ModuleType:',
         functions + '\n\ndef _install_production_corrective_set() -> ModuleType:',
-        "v45/v47/v48 installer functions",
+        "v45/v47/v48/v49 installer functions",
     )
     text = _replace_once(
         text,
         '    _install_runtime_execution_convergence()\n',
-        '    _install_writer_generation_handoff_v45()\n    _install_writer_generation_idempotence_v47()\n    _install_writer_lost_epoch_v48()\n    _install_runtime_execution_convergence()\n',
-        "v45/v47/v48 install order",
+        '    _install_writer_generation_handoff_v45()\n    _install_writer_generation_idempotence_v47()\n    _install_writer_lost_epoch_v48()\n    _install_writer_recovery_monitor_cleanup_v49()\n    _install_runtime_execution_convergence()\n',
+        "v45/v47/v48/v49 install order",
     )
     text = _replace_once(
         text,
         'v43_installed=true v44_installed=true v18_installed=true',
-        'v43_installed=true v44_installed=true v45_installed=true v47_installed=true v48_installed=true v18_installed=true',
+        'v43_installed=true v44_installed=true v45_installed=true v47_installed=true v48_installed=true v49_installed=true v18_installed=true',
         "ready attestation",
     )
     text = _replace_once(
         text,
         'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v44-v43-v42-v41-v40-v39-v38-v37-v18',
-        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260808-canonical-fast-entrypoint-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
+        'CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260808-canonical-fast-entrypoint-v49-v48-v47-v45-v44-v43-v42-v41-v40-v39-v38-v37-v18',
         "fast marker",
     )
 
@@ -74,15 +75,17 @@ def apply() -> bool:
         'V45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"',
         'V47_PATH = ROOT / "bot" / "writer_generation_idempotence_v47_patch.py"',
         'V48_PATH = ROOT / "bot" / "writer_lost_epoch_v48_patch.py"',
+        'V49_PATH = ROOT / "bot" / "writer_recovery_monitor_cleanup_v49_patch.py"',
         '_install_writer_generation_handoff_v45()',
         '_install_writer_generation_idempotence_v47()',
         '_install_writer_lost_epoch_v48()',
+        '_install_writer_recovery_monitor_cleanup_v49()',
     )
     missing = [item for item in required if item not in text]
     if missing:
         raise RuntimeError("writer generation launcher attestation missing: " + ", ".join(missing))
     print(
-        f"WRITER_GENERATION_V45_V47_V48_LAUNCHER_PATCHED marker={MARKER} v45=true v47=true v48=true",
+        f"WRITER_GENERATION_V45_V47_V48_V49_LAUNCHER_PATCHED marker={MARKER} v45=true v47=true v48=true v49=true",
         flush=True,
     )
     return True


### PR DESCRIPTION
## What changed

- Add `writer_recovery_monitor_cleanup_v49_patch.py` around v39's synchronous post-acquire authority verification.
- When a fresh-epoch recovery acquisition restarts `AuthorityHeartbeatMonitor` but synchronous distributed-authority verification fails, stop and clear that just-restarted monitor before v39 releases the failed epoch and retries.
- Preserve the monitor unchanged when synchronous authority verification succeeds.
- Keep execution explicitly fail-closed on verification failure.
- Wire v49 into the existing canonical launcher patcher and compile/attest it before runtime launch.

## Why

Production on merged v48 commit `cbe8d7db2a1b6787bbf111c60fa62642c34d6912` showed the authority monitor exiting with `locked_down=True` while runtime authority was still `0` and writer recovery was not yet established. v39 restarts the monitor before synchronous authority verification; if that verification fails, it releases the attempted writer epoch but does not stop the newly restarted monitor. That orphan monitor can independently hit its failure threshold and lock down the process during otherwise legitimate bounded fresh-epoch recovery.

The same log sample shows readiness initialization continuing and the OKX scan loop starting while `bootstrap_ready=False`; this PR does not reinterpret those table bits as execution authority and does not weaken any dispatch gate. It fixes the concrete recovery-monitor lifecycle leak.

Kraken was disconnected in the sample while Coinbase/OKX remained connected. v44 already owns authenticated Kraken recovery, so this change does not fabricate or force broker connectivity.

## Safety

- No writer lock is created, recreated, deleted, stolen, or force-extended by v49.
- No stale fencing token is reused.
- No writer authority check is skipped or weakened.
- Failed synchronous authority verification remains fail-closed and v39 still releases that failed epoch before retry.
- Successful verification leaves the authority monitor running normally.
- No SEAK, emergency-stop, kill-switch, terminal-risk, readiness, capital, risk, strategy, nonce, dispatch-health, or broker gate is bypassed.

## Validation

- Branch starts exactly from current production/main `cbe8d7db2a1b6787bbf111c60fa62642c34d6912`.
- Diff is limited to 3 intended files: v49 patch, focused v49 tests, and existing canonical launcher patcher wiring.
- Branch is 3 commits ahead and 0 behind base.
- Focused local regression suite: `4 passed`.
- Tests cover failed verification monitor cleanup, successful verification preservation, idempotence, and fail-closed behavior when no monitor exists.
- CI should validate the exact PR head before merge.