### PR TITLE
Invalidate stale writer state on release

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,9 +1,9 @@
 """Compatibility entrypoint for Railway/main.py.
 
 The canonical Render launcher keeps package-wide runtime hooks deferred while
-``main.py`` installs the audited safety set explicitly. Replaying every
+``main.py`` installs the audited safety set explicitly.  Replaying every
 historical compatibility installer here delayed ``bot_main.main()`` for many
-minutes while the health server reported the service as live. The canonical fast path therefore installs only narrow guards that are not already owned by
+minutes while the health server reported the service as live.  The canonical fast path therefore installs only narrow guards that are not already owned by
 ``main.py``, then hands off immediately.
 
 Direct/non-canonical launches retain the legacy installer set for compatibility.
@@ -20,6 +20,8 @@ from typing import Iterable
 logger = logging.getLogger("nija.bot_entrypoint")
 _FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v53-v32"
 
+# Each tuple is (module, success log label).  Names remain explicit so startup
+# attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
@@ -55,7 +57,12 @@ _LEGACY_INSTALLERS = (
 
 def _truthy(name: str) -> bool:
     return str(os.environ.get(name, "")).strip().lower() in {
-        "1", "true", "yes", "on", "enabled", "y",
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+        "y",
     }
 
 
@@ -73,23 +80,36 @@ def _install_guards(specs: Iterable[tuple[str, str]], *, mode: str) -> bool:
     for module_name, label in specs:
         try:
             module = importlib.import_module(module_name)
-            installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+            installer = getattr(module, "install_import_hook", None) or getattr(
+                module, "install", None
+            )
             if not callable(installer):
                 raise RuntimeError("installer_missing")
             result = installer()
             if result is False:
                 raise RuntimeError("installer_returned_false")
             installed.append(label)
-            logger.warning("%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s", label, mode)
+            logger.warning(
+                "%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s",
+                label,
+                mode,
+            )
         except Exception as exc:
             ready = False
             logger.critical(
                 "%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s",
-                label, mode, exc, exc_info=True,
+                label,
+                mode,
+                exc,
+                exc_info=True,
             )
     logger.critical(
-        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s installed=%s",
-        _FAST_PATH_MARKER, mode, ready, ",".join(installed) or "none",
+        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s "
+        "installed=%s",
+        _FAST_PATH_MARKER,
+        mode,
+        ready,
+        ",".join(installed) or "none",
     )
     return ready
 
@@ -98,14 +118,18 @@ if _canonical_fast_path_enabled():
     if not _install_guards(_FAST_PATH_INSTALLERS, mode="canonical_fast"):
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
-        raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
+        raise RuntimeError(
+            "canonical fast-path safety guards failed; trading remains fail closed"
+        )
     logger.critical(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s package_hook_fanout=deferred handoff=bot.bot_main",
+        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s "
+        "package_hook_fanout=deferred handoff=bot.bot_main",
         _FAST_PATH_MARKER,
     )
 else:
     logger.warning(
-        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false",
+        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s "
+        "canonical_fast_path=false",
         _FAST_PATH_MARKER,
     )
     _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,9 +1,9 @@
 """Compatibility entrypoint for Railway/main.py.
 
 The canonical Render launcher keeps package-wide runtime hooks deferred while
-``main.py`` installs the audited safety set explicitly.  Replaying every
+``main.py`` installs the audited safety set explicitly. Replaying every
 historical compatibility installer here delayed ``bot_main.main()`` for many
-minutes while the health server reported the service as live.  The canonical fast path therefore installs only narrow guards that are not already owned by
+minutes while the health server reported the service as live. The canonical fast path therefore installs only narrow guards that are not already owned by
 ``main.py``, then hands off immediately.
 
 Direct/non-canonical launches retain the legacy installer set for compatibility.
@@ -18,14 +18,13 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v52-v31"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v53-v32"
 
-# Each tuple is (module, success log label).  Names remain explicit so startup
-# attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
     ("bot.writer_distributed_loss_watchdog_v52_patch", "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52"),
