### PR TITLE
Guarantee bounded writer recovery handoff v55

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,9 +1,10 @@
 """Compatibility entrypoint for Railway/main.py.
 
 The canonical Render launcher keeps package-wide runtime hooks deferred while
-``main.py`` installs the audited safety set explicitly.  Replaying every
+``main.py`` installs the audited safety set explicitly. Replaying every
 historical compatibility installer here delayed ``bot_main.main()`` for many
-minutes while the health server reported the service as live.  The canonical fast path therefore installs only narrow guards that are not already owned by
+minutes while the health server reported the service as live. The canonical
+fast path therefore installs only narrow guards that are not already owned by
 ``main.py``, then hands off immediately.
 
 Direct/non-canonical launches retain the legacy installer set for compatibility.
@@ -18,9 +19,9 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v54-v33"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v55-v34"
 
-# Each tuple is (module, success log label).  Names remain explicit so startup
+# Each tuple is (module, success log label). Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -28,6 +29,7 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_distributed_loss_watchdog_v52_patch", "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52"),
     ("bot.writer_release_state_consistency_v53_patch", "WRITER_RELEASE_STATE_V53"),
     ("bot.writer_runtime_lifecycle_supervisor_v54_patch", "WRITER_RUNTIME_LIFECYCLE_V54"),
+    ("bot.writer_recovery_callback_guard_v55_patch", "WRITER_RECOVERY_CALLBACK_V55"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),

--- a/bot/tests/test_writer_recovery_callback_guard_v55.py
+++ b/bot/tests/test_writer_recovery_callback_guard_v55.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import threading
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH = ROOT / "bot" / "writer_recovery_callback_guard_v55_patch.py"
+BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, PATCH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_fake_v39(monkeypatch, started: list[tuple]) -> ModuleType:
+    v39 = ModuleType("bot.production_readiness_v39_patch")
+    v39._RECOVERY_LOCK = threading.Lock()
+    v39._RECOVERY_ACTIVE = False
+    v39._recoverable_writer_loss = (
+        lambda reason: "lock_missing_and_fencing_token_mismatch" in str(reason)
+    )
+
+    def _start_writer_recovery(bot_main, runtime, reason, fallback):
+        started.append((bot_main, runtime, reason, fallback))
+        with v39._RECOVERY_LOCK:
+            v39._RECOVERY_ACTIVE = True
+        return True
+
+    v39._start_writer_recovery = _start_writer_recovery
+    monkeypatch.setitem(sys.modules, "bot.production_readiness_v39_patch", v39)
+    return v39
+
+
+def _install_fake_bot_main(monkeypatch) -> ModuleType:
+    bot_main = ModuleType("bot.bot_main")
+    bot_main._shutdown_event = threading.Event()
+    bot_main._authority_heartbeat_monitor = None
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+    return bot_main
+
+
+def test_recoverable_loss_hands_off_to_v39_once(monkeypatch) -> None:
+    v55 = _load("test_writer_recovery_v55_recoverable")
+    started: list[tuple] = []
+    v39 = _install_fake_v39(monkeypatch, started)
+    bot_main = _install_fake_bot_main(monkeypatch)
+    generic: list[str] = []
+
+    class Runtime:
+        def __init__(self):
+            self._lost = threading.Event()
+            self._stop = threading.Event()
+            self._on_lost_callback = lambda reason: generic.append(reason)
+
+        @property
+        def lost(self):
+            return self._lost.is_set()
+
+        def set_on_lost_callback(self, callback):
+            self._on_lost_callback = callback
+
+        def _mark_lost(self, reason):
+            self._lost.set()
+            if self._on_lost_callback is not None:
+                self._on_lost_callback(reason)
+
+        def release(self):
+            self._lost.set()
+            return True
+
+    module = ModuleType("bot.entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = Runtime
+    assert v55._patch_entrypoint_module(module) is True
+
+    runtime = Runtime()
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+    runtime._mark_lost("lock_missing_and_fencing_token_mismatch")
+
+    assert len(started) == 1
+    assert started[0][1] is runtime
+    assert started[0][2] == "lock_missing_and_fencing_token_mismatch"
+    assert generic == []
+    assert bot_main._shutdown_event.is_set() is False
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+    with v39._RECOVERY_LOCK:
+        assert v39._RECOVERY_ACTIVE is True
+
+
+def test_nonrecoverable_loss_preserves_prior_callback(monkeypatch) -> None:
+    v55 = _load("test_writer_recovery_v55_nonrecoverable")
+    started: list[tuple] = []
+    _install_fake_v39(monkeypatch, started)
+    _install_fake_bot_main(monkeypatch)
+    generic: list[str] = []
+
+    class Runtime:
+        def __init__(self):
+            self._lost = threading.Event()
+            self._stop = threading.Event()
+            self._on_lost_callback = lambda reason: generic.append(reason)
+
+        @property
+        def lost(self):
+            return self._lost.is_set()
+
+        def set_on_lost_callback(self, callback):
+            self._on_lost_callback = callback
+
+        def _mark_lost(self, reason):
+            self._lost.set()
+            if self._on_lost_callback is not None:
+                self._on_lost_callback(reason)
+
+        def release(self):
+            return True
+
+    module = ModuleType("bot.entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = Runtime
+    assert v55._patch_entrypoint_module(module) is True
+
+    runtime = Runtime()
+    runtime._mark_lost("lock_owned_by_different_writer")
+
+    assert started == []
+    assert generic == ["lock_owned_by_different_writer"]
+
+
+def test_release_sets_stop_before_existing_release_stack(monkeypatch) -> None:
+    v55 = _load("test_writer_recovery_v55_release")
+
+    class Runtime:
+        def __init__(self):
+            self._lost = threading.Event()
+            self._stop = threading.Event()
+            self._on_lost_callback = None
+            self.stop_seen = False
+
+        @property
+        def lost(self):
+            return self._lost.is_set()
+
+        def set_on_lost_callback(self, callback):
+            self._on_lost_callback = callback
+
+        def _mark_lost(self, reason):
+            self._lost.set()
+
+        def release(self):
+            self.stop_seen = self._stop.is_set()
+            self._lost.set()
+            return True
+
+    module = ModuleType("entrypoint_writer_authority")
+    module.EntrypointWriterAuthority = Runtime
+    assert v55._patch_entrypoint_module(module) is True
+
+    runtime = Runtime()
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    assert runtime.release() is True
+    assert runtime.stop_seen is True
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
+
+
+def test_core_thread_loss_is_never_recoverable(monkeypatch) -> None:
+    v55 = _load("test_writer_recovery_v55_core_terminal")
+    started: list[tuple] = []
+    _install_fake_v39(monkeypatch, started)
+    _install_fake_bot_main(monkeypatch)
+
+    assert v55._recoverable(
+        "writer_lock_released_for_reelection:core_thread_dead name=core"
+    ) is False
+    assert started == []
+
+
+def test_canonical_fast_path_installs_v55() -> None:
+    source = BOT_ENTRYPOINT.read_text(encoding="utf-8")
+    fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
+        ")\n\n_LEGACY_INSTALLERS", 1
+    )[0]
+
+    assert "writer_recovery_callback_guard_v55_patch" in fast_block
+    assert "WRITER_RECOVERY_CALLBACK_V55" in fast_block

--- a/bot/writer_recovery_callback_guard_v55_patch.py
+++ b/bot/writer_recovery_callback_guard_v55_patch.py
@@ -1,0 +1,439 @@
+"""Writer recovery callback/lifecycle guard v55.
+
+Repairs two fail-closed writer lifecycle gaps observed after v54:
+
+* recoverable distributed writer loss can be detected by v52 while the runtime's
+  on-lost callback no longer points at v39's bounded fresh-epoch recovery path;
+* v53 invalidates ``_lost`` immediately before canonical ``release()`` sets the
+  stop event, leaving a small window where the heartbeat can observe lost state
+  as a heartbeat failure instead of an intentional quiesced release.
+
+v55 never grants writer authority. It composes the canonical loss callback so
+only reasons already accepted by v39/v46 enter the existing bounded recovery
+routine, while every non-recoverable reason keeps the prior callback/shutdown
+behavior. It also sets the writer stop event before delegating to the existing
+release stack, so intentional release is quiesced before v53 exposes lost state.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_recovery_callback_guard_v55")
+MARKER = "20260808-writer-recovery-callback-guard-v55"
+
+_LOCK = threading.RLock()
+_STOP = threading.Event()
+_STARTED = False
+_IMPORT_FLAG = "_NIJA_WRITER_RECOVERY_CALLBACK_V55_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_WRITER_RECOVERY_CALLBACK_V55_IMPORTLIB_HOOK"
+_MARK_PATCH = "_nija_writer_recovery_callback_v55_mark_lost"
+_SETTER_PATCH = "_nija_writer_recovery_callback_v55_setter"
+_RELEASE_PATCH = "_nija_writer_recovery_callback_v55_release"
+_CALLBACK_PATCH = "_nija_writer_recovery_callback_v55_callback"
+_TARGETS = {"bot.entrypoint_writer_authority", "entrypoint_writer_authority"}
+
+
+def _fail_closed() -> None:
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+
+
+def _bot_main() -> ModuleType | None:
+    module = sys.modules.get("bot.bot_main")
+    if isinstance(module, ModuleType):
+        return module
+    try:
+        module = importlib.import_module("bot.bot_main")
+    except Exception:
+        return None
+    return module if isinstance(module, ModuleType) else None
+
+
+def _v39() -> ModuleType | None:
+    for name in (
+        "bot.production_readiness_v39_patch",
+        "production_readiness_v39_patch",
+    ):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    try:
+        module = importlib.import_module("bot.production_readiness_v39_patch")
+    except Exception:
+        return None
+    return module if isinstance(module, ModuleType) else None
+
+
+def _recoverable(reason: str) -> bool:
+    text = str(reason or "")
+    if "core_thread_" in text:
+        return False
+    module = _v39()
+    predicate = getattr(module, "_recoverable_writer_loss", None) if module else None
+    if callable(predicate):
+        try:
+            return bool(predicate(text))
+        except Exception:
+            pass
+    return bool(
+        "lock_missing_and_fencing_token_mismatch" in text
+        or "writer_lock_released_for_reelection:authority_invariant_violated:"
+        in text
+    )
+
+
+def _recovery_active() -> bool:
+    module = _v39()
+    if module is None:
+        return False
+    lock = getattr(module, "_RECOVERY_LOCK", None)
+    try:
+        if lock is not None:
+            with lock:
+                return bool(getattr(module, "_RECOVERY_ACTIVE", False))
+    except Exception:
+        pass
+    return bool(getattr(module, "_RECOVERY_ACTIVE", False))
+
+
+def _stop_authority_monitor(bot_main: ModuleType | None) -> None:
+    if bot_main is None:
+        return
+    monitor = getattr(bot_main, "_authority_heartbeat_monitor", None)
+    stop = getattr(monitor, "stop", None)
+    if callable(stop):
+        try:
+            stop()
+        except Exception:
+            pass
+
+
+def _fallback_shutdown(reason: str) -> None:
+    _fail_closed()
+    bot_main = _bot_main()
+    shutdown = (
+        getattr(bot_main, "_shutdown_event", None)
+        if bot_main is not None
+        else None
+    )
+    setter = getattr(shutdown, "set", None)
+    if callable(setter):
+        setter()
+    LOGGER.critical(
+        "WRITER_RECOVERY_V55_SHUTDOWN marker=%s reason=%s "
+        "execution_fail_closed=true",
+        MARKER,
+        str(reason or "unknown"),
+    )
+
+
+def _start_recovery(runtime: Any, reason: str) -> bool:
+    if not _recoverable(reason):
+        return False
+    module = _v39()
+    starter = (
+        getattr(module, "_start_writer_recovery", None)
+        if module is not None
+        else None
+    )
+    bot_main = _bot_main()
+    if not callable(starter) or bot_main is None:
+        LOGGER.critical(
+            "WRITER_RECOVERY_V55_UNAVAILABLE marker=%s reason=%s v39=%s "
+            "bot_main=%s fail_closed=true",
+            MARKER,
+            reason,
+            bool(module),
+            bool(bot_main),
+        )
+        return False
+    _fail_closed()
+    _stop_authority_monitor(bot_main)
+    try:
+        started = bool(starter(bot_main, runtime, reason, _fallback_shutdown))
+    except Exception as exc:
+        LOGGER.error(
+            "WRITER_RECOVERY_V55_START_FAILED marker=%s reason=%s err=%s:%s",
+            MARKER,
+            reason,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    LOGGER.critical(
+        "WRITER_RECOVERY_V55_HANDOFF marker=%s reason=%s started=%s "
+        "bounded_v39=true execution_fail_closed=true",
+        MARKER,
+        reason,
+        started,
+    )
+    return started
+
+
+def _compose_callback(runtime: Any, callback: Any) -> Any:
+    if callable(callback) and bool(getattr(callback, _CALLBACK_PATCH, False)):
+        return callback
+
+    def guarded(reason: str) -> None:
+        text = str(reason or "")
+        if _recoverable(text):
+            if _start_recovery(runtime, text):
+                return
+            _fallback_shutdown(f"v55_recovery_start_failed:{text}")
+            return
+        if callable(callback):
+            callback(text)
+            return
+        _fallback_shutdown(f"v55_nonrecoverable_without_callback:{text}")
+
+    setattr(guarded, _CALLBACK_PATCH, True)
+    setattr(guarded, "_nija_prior_callback", callback)
+    return guarded
+
+
+def _patch_entrypoint_module(module: ModuleType) -> bool:
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    changed = False
+
+    current_setter = getattr(cls, "set_on_lost_callback", None)
+    if callable(current_setter) and not bool(
+        getattr(current_setter, _SETTER_PATCH, False)
+    ):
+        original_setter = current_setter
+
+        @wraps(original_setter)
+        def set_on_lost_callback(self: Any, callback: Any) -> Any:
+            return original_setter(self, _compose_callback(self, callback))
+
+        setattr(set_on_lost_callback, _SETTER_PATCH, True)
+        setattr(set_on_lost_callback, "__wrapped__", original_setter)
+        cls.set_on_lost_callback = set_on_lost_callback
+        changed = True
+
+    current_mark = getattr(cls, "_mark_lost", None)
+    if callable(current_mark) and not bool(getattr(current_mark, _MARK_PATCH, False)):
+        original_mark = current_mark
+
+        @wraps(original_mark)
+        def mark_lost(self: Any, reason: str) -> Any:
+            callback = getattr(self, "_on_lost_callback", None)
+            if not (
+                callable(callback)
+                and bool(getattr(callback, _CALLBACK_PATCH, False))
+            ):
+                setattr(
+                    self,
+                    "_on_lost_callback",
+                    _compose_callback(self, callback),
+                )
+            result = original_mark(self, reason)
+            if _recoverable(reason) and not _recovery_active():
+                if not _start_recovery(self, reason):
+                    _fallback_shutdown(
+                        f"v55_post_mark_recovery_failed:{reason}"
+                    )
+            return result
+
+        setattr(mark_lost, _MARK_PATCH, True)
+        setattr(mark_lost, "__wrapped__", original_mark)
+        cls._mark_lost = mark_lost
+        changed = True
+
+    current_release = getattr(cls, "release", None)
+    if callable(current_release) and not bool(
+        getattr(current_release, _RELEASE_PATCH, False)
+    ):
+        original_release = current_release
+
+        @wraps(original_release)
+        def release(self: Any, *args: Any, **kwargs: Any) -> Any:
+            stop = getattr(self, "_stop", None)
+            setter = getattr(stop, "set", None)
+            if callable(setter):
+                setter()
+            _fail_closed()
+            LOGGER.info(
+                "WRITER_RECOVERY_V55_RELEASE_QUIESCED marker=%s "
+                "stop_before_lost=true execution_fail_closed=true",
+                MARKER,
+            )
+            return original_release(self, *args, **kwargs)
+
+        setattr(release, _RELEASE_PATCH, True)
+        setattr(release, "__wrapped__", original_release)
+        cls.release = release
+        changed = True
+
+    return changed or bool(
+        callable(getattr(cls, "_mark_lost", None))
+        and getattr(getattr(cls, "_mark_lost"), _MARK_PATCH, False)
+    )
+
+
+def _runtime() -> Any:
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:
+                return None
+    return None
+
+
+def reconcile_once() -> dict[str, Any]:
+    runtime = _runtime()
+    if runtime is None:
+        return {"ok": False, "action": "runtime_unavailable"}
+
+    callback = getattr(runtime, "_on_lost_callback", None)
+    if not (
+        callable(callback) and bool(getattr(callback, _CALLBACK_PATCH, False))
+    ):
+        setattr(
+            runtime,
+            "_on_lost_callback",
+            _compose_callback(runtime, callback),
+        )
+        LOGGER.warning(
+            "WRITER_RECOVERY_V55_CALLBACK_REPAIRED marker=%s callback_drift=true",
+            MARKER,
+        )
+
+    lost = bool(getattr(runtime, "lost", False))
+    stop = getattr(runtime, "_stop", None)
+    stopped = bool(getattr(stop, "is_set", lambda: False)())
+    if lost and not stopped and not _recovery_active():
+        reason = str(os.environ.get("NIJA_WRITER_LAST_LOSS_REASON", "") or "")
+        if _recoverable(reason):
+            if _start_recovery(runtime, reason):
+                return {
+                    "ok": True,
+                    "action": "recovery_backstop_started",
+                    "reason": reason,
+                }
+            _fallback_shutdown(f"v55_backstop_recovery_failed:{reason}")
+            return {"ok": False, "action": "shutdown", "reason": reason}
+
+    return {"ok": True, "action": "callback_guarded"}
+
+
+def _patch_loaded() -> bool:
+    ok = False
+    seen: set[int] = set()
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        ok = _patch_entrypoint_module(module) or ok
+    return ok
+
+
+def _interesting(name: str) -> bool:
+    text = str(name or "")
+    return text in _TARGETS or text in {
+        "bot.bot_main",
+        "bot.production_readiness_v39_patch",
+        "production_readiness_v39_patch",
+    }
+
+
+def _supervisor_loop() -> None:
+    while not _STOP.wait(1.0):
+        try:
+            _patch_loaded()
+            reconcile_once()
+        except Exception as exc:
+            _fail_closed()
+            LOGGER.warning(
+                "WRITER_RECOVERY_V55_SUPERVISOR_ERROR marker=%s err=%s:%s "
+                "fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        _patch_loaded()
+
+        if not getattr(builtins, _IMPORT_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(
+                name: str,
+                globals: Any = None,
+                locals: Any = None,
+                fromlist: Any = (),
+                level: int = 0,
+            ):
+                result = original_import(name, globals, locals, fromlist, level)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _IMPORT_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if _interesting(name):
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        if not _STARTED:
+            _STOP.clear()
+            threading.Thread(
+                target=_supervisor_loop,
+                name="WriterRecoveryCallbackGuardV55",
+                daemon=True,
+            ).start()
+            _STARTED = True
+
+        os.environ["NIJA_WRITER_RECOVERY_CALLBACK_V55_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_RECOVERY_CALLBACK_V55_INSTALLED marker=%s bounded_v39=true "
+            "callback_guard=true release_quiesce=true lock_grant=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_recoverable",
+    "_start_recovery",
+    "_compose_callback",
+    "_patch_entrypoint_module",
+    "reconcile_once",
+]


### PR DESCRIPTION
## Purpose

Fix the remaining writer-authority recovery gap observed on deployed commit `3a331ef7caaa03200437f935d395dc9ba26da76c`.

## Production evidence

The deployed v54 runtime repeatedly reports all configured brokers connected and capital ready, while every canonical writer reader remains `generation=0`, `authoritative=False`, and execution stays disabled. Earlier in the same production process v52 observed a genuinely missing Redis process-writer lock and marked the loss recoverable, but the expected v39 bounded re-election telemetry did not follow. The process can subsequently remain alive in `LIVE_PENDING_CONFIRMATION` with `writer_lease_not_acquired`.

## Root cause

v52 correctly routes missing distributed ownership through `EntrypointWriterAuthority._mark_lost("lock_missing_and_fencing_token_mismatch")`, but bounded recovery still depends on the runtime's mutable `_on_lost_callback` continuing to be the v39 wrapper installed much earlier in startup. Later callback replacement or wrapper drift can therefore turn a recoverable loss into a generic shutdown/stuck-lost state.

There is also an intentional-release ordering window: v53 sets the runtime `_lost` event before canonical `release()` sets `_stop`, so a heartbeat can briefly observe `lost=True` while it is not yet quiesced and relabel the condition as `runtime_already_lost`.

## Changes

- Add `writer_recovery_callback_guard_v55_patch.py`.
- Compose every future `set_on_lost_callback()` registration so recoverable reasons hand off directly to the existing bounded v39 fresh-epoch recovery routine.
- Add `_mark_lost()` backstop logic so recoverable loss cannot be stranded if callback drift still occurs.
- Preserve prior callback/shutdown behavior for all nonrecoverable reasons.
- Explicitly reject core-thread loss as recoverable.
- Keep execution fail-closed throughout recovery and fall back to normal process shutdown if v39 recovery cannot be started.
- Set the writer `_stop` event before delegating through the existing release stack, removing the v53 lost-before-stop race without changing Redis release semantics.
- Install v55 on the canonical fast path after v54.
- Add focused tests for recoverable handoff, nonrecoverable delegation, release ordering, terminal core loss, and fast-path installation.

## Safety

- No writer lock creation, renewal, extension, deletion, stealing, or forced acquisition is added by v55.
- Fresh authority still comes only from v39 calling canonical `acquire_once()` followed by synchronous distributed-authority verification.
- No fabricated fencing token, generation, heartbeat, balance, capital, broker readiness, or execution permission.
- No risk threshold, kill-switch, nonce, strategy, or order-dispatch bypass.
- Nonrecoverable loss remains terminal/fail-closed.
- If recovery infrastructure is unavailable, v55 requests normal shutdown rather than granting authority.

## Validation

Local synthetic validation before publishing:
- module compiles successfully;
- recoverable missing-lock loss starts v39 exactly once and does not invoke the generic callback;
- nonrecoverable loss delegates to the prior callback;
- release sets `_stop` before the existing release stack executes.

Branch is based exactly on `3a331ef7caaa03200437f935d395dc9ba26da76c`, 3 commits ahead and 0 behind, changing only the v55 module, focused v55 tests, and `bot/bot.py` fast-path wiring.

## Expected production proof

After deployment, recoverable writer loss should emit `WRITER_RECOVERY_V55_HANDOFF ... started=True`, followed by the existing `WRITER_REELECTION_V39_STARTED` and either `WRITER_REELECTION_V39_RECOVERED` with a fresh positive generation or bounded exhaustion followed by normal shutdown. Intentional release should emit `WRITER_RECOVERY_V55_RELEASE_QUIESCED` before release-state invalidation. Core startup remains blocked unless v54 proves exact current Redis process-writer ownership.