### PR TITLE
Recover intentional writer re-election loss reasons

### DIFF
--- a/.github/workflows/runtime-repair-regression.yml
+++ b/.github/workflows/runtime-repair-regression.yml
@@ -8,6 +8,8 @@ on:
       - "secondary_venue_runtime_diagnostics.py"
       - "bot/tests/test_critical_runtime_repairs_v10.py"
       - "bot/bot.py"
+      - "bot/writer_reelection_loss_reason_v46_patch.py"
+      - "bot/tests/test_writer_reelection_loss_reason_v46.py"
       - "kraken_equity_freshness_v3_patch.py"
       - "bot/activation_pending_commit_monitor_patch.py"
       - "bot/okx_funding_wallet_readiness_patch.py"
@@ -58,6 +60,8 @@ on:
       - "secondary_venue_runtime_diagnostics.py"
       - "bot/tests/test_critical_runtime_repairs_v10.py"
       - "bot/bot.py"
+      - "bot/writer_reelection_loss_reason_v46_patch.py"
+      - "bot/tests/test_writer_reelection_loss_reason_v46.py"
       - "kraken_equity_freshness_v3_patch.py"
       - "bot/activation_pending_commit_monitor_patch.py"
       - "bot/okx_funding_wallet_readiness_patch.py"
@@ -143,6 +147,7 @@ jobs:
             bot/stalled_writer_release_guard_v21.py \
             bot/canonical_broker_prebootstrap_v22.py \
             bot/stalled_writer_release_guard_v22.py \
+            bot/writer_reelection_loss_reason_v46_patch.py \
             scripts/apply_startup_handoff_fix.py \
             scripts/canonical_runtime_launcher_v26.py \
             scripts/runtime_entrypoint_attestation.py \
@@ -179,6 +184,7 @@ jobs:
             bot/tests/test_stalled_writer_release_guard_v21.py \
             bot/tests/test_canonical_broker_prebootstrap_v22.py \
             bot/tests/test_stalled_writer_release_guard_v22.py \
+            bot/tests/test_writer_reelection_loss_reason_v46.py \
             bot/tests/test_secondary_venue_runtime_diagnostics.py \
             bot/tests/test_startup_handoff_all_fixes.py \
             bot/tests/test_canonical_fast_entrypoint_v28.py \

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,11 +19,12 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260725-canonical-fast-entrypoint-v28"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v46-v28"
 
 # Each tuple is (module, success log label).  Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
+    ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -62,6 +62,8 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
         ")\n\n_LEGACY_INSTALLERS", 1
     )[0]
+    assert "writer_reelection_loss_reason_v46_patch" in fast_block
+    assert "WRITER_REELECTION_LOSS_REASON_V46" in fast_block
     assert "okx_final_order_submission_bridge_patch" in fast_block
     assert "startup_authority_prereq_repair_patch" in fast_block
     assert "stalled_writer_release_guard_v22" in fast_block

