### PR TITLE
Preserve writer recovery wrappers in broker prebootstrap

### DIFF
--- a/bot/canonical_broker_prebootstrap_v22.py
+++ b/bot/canonical_broker_prebootstrap_v22.py
@@ -11,6 +11,15 @@ Redis writer authority is acquired and synchronously verified, the existing
 canonical manager singleton is initialized on the main bootstrap thread before
 SelfHealingStartup runs. A failed prebootstrap releases only this process's own
 lease and returns startup failure; no order, authority, or state gate is bypassed.
+
+Wrapper-order safety
+--------------------
+The writer-acquisition function is also wrapped by authority/recovery convergence
+layers (notably production_readiness_v39 and runtime_execution_convergence_v32).
+This module must preserve those wrappers. Repatching therefore detects an existing
+v22 layer anywhere in the __wrapped__ chain instead of unwrapping the chain to the
+base function. Stripping those layers disables bounded fresh-epoch writer recovery
+when a Redis writer lock disappears.
 """
 from __future__ import annotations
 
@@ -25,6 +34,7 @@ from typing import Any, Callable
 logger = logging.getLogger("nija.canonical_broker_prebootstrap")
 
 _MARKER = "20260723-canonical-broker-prebootstrap-v22"
+_WRAPPER_PRESERVATION_MARKER = "20260808-v22-writer-wrapper-preservation-v1"
 _LOCK = threading.RLock()
 _READY = False
 _INSTALLED = False
@@ -202,30 +212,38 @@ def prepare_canonical_broker_runtime() -> Any:
         return manager
 
 
-def _unwrap(current: Callable[..., Any]) -> Callable[..., Any]:
+def _wrapper_chain_has_marker(current: Callable[..., Any], marker_attr: str) -> bool:
+    """Return True when any callable in ``current``'s wrapper chain has marker_attr."""
     seen: set[int] = set()
-    base = current
-    while callable(getattr(base, "__wrapped__", None)) and id(base) not in seen:
-        seen.add(id(base))
-        candidate = getattr(base, "__wrapped__")
-        if not callable(candidate):
+    candidate: Any = current
+    while callable(candidate) and id(candidate) not in seen:
+        seen.add(id(candidate))
+        if bool(getattr(candidate, marker_attr, False)):
+            return True
+        wrapped = getattr(candidate, "__wrapped__", None)
+        if not callable(wrapped):
             break
-        base = candidate
-    return base
+        candidate = wrapped
+    return False
 
 
 def _patch_writer_acquire(module: ModuleType) -> bool:
     current = getattr(module, "_acquire_writer_authority_before_nonce", None)
     if not callable(current):
         return False
-    if bool(getattr(current, _ACQUIRE_WRAP_ATTR, False)):
+
+    # Do not strip or duplicate layers. v39/v32 and later convergence wrappers
+    # must remain callable because they arm writer-loss recovery and post-acquire
+    # reconciliation. If v22 is already present anywhere in the chain, leave the
+    # entire current chain untouched.
+    if _wrapper_chain_has_marker(current, _ACQUIRE_WRAP_ATTR):
         return True
 
-    base = _unwrap(current)
+    preserved_existing_layers = callable(getattr(current, "__wrapped__", None))
 
-    @wraps(base)
+    @wraps(current)
     def guarded_acquire(*args: Any, **kwargs: Any) -> bool:
-        acquired = bool(base(*args, **kwargs))
+        acquired = bool(current(*args, **kwargs))
         if not acquired:
             return False
         try:
@@ -255,13 +273,15 @@ def _patch_writer_acquire(module: ModuleType) -> bool:
             return False
 
     setattr(guarded_acquire, _ACQUIRE_WRAP_ATTR, True)
-    setattr(guarded_acquire, "__wrapped__", base)
+    setattr(guarded_acquire, "__wrapped__", current)
     setattr(module, "_acquire_writer_authority_before_nonce", guarded_acquire)
+    os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_WRAPPER_PRESERVATION"] = "1"
     logger.critical(
-        "CANONICAL_BROKER_PREBOOTSTRAP_V22_ACQUIRE_PATCHED marker=%s module=%s legacy_layers_unwrapped=%s",
+        "CANONICAL_BROKER_PREBOOTSTRAP_V22_ACQUIRE_PATCHED marker=%s wrapper_preservation_marker=%s module=%s existing_layers_preserved=%s",
         _MARKER,
+        _WRAPPER_PRESERVATION_MARKER,
         module.__name__,
-        base is not current,
+        preserved_existing_layers,
     )
     return True
 
@@ -270,7 +290,7 @@ def _patch_main(module: ModuleType) -> bool:
     current = getattr(module, "main", None)
     if not callable(current):
         return False
-    if bool(getattr(current, _MAIN_WRAP_ATTR, False)):
+    if _wrapper_chain_has_marker(current, _MAIN_WRAP_ATTR):
         return True
 
     @wraps(current)
@@ -304,9 +324,12 @@ def install_import_hook() -> bool:
         os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED"] = (
             "1" if _INSTALLED else "0"
         )
