### PR TITLE
Persist zero-signal cap reconvergence

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -3,8 +3,7 @@
 The canonical Render launcher keeps package-wide runtime hooks deferred while
 ``main.py`` installs the audited safety set explicitly.  Replaying every
 historical compatibility installer here delayed ``bot_main.main()`` for many
-minutes while the health server reported the service as live.  The canonical
-fast path therefore installs only narrow guards that are not already owned by
+minutes while the health server reported the service as live.  The canonical fast path therefore installs only narrow guards that are not already owned by
 ``main.py``, then hands off immediately.
 
 Direct/non-canonical launches retain the legacy installer set for compatibility.
@@ -19,13 +18,14 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v50-v29"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v51-v30"
 
 # Each tuple is (module, success log label).  Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
+    ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -4,12 +4,14 @@ import importlib.util
 import os
 from pathlib import Path
 import sys
+from types import ModuleType
 
 
 ROOT = Path(__file__).resolve().parents[2]
 LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
 BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
 ATTESTATION = ROOT / "scripts" / "runtime_entrypoint_attestation.py"
+V51 = ROOT / "bot" / "zero_signal_streak_cap_repair_v51_patch.py"
 
 
 def _load(name: str, path: Path):
@@ -73,6 +75,39 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     assert "stalled_writer_release_guard_v22" in fast_block
     assert "trading_engine_strategy_wrapper_patch" not in fast_block
     assert "canonical_broker_main_entry_guard_v20" not in fast_block
+
+
+def test_v51_restores_missing_cap_guard_without_removing_state_repair(monkeypatch) -> None:
+    v51 = _load("test_zero_signal_streak_cap_v51_fast_path", V51)
+    core = ModuleType("bot.nija_core_loop")
+
+    def leaf(self, broker, snapshot, symbols, slots, streak=0):
+        return streak
+
+    def state_repair(self, broker, snapshot, symbols, slots, streak=0):
+        return leaf(self, broker, snapshot, symbols, slots, streak)
+
+    state_repair.__wrapped__ = leaf
+    setattr(state_repair, v51._STATE_ATTR, True)
+    core.NijaCoreLoop = type(
+        "NijaCoreLoop",
+        (),
+        {"_phase3_scan_and_enter": state_repair},
+    )
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+
+    assert v51._install_on_core_loop(core) is True
+    current = core.NijaCoreLoop._phase3_scan_and_enter
+    cap_found, cap_cycle, _ = v51._chain_contains(current)
+    state_found, state_cycle, _ = v51._chain_contains(current, v51._STATE_ATTR)
+
+    assert cap_found is True
+    assert state_found is True
+    assert cap_cycle is False
+    assert state_cycle is False
+    assert current(object(), None, None, None, None, 99) == 12
 
 
 def test_runtime_attestation_requires_fast_path_and_strategy_handoff() -> None:

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -66,6 +66,8 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     assert "WRITER_REELECTION_LOSS_REASON_V46" in fast_block
     assert "writer_generation_state_gate_v50_patch" in fast_block
     assert "WRITER_GENERATION_STATE_GATE_V50" in fast_block
+    assert "zero_signal_streak_cap_repair_v51_patch" in fast_block
+    assert "ZERO_SIGNAL_STREAK_CAP_V51" in fast_block
     assert "okx_final_order_submission_bridge_patch" in fast_block
     assert "startup_authority_prereq_repair_patch" in fast_block
     assert "stalled_writer_release_guard_v22" in fast_block