--- a/bot/tests/test_writer_reelection_loss_reason_v46.py
+++ b/bot/tests/test_writer_reelection_loss_reason_v46.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+from types import ModuleType
+
+import bot.writer_reelection_loss_reason_v46_patch as v46
+
+
+def test_existing_missing_lock_reason_remains_recoverable() -> None:
+    assert v46._safe_recoverable_reason("lock_missing_and_fencing_token_mismatch") is True
+    assert v46._safe_recoverable_reason(
+        "entrypoint_writer_authority_lost:lock_missing_and_fencing_token_mismatch"
+    ) is True
+
+
+def test_authority_invariant_release_for_reelection_is_recoverable() -> None:
+    reason = (
+        "writer_lock_released_for_reelection:"
+        "authority_invariant_violated:lease_acquired_but_fencing_token_missing "
+        "NIJA_WRITER_LEASE_ACQUIRED='1'"
+    )
+    assert v46._newly_recoverable_reason(reason) is True
+    assert v46._safe_recoverable_reason(reason) is True
+
+
+def test_core_thread_loss_remains_terminal() -> None:
+    assert v46._newly_recoverable_reason(
+        "writer_lock_released_for_reelection:core_thread_not_alive"
+    ) is False
+    assert v46._safe_recoverable_reason(
+        "writer_lock_released_for_reelection:core_thread_not_alive"
+    ) is False
+    assert v46._safe_recoverable_reason(
+        "writer_lock_released_for_reelection:authority_invariant_violated:core_thread_dead"
+    ) is False
+
+
+def test_arbitrary_heartbeat_or_manual_loss_is_not_recoverable() -> None:
+    assert v46._safe_recoverable_reason("heartbeat_grace_expired:redis_timeout") is False
+    assert v46._safe_recoverable_reason("manual_operator_stop") is False
+    assert v46._safe_recoverable_reason("lock_owned_by_different_writer") is False
+
+
+def test_v39_predicate_extension_preserves_original_and_adds_narrow_case() -> None:
+    module = ModuleType("nija_production_readiness_v39_prebot")
+    module.MARKER = "20260807-production-readiness-v39"
+    module._recoverable_writer_loss = lambda reason: str(reason) == "legacy-safe"
+
+    assert v46._patch_v39_module(module) is True
+    assert module._recoverable_writer_loss("legacy-safe") is True
+    assert module._recoverable_writer_loss(
+        "writer_lock_released_for_reelection:"
+        "authority_invariant_violated:singleton_acquired_but_env_cleared"
+    ) is True
+    assert module._recoverable_writer_loss("lock_owned_by_different_writer") is False
+
+
+def test_entrypoint_observability_is_published_before_original_loss_handler(monkeypatch) -> None:
+    observed: list[tuple[str, str, str, str]] = []
+
+    class Authority:
+        def _mark_lost(self, reason: str) -> None:
+            observed.append(
+                (
+                    str(reason),
+                    os.environ.get("NIJA_WRITER_LAST_LOSS_REASON", ""),
+                    os.environ.get("NIJA_WRITER_LAST_LOSS_RECOVERABLE", ""),
+                    os.environ.get("NIJA_WRITER_LEASE_GENERATION", ""),
+                )
+            )
+            os.environ.pop("NIJA_WRITER_LEASE_GENERATION", None)
+            os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
+
+    module = ModuleType("bot.entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = Authority
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "4412")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-4412")
+
+    assert v46._patch_entrypoint_module(module) is True
+    reason = (
+        "writer_lock_released_for_reelection:"
+        "authority_invariant_violated:singleton_acquired_but_env_cleared"
+    )
+    Authority()._mark_lost(reason)
+
+    assert observed == [(reason, reason, "1", "4412")]
+    assert os.environ.get("NIJA_WRITER_LAST_LOSS_REASON") == reason
+    assert os.environ.get("NIJA_WRITER_LAST_LOSS_RECOVERABLE") == "1"
+    assert float(os.environ.get("NIJA_WRITER_LAST_LOSS_TS", "0")) > 0.0
+    assert "NIJA_WRITER_LEASE_GENERATION" not in os.environ
+    assert "NIJA_WRITER_FENCING_TOKEN" not in os.environ

