### PR TITLE
Close writer recovery and OKX convergence gaps v56-v58

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
+      # Keep ordinary CI Python processes from importing production startup
+      # hooks that can start writer, broker, activation, or execution monitors.
+      NIJA_DEFER_RUNTIME_SITE_HOOKS: "1"
       # Repository secrets used by tests when present.
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       COINBASE_API_KEY: ${{ secrets.COINBASE_API_KEY }}
@@ -39,6 +43,9 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.11'
+
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
 
       - name: Install deps
         run: |

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v56-v34"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v57-v34"
 
 # Each tuple is (module, success log label). Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
@@ -31,6 +31,7 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_runtime_lifecycle_supervisor_v54_patch", "WRITER_RUNTIME_LIFECYCLE_V54"),
     ("bot.writer_recovery_callback_guard_v55_patch", "WRITER_RECOVERY_CALLBACK_V55"),
     ("bot.writer_runtime_core_thread_backstop_v56_patch", "WRITER_RUNTIME_CORE_THREAD_BACKSTOP_V56"),
+    ("bot.writer_authority_generation_convergence_v57_patch", "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v55-v34"
+_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v56-v34"
 
 # Each tuple is (module, success log label). Names remain explicit so startup
 # attestation and source audits can prove which guards are eligible.
@@ -30,6 +30,7 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_release_state_consistency_v53_patch", "WRITER_RELEASE_STATE_V53"),
     ("bot.writer_runtime_lifecycle_supervisor_v54_patch", "WRITER_RUNTIME_LIFECYCLE_V54"),
     ("bot.writer_recovery_callback_guard_v55_patch", "WRITER_RECOVERY_CALLBACK_V55"),
+    ("bot.writer_runtime_core_thread_backstop_v56_patch", "WRITER_RUNTIME_CORE_THREAD_BACKSTOP_V56"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),

--- a/bot/okx_router_connection_convergence_patch.py
+++ b/bot/okx_router_connection_convergence_patch.py
@@ -3,6 +3,11 @@
 Repairs duplicate import identities and the bridge idempotency contract. It never
 fabricates credentials or balances and never marks OKX ready until an existing
 broker returns a successful private balance response.
+
+The connection watchdog is deliberately venue-local and bounded in intensity:
+terminal configuration/authentication states stop reconnect attempts, while
+transient failures use exponential backoff and isolate only OKX. Kraken and
+Coinbase readiness are never changed here.
 """
 from __future__ import annotations
 
@@ -16,9 +21,10 @@ from types import ModuleType
 from typing import Any, Mapping
 
 logger = logging.getLogger("nija.okx_router_connection_convergence")
-_MARKER = "20260719-okx-router-connection-v2"
+_MARKER = "20260808-okx-router-connection-v3"
 _LOCK = threading.RLock()
 _STARTED = False
+_LAST_DIAGNOSTIC = ""
 
 _BRIDGE_NAMES = ("bot.okx_final_order_submission_bridge_patch", "okx_final_order_submission_bridge_patch")
 _ROUTER_NAMES = ("bot.multi_broker_execution_router", "multi_broker_execution_router")
@@ -27,10 +33,55 @@ _CREDENTIAL_GROUPS = (
     ("OKX_API_SECRET", "OKX_PLATFORM_API_SECRET"),
     ("OKX_PASSPHRASE", "OKX_API_PASSPHRASE", "OKX_PLATFORM_PASSPHRASE"),
 )
+_ENABLE_FLAGS = (
+    "ENABLE_OKX_TRADING",
+    "OKX_LIVE_TRADING_ENABLED",
+    "NIJA_OKX_EXECUTION_ENABLED",
+    "NIJA_OKX_LIVE_TRADING_ENABLED",
+)
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_FALSE = {"0", "false", "no", "off", "disabled", "n"}
+_FATAL_AUTH_CODES = {"401", "403", "50100", "50101", "50111", "50112", "50113", "50119"}
+_FATAL_AUTH_WORDS = (
+    "api key",
+    "apikey",
+    "passphrase",
+    "signature",
+    "authentication",
+    "unauthorized",
+    "forbidden",
+    "permission denied",
+    "invalid key",
+    "invalid secret",
+)
+_TERMINAL_STATES = {
+    "disabled",
+    "blocked_credentials",
+    "credential_quarantined",
+    "authentication_failed",
+    "connected_no_spendable_quote",
+}
+_RETRY_BACKOFF_S = (2.0, 5.0, 15.0, 30.0, 60.0, 120.0, 300.0)
+_TRANSIENT_QUARANTINE_AFTER = 4
+_MAX_TRANSIENT_ATTEMPTS = 64
 
 
 def _truthy(name: str) -> bool:
-    return str(os.getenv(name, "") or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return str(os.getenv(name, "") or "").strip().lower() in _TRUE
+
+
+def _explicit_false(name: str) -> bool:
+    raw = str(os.getenv(name, "") or "").strip().lower()
+    return bool(raw) and raw in _FALSE
+
+
+def _okx_enabled() -> tuple[bool, str]:
+    if _truthy("NIJA_DISABLE_OKX"):
+        return False, "NIJA_DISABLE_OKX=true"
+    disabled = [name for name in _ENABLE_FLAGS if _explicit_false(name)]
+    if disabled:
+        return False, "disabled_flags=" + ",".join(disabled)
+    return True, "enabled"
 
 
 def _credentials_ready() -> tuple[bool, list[str]]:
@@ -39,6 +90,56 @@ def _credentials_ready() -> tuple[bool, list[str]]:
         if not any(str(os.getenv(name, "") or "").strip() for name in aliases):
             missing.append(aliases[0])
     return not missing, missing
+
+
+def _credential_quarantined() -> bool:
+    return _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED") or _truthy("NIJA_OKX_RECONNECT_DISABLED")
+
+
+def _set_state(state: str, *, ready: bool = False) -> None:
+    os.environ["NIJA_OKX_ACTIVATION_STATE"] = state
+    os.environ["NIJA_OKX_TRADING_READY"] = "1" if ready else "0"
+    if not ready:
+        os.environ["NIJA_OKX_FULLY_CONNECTED"] = "0"
+
+
+def _log_transition(level: int, key: str, message: str, *args: Any) -> None:
+    global _LAST_DIAGNOSTIC
+    with _LOCK:
+        if key == _LAST_DIAGNOSTIC:
+            return
+        _LAST_DIAGNOSTIC = key
+    logger.log(level, message, *args)
+
+
+def _publish_terminal(state: str, reason: str) -> None:
+    _set_state(state)
+    os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "1"
+    os.environ["NIJA_OKX_RETRY_STATE"] = "terminal"
+    os.environ["NIJA_OKX_RECONNECT_DISABLED"] = "1"
+    _log_transition(
+        logging.ERROR if state not in {"disabled", "connected_no_spendable_quote"} else logging.WARNING,
+        f"terminal:{state}",
+        "OKX_CONNECTION_TERMINAL marker=%s state=%s reason=%s scope=okx_only "
+        "kraken_affected=false coinbase_affected=false retries_disabled=true",
+        _MARKER,
+        state,
+        reason,
+    )
+
+
+def _clear_recovery_state() -> None:
+    os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "0"
+    os.environ["NIJA_OKX_RETRY_STATE"] = "ready"
+    if not _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED"):
+        os.environ["NIJA_OKX_RECONNECT_DISABLED"] = "0"
+
+
+def _looks_fatal_auth(detail: object) -> bool:
+    text = str(detail or "").strip().lower()
+    if any(code in text for code in _FATAL_AUTH_CODES):
+        return True
+    return any(word in text for word in _FATAL_AUTH_WORDS)
 
 
 def _canonical_import(primary: str, alias: str) -> ModuleType:
@@ -79,7 +180,6 @@ def _converge_router() -> bool:
     if ready:
         bridge._ROUTER_PATCHED = True
         os.environ["NIJA_OKX_ROUTER_PATCHED"] = "1"
-        os.environ["NIJA_OKX_ROUTER_QUARANTINED"] = "0"
         logger.critical("OKX_ROUTER_IDENTITY_CONVERGED marker=%s bridge=%s router=%s", _MARKER, bridge.__name__, router.__name__)
     return ready
 
@@ -165,83 +265,225 @@ def _attempt_existing_broker_recovery(manager: Any, broker: Any) -> Any:
             setattr(manager, "_platform_init_complete", False)
             initializer()
         except Exception as exc:
-            logger.warning("OKX_PLATFORM_REINITIALIZE_FAILED marker=%s error=%s", _MARKER, exc)
+            _log_transition(
+                logging.WARNING,
+                "platform_reinitialize_failed",
+                "OKX_PLATFORM_REINITIALIZE_FAILED marker=%s error=%s",
+                _MARKER,
+                exc,
+            )
     _, recovered = _runtime_broker()
     return recovered
 
 
 def _converge_connection() -> bool:
+    enabled, enable_reason = _okx_enabled()
+    if not enabled:
+        _publish_terminal("disabled", enable_reason)
+        return False
+
+    if _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED"):
+        code = os.getenv("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "credential_rejected")
+        _publish_terminal("credential_quarantined", f"credential_code={code}")
+        return False
+
     credentials, missing = _credentials_ready()
     if not credentials:
-        os.environ["NIJA_OKX_ACTIVATION_STATE"] = "blocked_credentials"
-        os.environ["NIJA_OKX_TRADING_READY"] = "0"
-        logger.error("OKX_CONNECTION_BLOCKED marker=%s reason=missing_credentials missing=%s", _MARKER, ",".join(missing))
+        _publish_terminal("blocked_credentials", "missing=" + ",".join(missing))
         return False
+
     manager, broker = _runtime_broker()
     broker = _attempt_existing_broker_recovery(manager, broker)
     if broker is None:
-        os.environ["NIJA_OKX_ACTIVATION_STATE"] = "waiting_broker"
-        logger.warning("OKX_CONNECTION_WAITING marker=%s reason=broker_not_registered", _MARKER)
+        _set_state("waiting_broker")
+        _log_transition(
+            logging.WARNING,
+            "waiting_broker",
+            "OKX_CONNECTION_WAITING marker=%s reason=broker_not_registered",
+            _MARKER,
+        )
         return False
+
     if not _connected(broker):
+        if not _truthy("NIJA_WRITER_HEARTBEAT_ACTIVE"):
+            _set_state("waiting_writer")
+            _log_transition(
+                logging.WARNING,
+                "waiting_writer",
+                "OKX_CONNECTION_WAITING marker=%s reason=writer_heartbeat_not_active",
+                _MARKER,
+            )
+            return False
         connect = getattr(broker, "connect", None)
-        if callable(connect) and _truthy("NIJA_WRITER_HEARTBEAT_ACTIVE"):
+        if callable(connect):
             try:
                 connect()
             except Exception as exc:
-                os.environ["NIJA_OKX_ACTIVATION_STATE"] = "authentication_failed"
-                logger.error("OKX_AUTHENTICATION_FAILED marker=%s error=%s", _MARKER, exc)
+                detail = f"{type(exc).__name__}:{exc}"
+                if _looks_fatal_auth(detail):
+                    _publish_terminal("authentication_failed", detail[:240])
+                else:
+                    _set_state("connection_failed")
+                    _log_transition(
+                        logging.ERROR,
+                        "connection_failed",
+                        "OKX_CONNECTION_FAILED marker=%s class=transient error=%s retry=backoff",
+                        _MARKER,
+                        detail[:240],
+                    )
                 return False
-    connected = _connected(broker)
-    balance_ok, spendable, source = _balance(broker) if connected else (False, 0.0, "not_connected")
-    if not connected or not balance_ok:
-        os.environ["NIJA_OKX_ACTIVATION_STATE"] = "connection_failed"
-        os.environ["NIJA_OKX_TRADING_READY"] = "0"
-        logger.error("OKX_CONNECTION_UNVERIFIED marker=%s connected=%s balance_ok=%s source=%s", _MARKER, connected, balance_ok, source)
+
+    if _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED"):
+        code = os.getenv("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "credential_rejected")
+        _publish_terminal("credential_quarantined", f"credential_code={code}")
         return False
+
+    connected = _connected(broker)
+    if not connected:
+        _set_state("connection_failed")
+        _log_transition(
+            logging.ERROR,
+            "connection_failed",
+            "OKX_CONNECTION_UNVERIFIED marker=%s connected=false balance_ok=false source=not_connected retry=backoff",
+            _MARKER,
+        )
+        return False
+
+    balance_ok, spendable, source = _balance(broker)
+    if not balance_ok:
+        if _looks_fatal_auth(source):
+            _publish_terminal("authentication_failed", source[:240])
+        else:
+            _set_state("connection_failed")
+            _log_transition(
+                logging.ERROR,
+                "balance_unverified",
+                "OKX_CONNECTION_UNVERIFIED marker=%s connected=true balance_ok=false source=%s retry=backoff",
+                _MARKER,
+                source[:240],
+            )
+        return False
+
     os.environ["NIJA_OKX_BALANCE_OBSERVED"] = "1"
     os.environ["NIJA_OKX_TRADING_SPENDABLE"] = f"{spendable:.8f}"
     if spendable <= 0.0:
-        os.environ["NIJA_OKX_ACTIVATION_STATE"] = "connected_no_spendable_quote"
-        os.environ["NIJA_OKX_TRADING_READY"] = "0"
-        logger.warning("OKX_CONNECTED_NO_SPENDABLE_QUOTE marker=%s source=%s", _MARKER, source)
+        _publish_terminal("connected_no_spendable_quote", f"source={source}")
         return False
-    os.environ["NIJA_OKX_ACTIVATION_STATE"] = "ready"
-    os.environ["NIJA_OKX_TRADING_READY"] = "1"
-    logger.critical("OKX_CONNECTION_VERIFIED marker=%s connected=true spendable=%.8f source=%s", _MARKER, spendable, source)
+
+    _clear_recovery_state()
+    _set_state("ready", ready=True)
+    _log_transition(
+        logging.CRITICAL,
+        "ready",
+        "OKX_CONNECTION_VERIFIED marker=%s connected=true spendable=%.8f source=%s",
+        _MARKER,
+        spendable,
+        source,
+    )
     return True
 
 
+def _retry_delay(attempt: int, state: str) -> float:
+    if state in {"waiting_broker", "waiting_writer"} and attempt < 10:
+        return 1.0
+    return _RETRY_BACKOFF_S[min(max(0, attempt), len(_RETRY_BACKOFF_S) - 1)]
+
+
 def _watchdog() -> None:
-    last = None
-    for _ in range(900):
+    for attempt in range(_MAX_TRANSIENT_ATTEMPTS):
+        state = "unknown"
         try:
             router = _converge_router()
             connection = _converge_connection()
-            state = (router, connection)
-            if state != last:
-                logger.warning("OKX_CONVERGENCE_STATE marker=%s router=%s connection=%s", _MARKER, router, connection)
-                last = state
+            state = str(os.environ.get("NIJA_OKX_ACTIVATION_STATE", "unknown") or "unknown")
             if router and connection:
                 os.environ["NIJA_OKX_FULLY_CONNECTED"] = "1"
+                os.environ["NIJA_OKX_RETRY_STATE"] = "ready"
                 logger.critical("OKX_ROUTER_CONNECTION_READY marker=%s", _MARKER)
                 return
-        except Exception:
-            logger.exception("OKX_CONVERGENCE_RETRY marker=%s", _MARKER)
-        time.sleep(1.0)
-    logger.error("OKX_ROUTER_CONNECTION_WATCHDOG_EXHAUSTED marker=%s", _MARKER)
+            if state in _TERMINAL_STATES:
+                logger.warning(
+                    "OKX_ROUTER_CONNECTION_STOPPED marker=%s state=%s terminal=true scope=okx_only",
+                    _MARKER,
+                    state,
+                )
+                return
+        except Exception as exc:
+            state = "connection_failed"
+            _set_state(state)
+            _log_transition(
+                logging.ERROR,
+                "watchdog_exception",
+                "OKX_CONVERGENCE_RETRY marker=%s class=transient error=%s retry=backoff",
+                _MARKER,
+                f"{type(exc).__name__}:{exc}"[:240],
+            )
+
+        delay = _retry_delay(attempt, state)
+        isolated = attempt + 1 >= _TRANSIENT_QUARANTINE_AFTER
+        os.environ["NIJA_OKX_RETRY_STATE"] = "transient_quarantined" if isolated else "backoff"
+        os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "1" if isolated else "0"
+        os.environ["NIJA_OKX_NEXT_RETRY_S"] = f"{delay:.0f}"
+        if attempt == 0 or attempt + 1 == _TRANSIENT_QUARANTINE_AFTER or delay == _RETRY_BACKOFF_S[-1]:
+            _log_transition(
+                logging.WARNING,
+                f"backoff:{'quarantined' if isolated else 'initial'}:{delay:.0f}",
+                "OKX_CONNECTION_BACKOFF marker=%s attempt=%s state=%s next_retry_s=%.0f "
+                "isolated=%s scope=okx_only kraken_affected=false coinbase_affected=false",
+                _MARKER,
+                attempt + 1,
+                state,
+                delay,
+                str(isolated).lower(),
+            )
+        time.sleep(delay)
+
+    _set_state("transient_quarantined")
+    os.environ["NIJA_OKX_ENTRY_ISOLATED"] = "1"
+    os.environ["NIJA_OKX_RETRY_STATE"] = "exhausted"
+    logger.error(
+        "OKX_ROUTER_CONNECTION_WATCHDOG_EXHAUSTED marker=%s attempts=%s scope=okx_only "
+        "kraken_affected=false coinbase_affected=false",
+        _MARKER,
+        _MAX_TRANSIENT_ATTEMPTS,
+    )
 
 
 def install() -> bool:
     global _STARTED
     with _LOCK:
+        enabled, enable_reason = _okx_enabled()
+        if not enabled:
+            _publish_terminal("disabled", enable_reason)
+            os.environ["NIJA_OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED"] = "1"
+            return True
+
+        credentials, missing = _credentials_ready()
+        if not credentials:
+            _publish_terminal("blocked_credentials", "missing=" + ",".join(missing))
+            os.environ["NIJA_OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED"] = "1"
+            return True
+
+        if _truthy("NIJA_OKX_CREDENTIALS_QUARANTINED"):
+            code = os.getenv("NIJA_OKX_CREDENTIAL_QUARANTINE_CODE", "credential_rejected")
+            _publish_terminal("credential_quarantined", f"credential_code={code}")
+            os.environ["NIJA_OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED"] = "1"
+            return True
+
         _converge_router()
         if not _STARTED:
             _STARTED = True
             threading.Thread(target=_watchdog, name="OKXRouterConnectionConvergence", daemon=True).start()
         os.environ["NIJA_OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED"] = "1"
-        logger.critical("OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED marker=%s", _MARKER)
+        logger.critical("OKX_ROUTER_CONNECTION_CONVERGENCE_INSTALLED marker=%s policy=bounded_backoff", _MARKER)
         return True
 
 
-__all__ = ["install"]
+__all__ = [
+    "install",
+    "_converge_connection",
+    "_watchdog",
+    "_retry_delay",
+    "_looks_fatal_auth",
+    "_okx_enabled",
+]

--- a/bot/tests/test_okx_router_connection_backoff_v58.py
+++ b/bot/tests/test_okx_router_connection_backoff_v58.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def mod(monkeypatch):
+    names = (
+        "NIJA_DISABLE_OKX",
+        "ENABLE_OKX_TRADING",
+        "OKX_LIVE_TRADING_ENABLED",
+        "NIJA_OKX_EXECUTION_ENABLED",
+        "NIJA_OKX_LIVE_TRADING_ENABLED",
+        "OKX_API_KEY",
+        "OKX_PLATFORM_API_KEY",
+        "OKX_API_SECRET",
+        "OKX_PLATFORM_API_SECRET",
+        "OKX_PASSPHRASE",
+        "OKX_API_PASSPHRASE",
+        "OKX_PLATFORM_PASSPHRASE",
+        "NIJA_OKX_CREDENTIALS_QUARANTINED",
+        "NIJA_OKX_CREDENTIAL_QUARANTINE_CODE",
+        "NIJA_OKX_RECONNECT_DISABLED",
+        "NIJA_OKX_ACTIVATION_STATE",
+        "NIJA_OKX_TRADING_READY",
+        "NIJA_OKX_FULLY_CONNECTED",
+        "NIJA_OKX_ENTRY_ISOLATED",
+        "NIJA_OKX_RETRY_STATE",
+        "NIJA_OKX_NEXT_RETRY_S",
+        "NIJA_WRITER_HEARTBEAT_ACTIVE",
+        "NIJA_KRAKEN_TRADING_READY",
+        "NIJA_COINBASE_TRADING_READY",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+    module = importlib.import_module("bot.okx_router_connection_convergence_patch")
+    monkeypatch.setattr(module, "_LAST_DIAGNOSTIC", "")
+    return module
+
+
+def _credentials(monkeypatch):
+    monkeypatch.setenv("OKX_API_KEY", "key")
+    monkeypatch.setenv("OKX_API_SECRET", "secret")
+    monkeypatch.setenv("OKX_PASSPHRASE", "pass")
+
+
+def test_explicit_disable_is_terminal_and_venue_local(mod, monkeypatch):
+    monkeypatch.setenv("NIJA_DISABLE_OKX", "1")
+    monkeypatch.setenv("NIJA_KRAKEN_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_COINBASE_TRADING_READY", "1")
+
+    enabled, reason = mod._okx_enabled()
+    assert enabled is False
+    assert "NIJA_DISABLE_OKX" in reason
+
+    mod._publish_terminal("disabled", reason)
+
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "disabled"
+    assert os.environ["NIJA_OKX_TRADING_READY"] == "0"
+    assert os.environ["NIJA_OKX_RECONNECT_DISABLED"] == "1"
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "1"
+    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "1"
+    assert os.environ["NIJA_COINBASE_TRADING_READY"] == "1"
+
+
+def test_missing_credentials_becomes_terminal_without_connect(mod, monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_TRADING_READY", "1")
+    monkeypatch.setattr(mod, "_runtime_broker", lambda: (_ for _ in ()).throw(AssertionError("broker lookup must not run")))
+
+    assert mod._converge_connection() is False
+
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "blocked_credentials"
+    assert os.environ["NIJA_OKX_RECONNECT_DISABLED"] == "1"
+    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "1"
+
+
+def test_fatal_auth_exception_is_terminal(mod, monkeypatch):
+    _credentials(monkeypatch)
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+    monkeypatch.setenv("NIJA_KRAKEN_TRADING_READY", "1")
+
+    class Broker:
+        connected = False
+
+        def connect(self):
+            raise RuntimeError("50111 invalid API key")
+
+    broker = Broker()
+    monkeypatch.setattr(mod, "_runtime_broker", lambda: (object(), broker))
+    monkeypatch.setattr(mod, "_attempt_existing_broker_recovery", lambda manager, current: current)
+
+    assert mod._converge_connection() is False
+
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "authentication_failed"
+    assert os.environ["NIJA_OKX_RECONNECT_DISABLED"] == "1"
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "1"
+    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "1"
+
+
+def test_transient_connect_failure_uses_backoff_not_terminal(mod, monkeypatch):
+    _credentials(monkeypatch)
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+
+    class Broker:
+        connected = False
+
+        def connect(self):
+            raise TimeoutError("temporary network timeout")
+
+    broker = Broker()
+    monkeypatch.setattr(mod, "_runtime_broker", lambda: (object(), broker))
+    monkeypatch.setattr(mod, "_attempt_existing_broker_recovery", lambda manager, current: current)
+
+    assert mod._converge_connection() is False
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "connection_failed"
+    assert os.environ.get("NIJA_OKX_RECONNECT_DISABLED", "0") != "1"
+    assert mod._retry_delay(0, "connection_failed") == 2.0
+    assert mod._retry_delay(1, "connection_failed") == 5.0
+    assert mod._retry_delay(6, "connection_failed") == 300.0
+    assert mod._retry_delay(99, "connection_failed") == 300.0
+
+
+def test_watchdog_stops_immediately_on_terminal_state(mod, monkeypatch):
+    calls = {"connection": 0, "sleep": 0}
+
+    monkeypatch.setattr(mod, "_converge_router", lambda: True)
+
+    def terminal_connection():
+        calls["connection"] += 1
+        mod._publish_terminal("credential_quarantined", "credential_code=50111")
+        return False
+
+    monkeypatch.setattr(mod, "_converge_connection", terminal_connection)
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: calls.__setitem__("sleep", calls["sleep"] + 1))
+
+    mod._watchdog()
+
+    assert calls["connection"] == 1
+    assert calls["sleep"] == 0
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "credential_quarantined"
+
+
+def test_watchdog_quarantines_transient_failures_after_four_attempts(mod, monkeypatch):
+    calls = {"connection": 0}
+    delays = []
+
+    monkeypatch.setattr(mod, "_MAX_TRANSIENT_ATTEMPTS", 4)
+    monkeypatch.setattr(mod, "_converge_router", lambda: True)
+
+    def transient_connection():
+        calls["connection"] += 1
+        mod._set_state("connection_failed")
+        return False
+
+    monkeypatch.setattr(mod, "_converge_connection", transient_connection)
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: delays.append(seconds))
+
+    mod._watchdog()
+
+    assert calls["connection"] == 4
+    assert delays == [2.0, 5.0, 15.0, 30.0]
+    assert os.environ["NIJA_OKX_ENTRY_ISOLATED"] == "1"
+    assert os.environ["NIJA_OKX_RETRY_STATE"] == "exhausted"
+    assert os.environ["NIJA_OKX_ACTIVATION_STATE"] == "transient_quarantined"
+
+
+def test_fatal_auth_classifier_is_narrow(mod):
+    assert mod._looks_fatal_auth("RuntimeError:50111 invalid API key") is True
+    assert mod._looks_fatal_auth("403 forbidden") is True
+    assert mod._looks_fatal_auth("TimeoutError:temporary network timeout") is False
+    assert mod._looks_fatal_auth("ConnectionError:peer reset") is False

--- a/bot/tests/test_writer_authority_generation_convergence_v57.py
+++ b/bot/tests/test_writer_authority_generation_convergence_v57.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH = ROOT / "bot" / "writer_authority_generation_convergence_v57_patch.py"
+BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, PATCH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_v45(monkeypatch, *, proof, reason="") -> ModuleType:
+    v45 = ModuleType("bot.writer_generation_handoff_v45_patch")
+    v45._prove_process_writer = lambda: (proof, reason)
+
+    def repair(source: str):
+        if proof is None:
+            return False, 0, reason or "proof_failed"
+        generation = int(proof["generation"])
+        value = str(generation)
+        os.environ["NIJA_WRITER_LEASE_GENERATION"] = value
+        os.environ["NIJA_WRITER_GENERATION"] = value
+        os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = value
+        return True, generation, "proof_verified"
+
+    v45.repair_process_generation = repair
+    monkeypatch.setitem(sys.modules, "bot.writer_generation_handoff_v45_patch", v45)
+    return v45
+
+
+def _eac() -> ModuleType:
+    module = ModuleType("bot.execution_authority_context")
+    module.assert_distributed_writer_authority = lambda: None
+    module._FENCE_LAST_CHECK_TS = 0.0
+    module._FENCE_LAST_OK = False
+    module._FENCE_LAST_ERR = "stale"
+    return module
+
+
+def test_stale_local_generation_repairs_only_after_exact_proof(monkeypatch) -> None:
+    v57 = _load("test_writer_authority_v57_repair")
+    proof = {
+        "generation": 3359,
+        "token": "2056-token",
+        "pttl_ms": 118993,
+    }
+    _install_v45(monkeypatch, proof=proof)
+    eac = _eac()
+
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "3358")
+    monkeypatch.setenv("NIJA_WRITER_GENERATION", "3358")
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION_LAST", "3358")
+
+    assert v57._patch_execution_authority_context(eac) is True
+    eac.assert_distributed_writer_authority()
+
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "3359"
+    assert os.environ["NIJA_WRITER_GENERATION"] == "3359"
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] == "3359"
+    assert os.environ["NIJA_WRITER_LEASE_ACQUIRED"] == "1"
+    assert eac._FENCE_LAST_OK is True
+    assert eac._FENCE_LAST_ERR == ""
+
+
+def test_missing_exact_proof_stays_fail_closed(monkeypatch) -> None:
+    v57 = _load("test_writer_authority_v57_fail_closed")
+    _install_v45(monkeypatch, proof=None, reason="redis_lock_missing")
+    eac = _eac()
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "3358")
+
+    assert v57._patch_execution_authority_context(eac) is True
+    with pytest.raises(RuntimeError, match="exact process writer proof failed:redis_lock_missing"):
+        eac.assert_distributed_writer_authority()
+
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "3358"
+    assert eac._FENCE_LAST_OK is False
+
+
+def test_live_bypass_is_still_rejected(monkeypatch) -> None:
+    v57 = _load("test_writer_authority_v57_bypass")
+    proof = {"generation": 3359, "token": "2056-token", "pttl_ms": 1000}
+    _install_v45(monkeypatch, proof=proof)
+    eac = _eac()
+
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
+    monkeypatch.setenv("DRY_RUN_MODE", "false")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK", "true")
+
+    assert v57._patch_execution_authority_context(eac) is True
+    with pytest.raises(RuntimeError, match="live distributed-lock bypass refused"):
+        eac.assert_distributed_writer_authority()
+
+
+def test_canonical_fast_path_installs_v57() -> None:
+    source = BOT_ENTRYPOINT.read_text(encoding="utf-8")
+    fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
+        ")\n\n_LEGACY_INSTALLERS", 1
+    )[0]
+
+    assert "writer_authority_generation_convergence_v57_patch" in fast_block
+    assert "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57" in fast_block

--- a/bot/tests/test_writer_runtime_core_thread_backstop_v56.py
+++ b/bot/tests/test_writer_runtime_core_thread_backstop_v56.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH = ROOT / "bot" / "writer_runtime_core_thread_backstop_v56_patch.py"
+BOT_ENTRYPOINT = ROOT / "bot" / "bot.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, PATCH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Thread:
+    def __init__(self, alive: bool) -> None:
+        self.alive = alive
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+
+def _install_entrypoint(monkeypatch, thread) -> None:
+    runtime = type("Runtime", (), {})()
+    runtime._core_thread = thread
+    entrypoint = ModuleType("bot.entrypoint_writer_authority")
+    entrypoint.get_entrypoint_writer_authority = lambda: runtime
+    monkeypatch.setitem(sys.modules, "bot.entrypoint_writer_authority", entrypoint)
+
+
+def test_writer_registered_core_thread_is_seen_by_v54(monkeypatch) -> None:
+    v56 = _load("test_writer_runtime_v56_registered_core")
+
+    bot_main = ModuleType("bot.bot_main")
+    bot_main._core_loop_thread = None
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+    _install_entrypoint(monkeypatch, _Thread(True))
+
+    v54 = ModuleType("bot.writer_runtime_lifecycle_supervisor_v54_patch")
+    v54._core_thread_alive = lambda module=None: False
+    monkeypatch.setitem(sys.modules, "bot.writer_runtime_lifecycle_supervisor_v54_patch", v54)
+
+    assert v56.install_import_hook() is True
+    assert v54._core_thread_alive(bot_main) is True
+
+
+def test_bot_main_core_thread_remains_authoritative(monkeypatch) -> None:
+    v56 = _load("test_writer_runtime_v56_bot_main_core")
+
+    bot_main = ModuleType("bot.bot_main")
+    bot_main._core_loop_thread = _Thread(True)
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+    _install_entrypoint(monkeypatch, None)
+
+    assert v56._canonical_core_thread_alive(bot_main) is True
+
+
+def test_no_live_core_thread_returns_false(monkeypatch) -> None:
+    v56 = _load("test_writer_runtime_v56_no_core")
+
+    bot_main = ModuleType("bot.bot_main")
+    bot_main._core_loop_thread = _Thread(False)
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+    _install_entrypoint(monkeypatch, _Thread(False))
+
+    assert v56._canonical_core_thread_alive(bot_main) is False
+
+
+def test_canonical_fast_path_installs_v56() -> None:
+    source = BOT_ENTRYPOINT.read_text(encoding="utf-8")
+    fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
+        ")\n\n_LEGACY_INSTALLERS", 1
+    )[0]
+
+    assert "writer_runtime_core_thread_backstop_v56_patch" in fast_block
+    assert "WRITER_RUNTIME_CORE_THREAD_BACKSTOP_V56" in fast_block

--- a/bot/writer_authority_generation_convergence_v57_patch.py
+++ b/bot/writer_authority_generation_convergence_v57_patch.py
@@ -1,0 +1,296 @@
+"""Exact process-writer authority generation convergence v57.
+
+Production after v55 proved the bounded recovery chain could acquire a fresh
+writer epoch, but runtime authority could remain fail-closed on stale local
+generation telemetry from the immediately preceding epoch.  The observed
+sequence was a canonical v39 re-election from generation 3358 to 3359 followed
+by exact writer acquisition while ``execution_authority_context`` still reported
+``local=3358 redis=3359``.
+
+v57 makes the distributed-authority assertion use the same v45 exact
+process-writer proof already required by the trading-state generation gate.
+That proof requires the canonical EntrypointWriterAuthority runtime to be
+acquired and not lost, the exact Redis lock value and fencing token to match,
+the lock TTL to be positive, and the Redis process-generation key to equal the
+runtime generation.  Only after that proof succeeds may v45 repair mutable
+process-local generation telemetry.
+
+Safety contract:
+* no Redis lock is created, renewed, extended, deleted, stolen, or fabricated;
+* local generation is repaired only from an exact current distributed proof;
+* live-mode distributed-lock bypass flags remain rejected;
+* missing, stale, mismatched, or unavailable proof remains fail-closed;
+* no capital, broker, nonce, SEAK, risk, strategy, or order gate is bypassed.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_authority_generation_convergence_v57")
+MARKER = "20260808-writer-authority-generation-convergence-v57"
+
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_writer_authority_generation_convergence_v57"
+_INSTALL_FLAG = "_NIJA_WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_IMPORT_HOOK"
+_IMPORTLIB_FLAG = "_NIJA_WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_IMPORTLIB_HOOK"
+_TARGETS = {"bot.execution_authority_context", "execution_authority_context"}
+_V45_NAMES = (
+    "nija_writer_generation_handoff_v45_prebot",
+    "bot.writer_generation_handoff_v45_patch",
+    "writer_generation_handoff_v45_patch",
+)
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _live_mode() -> bool:
+    return bool(
+        _truthy("LIVE_CAPITAL_VERIFIED")
+        and not _truthy("DRY_RUN_MODE")
+        and not _truthy("PAPER_MODE")
+    )
+
+
+def _v45_module() -> ModuleType | None:
+    seen: set[int] = set()
+    for name in _V45_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            if callable(getattr(module, "_prove_process_writer", None)):
+                return module
+    for name in _V45_NAMES:
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(module, ModuleType) and callable(
+            getattr(module, "_prove_process_writer", None)
+        ):
+            return module
+    return None
+
+
+def _exact_process_writer(source: str) -> tuple[dict[str, Any] | None, str]:
+    v45 = _v45_module()
+    if v45 is None:
+        return None, "v45_process_writer_proof_unavailable"
+    prove = getattr(v45, "_prove_process_writer", None)
+    if not callable(prove):
+        return None, "v45_process_writer_proof_unavailable"
+    try:
+        proof, reason = prove()
+    except Exception as exc:
+        return None, f"v45_process_writer_proof_error:{type(exc).__name__}:{exc}"
+    if proof is None:
+        return None, str(reason or "process_writer_proof_failed")
+
+    try:
+        generation = int(proof.get("generation", 0) or 0)
+    except Exception:
+        generation = 0
+    token = str(proof.get("token", "") or "").strip()
+    pttl_ms = int(proof.get("pttl_ms", -2) or -2)
+    if generation <= 0:
+        return None, "canonical_generation_invalid"
+    if not token:
+        return None, "canonical_fencing_token_missing"
+    if pttl_ms <= 0:
+        return None, f"canonical_writer_ttl_not_positive:{pttl_ms}"
+
+    repair = getattr(v45, "repair_process_generation", None)
+    if not callable(repair):
+        return None, "v45_process_generation_repair_unavailable"
+    try:
+        ok, repaired_generation, repair_reason = repair(source)
+    except Exception as exc:
+        return None, f"v45_process_generation_repair_error:{type(exc).__name__}:{exc}"
+    if not bool(ok):
+        return None, f"v45_process_generation_repair_failed:{repair_reason}"
+    if int(repaired_generation or 0) != generation:
+        return None, (
+            "v45_process_generation_repair_mismatch:"
+            f"proof={generation}:repaired={repaired_generation}"
+        )
+
+    # A successful v45 proof means the canonical singleton is acquired and
+    # owns the exact current Redis process-writer lock.  Re-publish only the
+    # local acquisition telemetry that can legitimately lag a fresh epoch.
+    os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "1"
+    return dict(proof), ""
+
+
+def _patch_execution_authority_context(module: ModuleType) -> bool:
+    current = getattr(module, "assert_distributed_writer_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    def assert_distributed_writer_authority() -> None:
+        if _live_mode() and (
+            _truthy("NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK")
+            or _truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
+            or _truthy("NIJA_WRITER_FENCING_TOKEN_FALLBACK")
+        ):
+            raise RuntimeError(
+                "STRICT_SINGLE_WRITER_REQUIRED: live distributed-lock bypass refused"
+            )
+
+        before = str(
+            os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")
+            or os.environ.get("NIJA_WRITER_GENERATION", "")
+            or ""
+        ).strip()
+        proof, reason = _exact_process_writer("distributed_authority_v57")
+        if proof is None:
+            raise RuntimeError(
+                "STRICT_SINGLE_WRITER_REQUIRED: exact process writer proof failed:"
+                f"{reason}"
+            )
+
+        generation = int(proof["generation"])
+        token = str(proof["token"])
+        after = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+
+        lock = getattr(module, "_FENCE_VERIFY_LOCK", None)
+        try:
+            if lock is not None:
+                with lock:
+                    module._FENCE_LAST_CHECK_TS = time.monotonic()
+                    module._FENCE_LAST_OK = True
+                    module._FENCE_LAST_ERR = ""
+            else:
+                module._FENCE_LAST_CHECK_TS = time.monotonic()
+                module._FENCE_LAST_OK = True
+                module._FENCE_LAST_ERR = ""
+        except Exception:
+            pass
+
+        last_generation = int(
+            getattr(module, "_NIJA_WRITER_AUTHORITY_V57_LAST_GENERATION", 0) or 0
+        )
+        if last_generation != generation or (before and before != after):
+            module._NIJA_WRITER_AUTHORITY_V57_LAST_GENERATION = generation
+            LOGGER.critical(
+                "WRITER_AUTHORITY_V57_PROVEN marker=%s generation=%s "
+                "token_prefix=%s local_before=%s local_after=%s "
+                "proof=exact_redis_process_writer execution_grant=false",
+                MARKER,
+                generation,
+                token[:8],
+                before or "unset",
+                after or "unset",
+            )
+
+    setattr(assert_distributed_writer_authority, _PATCH_ATTR, True)
+    setattr(assert_distributed_writer_authority, "__wrapped__", original)
+    module.assert_distributed_writer_authority = assert_distributed_writer_authority
+    os.environ["NIJA_WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_PATCHED"] = "1"
+    LOGGER.critical(
+        "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_PATCHED marker=%s module=%s "
+        "exact_v45_proof=true local_generation_repair=proof_driven lock_mutation=false",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen: set[int] = set()
+    for name in _TARGETS:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        try:
+            patched = _patch_execution_authority_context(module) or patched
+        except Exception as exc:
+            LOGGER.warning(
+                "WRITER_AUTHORITY_V57_PATCH_DEFERRED marker=%s module=%s err=%s:%s",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+            )
+    return patched
+
+
+def _interesting(name: str) -> bool:
+    return str(name or "") in {*_TARGETS, *_V45_NAMES}
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+
+        if not getattr(builtins, _INSTALL_FLAG, False):
+            original_import = builtins.__import__
+
+            def importing(
+                name: str,
+                globals: Any = None,
+                locals: Any = None,
+                fromlist: Any = (),
+                level: int = 0,
+            ):
+                result = original_import(name, globals, locals, fromlist, level)
+                if _interesting(str(name or "")):
+                    _patch_loaded()
+                return result
+
+            setattr(importing, "__wrapped__", original_import)
+            builtins.__import__ = importing
+            setattr(builtins, _INSTALL_FLAG, True)
+
+        if not getattr(importlib, _IMPORTLIB_FLAG, False):
+            original_import_module = importlib.import_module
+
+            def import_module(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if _interesting(str(name or "")):
+                    _patch_loaded()
+                return result
+
+            setattr(import_module, "__wrapped__", original_import_module)
+            importlib.import_module = import_module  # type: ignore[assignment]
+            setattr(importlib, _IMPORTLIB_FLAG, True)
+
+        available = _v45_module() is not None
+        os.environ["NIJA_WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_INSTALLED"] = (
+            "1" if available else "0"
+        )
+        LOGGER.critical(
+            "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57_INSTALLED marker=%s "
+            "v45_available=%s future_import_hook=true fail_closed=true lock_mutation=false",
+            MARKER,
+            available,
+        )
+        return available
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_exact_process_writer",
+    "_patch_execution_authority_context",
+]

--- a/bot/writer_runtime_core_thread_backstop_v56_patch.py
+++ b/bot/writer_runtime_core_thread_backstop_v56_patch.py
@@ -1,0 +1,134 @@
+"""Writer runtime core-thread observer backstop v56.
+
+Production on the v55 build exposed a remaining observer split: the canonical
+EntrypointWriterAuthority had a live core thread registered on ``runtime._core_thread``
+while the v54 lifecycle supervisor only inspected ``bot_main._core_loop_thread``.
+If those references diverge, v54 can skip its process-lifetime writer proof even
+while the core scan thread is alive. That leaves a fail-closed but half-live
+process repeatedly reporting stale writer/scan deadlines instead of entering the
+existing bounded recovery or normal-shutdown path.
+
+v56 does not acquire, renew, extend, delete, steal, or fabricate writer authority.
+It only broadens v54's read-only core-thread liveness observer so either canonical
+reference counts as a live core thread. v54 remains responsible for exact v45
+Redis ownership proof, the v39 recovery window, fail-closed execution state, and
+normal shutdown when authority cannot be proven.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_runtime_core_thread_backstop_v56")
+MARKER = "20260808-writer-runtime-core-thread-backstop-v56"
+
+_LOCK = threading.RLock()
+_INSTALLED = False
+_PATCH_ATTR = "_nija_writer_runtime_core_thread_backstop_v56"
+_ENTRYPOINT_NAMES = ("bot.entrypoint_writer_authority", "entrypoint_writer_authority")
+
+
+def _thread_alive(thread: Any) -> bool:
+    if thread is None or not callable(getattr(thread, "is_alive", None)):
+        return False
+    try:
+        return bool(thread.is_alive())
+    except Exception:
+        return False
+
+
+def _entrypoint_runtime() -> Any:
+    seen: set[int] = set()
+    for name in _ENTRYPOINT_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if not callable(getter):
+            continue
+        try:
+            runtime = getter()
+        except Exception:
+            continue
+        if runtime is not None:
+            return runtime
+    return None
+
+
+def _canonical_core_thread_alive(module: ModuleType | None = None) -> bool:
+    """Return true when either canonical core-thread reference is alive."""
+    module = module or sys.modules.get("bot.bot_main")
+    if isinstance(module, ModuleType) and _thread_alive(
+        getattr(module, "_core_loop_thread", None)
+    ):
+        return True
+
+    runtime = _entrypoint_runtime()
+    if runtime is not None and _thread_alive(getattr(runtime, "_core_thread", None)):
+        return True
+    return False
+
+
+setattr(_canonical_core_thread_alive, _PATCH_ATTR, True)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        try:
+            v54 = importlib.import_module("bot.writer_runtime_lifecycle_supervisor_v54_patch")
+        except Exception as exc:
+            LOGGER.critical(
+                "WRITER_RUNTIME_V56_INSTALL_FAILED marker=%s reason=v54_import error=%s:%s",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+        current = getattr(v54, "_core_thread_alive", None)
+        if getattr(current, _PATCH_ATTR, False):
+            _INSTALLED = True
+            os.environ["NIJA_WRITER_RUNTIME_CORE_THREAD_BACKSTOP_V56_INSTALLED"] = "1"
+            return True
+        if not callable(current):
+            LOGGER.critical(
+                "WRITER_RUNTIME_V56_INSTALL_FAILED marker=%s reason=v54_core_observer_missing",
+                MARKER,
+            )
+            return False
+
+        setattr(_canonical_core_thread_alive, "__wrapped__", current)
+        v54._core_thread_alive = _canonical_core_thread_alive
+        _INSTALLED = True
+        os.environ["NIJA_WRITER_RUNTIME_CORE_THREAD_BACKSTOP_V56_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_RUNTIME_V56_BACKSTOP_INSTALLED marker=%s "
+            "bot_main_core=true writer_registered_core=true lock_mutation=false "
+            "v54_shutdown_semantics=preserved v39_recovery_semantics=preserved",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_core_thread_alive",
+]


### PR DESCRIPTION
## Purpose

Production logs from merge commit `8d8fd0356a06cbc620bbc311fce666a6c632e23a` exposed three runtime convergence defects:

1. the canonical writer had an alive registered core thread that v54 could miss;
2. v55/v39 fresh-epoch recovery succeeded but stale local generation telemetry could still block runtime authority convergence;
3. a degraded OKX venue could repeatedly call `connect()` / private balance verification once per second, producing a noisy connection-error loop instead of converging to a controlled venue-local state.

## Root causes

1. **v54 core-thread observer gap**: v54 only checked `bot_main._core_loop_thread`, while `EntrypointWriterAuthority.register_core_thread()` separately stores the canonical writer core at `runtime._core_thread`.
2. **post-re-election generation convergence gap**: after v39 acquired a fresh exact writer epoch and v45 repaired generation, runtime distributed-authority validation could still reject stale local telemetry before reusing the exact current-owner proof.
3. **OKX retry storm**: `okx_router_connection_convergence_patch` retried failed connection verification every second for up to 900 iterations. Terminal configuration/authentication states and transient transport failures were not separated strongly enough at the watchdog layer.

## Fix

### v56
- Add a read-only backstop for v54.
- Treat either `bot_main._core_loop_thread` or the canonical writer runtime's registered `_core_thread` as evidence that the core is alive.
- Preserve v54 exact v45 Redis proof, v39 bounded recovery, fail-closed execution state, and normal shutdown behavior unchanged.

### v57
- Patch `execution_authority_context.assert_distributed_writer_authority()` to use v45's exact process-writer proof.
- Require canonical runtime acquired/not lost, exact Redis lock value/fencing token, positive lock TTL, and Redis process-generation equality.
- Only after that proof succeeds, allow v45 to repair stale mutable local generation telemetry.
- Keep live distributed-lock bypass flags rejected and all proof failures fail-closed.

### v58 OKX bounded recovery
- Replace one-second OKX retry storms with bounded exponential backoff: 2s, 5s, 15s, 30s, 60s, 120s, then 300s cap.
- Treat explicit disable, missing credentials, definitive credential quarantine/auth rejection, and connected-with-no-spendable-quote as terminal OKX-local states.
- Stop reconnect attempts immediately for terminal states.
- Isolate OKX after repeated transient failures while leaving Kraken and Coinbase state untouched.
- Preserve transient recovery attempts with capped backoff instead of disabling OKX on ordinary network timeouts.
- Suppress duplicate diagnostics by logging state transitions/backoff changes rather than the same watchdog error every second.

## Tests

- v56 writer-registered core detection
- v56 bot_main core detection
- v56 no-live-thread behavior
- v57 stale local generation -> exact proven new generation repair
- v57 missing exact proof remains fail-closed
- v57 live bypass remains rejected
- explicit OKX disable is terminal and venue-local
- missing OKX credentials stop before broker connect
- fatal OKX auth rejection becomes terminal
- transient OKX network failures use capped exponential backoff
- terminal OKX state stops watchdog immediately
- repeated transient failure isolates only OKX
- fatal-auth classifier does not misclassify ordinary network timeouts

## Safety

Writer changes do not create, renew, extend, delete, steal, or fabricate a Redis writer lock and do not grant execution authority independently. The OKX change is venue-local: it does not change Kraken/Coinbase readiness, global writer authority, capital, risk, strategy, or order-admission controls. A degraded OKX venue is excluded; it cannot authorize another venue or fabricate a successful connection.

## Expected production proof

Writer recovery:
1. `WRITER_RECOVERY_V55_HANDOFF ... started=True`
2. `WRITER_REELECTION_V39_STARTED`
3. fresh writer acquisition with a higher generation
4. `WRITER_AUTHORITY_V57_PROVEN ... proof=exact_redis_process_writer`
5. runtime authority converges without stale local-generation blocking

OKX:
- healthy: `OKX_CONNECTION_VERIFIED` -> `OKX_ROUTER_CONNECTION_READY`
- explicitly disabled/missing/fatally rejected: one `OKX_CONNECTION_TERMINAL ... scope=okx_only` and watchdog stops
- transient network failure: `OKX_CONNECTION_BACKOFF` with increasing delay; after repeated failures OKX is isolated while Kraken/Coinbase remain unaffected