+    ("bot.writer_release_state_consistency_v53_patch", "WRITER_RELEASE_STATE_V53"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
@@ -56,12 +55,7 @@ _LEGACY_INSTALLERS = (
 
 def _truthy(name: str) -> bool:
     return str(os.environ.get(name, "")).strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-        "enabled",
-        "y",
+        "1", "true", "yes", "on", "enabled", "y",
     }
 
 
@@ -79,36 +73,23 @@ def _install_guards(specs: Iterable[tuple[str, str]], *, mode: str) -> bool:
     for module_name, label in specs:
         try:
             module = importlib.import_module(module_name)
-            installer = getattr(module, "install_import_hook", None) or getattr(
-                module, "install", None
-            )
+            installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
             if not callable(installer):
                 raise RuntimeError("installer_missing")
             result = installer()
             if result is False:
                 raise RuntimeError("installer_returned_false")
             installed.append(label)
-            logger.warning(
-                "%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s",
-                label,
-                mode,
-            )
+            logger.warning("%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s", label, mode)
         except Exception as exc:
             ready = False
             logger.critical(
                 "%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s",
-                label,
-                mode,
-                exc,
-                exc_info=True,
+                label, mode, exc, exc_info=True,
             )
     logger.critical(
-        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s "
-        "installed=%s",
-        _FAST_PATH_MARKER,
-        mode,
-        ready,
-        ",".join(installed) or "none",
+        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s installed=%s",
+        _FAST_PATH_MARKER, mode, ready, ",".join(installed) or "none",
     )
     return ready
 
@@ -117,18 +98,14 @@ if _canonical_fast_path_enabled():
     if not _install_guards(_FAST_PATH_INSTALLERS, mode="canonical_fast"):
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
-        raise RuntimeError(
-            "canonical fast-path safety guards failed; trading remains fail closed"
-        )
+        raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
     logger.critical(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s "
-        "package_hook_fanout=deferred handoff=bot.bot_main",
+        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s package_hook_fanout=deferred handoff=bot.bot_main",
         _FAST_PATH_MARKER,
     )
 else:
     logger.warning(
-        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s "
-        "canonical_fast_path=false",
+        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false",
         _FAST_PATH_MARKER,
     )
     _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import sys
 from types import ModuleType
+import threading
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,6 +14,7 @@ BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
 ATTESTATION = ROOT / "scripts" / "runtime_entrypoint_attestation.py"
 V51 = ROOT / "bot" / "zero_signal_streak_cap_repair_v51_patch.py"
 V52 = ROOT / "bot" / "writer_distributed_loss_watchdog_v52_patch.py"
+V53 = ROOT / "bot" / "writer_release_state_consistency_v53_patch.py"
 
 
 def _load(name: str, path: Path):
@@ -24,9 +26,7 @@ def _load(name: str, path: Path):
     return module
 
 
-def test_launcher_preserves_defer_flag_through_main_handoff(
-    monkeypatch, tmp_path
-) -> None:
+def test_launcher_preserves_defer_flag_through_main_handoff(monkeypatch, tmp_path) -> None:
     launcher = _load("test_canonical_fast_entrypoint_v28", LAUNCHER)
     fake_main = tmp_path / "main.py"
     fake_main.write_text("pass\n", encoding="utf-8")
@@ -71,6 +71,8 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     assert "WRITER_GENERATION_STATE_GATE_V50" in fast_block
     assert "writer_distributed_loss_watchdog_v52_patch" in fast_block
     assert "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52" in fast_block
+    assert "writer_release_state_consistency_v53_patch" in fast_block
+    assert "WRITER_RELEASE_STATE_V53" in fast_block
     assert "zero_signal_streak_cap_repair_v51_patch" in fast_block
     assert "ZERO_SIGNAL_STREAK_CAP_V51" in fast_block
     assert "okx_final_order_submission_bridge_patch" in fast_block
@@ -92,11 +94,7 @@ def test_v51_restores_missing_cap_guard_without_removing_state_repair(monkeypatc
 
     state_repair.__wrapped__ = leaf
     setattr(state_repair, v51._STATE_ATTR, True)
-    core.NijaCoreLoop = type(
-        "NijaCoreLoop",
-        (),
-        {"_phase3_scan_and_enter": state_repair},
-    )
+    core.NijaCoreLoop = type("NijaCoreLoop", (), {"_phase3_scan_and_enter": state_repair})
     monkeypatch.setitem(sys.modules, "bot.nija_core_loop", core)
     monkeypatch.delitem(sys.modules, "nija_core_loop", raising=False)
     monkeypatch.setenv("NIJA_ZERO_SIGNAL_STREAK_CAP", "12")
@@ -147,6 +145,44 @@ def test_v52_missing_distributed_lock_marks_existing_runtime_lost(monkeypatch) -
     assert result["action"] == "mark_lost_recoverable"
     assert runtime.marked == ["lock_missing_and_fencing_token_mismatch"]
     assert runtime.lost is True
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_v53_release_invalidates_stale_local_acquisition_without_callback(monkeypatch) -> None:
+    v53 = _load("test_writer_release_state_v53_fast_path", V53)
+    calls = []
+
+    class Runtime:
+        def __init__(self):
+            self._lost = threading.Event()
+            self._result = type("Result", (), {"acquired": True})()
+            self._on_lost_callback = lambda reason: calls.append(reason)
+
+        @property
+        def acquired(self):
+            return bool(self._result and self._result.acquired and not self._lost.is_set())
+
+        @property
+        def lost(self):
+            return self._lost.is_set()
+
+        def release(self):
+            return True
+
+    module = ModuleType("bot.entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = Runtime
+    assert v53._patch_entrypoint_writer_authority(module) is True
+
+    runtime = Runtime()
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    assert runtime.acquired is True
+    assert runtime.release() is True
+    assert runtime.acquired is False
+    assert runtime.lost is True
+    assert calls == []
     assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
     assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
 

--- a/bot/writer_release_state_consistency_v53_patch.py
+++ b/bot/writer_release_state_consistency_v53_patch.py
@@ -1,0 +1,169 @@
+"""Writer release-state consistency v53.
+
+Production on the v52 build exposed a local/distributed writer split after an
+explicit EntrypointWriterAuthority.release(): Redis and writer environment state
+were cleared, but the singleton could still report ``acquired=True`` because
+``release()`` did not set its internal ``_lost`` event. The release path also
+left process-level execution-authority claims untouched.
+
+That stale local acquisition can poison fresh-epoch recovery: a subsequent
+``acquire_once()`` may return the previous successful result without touching
+Redis, while heartbeat/readiness correctly observe generation 0 and no
+canonical authority.
+
+v53 wraps only the canonical release method. Before any release-side Redis
+mutation it invalidates local acquisition and process execution claims. The
+existing release implementation still owns heartbeat quiescing and
+compare-and-delete semantics. Intentional release does not invoke the on-lost
+callback, does not halt SEAK, and does not fabricate or reacquire authority.
+A future acquire must pass through the normal Redis election path, where the
+canonical activation code clears ``_lost`` only after a new lease succeeds.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_release_state_consistency_v53")
+MARKER = "20260808-writer-release-state-v53"
+
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_writer_release_state_v53"
+_INSTALL_FLAG = "_NIJA_WRITER_RELEASE_STATE_V53_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_WRITER_RELEASE_STATE_V53_IMPORTLIB_HOOK"
+_TARGETS = {"bot.entrypoint_writer_authority", "entrypoint_writer_authority"}
+
+
+def _invalidate_local_release_state(runtime: Any) -> None:
+    lost = getattr(runtime, "_lost", None)
+    setter = getattr(lost, "set", None)
+    if callable(setter):
+        setter()
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+    os.environ["NIJA_WRITER_RELEASE_STATE_V53_INVALIDATED"] = "1"
+
+
+def _patch_entrypoint_writer_authority(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "release", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def release(self: Any, *args: Any, **kwargs: Any):
+        # Invalidate local authority before heartbeat shutdown / Redis deletion,
+        # so no concurrent reader can observe an intentionally released writer
+        # as still acquired. Do not call _mark_lost(): intentional release must
+        # not invoke loss callbacks or SEAK emergency-halt semantics.
+        _invalidate_local_release_state(self)
+        result = original(self, *args, **kwargs)
+        # Preserve fail-closed state even if a legacy release wrapper mutates
+        # environment variables after the canonical release returns.
+        _invalidate_local_release_state(self)
+        LOGGER.critical(
+            "WRITER_RELEASE_STATE_V53_INVALIDATED marker=%s acquired=%s lost=%s "
+            "execution_authority=0 execution_active=false reacquire_requires_redis=true",
+            MARKER,
+            str(bool(getattr(self, "acquired", False))).lower(),
+            str(bool(getattr(self, "lost", False))).lower(),
+        )
+        return result
+
+    setattr(release, _PATCH_ATTR, True)
+    setattr(release, "__wrapped__", original)
+    cls.release = release
+    LOGGER.critical(
+        "WRITER_RELEASE_STATE_V53_PATCHED marker=%s module=%s "
+        "intentional_release_callback=false redis_semantics=delegated",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        changed = _patch_entrypoint_writer_authority(module) or changed
+    return changed
+
+
+def _interesting(name: str) -> bool:
+    return str(name or "") in _TARGETS
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+
+        if not getattr(builtins, _INSTALL_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(
+                name: str,
+                globals: Any = None,
+                locals: Any = None,
+                fromlist: Any = (),
+                level: int = 0,
+            ):
+                result = original_import(name, globals, locals, fromlist, level)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _INSTALL_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        os.environ["NIJA_WRITER_RELEASE_STATE_V53_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_RELEASE_STATE_V53_INSTALLED marker=%s fail_closed=true "
+            "lock_acquire=false lock_extend=false lock_delete=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_invalidate_local_release_state",
+    "_patch_entrypoint_writer_authority",
+]


### PR DESCRIPTION
## Purpose

Close the writer lifecycle split observed on production commit `4041d5a7c8785653ed5d5ab668283051a809a0de`.

## Production evidence

The deployed v52 process shows all three brokers connected and runtime/module guards healthy, while canonical heartbeat readers repeatedly report `generation=0`, `healthy=False`, `authoritative=False`, and writer reentry proof remains false. This means broker connectivity survived while canonical writer authority disappeared.

## Root cause

`EntrypointWriterAuthority.release()` clears the Redis writer lock plus fencing/generation environment state, but it does not set the singleton's internal `_lost` event and does not clear process execution-authority claims. Since `acquired` is derived from the previous successful result plus `_lost`, a released singleton can continue to report `acquired=True`. A later `acquire_once()` can then return that stale successful result without performing a new Redis election.

## Changes

- Add `writer_release_state_consistency_v53_patch.py`.
- Wrap canonical `release()` so local acquisition is invalidated before release-side Redis mutation.
- Clear `NIJA_RUNTIME_EXECUTION_AUTHORITY` and `NIJA_EXECUTION_ACTIVE` on intentional release.
- Do not call `_mark_lost()` for intentional release, avoiding loss callback / SEAK emergency-halt semantics.
- Preserve the existing heartbeat-quiesce and compare-and-delete implementation.
- Install v53 on the canonical fast path.
- Extend the already-required canonical fast-path regression suite to prove release makes `acquired=False`, sets `lost=True`, leaves loss callbacks untouched, and clears execution claims.

## Safety

- No writer lock creation, extension, deletion, or stealing is added by v53.
- Reacquisition still goes through the existing Redis election path.
- No fabricated token/generation.
- No broker, capital, nonce, risk, readiness, kill-switch, or execution bypass.

## Expected production proof

After deployment, any intentional writer release should emit `WRITER_RELEASE_STATE_V53_INVALIDATED ... acquired=false lost=true`. A subsequent recovery must obtain a fresh Redis lease and publish a positive writer generation before heartbeat/readiness can become authoritative again.