### PR TITLE
Detect distributed writer loss immediately

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -18,13 +18,14 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v51-v30"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v52-v31"
 
 # Each tuple is (module, success log label).  Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
+    ("bot.writer_distributed_loss_watchdog_v52_patch", "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -12,6 +12,7 @@ LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
 BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
 ATTESTATION = ROOT / "scripts" / "runtime_entrypoint_attestation.py"
 V51 = ROOT / "bot" / "zero_signal_streak_cap_repair_v51_patch.py"
+V52 = ROOT / "bot" / "writer_distributed_loss_watchdog_v52_patch.py"
 
 
 def _load(name: str, path: Path):
@@ -68,6 +69,8 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     assert "WRITER_REELECTION_LOSS_REASON_V46" in fast_block
     assert "writer_generation_state_gate_v50_patch" in fast_block
     assert "WRITER_GENERATION_STATE_GATE_V50" in fast_block
+    assert "writer_distributed_loss_watchdog_v52_patch" in fast_block
+    assert "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52" in fast_block
     assert "zero_signal_streak_cap_repair_v51_patch" in fast_block
     assert "ZERO_SIGNAL_STREAK_CAP_V51" in fast_block
     assert "okx_final_order_submission_bridge_patch" in fast_block
@@ -108,6 +111,44 @@ def test_v51_restores_missing_cap_guard_without_removing_state_repair(monkeypatc
     assert cap_cycle is False
     assert state_cycle is False
     assert current(object(), None, None, None, None, 99) == 12
+
+
+def test_v52_missing_distributed_lock_marks_existing_runtime_lost(monkeypatch) -> None:
+    v52 = _load("test_writer_distributed_loss_v52_fast_path", V52)
+
+    class Client:
+        def get(self, _key):
+            return None
+
+    class Runtime:
+        acquired = True
+        lost = False
+        _local_fallback = False
+        _client = Client()
+        _lock_key = "nija:writer_lock:process"
+        _lock_value = "2044:owner"
+        _token = "2044"
+        _generation = 18
+
+        def __init__(self):
+            self.marked = []
+
+        def _mark_lost(self, reason):
+            self.marked.append(reason)
+            self.lost = True
+
+    runtime = Runtime()
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    result = v52.reconcile_once(runtime)
+
+    assert result["state"] == "missing"
+    assert result["action"] == "mark_lost_recoverable"
+    assert runtime.marked == ["lock_missing_and_fencing_token_mismatch"]
+    assert runtime.lost is True
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
 
 
 def test_runtime_attestation_requires_fast_path_and_strategy_handoff() -> None:

--- a/bot/tests/test_writer_distributed_loss_watchdog_v52.py
+++ b/bot/tests/test_writer_distributed_loss_watchdog_v52.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib
+import os
+
+
+MODULE = "bot.writer_distributed_loss_watchdog_v52_patch"
+
+
+class _Client:
+    def __init__(self, value=None, error: Exception | None = None):
+        self.value = value
+        self.error = error
+
+    def get(self, _key):
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+class _Runtime:
+    def __init__(self, redis_value=None):
+        self._client = _Client(redis_value)
+        self._lock_key = "nija:writer_lock:process"
+        self._lock_value = "2044:owner"
+        self._token = "2044"
+        self._generation = 18
+        self._local_fallback = False
+        self.acquired = True
+        self.lost = False
+        self.marked: list[str] = []
+
+    def _mark_lost(self, reason: str) -> None:
+        self.marked.append(reason)
+        self.lost = True
+
+
+def _load():
+    return importlib.import_module(MODULE)
+
+
+def test_missing_lock_marks_recoverable_loss_even_without_renewal_staleness(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    result = mod.reconcile_once(runtime)
+
+    assert result["state"] == "missing"
+    assert result["action"] == "mark_lost_recoverable"
+    assert runtime.marked == ["lock_missing_and_fencing_token_mismatch"]
+    assert runtime.lost is True
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_other_owner_marks_nonrecoverable_loss(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value="9999:other")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    result = mod.reconcile_once(runtime)
+
+    assert result["state"] == "other"
+    assert result["action"] == "mark_lost_nonrecoverable"
+    assert runtime.marked == ["lock_owned_by_different_writer"]
+    assert runtime.lost is True
+
+
+def test_exact_owner_remains_healthy_and_unmodified():
+    mod = _load()
+    runtime = _Runtime(redis_value="2044:owner")
+
+    result = mod.reconcile_once(runtime)
+
+    assert result["ok"] is True
+    assert result["state"] == "owned"
+    assert result["action"] == "none"
+    assert runtime.marked == []
+    assert runtime.lost is False
+
+
+def test_redis_error_fails_closed_without_inferred_loss(monkeypatch):
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    runtime._client = _Client(error=TimeoutError("redis timeout"))
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    result = mod.reconcile_once(runtime)
+
+    assert result["state"] == "error"
+    assert result["action"] == "fail_closed_retry"
+    assert runtime.marked == []
+    assert runtime.lost is False
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_local_fallback_does_not_probe_distributed_lock():
+    mod = _load()
+    runtime = _Runtime(redis_value=None)
+    runtime._local_fallback = True
+
+    result = mod.reconcile_once(runtime)
+
+    assert result["ok"] is True
+    assert result["state"] == "local_fallback"
+    assert runtime.marked == []

--- a/bot/writer_distributed_loss_watchdog_v52_patch.py
+++ b/bot/writer_distributed_loss_watchdog_v52_patch.py
@@ -1,0 +1,234 @@
+"""Read-only distributed writer-loss watchdog v52.
+
+Production can transiently retain a locally acquired EntrypointWriterAuthority
+object after the Redis process-writer lock has disappeared. Earlier recovery
+logic waited for a specific renewal-health reason before inspecting Redis, which
+left a gap when the heartbeat thread was stopped, missing, or still considered
+fresh while the distributed lock was already gone.
+
+v52 closes that gap with a read-only ownership probe while the runtime reports
+itself acquired. It never creates, extends, deletes, or steals a writer lock.
+Missing ownership transitions through the existing canonical _mark_lost path so
+v39/v46 can perform bounded fresh-epoch re-election. A different current owner
+remains non-recoverable. Redis read errors stay fail-closed without inferring
+ownership loss.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_distributed_loss_watchdog_v52")
+MARKER = "20260808-writer-distributed-loss-watchdog-v52"
+
+_LOCK = threading.RLock()
+_STARTED = False
+_STOP = threading.Event()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_ENTRYPOINT_NAMES = ("bot.entrypoint_writer_authority", "entrypoint_writer_authority")
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _runtime() -> Any:
+    for name in _ENTRYPOINT_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if callable(getter):
+            try:
+                runtime = getter()
+            except Exception:
+                continue
+            if runtime is not None:
+                return runtime
+    return None
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def classify_distributed_ownership(runtime: Any) -> tuple[str, str]:
+    client = getattr(runtime, "_client", None)
+    lock_key = str(
+        getattr(runtime, "_lock_key", "")
+        or os.environ.get("NIJA_WRITER_LOCK_KEY", "")
+        or ""
+    ).strip()
+    expected = str(getattr(runtime, "_lock_value", "") or "").strip()
+    token = str(
+        getattr(runtime, "_token", "")
+        or os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")
+        or ""
+    ).strip()
+    if client is None:
+        return "error", "redis_client_missing"
+    if not lock_key:
+        return "error", "lock_key_missing"
+    if not expected or not token:
+        return "error", "local_writer_identity_incomplete"
+    try:
+        current = _as_text(client.get(lock_key)).strip()
+    except Exception as exc:
+        return "error", f"redis_lock_read_error:{type(exc).__name__}:{exc}"
+    if not current:
+        return "missing", f"lock_missing key={lock_key}"
+    if current == expected:
+        return "owned", f"lock_owned_exact key={lock_key}"
+    current_token = current.split(":", 1)[0]
+    if current_token == token:
+        return "owned", f"lock_owned_token key={lock_key}"
+    return (
+        "other",
+        f"lock_owned_by_other key={lock_key} current_prefix={current_token[:8]} expected_prefix={token[:8]}",
+    )
+
+
+def _mark_lost(runtime: Any, reason: str) -> bool:
+    marker = getattr(runtime, "_mark_lost", None)
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+    if not callable(marker):
+        LOGGER.critical(
+            "WRITER_DISTRIBUTED_LOSS_V52_MARK_LOST_UNAVAILABLE marker=%s reason=%s fail_closed=true",
+            MARKER,
+            reason,
+        )
+        return False
+    if bool(getattr(runtime, "lost", False)):
+        return True
+    LOGGER.critical(
+        "WRITER_DISTRIBUTED_LOSS_V52_TRANSITION_LOST marker=%s generation=%s token_prefix=%s reason=%s fresh_epoch_required=true",
+        MARKER,
+        getattr(runtime, "_generation", 0),
+        str(getattr(runtime, "_token", "") or "")[:8],
+        reason,
+    )
+    marker(reason)
+    return True
+
+
+def reconcile_once(runtime: Any | None = None) -> dict[str, Any]:
+    runtime = runtime or _runtime()
+    result: dict[str, Any] = {
+        "ok": False,
+        "state": "unavailable",
+        "action": "none",
+        "reason": "runtime_unavailable",
+    }
+    if runtime is None:
+        return result
+    if bool(getattr(runtime, "lost", False)):
+        result.update(ok=True, state="lost", reason="runtime_already_lost")
+        return result
+    if not bool(getattr(runtime, "acquired", False)):
+        result.update(ok=True, state="standby", reason="runtime_not_acquired")
+        return result
+    if bool(getattr(runtime, "_local_fallback", False)):
+        result.update(ok=True, state="local_fallback", reason="distributed_probe_not_applicable")
+        return result
+
+    state, detail = classify_distributed_ownership(runtime)
+    result["state"] = state
+    result["reason"] = detail
+    if state == "owned":
+        result["ok"] = True
+        return result
+    if state == "missing":
+        _mark_lost(runtime, "lock_missing_and_fencing_token_mismatch")
+        result["action"] = "mark_lost_recoverable"
+        return result
+    if state == "other":
+        _mark_lost(runtime, "lock_owned_by_different_writer")
+        result["action"] = "mark_lost_nonrecoverable"
+        return result
+
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+    result["action"] = "fail_closed_retry"
+    return result
+
+
+def _interval() -> float:
+    try:
+        return max(
+            0.5,
+            float(os.environ.get("NIJA_WRITER_DISTRIBUTED_LOSS_V52_POLL_S", "2.0") or 2.0),
+        )
+    except Exception:
+        return 2.0
+
+
+def _watchdog() -> None:
+    last_signature = ""
+    while not _STOP.wait(_interval()):
+        try:
+            state = reconcile_once()
+            signature = f"{state.get('state')}:{state.get('action')}:{state.get('reason')}"
+            if signature != last_signature:
+                last_signature = signature
+                level = logging.INFO if state.get("ok") else logging.WARNING
+                LOGGER.log(
+                    level,
+                    "WRITER_DISTRIBUTED_LOSS_V52_WATCHDOG marker=%s state=%s action=%s reason=%s",
+                    MARKER,
+                    state.get("state"),
+                    state.get("action"),
+                    state.get("reason"),
+                )
+        except Exception as exc:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            LOGGER.warning(
+                "WRITER_DISTRIBUTED_LOSS_V52_WATCHDOG_ERROR marker=%s error=%s:%s fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        if not _STARTED:
+            _STOP.clear()
+            threading.Thread(
+                target=_watchdog,
+                name="WriterDistributedLossWatchdogV52",
+                daemon=True,
+            ).start()
+            _STARTED = True
+        os.environ["NIJA_WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52_INSTALLED marker=%s read_only=true fail_closed=true lock_mutation=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "classify_distributed_ownership",
+    "reconcile_once",
+]


### PR DESCRIPTION
## Purpose

Fix the remaining writer-authority split observed on production commit `83d058f1452072a137cbe5764111925d9b8cd43c`.

## Production evidence

The runtime remained alive with capital and module-identity guards healthy, but emitted `PROCESS_WRITER_LOCK_MISSING` and later `WRITER_STATE_INCONSISTENT ... writer_ready=False missing=heartbeat_healthy,distributed_authority_ok` while local authority still reported acquired/not-lost. Kraken remained disconnected downstream of that writer-authority loss.

## Root cause

v40 stale-renewal recovery only inspects Redis when renewal health fails specifically as `renewal_success_stale`. That leaves a gap when the local runtime still reports acquired but the Redis process-writer lock is already missing while the last renewal is still considered fresh, or when the renewal thread is missing/stopped for another reason. In that state the canonical fresh-epoch re-election callback is never triggered promptly.

## Changes

- Add `writer_distributed_loss_watchdog_v52_patch.py`.
- While the runtime reports distributed authority acquired, probe the exact Redis process-writer lock read-only.
- Exact current ownership remains healthy and untouched.
- Missing lock invokes the existing canonical recoverable loss reason `lock_missing_and_fencing_token_mismatch` so v39/v46 can perform bounded fresh-epoch re-election.
- A different current owner invokes the existing nonrecoverable `lock_owned_by_different_writer` path.
- Redis read errors fail closed and retry without inferring ownership loss.
- Local-fallback mode is not subjected to the distributed probe.
- Install v52 on the canonical fast path.
- Add focused regressions for missing lock, other owner, exact owner, Redis errors, and fast-path installation.

## Safety

- No lock creation, extension, deletion, stealing, or forced acquisition.
- No fabricated fencing token or generation.
- No broker, capital, kill-switch, risk, readiness, nonce, or execution bypass.
- Distributed ambiguity remains fail-closed.

## Expected production proof

After deployment, a missing process-writer lock should produce `WRITER_DISTRIBUTED_LOSS_V52_TRANSITION_LOST ... reason=lock_missing_and_fencing_token_mismatch`, followed by the existing bounded fresh-epoch recovery. Healthy steady state should show the v52 watchdog observing exact ownership while writer heartbeat/distributed authority stay healthy and Kraken can reconverge.