+        if _INSTALLED:
+            os.environ["NIJA_CANONICAL_BROKER_PREBOOTSTRAP_WRAPPER_PRESERVATION"] = "1"
         logger.critical(
-            "CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED marker=%s acquire_patched=%s main_patched=%s",
+            "CANONICAL_BROKER_PREBOOTSTRAP_V22_INSTALLED marker=%s wrapper_preservation_marker=%s acquire_patched=%s main_patched=%s",
             _MARKER,
+            _WRAPPER_PRESERVATION_MARKER,
             acquire_patched,
             main_patched,
         )
@@ -325,6 +348,7 @@ __all__ = [
     "_manager_contract",
     "_initialize_manager",
     "_platform_counts",
+    "_wrapper_chain_has_marker",
     "_patch_writer_acquire",
     "_patch_main",
 ]

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -35,16 +35,29 @@ def _remove_kill_switch_artifacts() -> None:
             pass  # best-effort cleanup
 
 
+def _reset_readiness_authority_state() -> None:
+    """Keep process-global readiness publication from leaking across tests."""
+    try:
+        readiness_module = sys.modules.get("bot.readiness_table")
+        table = getattr(readiness_module, "_TABLE", None) if readiness_module else None
+        if isinstance(table, dict):
+            table["authority_ready"] = False
+    except Exception:
+        pass
+
+
 @pytest.fixture(autouse=True)
 def _clean_kill_switch_state():
     """
-    Auto-use fixture: remove kill-switch state files before and after every
-    test so that a test that activates the real KillSwitch does not bleed
-    EMERGENCY_STOP or triggered-protector state into unrelated tests.
+    Auto-use fixture: remove kill-switch state files and reset process-global
+    readiness authority before and after every test so runtime state does not
+    bleed into unrelated tests.
     """
     _remove_kill_switch_artifacts()
+    _reset_readiness_authority_state()
     yield
     _remove_kill_switch_artifacts()
+    _reset_readiness_authority_state()
 
     # Also reset the module-level KillSwitch singleton so its in-memory
     # is_active flag doesn't persist across tests.

--- a/bot/tests/test_canonical_broker_prebootstrap_v22.py
+++ b/bot/tests/test_canonical_broker_prebootstrap_v22.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import types
+from functools import wraps
 
 import bot.canonical_broker_prebootstrap_v22 as guard
 
@@ -62,7 +63,6 @@ def test_initialize_retries_only_missing_fsm_latch():
 
     assert calls == ["initialize", "repair", "initialize"]
     assert manager._fsm_initialized is True
-
 
 
 def test_initialize_repairs_silent_missing_fsm_latch():
@@ -164,3 +164,71 @@ def test_writer_wrapper_releases_own_lease_on_prebootstrap_failure(monkeypatch):
     assert guard._patch_writer_acquire(module)
     assert module._acquire_writer_authority_before_nonce() is False
     assert sequence == ["authority", "prebootstrap", "release"]
+
+
+def test_writer_wrapper_preserves_existing_recovery_layer(monkeypatch):
+    sequence = []
+
+    def base():
+        sequence.append("base")
+        return True
+
+    @wraps(base)
+    def recovery_layer():
+        sequence.append("recovery")
+        return base()
+
+    recovery_layer._nija_writer_reelection_v39 = True
+
+    module = types.SimpleNamespace(
+        __name__="bot.bot_main",
+        _acquire_writer_authority_before_nonce=recovery_layer,
+        _release_writer_authority=lambda: sequence.append("release"),
+    )
+    monkeypatch.setattr(
+        guard,
+        "prepare_canonical_broker_runtime",
+        lambda: sequence.append("prebootstrap"),
+    )
+
+    assert guard._patch_writer_acquire(module)
+    wrapped = module._acquire_writer_authority_before_nonce
+    assert wrapped() is True
+    assert sequence == ["recovery", "base", "prebootstrap"]
+    assert getattr(wrapped.__wrapped__, "_nija_writer_reelection_v39", False) is True
+
+
+def test_writer_wrapper_repatch_does_not_duplicate_or_unwrap_layers(monkeypatch):
+    sequence = []
+
+    def base():
+        sequence.append("base")
+        return True
+
+    @wraps(base)
+    def recovery_layer():
+        sequence.append("recovery")
+        return base()
+
+    recovery_layer._nija_writer_reelection_v39 = True
+
+    module = types.SimpleNamespace(
+        __name__="bot.bot_main",
+        _acquire_writer_authority_before_nonce=recovery_layer,
+        _release_writer_authority=lambda: sequence.append("release"),
+    )
+    monkeypatch.setattr(
+        guard,
+        "prepare_canonical_broker_runtime",
+        lambda: sequence.append("prebootstrap"),
+    )
+
+    assert guard._patch_writer_acquire(module)
+    first = module._acquire_writer_authority_before_nonce
+    assert guard._patch_writer_acquire(module)
+    second = module._acquire_writer_authority_before_nonce
+
+    assert second is first
+    assert guard._wrapper_chain_has_marker(second, guard._ACQUIRE_WRAP_ATTR)
+    assert second() is True
+    assert sequence == ["recovery", "base", "prebootstrap"]

