### PR TITLE
Stabilize post-v55 CI and canary workflows

### DIFF
--- a/.github/workflows/canary-deployment.yml
+++ b/.github/workflows/canary-deployment.yml
@@ -1,8 +1,10 @@
 name: Canary Deployment with Automated Rollback
 
+# Production is deployed by Render. Kubernetes canary rollout is intentionally
+# opt-in (manual) or release-tag driven so an unrelated K8s environment cannot
+# fail every normal main push after Render has already deployed successfully.
 on:
   push:
-    branches: [ main ]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -33,247 +35,247 @@ jobs:
       packages: write
       security-events: write
       id-token: write
-    
+
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       image-tag: ${{ steps.primary-tag.outputs.image }}
-      
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
 
-    - name: Select primary image tag
-      id: primary-tag
-      run: |
-        IMAGE_TAG="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | sed -n '1p')"
-        if [ -z "${IMAGE_TAG}" ]; then
-          echo "No image tags were generated" >&2
-          exit 1
-        fi
-        echo "image=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+      - name: Select primary image tag
+        id: primary-tag
+        run: |
+          IMAGE_TAG="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | sed -n '1p')"
+          if [ -z "${IMAGE_TAG}" ]; then
+            echo "No image tags were generated" >&2
+            exit 1
+          fi
+          echo "image=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
 
-    - name: Build and push Docker image
-      id: build
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-          GIT_COMMIT=${{ github.sha }}
-          GIT_BRANCH=${{ github.ref_name }}
-          BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
 
-    # Scan image for vulnerabilities
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: ${{ steps.primary-tag.outputs.image }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        severity: 'CRITICAL,HIGH'
-      continue-on-error: true
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.primary-tag.outputs.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+        continue-on-error: true
 
-    - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
-      continue-on-error: true
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+        continue-on-error: true
 
-    # Sign the container image
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
 
-    - name: Sign container image
-      run: |
-        cosign sign --yes "${{ steps.primary-tag.outputs.image }}@${{ steps.build.outputs.digest }}"
-      env:
-        COSIGN_EXPERIMENTAL: 1
+      - name: Sign container image
+        run: |
+          cosign sign --yes "${{ steps.primary-tag.outputs.image }}@${{ steps.build.outputs.digest }}"
+        env:
+          COSIGN_EXPERIMENTAL: 1
 
   deploy-canary:
     name: Deploy Canary
     runs-on: ubuntu-latest
     needs: build-and-scan
-    environment: 
+    environment:
       name: ${{ github.event.inputs.environment || 'staging' }}
-      
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
 
-    - name: Configure kubectl
-      run: |
-        echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > kubeconfig
-        echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+      - name: Configure and verify kubectl
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KUBE_CONFIG_B64}" ]; then
+            echo "KUBE_CONFIG secret is not configured for this environment" >&2
+            exit 1
+          fi
+          printf '%s' "${KUBE_CONFIG_B64}" | base64 -d > kubeconfig
+          chmod 600 kubeconfig
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> "${GITHUB_ENV}"
+          KUBECONFIG="$(pwd)/kubeconfig" kubectl cluster-info
+          KUBECONFIG="$(pwd)/kubeconfig" kubectl get namespace nija
 
-    # Deploy canary version
-    - name: Deploy Canary Version
-      run: |
-        export CANARY_IMAGE="${{ needs.build-and-scan.outputs.image-tag }}"
-        export CANARY_PERCENTAGE="${{ github.event.inputs.canary_percentage || '10' }}"
-        
-        # Apply canary deployment
-        envsubst < k8s/canary/deployment-canary.yaml | kubectl apply -f -
-        
-        # Update traffic split
-        envsubst < k8s/canary/traffic-split.yaml | kubectl apply -f -
-        
-        # Wait for canary to be ready
-        kubectl rollout status deployment/nija-canary -n nija --timeout=5m
+      - name: Deploy Canary Version
+        id: deploy
+        run: |
+          set -euo pipefail
+          export CANARY_IMAGE="${{ needs.build-and-scan.outputs.image-tag }}"
+          export CANARY_PERCENTAGE="${{ github.event.inputs.canary_percentage || '10' }}"
+          envsubst < k8s/canary/deployment-canary.yaml | kubectl apply -f -
+          envsubst < k8s/canary/traffic-split.yaml | kubectl apply -f -
+          kubectl rollout status deployment/nija-canary -n nija --timeout=5m
 