--- a/bot/tests/test_zero_signal_streak_cap_repair_v51.py
+++ b/bot/tests/test_zero_signal_streak_cap_repair_v51.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import bot.zero_signal_streak_cap_repair_v51_patch as v51
+
+
+def _core_module(func):
+    module = ModuleType("bot.nija_core_loop")
+    module.NijaCoreLoop = type("NijaCoreLoop", (), {"_phase3_scan_and_enter": func})
+    return module
+
+
+def test_v51_restores_missing_cap_without_removing_state_guard(monkeypatch):
+    def leaf(self, broker, snapshot, symbols, slots, streak=0):
+        return streak
+
+    def state(self, broker, snapshot, symbols, slots, streak=0):
+        return leaf(self, broker, snapshot, symbols, slots, streak)
+
+    state.__wrapped__ = leaf
+    setattr(state, v51._STATE_ATTR, True)
+    core = _core_module(state)
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
+
+    assert v51._install_on_core_loop(core) is True
+    current = core.NijaCoreLoop._phase3_scan_and_enter
+    cap_found, cycle, _ = v51._chain_contains(current)
+    state_found, state_cycle, _ = v51._chain_contains(current, v51._STATE_ATTR)
+
+    assert cap_found is True
+    assert state_found is True
+    assert cycle is False
+    assert state_cycle is False
+    assert current(object(), None, None, None, None, 99) == 12
+
+
+def test_v51_is_idempotent(monkeypatch):
+    def leaf(self, broker, snapshot, symbols, slots, streak=0):
+        return streak
+
+    core = _core_module(leaf)
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
+
+    assert v51._install_on_core_loop(core) is True
+    first = core.NijaCoreLoop._phase3_scan_and_enter
+    assert v51._install_on_core_loop(core) is True
+    second = core.NijaCoreLoop._phase3_scan_and_enter
+
+    assert first is second
+
+
+def test_v51_rejects_wrapper_cycle(monkeypatch):
+    def first(self, broker, snapshot, symbols, slots, streak=0):
+        return streak
+
+    def second(self, broker, snapshot, symbols, slots, streak=0):
+        return streak
+
+    first.__wrapped__ = second
+    second.__wrapped__ = first
+    core = _core_module(first)
+    monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
+    monkeypatch.delenv("NIJA_ZERO_SIGNAL_STREAK_CAP_READY", raising=False)
+
+    assert v51._install_on_core_loop(core) is False
+    assert v51.os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] == "0"
+
+
+def test_v51_cap_is_bounded_by_policy(monkeypatch):
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "999")
+    assert v51._cap_value() == 12
+    monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "1")
+    assert v51._cap_value() == 2