--- a/bot/tests/test_live_active_dispatch_bridge_recovery.py
+++ b/bot/tests/test_live_active_dispatch_bridge_recovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import threading
+import time
 from pathlib import Path
 from types import ModuleType
 
@@ -36,6 +37,20 @@ def _install_local_authority(
     )
     monkeypatch.delitem(sys.modules, "entrypoint_writer_authority", raising=False)
     return authority
+
+
+def _prime_writer_ready_env(
+    monkeypatch, *, token: str, generation: str, runtime_auth: str
+) -> None:
+    """Publish the canonical writer proofs expected by WriterAuthority."""
+    monkeypatch.setenv("NIJA_WRITER_STATE", "ACTIVE")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", token)
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", generation)
+    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ALIVE_TS", str(time.time()))
+    monkeypatch.setenv("NIJA_CORE_THREAD_ALIVE", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", runtime_auth)
 
 
 def test_broker_bootstrap_accepts_active_broker_manager_alias(monkeypatch) -> None:
@@ -89,11 +104,12 @@ def test_writer_authority_is_separate_from_runtime_authority(monkeypatch) -> Non
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("DRY_RUN_MODE", "false")
     monkeypatch.setenv("PAPER_MODE", "false")
-    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "123")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
-    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
-    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    _prime_writer_ready_env(
+        monkeypatch,
+        token="123",
+        generation="9",
+        runtime_auth="0",
+    )
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
     monkeypatch.setattr(module, "_loop_thread_running", lambda: False)
     monkeypatch.setattr(module, "_state_machine_live_active", lambda: False)
@@ -110,10 +126,12 @@ def test_writer_authority_is_separate_from_runtime_authority(monkeypatch) -> Non
 def test_runtime_convergence_uses_existing_fail_closed_repair(monkeypatch) -> None:
     module = _load_module()
     _install_local_authority(monkeypatch)
-    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "123")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "9")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
-    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    _prime_writer_ready_env(
+        monkeypatch,
+        token="123",
+        generation="9",
+        runtime_auth="0",
+    )
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "OFF")
 
     convergence = ModuleType("bot.runtime_authority_convergence_repair_patch")
@@ -328,10 +346,12 @@ def test_writer_snapshot_accepts_only_locally_acquired_authority(monkeypatch) ->
         authority_module,
     )
     monkeypatch.delitem(sys.modules, "entrypoint_writer_authority", raising=False)
-    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "1140")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "1801")
-    monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
-    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    _prime_writer_ready_env(
+        monkeypatch,
+        token="1140",
+        generation="1801",
+        runtime_auth="1",
+    )
 
     snapshot = module._writer_authority_snapshot()
 


### PR DESCRIPTION
## Owner

- Primary owner: dantelrharrell-debug

## Purpose

Restore the intended bounded fresh-epoch writer recovery path for production writer-lock loss.

Production commit `25ec6e97a3fa47be408885c5d37be10ef4b212c4` reached `entrypoint_writer_authority_lost:lock_missing_and_fencing_token_mismatch`, but the v39 recovery interception never ran. `canonical_broker_prebootstrap_v22` unwrapped `_acquire_writer_authority_before_nonce` to its base callable before installing its guard, discarding existing recovery/convergence wrappers, including the v39 layer that arms writer-loss recovery.

## Changes

- Stop v22 from unwrapping the writer-acquisition function.
- Preserve existing authority/recovery/convergence wrappers.
- Detect the v22 marker anywhere in the `__wrapped__` chain for idempotent repatching.
- Keep prebootstrap failures fail-closed and preserve existing lease-release behavior.
- Add regression tests for v39-like wrapper preservation and repeated v22 repatching.
- Repair pre-existing focused-runtime test isolation: reset the process-global readiness authority bit between tests and initialize current canonical writer-state/heartbeat/core-thread proofs in dispatch-bridge tests. These are test-only changes; production authority semantics are unchanged.

## Risk Assessment

- Risk level: medium
- Impacted production areas: writer-authority startup wrapper composition, canonical broker prebootstrap, writer-lock loss recovery.
- No Redis lock is created, recreated, stolen, or force-renewed by this change; no execution, capital, broker, risk, or SEAK gate is bypassed.

## Rollback Plan

Revert the commits on this PR. No schema, Redis-key, exchange-state, or migration rollback is required.

## Validation

Current head: `4957059aa594fd9738bb70ea61b12c6761ffae24`

Passing:
- Runtime repair regression tests: 128/128
- CI preflight check & lint
- CI imports smoke test
- Canonical startup launcher v26
- Branch policy
- gh Auth Verify

Repository-wide build/security scans are still running. This PR remains draft and unmerged until those protections complete.

Baseline note: before this branch, `main` already failed the same four focused-runtime tests (122 passed / 4 failed). The test-only isolation/proof updates on this branch remove those existing failures without weakening production runtime gates.