-    # Health check for canary
-    - name: Canary Health Check
-      id: health-check
-      run: |
-        python scripts/canary_health_check.py \
-          --namespace nija \
-          --deployment nija-canary \
-          --duration 300 \
-          --error-threshold 5
-      continue-on-error: true
+      - name: Canary Health Check
+        id: health-check
+        if: success()
+        run: |
+          python scripts/canary_health_check.py \
+            --namespace nija \
+            --deployment nija-canary \
+            --duration 300 \
+            --error-threshold 5
+        continue-on-error: true
 
-    # Automated rollback if health check fails
-    - name: Rollback Canary on Failure
-      if: steps.health-check.outcome == 'failure'
-      run: |
-        echo "::error::Canary health check failed - initiating rollback"
-        kubectl delete deployment nija-canary -n nija
-        kubectl apply -f k8s/canary/traffic-split-stable.yaml
-        exit 1
+      - name: Rollback Canary on Failure
+        if: ${{ failure() || steps.health-check.outcome == 'failure' }}
+        run: |
+          echo "::error::Canary deployment or health check failed - initiating rollback"
+          kubectl apply -f k8s/canary/traffic-split-stable.yaml || true
+          kubectl delete deployment nija-canary -n nija --ignore-not-found=true || true
+        continue-on-error: true
 
-    # Store canary metrics
-    - name: Collect Canary Metrics
-      if: always()
-      run: |
-        python scripts/collect_canary_metrics.py \
-          --namespace nija \
-          --deployment nija-canary \
-          --output canary-metrics.json
-      continue-on-error: true
+      - name: Fail unhealthy canary
+        if: ${{ steps.health-check.outcome == 'failure' }}
+        run: exit 1
 
-    - name: Upload Canary Metrics
-      uses: actions/upload-artifact@v4.4.3
-      if: always()
-      with:
-        name: canary-metrics
-        path: canary-metrics.json
+      - name: Collect Canary Metrics
+        if: always()
+        run: |
+          python scripts/collect_canary_metrics.py \
+            --namespace nija \
+            --deployment nija-canary \
+            --output canary-metrics.json
+        continue-on-error: true
+
+      - name: Upload Canary Metrics
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: canary-metrics
+          path: canary-metrics.json
+          if-no-files-found: ignore
 
   progressive-rollout:
     name: Progressive Traffic Shift
     runs-on: ubuntu-latest
     needs: deploy-canary
-    environment: 
+    environment:
       name: ${{ github.event.inputs.environment || 'staging' }}
-    
-    strategy:
-      matrix:
-        traffic_percentage: [25, 50, 75, 100]
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
 
-    - name: Configure kubectl
-      run: |
-        echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > kubeconfig
-        echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+      - name: Configure kubectl
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${KUBE_CONFIG_B64}" | base64 -d > kubeconfig
+          chmod 600 kubeconfig
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> "${GITHUB_ENV}"
 
-    # Shift traffic gradually
-    - name: Shift Traffic to ${{ matrix.traffic_percentage }}%
-      run: |
-        export CANARY_PERCENTAGE="${{ matrix.traffic_percentage }}"
-        envsubst < k8s/canary/traffic-split.yaml | kubectl apply -f -
-        sleep 60
+      - name: Shift traffic progressively
+        id: rollout
+        run: |
+          set -euo pipefail
+          for CANARY_PERCENTAGE in 25 50 75 100; do
+            export CANARY_PERCENTAGE
+            echo "Shifting canary traffic to ${CANARY_PERCENTAGE}%"
+            envsubst < k8s/canary/traffic-split.yaml | kubectl apply -f -
+            sleep 60
+            python scripts/canary_health_check.py \
+              --namespace nija \
+              --deployment nija-canary \
+              --duration 180 \
+              --error-threshold 5 \
+              --latency-threshold-ms 1000
+          done
 
-    # Monitor metrics at each stage
-    - name: Monitor Canary at ${{ matrix.traffic_percentage }}%
-      id: monitor
-      run: |
-        python scripts/canary_health_check.py \
-          --namespace nija \
-          --deployment nija-canary \
-          --duration 180 \
-          --error-threshold 5 \
-          --latency-threshold-ms 1000
-      continue-on-error: true
-
-    # Rollback if issues detected
-    - name: Rollback on Issues at ${{ matrix.traffic_percentage }}%
-      if: steps.monitor.outcome == 'failure'
-      run: |
-        echo "::error::Issues detected at ${{ matrix.traffic_percentage }}% - rolling back"
-        kubectl apply -f k8s/canary/traffic-split-stable.yaml
-        kubectl delete deployment nija-canary -n nija
-        exit 1
+      - name: Rollback progressive rollout on failure
+        if: failure()
+        run: |
+          echo "::error::Progressive rollout failed - restoring stable traffic"
+          kubectl apply -f k8s/canary/traffic-split-stable.yaml || true
+          kubectl delete deployment nija-canary -n nija --ignore-not-found=true || true
+        continue-on-error: true
 
   finalize-deployment:
     name: Finalize Deployment
     runs-on: ubuntu-latest