--- a/bot/zero_signal_streak_cap_repair_v51_patch.py
+++ b/bot/zero_signal_streak_cap_repair_v51_patch.py
@@ -1,0 +1,212 @@
+"""Persistently restore the NijaCoreLoop zero-signal streak cap guard.
+
+The legacy runtime-convergence hardening layer installs
+``_nija_zero_streak_cap_e`` on ``NijaCoreLoop._phase3_scan_and_enter`` but its
+watchdog is intentionally time-bounded. Production can load a later Phase-3
+wrapper after that watchdog exits, leaving the process-lifetime zero-signal
+state repair present while the parameter cap guard disappears. The module
+identity guard correctly treats that state as unsafe and blocks live trading.
+
+v51 makes only the cap layer persistent. It never grants execution authority,
+changes writer/nonce state, touches broker connectivity, or weakens the module
+identity gate. If the wrapper chain is cyclic or the core loop is unavailable,
+readiness stays fail-closed until a safe chain can be proven.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.zero_signal_streak_cap_v51")
+MARKER = "20260808-zero-signal-cap-repair-v51"
+
+_ATTR = "_nija_zero_streak_cap_e"
+_STATE_ATTR = "_nija_zero_signal_state_repair_v1"
+_LOCK = threading.RLock()
+_STARTED = False
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default)) or default))
+    except Exception:
+        return default
+
+
+def _cap_value() -> int:
+    return max(2, min(_int_env("NIJA_ZERO_SIGNAL_STREAK_CAP", 12), 12))
+
+
+def _chain_contains(func: Any, attr: str = _ATTR) -> tuple[bool, bool, int]:
+    current = func
+    seen: set[int] = set()
+    depth = 0
+    while callable(current):
+        ident = id(current)
+        if ident in seen:
+            return False, True, depth
+        seen.add(ident)
+        if bool(getattr(current, attr, False)):
+            return True, False, depth
+        current = getattr(current, "__wrapped__", None)
+        if not callable(current):
+            return False, False, depth
+        depth += 1
+        if depth >= 4096:
+            return False, True, depth
+    return False, False, depth
+
+
+def _install_on_core_loop(module: ModuleType) -> bool:
+    cls = getattr(module, "NijaCoreLoop", None)
+    current = getattr(cls, "_phase3_scan_and_enter", None) if isinstance(cls, type) else None
+    if not callable(current):
+        return False
+
+    found, cycle, depth = _chain_contains(current)
+    if cycle:
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "0"
+        LOGGER.critical(
+            "ZERO_SIGNAL_CAP_V51_WRAPPER_CYCLE marker=%s module=%s depth=%d fail_closed=true",
+            MARKER,
+            module.__name__,
+            depth,
+        )
+        return False
+    if found:
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "1"
+        return True
+
+    @wraps(current)
+    def phase3(
+        self: Any,
+        broker: Any,
+        snapshot: Any,
+        symbols: Any,
+        available_slots: Any,
+        zero_signal_streak: int = 0,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        cap = _cap_value()
+        try:
+            raw = int(zero_signal_streak or 0)
+        except Exception:
+            raw = 0
+        bounded = min(max(raw, 0), cap)
+        if bounded != raw:
+            LOGGER.warning(
+                "ZERO_SIGNAL_CAP_V51_REPAIRED marker=%s raw=%d bounded=%d cap=%d",
+                MARKER,
+                raw,
+                bounded,
+                cap,
+            )
+        return current(
+            self,
+            broker,
+            snapshot,
+            symbols,
+            available_slots,
+            bounded,
+            *args,
+            **kwargs,
+        )
+
+    setattr(phase3, _ATTR, True)
+    phase3.__wrapped__ = current
+    cls._phase3_scan_and_enter = phase3
+    os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "1"
+    LOGGER.critical(
+        "ZERO_SIGNAL_CAP_V51_INSTALLED marker=%s module=%s persistent=true state_guard_present=%s cap=%d",
+        MARKER,
+        module.__name__,
+        str(_chain_contains(phase3, _STATE_ATTR)[0]).lower(),
+        _cap_value(),
+    )
+    return True
+
+
+def _try_loaded() -> bool:
+    ready = False
+    seen: set[int] = set()
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        ready = _install_on_core_loop(module) or ready
+    return ready
+
+
+def _monitor_interval() -> float:
+    try:
+        return max(
+            0.25,
+            float(os.environ.get("NIJA_ZERO_SIGNAL_CAP_V51_MONITOR_S", "1.0") or 1.0),
+        )
+    except Exception:
+        return 1.0
+
+
+def _watchdog() -> None:
+    last_ready: bool | None = None
+    while True:
+        try:
+            ready = _try_loaded()
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "1" if ready else "0"
+            if ready != last_ready:
+                LOGGER.log(
+                    logging.INFO if ready else logging.WARNING,
+                    "ZERO_SIGNAL_CAP_V51_MONITOR marker=%s ready=%s persistent=true",
+                    MARKER,
+                    str(ready).lower(),
+                )
+                last_ready = ready
+        except Exception:
+            os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "0"
+            LOGGER.exception("ZERO_SIGNAL_CAP_V51_RETRY marker=%s fail_closed=true", MARKER)
+        time.sleep(_monitor_interval())
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        ready = _try_loaded()
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_READY"] = "1" if ready else "0"
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(
+                target=_watchdog,
+                name="ZeroSignalStreakCapV51",
+                daemon=True,
+            ).start()
+        os.environ["NIJA_ZERO_SIGNAL_STREAK_CAP_V51_INSTALLED"] = "1"
+        LOGGER.critical(
+            "ZERO_SIGNAL_CAP_V51_GUARD_ARMED marker=%s ready_now=%s persistent=true fail_closed=true",
+            MARKER,
+            str(ready).lower(),
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_cap_value",
+    "_chain_contains",
+    "_install_on_core_loop",
+    "_try_loaded",
+    "_monitor_interval",
+]


### PR DESCRIPTION
## Purpose

Fix the remaining live-readiness blocker observed on production commit `33fb4b4faf88c9414b7b7aa6bd6ee3eecf22e0ca` after #2442 successfully restored all broker connectivity.

## Production evidence

The deployed runtime now has Kraken, Coinbase, and OKX all connected and funded, but `RUNTIME_MODULE_IDENTITY_AUDIT` still reports `ready=false` because `zero_signal_streak_chain` has `cap_guard=False;state_repair=True;cycle=False`.

## Root cause

The legacy `runtime_convergence_hardening_patch` installs `_nija_zero_streak_cap_e` on `NijaCoreLoop._phase3_scan_and_enter`, but its watchdog is time-bounded. The newer zero-signal state repair uses a process-lifetime watchdog, so a later Phase-3 replacement can leave the state repair present while the cap wrapper disappears. The module-identity guard correctly fail-closes live trading in that state.

## Changes

- Add `bot/zero_signal_streak_cap_repair_v51_patch.py` with a process-lifetime, idempotent cap-wrapper monitor.
- Preserve any existing zero-signal state-repair wrapper in the chain.
- Reject cyclic wrapper chains and remain fail-closed when the core loop is unavailable.
- Bound the cap to the existing safety policy range of 2..12.
- Install v51 on the canonical fast path.
- Add regression coverage for the exact production drift and source-level fast-path requirement.

## Safety

- No writer/nonce authority changes.
- No broker-connectivity manipulation.
- No kill-switch, risk, capital, readiness, or execution bypass.
- No acceptance of cyclic wrapper chains.
- The module-identity gate remains authoritative; v51 only restores its required cap wrapper.

## Expected production proof

After deployment, expect `ZERO_SIGNAL_CAP_V51_GUARD_ARMED`, then `zero_signal_streak_chain cap_guard=True;state_repair=True;cycle=False`, followed by `RUNTIME_MODULE_IDENTITY_AUDIT ... ready=true` if no other blocker remains.