--- a/bot/writer_reelection_loss_reason_v46_patch.py
+++ b/bot/writer_reelection_loss_reason_v46_patch.py
@@ -1,0 +1,262 @@
+"""NIJA writer re-election loss-reason convergence v46.
+
+Production after the v39 wrapper-preservation fix still exposed a zero-generation
+writer state. ``EntrypointWriterAuthority`` intentionally releases its own exact
+Redis lock and marks itself lost when a process-local authority invariant is
+violated, using a reason of the form::
+
+    writer_lock_released_for_reelection:authority_invariant_violated:...
+
+That path is explicitly a request for a fresh writer election, but v39 only
+classified ``lock_missing_and_fencing_token_mismatch`` as recoverable. The
+intentional re-election reason therefore fell through to the original shutdown
+callback and left downstream heartbeat/Kraken recovery readers with generation 0.
+
+v46 does not grant writer authority and does not create, extend, steal, or rewrite
+any Redis lock. It only lets v39's existing bounded re-election flow run for the
+runtime's explicit authority-invariant re-election reason. That existing flow must
+still acquire a fresh Redis lease, synchronously verify distributed authority,
+restart the authority monitor, and prove SEAK eligibility before execution can
+resume. Dead-core, arbitrary heartbeat, manual stop, and unrelated Redis failures
+remain non-recoverable.
+
+The patch also publishes the exact last writer-loss reason and timestamp before
+the canonical loss handler clears generation/token telemetry. Those fields are
+observability only and are never consumed as authority proof.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_reelection_loss_reason_v46")
+MARKER = "20260808-writer-reelection-loss-reason-v46"
+
+_V39_MARKER = "20260807-production-readiness-v39"
+_SAFE_REELECTION_TOKEN = (
+    "writer_lock_released_for_reelection:authority_invariant_violated:"
+)
+_V39_PATCH = "_nija_writer_reelection_loss_reason_v46"
+_ENTRYPOINT_PATCH = "_nija_writer_loss_observability_v46"
+_IMPORT_HOOK_FLAG = "_NIJA_WRITER_REELECTION_LOSS_REASON_V46_IMPORT_HOOK"
+_IMPORTLIB_HOOK_FLAG = "_NIJA_WRITER_REELECTION_LOSS_REASON_V46_IMPORTLIB_HOOK"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _newly_recoverable_reason(reason: str) -> bool:
+    """Return True only for the canonical intentional invariant re-election path."""
+
+    text = str(reason or "")
+    if _SAFE_REELECTION_TOKEN not in text:
+        return False
+    # Core-thread loss is intentionally terminal for this process. Even if a
+    # future caller wraps that reason, v46 must never use writer re-election to
+    # mask a dead execution worker.
+    if "core_thread_" in text:
+        return False
+    return True
+
+
+def _safe_recoverable_reason(reason: str) -> bool:
+    """Mirror v39's existing case plus v46's one narrow re-election case."""
+
+    text = str(reason or "")
+    return bool(
+        "lock_missing_and_fencing_token_mismatch" in text
+        or _newly_recoverable_reason(text)
+    )
+
+
+def _patch_v39_module(module: ModuleType) -> bool:
+    current = getattr(module, "_recoverable_writer_loss", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _V39_PATCH, False)):
+        return True
+
+    @wraps(current)
+    def recoverable_writer_loss(reason: str) -> bool:
+        if bool(current(reason)):
+            return True
+        if not _newly_recoverable_reason(reason):
+            return False
+        LOGGER.critical(
+            "WRITER_REELECTION_V46_REASON_ACCEPTED marker=%s reason=%s "
+            "safety=existing_v39_bounded_redis_proven_flow",
+            MARKER,
+            str(reason or ""),
+        )
+        return True
+
+    setattr(recoverable_writer_loss, _V39_PATCH, True)
+    setattr(recoverable_writer_loss, "__wrapped__", current)
+    setattr(module, "_recoverable_writer_loss", recoverable_writer_loss)
+    LOGGER.critical(
+        "WRITER_REELECTION_V46_V39_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_entrypoint_module(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_mark_lost", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _ENTRYPOINT_PATCH, False)):
+        return True
+
+    @wraps(current)
+    def mark_lost(self: Any, reason: str) -> Any:
+        text = str(reason or "")
+        recoverable = _safe_recoverable_reason(text)
+        os.environ["NIJA_WRITER_LAST_LOSS_REASON"] = text
+        os.environ["NIJA_WRITER_LAST_LOSS_TS"] = str(time.time())
+        os.environ["NIJA_WRITER_LAST_LOSS_RECOVERABLE"] = "1" if recoverable else "0"
+        LOGGER.critical(
+            "WRITER_LOSS_V46_OBSERVED marker=%s recoverable=%s reason=%s",
+            MARKER,
+            recoverable,
+            text,
+        )
+        return current(self, reason)
+
+    setattr(mark_lost, _ENTRYPOINT_PATCH, True)
+    setattr(mark_lost, "__wrapped__", current)
+    setattr(cls, "_mark_lost", mark_lost)
+    LOGGER.critical(
+        "WRITER_LOSS_V46_OBSERVABILITY_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _is_v39_module(module: ModuleType) -> bool:
+    return bool(
+        str(getattr(module, "MARKER", "") or "") == _V39_MARKER
+        or module.__name__.endswith("production_readiness_v39_patch")
+        or module.__name__ == "nija_production_readiness_v39_prebot"
+    )
+
+
+def _is_entrypoint_module(module: ModuleType) -> bool:
+    return module.__name__ in {
+        "bot.entrypoint_writer_authority",
+        "entrypoint_writer_authority",
+    }
+
+
+def _patch_loaded() -> tuple[bool, bool]:
+    v39_ok = False
+    entrypoint_ok = False
+    seen: set[int] = set()
+    for module in list(sys.modules.values()):
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        try:
+            if _is_v39_module(module):
+                v39_ok = _patch_v39_module(module) or v39_ok
+            if _is_entrypoint_module(module):
+                entrypoint_ok = _patch_entrypoint_module(module) or entrypoint_ok
+        except Exception as exc:
+            LOGGER.warning(
+                "WRITER_REELECTION_V46_PATCH_DEFERRED marker=%s module=%s err=%s:%s",
+                MARKER,
+                getattr(module, "__name__", "unknown"),
+                type(exc).__name__,
+                exc,
+            )
+    return v39_ok, entrypoint_ok
+
+
+def _install_builtin_import_hook() -> None:
+    if bool(getattr(builtins, _IMPORT_HOOK_FLAG, False)):
+        return
+    original_import = builtins.__import__
+
+    @wraps(original_import)
+    def importing(
+        name: str,
+        globals: Any = None,
+        locals: Any = None,
+        fromlist: Any = (),
+        level: int = 0,
+    ):
+        module = original_import(name, globals, locals, fromlist, level)
+        text = str(name or "")
+        if "production_readiness_v39" in text or "entrypoint_writer_authority" in text:
+            _patch_loaded()
+        return module
+
+    builtins.__import__ = importing
+    setattr(builtins, _IMPORT_HOOK_FLAG, True)
+
+
+def _install_importlib_hook() -> None:
+    if bool(getattr(importlib, _IMPORTLIB_HOOK_FLAG, False)):
+        return
+    original_import_module = importlib.import_module
+
+    @wraps(original_import_module)
+    def import_module(name: str, package: str | None = None):
+        module = original_import_module(name, package)
+        text = str(name or "")
+        if "production_readiness_v39" in text or "entrypoint_writer_authority" in text:
+            _patch_loaded()
+        return module
+
+    importlib.import_module = import_module
+    setattr(importlib, _IMPORTLIB_HOOK_FLAG, True)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        v39_ok, entrypoint_ok = _patch_loaded()
+        _install_builtin_import_hook()
+        _install_importlib_hook()
+        # The canonical launcher loads v46 immediately after v39, and v24 has
+        # already caused bot_main/EntrypointWriterAuthority to load. Failing
+        # either attachment here is therefore a startup-contract failure rather
+        # than a reason to pretend the corrective layer is active.
+        _INSTALLED = bool(v39_ok and entrypoint_ok)
+        os.environ["NIJA_WRITER_REELECTION_LOSS_REASON_V46_INSTALLED"] = (
+            "1" if _INSTALLED else "0"
+        )
+        LOGGER.critical(
+            "WRITER_REELECTION_LOSS_REASON_V46_INSTALLED marker=%s v39_patched=%s "
+            "entrypoint_patched=%s installed=%s",
+            MARKER,
+            v39_ok,
+            entrypoint_ok,
+            _INSTALLED,
+        )
+        return _INSTALLED
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_newly_recoverable_reason",
+    "_safe_recoverable_reason",
+    "_patch_v39_module",
+    "_patch_entrypoint_module",
+]

--- a/bot/writer_reelection_loss_reason_v46_patch.py
+++ b/bot/writer_reelection_loss_reason_v46_patch.py
@@ -229,17 +229,16 @@ def install_import_hook() -> bool:
         v39_ok, entrypoint_ok = _patch_loaded()
         _install_builtin_import_hook()
         _install_importlib_hook()
-        # The canonical launcher loads v46 immediately after v39, and v24 has
-        # already caused bot_main/EntrypointWriterAuthority to load. Failing
-        # either attachment here is therefore a startup-contract failure rather
-        # than a reason to pretend the corrective layer is active.
-        _INSTALLED = bool(v39_ok and entrypoint_ok)
+        # v39 must already be present because v46 only extends its bounded
+        # recovery predicate. EntrypointWriterAuthority may legitimately load
+        # later in bot_main; the import hooks above attach observability then.
+        _INSTALLED = bool(v39_ok)
         os.environ["NIJA_WRITER_REELECTION_LOSS_REASON_V46_INSTALLED"] = (
             "1" if _INSTALLED else "0"
         )
         LOGGER.critical(
             "WRITER_REELECTION_LOSS_REASON_V46_INSTALLED marker=%s v39_patched=%s "
-            "entrypoint_patched=%s installed=%s",
+            "entrypoint_patched=%s entrypoint_future_hook=true installed=%s",
             MARKER,
             v39_ok,
             entrypoint_ok,


### PR DESCRIPTION
## Purpose

Fix the second writer-authority defect observed on deployed commit `7dc96e5151b512dcbba1db3e8b15010b4010fc93` after #2440.

Production is still reaching heartbeat `generation=0` / `expected_generation_missing` after writer loss. The canonical authority runtime intentionally releases its own exact Redis writer lock for process-local authority-invariant violations using `writer_lock_released_for_reelection:authority_invariant_violated:...`, but v39 only classifies `lock_missing_and_fencing_token_mismatch` as recoverable. That intentional re-election path therefore falls through to the original shutdown callback after generation/token telemetry is cleared.

## Changes

- Add `writer_reelection_loss_reason_v46_patch.py`.
- Extend v39's bounded fresh-epoch recovery predicate only for the canonical explicit authority-invariant re-election reason.
- Keep dead-core, arbitrary heartbeat, manual stop, and different-writer ownership failures non-recoverable.
- Preserve all existing Redis acquisition, distributed-authority verification, SEAK, capital, broker, and risk gates.
- Publish observability-only last writer-loss reason/timestamp/recoverable classification before canonical loss handling clears generation/token telemetry.
- Install v46 on the canonical fast path before `bot_main` import; startup remains fail-closed if v39 is not available.
- Add focused regression tests and include v46 in runtime repair compile/test CI.

## Kraken relationship

Kraken remains configured but disconnected in the production snapshot while Coinbase/OKX are connected. Kraken authenticated recovery intentionally waits for valid writer lineage, and v39 re-triggers that recovery only after a fresh writer lease is synchronously proven. This PR does not weaken that prerequisite.

## Safety

- No lock stealing or forced renewal.
- No fabricated generation/token.
- No SEAK bypass.
- No broker/capital/risk gate bypass.
- Core-thread loss remains terminal.
- Automatic recovery still uses v39's existing bounded `acquire_once()` + distributed-authority verification path.

## Validation

Passing on current head `50de6d9226291fce42e9453cfecb4803e670de56`:
- Runtime repair regression tests: **134 passed**
- v46 module compile
- Canonical startup launcher v26
- CI preflight check & lint
- CI imports smoke test
- Branch policy
- gh Auth Verify

Repository-wide Build image, CodeQL, Security Scanning, Artifact Scanning, Zero-Trust CI Isolation, and Continuous Threat Modeling are still running. PR remains draft/unmerged until they complete.