-    needs: progressive-rollout
-    environment: 
+    needs: [build-and-scan, progressive-rollout]
+    environment:
       name: ${{ github.event.inputs.environment || 'staging' }}
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
 
-    - name: Configure kubectl
-      run: |
-        echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > kubeconfig
-        echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+      - name: Configure kubectl
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${KUBE_CONFIG_B64}" | base64 -d > kubeconfig
+          chmod 600 kubeconfig
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> "${GITHUB_ENV}"
 
-    # Promote canary to stable
-    - name: Promote Canary to Stable
-      run: |
-        # Update stable deployment with canary image
-        kubectl set image deployment/nija-stable \
-          nija=${{ needs.build-and-scan.outputs.image-tag }} \
-          -n nija
-        
-        # Wait for stable deployment
-        kubectl rollout status deployment/nija-stable -n nija --timeout=5m
-        
-        # Remove canary deployment
-        kubectl delete deployment nija-canary -n nija
-        
-        # Restore 100% traffic to stable
-        kubectl apply -f k8s/canary/traffic-split-stable.yaml
+      - name: Promote Canary to Stable
+        run: |
+          set -euo pipefail
+          kubectl set image deployment/nija-stable \
+            nija=${{ needs.build-and-scan.outputs.image-tag }} \
+            -n nija
+          kubectl rollout status deployment/nija-stable -n nija --timeout=5m
+          kubectl delete deployment nija-canary -n nija --ignore-not-found=true
+          kubectl apply -f k8s/canary/traffic-split-stable.yaml
 
-    - name: Deployment Success Notification
-      run: |
-        echo "::notice::Canary deployment successfully promoted to stable"
+      - name: Deployment Success Notification
+        run: |
+          echo "::notice::Canary deployment successfully promoted to stable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Start SSH agent and add private key
         if: ${{ env.SSH_PRIVATE_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,33 +9,34 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # These must exist as repository secrets
+      # Repository secrets used by tests when present.
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       COINBASE_API_KEY: ${{ secrets.COINBASE_API_KEY }}
       COINBASE_API_SECRET: ${{ secrets.COINBASE_API_SECRET }}
-      COINBASE_PEM_CONTENT: ${{ secrets.COINBASE_PEM_CONTENT }} # optional
+      COINBASE_PEM_CONTENT: ${{ secrets.COINBASE_PEM_CONTENT }}
+      # Secrets cannot be referenced directly in a step-level `if:` expression.
+      # Copy the optional SSH key into job env and gate on env instead.
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      # Add SSH key and known_hosts only when a private key secret exists
       - name: Start SSH agent and add private key
-        if: ${{ secrets.SSH_PRIVATE_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.7.0
+        if: ${{ env.SSH_PRIVATE_KEY != '' }}
+        uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
 
       - name: Ensure github.com known host
-        if: ${{ secrets.SSH_PRIVATE_KEY != '' }}
+        if: ${{ env.SSH_PRIVATE_KEY != '' }}
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      # (Add your build/test/publish steps below)
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## What changed

- Repair `.github/workflows/ci.yml` so the optional SSH secret is gated through job environment instead of directly referencing `secrets` in step `if` expressions.
- Update CI actions to current Node 24-capable releases.
- Stop Kubernetes canary deployment from running on every normal `main` push; production deploys are already handled by Render.
- Keep canary deployment available for `v*` release tags and manual dispatches.
- Validate Kubernetes configuration and namespace before deployment.
- Roll back when deployment itself fails, not only after an unhealthy health check.
- Make progressive traffic shifts sequential instead of concurrently applying 25/50/75/100% via a matrix.
- Fix final promotion dependencies so the build image output is actually available.
- Update checkout, kubectl, and artifact actions to Node 24-capable versions.

## Why

Merge commit `725810954a637010dae68c9867fa8b0bc9573f77` successfully deployed to Render, but two post-merge GitHub workflows were red: the legacy CI workflow failed before creating any jobs, and the Kubernetes canary workflow failed at `Deploy Canary Version` even though the build/security stage passed. These fixes remove those unrelated stopping points without weakening writer-authority or fail-closed runtime behavior.

## Runtime safety

No v55 writer recovery, v39 bounded re-election, v54 writer proof, Redis authority, execution gating, risk controls, broker routing, or trading logic is changed by this PR.