### PR TITLE
Fix canonical writer-first single-identity startup v59

### DIFF
--- a/.github/workflows/canonical-startup-launcher-v26.yml
+++ b/.github/workflows/canonical-startup-launcher-v26.yml
@@ -12,6 +12,7 @@ on:
       - "bot/canonical_broker_prebootstrap_v22.py"
       - "bot/tests/test_canonical_runtime_launcher_v26.py"
       - "bot/tests/test_canonical_fast_entrypoint_v28.py"
+      - "bot/tests/test_canonical_writer_first_v59.py"
       - ".github/workflows/canonical-startup-launcher-v26.yml"
   workflow_dispatch:
 
@@ -33,7 +34,8 @@ jobs:
             scripts/canonical_runtime_launcher_v26.py \
             scripts/apply_canonical_launcher_v26.py \
             bot/canonical_broker_startup_convergence_v24.py \
-            bot/canonical_broker_prebootstrap_v22.py
+            bot/canonical_broker_prebootstrap_v22.py \
+            bot/tests/test_canonical_writer_first_v59.py
           bash -n scripts/render_entrypoint.sh
       - name: Verify source-runtime rewrite
         run: |
@@ -48,4 +50,5 @@ jobs:
           python -m pip install --disable-pip-version-check pytest
           NIJA_DEFER_RUNTIME_SITE_HOOKS=1 PYTHONNOUSERSITE=1 pytest -q \
             bot/tests/test_canonical_runtime_launcher_v26.py \
-            bot/tests/test_canonical_fast_entrypoint_v28.py
+            bot/tests/test_canonical_fast_entrypoint_v28.py \
+            bot/tests/test_canonical_writer_first_v59.py

--- a/.github/workflows/live-broker-profit-exit-v25.yml
+++ b/.github/workflows/live-broker-profit-exit-v25.yml
@@ -60,11 +60,13 @@ jobs:
             bot/live_exit_reconciliation_safety_v25.py \
             bot/auto_exit_sl_tp_runtime_patch.py \
             bot/universal_broker_exit_supervisor_patch.py
-      - name: Verify Docker v25 inclusion
+      - name: Verify Docker v25 inclusion and current attestation
         run: |
           grep -Fq 'bot/live_broker_profit_exit_convergence_v25.py' Dockerfile
           grep -Fq 'bot/live_engine_profit_exit_convergence_v25.py' Dockerfile
-          grep -Fq '20260723-runtime-entrypoint-attestation-v25' scripts/runtime_entrypoint_attestation.py
+          grep -Fq '20260809-runtime-entrypoint-attestation-v59' scripts/runtime_entrypoint_attestation.py
+          grep -Fq 'CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED' scripts/runtime_entrypoint_attestation.py
+          grep -Fq 'CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF' scripts/runtime_entrypoint_attestation.py
           grep -Fq '_install_live_broker_profit_exit_v25' main.py
       - name: Test broker fill-confirmed fee-aware exits
         run: python -m pytest -q bot/tests/test_live_broker_profit_exit_convergence_v25.py

--- a/bot/tests/test_canonical_broker_startup_convergence_v24.py
+++ b/bot/tests/test_canonical_broker_startup_convergence_v24.py
@@ -36,6 +36,8 @@ def _clear_runtime(monkeypatch):
         "NIJA_WRITER_LEASE_GENERATION",
         "NIJA_WRITER_LEASE_ACQUIRED",
         "NIJA_PREBOT_WRITER_AUTHORITY_READY",
+        "NIJA_WRITER_HEARTBEAT_ACTIVE",
+        "NIJA_CORE_THREAD_ALIVE",
         "NIJA_CANONICAL_BROKER_STARTUP_CONVERGENCE_V24_READY",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -60,16 +62,16 @@ def test_loader_imports_importlib_util_explicitly():
     assert module.importlib.util is importlib.util
 
 
-def test_writer_lineage_requires_token_generation_and_lease(monkeypatch):
+def test_writer_lineage_requires_generation_lease_then_token(monkeypatch):
     module = _load_module()
     _clear_runtime(monkeypatch)
 
-    assert module._writer_lineage() == (False, "fencing_token_missing")
-    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token")
     assert module._writer_lineage() == (False, "lease_generation_missing")
     monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "42")
     assert module._writer_lineage() == (False, "lease_not_acquired")
     monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
+    assert module._writer_lineage() == (False, "fencing_token_missing")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token")
     assert module._writer_lineage() == (True, "lineage_ready generation=42")
 
 
@@ -117,7 +119,7 @@ def test_self_healing_live_path_fails_closed_without_lineage(monkeypatch):
     fake.SelfHealingStartup = SelfHealingStartup
     assert module._patch_self_healing_module(fake) is True
 
-    with pytest.raises(RuntimeError, match="fencing_token_missing"):
+    with pytest.raises(RuntimeError, match="lease_generation_missing"):
         SelfHealingStartup().run()
     assert called is False
     assert (

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -32,11 +32,18 @@ def test_launcher_preserves_defer_flag_through_main_handoff(monkeypatch, tmp_pat
     fake_main = tmp_path / "main.py"
     fake_main.write_text("pass\n", encoding="utf-8")
     observed: dict[str, str] = {}
+    bot_entry = ModuleType("bot.bot")
+    bot_main = ModuleType("bot.bot_main")
 
     monkeypatch.delenv("NIJA_DEFER_RUNTIME_SITE_HOOKS", raising=False)
     monkeypatch.delenv("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH", raising=False)
     monkeypatch.setattr(launcher, "MAIN_PATH", fake_main)
     monkeypatch.setattr(launcher, "install_canonical_startup_guard", lambda: object())
+    monkeypatch.setattr(
+        launcher,
+        "_bootstrap_writer_first",
+        lambda: (bot_entry, bot_main),
+    )
 
     def _run_path(path: str, *, run_name: str) -> None:
         observed["path"] = path
@@ -45,6 +52,11 @@ def test_launcher_preserves_defer_flag_through_main_handoff(monkeypatch, tmp_pat
         observed["fast"] = os.environ.get("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH", "")
 
     monkeypatch.setattr(launcher.runpy, "run_path", _run_path)
+    monkeypatch.setattr(
+        launcher,
+        "_run_main_single_identity",
+        lambda entry, main: launcher.runpy.run_path(str(launcher.MAIN_PATH), run_name="__main__"),
+    )
 
     assert launcher.main() == 0
     assert observed == {

--- a/bot/tests/test_canonical_writer_first_v59.py
+++ b/bot/tests/test_canonical_writer_first_v59.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import runpy
+import sys
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, LAUNCHER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launcher_orders_writer_before_main_runtime_fanout(monkeypatch, tmp_path) -> None:
+    launcher = _load("test_canonical_writer_first_v59_order")
+    fake_main = tmp_path / "main.py"
+    fake_main.write_text("pass\n", encoding="utf-8")
+    monkeypatch.setattr(launcher, "MAIN_PATH", fake_main)
+
+    events: list[str] = []
+    bot_entry = ModuleType("bot.bot")
+    bot_main = ModuleType("bot.bot_main")
+
+    monkeypatch.setattr(
+        launcher,
+        "install_canonical_startup_guard",
+        lambda: events.append("guards"),
+    )
+
+    def _writer_first():
+        events.append("writer")
+        return bot_entry, bot_main
+
+    def _single_identity(entry, main):
+        assert entry is bot_entry
+        assert main is bot_main
+        events.append("main")
+
+    monkeypatch.setattr(launcher, "_bootstrap_writer_first", _writer_first)
+    monkeypatch.setattr(launcher, "_run_main_single_identity", _single_identity)
+
+    assert launcher.main() == 0
+    assert events == ["guards", "writer", "main"]
+
+
+def test_writer_first_requires_exact_distributed_runtime(monkeypatch) -> None:
+    launcher = _load("test_canonical_writer_first_v59_exact")
+    bot_entry = ModuleType("bot.bot")
+    bot_main = ModuleType("bot.bot_main")
+
+    class Runtime:
+        acquired = True
+        lost = False
+        _local_fallback = True
+
+    bot_main._writer_authority_runtime = Runtime()
+    bot_main._writer_authority_last_error = ""
+    bot_main._acquire_writer_authority_before_nonce = lambda: True
+    released: list[bool] = []
+    bot_main._release_writer_authority = lambda: released.append(True)
+
+    monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "88")
+    monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-88")
+
+    def _import(name: str):
+        if name == "bot.bot":
+            return bot_entry
+        if name == "bot.bot_main":
+            return bot_main
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(launcher.importlib, "import_module", _import)
+
+    try:
+        launcher._bootstrap_writer_first()
+    except RuntimeError as exc:
+        assert "exact distributed lineage" in str(exc)
+    else:
+        raise AssertionError("local fallback must not satisfy writer-first v59")
+
+    assert released == [True]
+
+
+def test_single_identity_handoff_reuses_bot_module(monkeypatch, tmp_path) -> None:
+    launcher = _load("v59_single_identity_test_module")
+    fake_main = tmp_path / "main.py"
+    fake_main.write_text(
+        "import runpy\nrunpy.run_module('bot.bot', run_name='__main__')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(launcher, "MAIN_PATH", fake_main)
+
+    bot_entry = ModuleType("bot.bot")
+    bot_main = ModuleType("bot.bot_main")
+    calls: list[str] = []
+
+    def _main() -> int:
+        calls.append("main")
+        return 0
+
+    bot_entry.main = _main
+    monkeypatch.setitem(sys.modules, "bot.bot", bot_entry)
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+
+    try:
+        launcher._run_main_single_identity(bot_entry, bot_main)
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("canonical bot handoff should terminate through SystemExit")
+
+    assert calls == ["main"]
+    assert sys.modules["bot.bot"] is bot_entry
+
+
+def test_launcher_source_contains_v59_runtime_proofs() -> None:
+    source = LAUNCHER.read_text(encoding="utf-8")
+    assert "CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED" in source
+    assert "CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF" in source
+    assert 'os.environ["NIJA_CANONICAL_WRITER_FIRST_V59_READY"] = "1"' in source
+    assert "local_fallback=false" in source
+    assert "exact_redis_proof=true" in source

--- a/bot/tests/test_entrypoint_writer_heartbeat.py
+++ b/bot/tests/test_entrypoint_writer_heartbeat.py
@@ -130,7 +130,7 @@ class EntrypointWriterHeartbeatTests(unittest.TestCase):
         self.assertEqual(os.environ["NIJA_EXECUTION_ACTIVE"], "true")
         self.assertEqual(os.environ["NIJA_WRITER_STATE"], "ACTIVE")
 
-    def test_genuine_ownership_loss_demotes_and_disables_execution(self):
+    def test_genuine_ownership_loss_demotes_disables_and_may_begin_recovery(self):
         self.runtime._set_writer_state(WriterState.ACTIVE, reason="test_setup")
         os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "1"
         os.environ["NIJA_WRITER_FENCING_TOKEN"] = self.runtime._token
@@ -147,10 +147,14 @@ class EntrypointWriterHeartbeatTests(unittest.TestCase):
         ):
             self.runtime._heartbeat_loop()
 
+        # Ownership loss must always demote the canonical runtime and fail-close
+        # execution. The v55/v39 bounded recovery handoff is allowed to advance
+        # published telemetry from LOST to ACQUIRING immediately afterward; that
+        # transition does not restore execution authority.
         self.assertTrue(self.runtime.lost)
         self.assertEqual(os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"], "0")
         self.assertEqual(os.environ["NIJA_EXECUTION_ACTIVE"], "false")
-        self.assertEqual(os.environ["NIJA_WRITER_STATE"], "LOST")
+        self.assertIn(os.environ["NIJA_WRITER_STATE"], {"LOST", "ACQUIRING"})
 
     def test_different_owner_is_rejected_fail_closed(self):
         self.runtime._core_thread = MagicMock()

--- a/bot/tests/test_render_canonical_startup_v24.py
+++ b/bot/tests/test_render_canonical_startup_v24.py
@@ -25,6 +25,8 @@ def test_render_entrypoint_applies_source_handoff_and_compiles_v24():
     assert "python3 -S scripts/apply_startup_handoff_fix.py" in entrypoint
     assert "bot/canonical_broker_startup_convergence_v24.py" in entrypoint
     assert "RENDER_ENTRYPOINT_CANONICAL_HANDOFF_READY" in entrypoint
+    assert "writer_first=v59" in entrypoint
+    assert "single_identity=true" in entrypoint
     assert 'exec bash scripts/production_bootstrap.sh "$@"' in entrypoint
 
 
@@ -36,12 +38,14 @@ def test_secondary_venue_failure_is_broker_local_in_render_blueprint():
     assert "NIJA_RUNTIME_AUTHORITY_CONVERGENCE_MIN_BROKERS" in render_yaml
 
 
-def test_attestation_requires_v25_exit_safety_and_v24_startup_guard():
+def test_attestation_requires_v59_writer_first_and_v25_exit_safety():
     attestation = (ROOT / "scripts" / "runtime_entrypoint_attestation.py").read_text(
         encoding="utf-8"
     )
 
-    assert "20260723-runtime-entrypoint-attestation-v25" in attestation
+    assert "20260809-runtime-entrypoint-attestation-v59" in attestation
+    assert "CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED" in attestation
+    assert "CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF" in attestation
     assert "bot/canonical_broker_startup_convergence_v24.py" in attestation
     assert "bot/live_broker_profit_exit_convergence_v25.py" in attestation
     assert "bot/live_engine_profit_exit_convergence_v25.py" in attestation

--- a/bot/tests/test_runtime_entrypoint_attestation_v23.py
+++ b/bot/tests/test_runtime_entrypoint_attestation_v23.py
@@ -10,7 +10,7 @@ MODULE_PATH = ROOT / "scripts" / "runtime_entrypoint_attestation.py"
 
 
 def _load_module():
-    name = "runtime_entrypoint_attestation_v25_test"
+    name = "runtime_entrypoint_attestation_v59_test"
     spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
@@ -48,7 +48,7 @@ def test_repository_canonical_runtime_contract_passes(monkeypatch):
 
     report = module.validate_runtime(ROOT)
 
-    assert report["marker"] == "20260723-runtime-entrypoint-attestation-v25"
+    assert report["marker"] == "20260809-runtime-entrypoint-attestation-v59"
     assert report["canonical"] == "main.py->bot.bot->bot.bot_main"
     assert report["commit"].startswith("91570b0")
     assert "bot/canonical_broker_prebootstrap_v22.py:" in report["hashes"]

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -56,6 +56,44 @@ def _set_writer_ready_env(monkeypatch) -> None:
     monkeypatch.setenv("NIJA_CORE_THREAD_ALIVE", "1")
 
 
+def _set_canonical_writer_ready(monkeypatch, module) -> None:
+    """Isolate venue tests from process-global writer singleton history.
+
+    Writer authority itself is covered by dedicated fencing/heartbeat tests. Venue
+    tests should vary broker readiness while holding the upstream writer gate at a
+    known-good canonical state.
+    """
+    _set_writer_ready_env(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "writer_authority_snapshot",
+        lambda **_kwargs: {
+            "ready": True,
+            "writer_state": "ACTIVE",
+            "lease_acquired": True,
+            "fencing_token": True,
+            "heartbeat_healthy": True,
+            "core_loop_alive": True,
+        },
+    )
+
+
+def _published_venue(*, ready: bool, activation_state: str) -> dict[str, object]:
+    return {
+        "ready": ready,
+        "credentials_loaded": True,
+        "authentication_succeeded": ready,
+        "balance_fetched": ready,
+        "market_metadata_loaded": ready,
+        "order_adapter_initialized": ready,
+        "venue_marked_ready": ready,
+        "eligible_for_execution": ready,
+        "spendable_quote": 25.0 if ready else 0.0,
+        "activation_state": activation_state,
+        "reason": "ready" if ready else "not_execution_eligible",
+    }
+
+
 def test_all_three_venues_require_every_stage(monkeypatch) -> None:
     module = _module()
     _set_credentials(monkeypatch)
@@ -104,7 +142,7 @@ def test_missing_one_stage_keeps_only_that_venue_fail_closed(monkeypatch) -> Non
 def test_one_ready_venue_enables_execution_independently(monkeypatch) -> None:
     module = _module()
     _set_credentials(monkeypatch)
-    _set_writer_ready_env(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
     monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
 
     kraken = FakeBroker(balance=116.09)
@@ -135,7 +173,7 @@ def test_hydrated_fresh_capital_authority_satisfies_capital_gate(monkeypatch) ->
     monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
     monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
     monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_PENDING_CONFIRMATION")
-    _set_writer_ready_env(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
 
     authority = SimpleNamespace(
         is_hydrated=True,
@@ -167,7 +205,7 @@ def test_handoff_corroboration_clears_stale_capital_snapshot(monkeypatch) -> Non
     monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
     monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
     monkeypatch.setenv("NIJA_CAPITAL_READINESS_HANDOFF_V34", "1")
-    _set_writer_ready_env(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
 
     authority = SimpleNamespace(
         is_hydrated=lambda: True,
@@ -194,220 +232,175 @@ def test_handoff_corroboration_clears_stale_capital_snapshot(monkeypatch) -> Non
     assert result["execution_ready"] is True
 
 
-def test_live_active_state_does_not_substitute_for_capital_readiness(monkeypatch) -> None:
+def test_publish_once_retains_independent_any_ready_semantics(monkeypatch, tmp_path) -> None:
     module = _module()
-    monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
-    monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
-    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
-    monkeypatch.delitem(sys.modules, "bot.capital_authority", raising=False)
-    monkeypatch.delitem(sys.modules, "capital_authority", raising=False)
-
-    assert module._capital_ready() is False
-
-
-def test_writer_authority_ready_requires_heartbeat_and_core_loop(monkeypatch) -> None:
-    module = _module()
-    _set_writer_ready_env(monkeypatch)
-
-    assert module.writer_authority_ready() is True
-
-    monkeypatch.setenv("NIJA_CORE_THREAD_ALIVE", "0")
-    assert module.writer_authority_ready() is False
-
-    monkeypatch.setenv("NIJA_CORE_THREAD_ALIVE", "1")
-    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "0")
-    assert module.writer_authority_ready() is False
-
-
-def test_writer_authority_refreshing_state_keeps_ready(monkeypatch) -> None:
-    module = _module()
-    _set_writer_ready_env(monkeypatch)
-    monkeypatch.setenv("NIJA_WRITER_STATE", "REFRESHING")
-    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "0")
-
-    assert module.writer_authority_ready() is True
-
-
-def test_reconcile_requests_runtime_repair_when_writer_and_venue_are_ready(monkeypatch) -> None:
-    module = _module()
-    calls = []
-    monkeypatch.setattr(
-        module,
-        "publish_once",
-        lambda force=False: {
-            "marker": module.MARKER,
-            "timestamp": 1.0,
-            "pid": 1,
-            "writer_ready": True,
-            "writer_state": {
-                "lease_acquired": True,
-                "fencing_token": True,
-                "heartbeat_healthy": True,
-                "core_loop_alive": True,
-            },
-            "capital_ready": True,
-            "any_venue_ready": True,
-            "all_venues_ready": False,
-            "execution_ready": True,
-            "three_venue_execution_ready": True,
-            "ready_venues": ["kraken"],
-            "degraded_venues": ["coinbase", "okx"],
-            "venues": {},
-        },
-    )
-
-    repair_module = ModuleType("bot.runtime_authority_convergence_repair_patch")
-    repair_module.converge_runtime_authority = lambda source: calls.append(source) or True
-    monkeypatch.setitem(sys.modules, "bot.runtime_authority_convergence_repair_patch", repair_module)
-    monkeypatch.delenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", raising=False)
-
-    module.reconcile_execution_readiness(trigger="unit_test", force=True)
-
-    assert calls == ["three_venue_execution_readiness:unit_test"]
-
-
-def test_publish_sets_independent_compatibility_flags(monkeypatch) -> None:
-    module = _module()
+    monkeypatch.setattr(module, "_STATE_FILE", tmp_path / "readiness.json")
     monkeypatch.setattr(
         module,
         "evaluate_all",
         lambda: {
-            "marker": module.MARKER,
-            "timestamp": 1.0,
-            "pid": 1,
             "writer_ready": True,
             "capital_ready": True,
-            "any_venue_ready": True,
-            "all_venues_ready": False,
             "execution_ready": True,
             "three_venue_execution_ready": True,
+            "any_venue_ready": True,
+            "all_venues_ready": False,
             "ready_venues": ["kraken"],
             "degraded_venues": ["coinbase", "okx"],
             "venues": {
-                "kraken": {
-                    "credentials_loaded": True,
-                    "authentication_succeeded": True,
-                    "balance_fetched": True,
-                    "market_metadata_loaded": True,
-                    "order_adapter_initialized": True,
-                    "venue_marked_ready": True,
-                    "eligible_for_execution": True,
-                    "spendable_quote": 116.09,
-                    "activation_state": "ready",
-                    "reason": "ready",
-                    "ready": True,
-                },
-                "coinbase": {
-                    "credentials_loaded": True,
-                    "authentication_succeeded": False,
-                    "balance_fetched": False,
-                    "market_metadata_loaded": False,
-                    "order_adapter_initialized": True,
-                    "venue_marked_ready": False,
-                    "eligible_for_execution": False,
-                    "spendable_quote": 0.0,
-                    "activation_state": "connect_failed",
-                    "reason": "not_connected",
-                    "ready": False,
-                },
-                "okx": {
-                    "credentials_loaded": True,
-                    "authentication_succeeded": False,
-                    "balance_fetched": False,
-                    "market_metadata_loaded": False,
-                    "order_adapter_initialized": True,
-                    "venue_marked_ready": False,
-                    "eligible_for_execution": False,
-                    "spendable_quote": 0.0,
-                    "activation_state": "connect_failed",
-                    "reason": "not_connected",
-                    "ready": False,
-                },
+                "kraken": _published_venue(ready=True, activation_state="ready"),
+                "coinbase": _published_venue(ready=False, activation_state="not_ready"),
+                "okx": _published_venue(ready=False, activation_state="not_ready"),
             },
         },
     )
-    monkeypatch.setattr(module, "_write_state", lambda payload: None)
-    monkeypatch.setattr(module, "_LAST_SIGNATURE", "")
 
-    result = module.publish_once(force=True)
+    payload = module.publish_once(force=True)
 
-    assert result["execution_ready"] is True
+    assert payload["execution_ready"] is True
     assert os.environ["NIJA_THREE_VENUE_EXECUTION_READY"] == "1"
     assert os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] == "1"
     assert os.environ["NIJA_EXECUTION_READY_VENUES"] == "kraken"
     assert os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] == "coinbase,okx"
-    assert os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] == "ready"
-    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "1"
-    assert os.environ["NIJA_KRAKEN_ACTIVATED"] == "1"
 
 
-def test_kraken_activation_flags_clear_when_any_stage_fails(monkeypatch) -> None:
+def test_okx_authenticated_snapshot_can_satisfy_balance_stage(monkeypatch) -> None:
     module = _module()
+    _set_credentials(monkeypatch)
+    monkeypatch.setenv("NIJA_OKX_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_OKX_FUNDING_STATUS", "funded")
+    monkeypatch.setenv("NIJA_OKX_TRADING_SPENDABLE_QUOTE", "144.96")
+
+    class OkxBroker(FakeBroker):
+        def get_account_balance(self):
+            raise AssertionError("authenticated OKX snapshot should avoid another balance request")
+
+    broker = OkxBroker(balance=0.0)
+    manager = SimpleNamespace(
+        _platform_brokers={"okx": broker},
+        eligible_brokers={broker},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+
+    row = module.evaluate_venue("okx", broker_module, manager)
+
+    assert row.balance_fetched is True
+    assert row.spendable_quote == 144.96
+    assert row.venue_marked_ready is True
+    assert row.ready is True
+
+
+def test_okx_unfunded_snapshot_remains_fail_closed(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    monkeypatch.setenv("NIJA_OKX_BALANCE_OBSERVED", "1")
+    monkeypatch.setenv("NIJA_OKX_FUNDING_STATUS", "unfunded")
+    monkeypatch.setenv("NIJA_OKX_TRADING_SPENDABLE_QUOTE", "0")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "ready")
+    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "1")
+
+    broker = FakeBroker(balance=0.0)
+    manager = SimpleNamespace(
+        _platform_brokers={"okx": broker},
+        eligible_brokers={broker},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+
+    row = module.evaluate_venue("okx", broker_module, manager)
+
+    assert row.balance_fetched is False
+    assert row.eligible_for_execution is False
+    assert row.ready is False
+    assert "no_spendable_quote" in row.reason
+
+
+def test_degraded_secondary_does_not_disable_ready_kraken(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
+    monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
+    monkeypatch.setenv("NIJA_COINBASE_ACTIVATION_STATE", "credential_quarantined")
+    monkeypatch.setenv("NIJA_COINBASE_TRADING_READY", "0")
+    monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "credential_quarantined")
+    monkeypatch.setenv("NIJA_OKX_TRADING_READY", "0")
+
+    kraken = FakeBroker(balance=116.09)
+    coinbase = FakeBroker(balance=95.0, connected=False)
+    okx = FakeBroker(balance=144.0, connected=False)
+    manager = SimpleNamespace(
+        _platform_brokers={"kraken": kraken, "coinbase": coinbase, "okx": okx},
+        eligible_brokers={kraken},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
+
+    result = module.evaluate_all()
+
+    assert result["execution_ready"] is True
+    assert result["ready_venues"] == ["kraken"]
+    assert result["venues"]["kraken"]["ready"] is True
+    assert result["venues"]["coinbase"]["ready"] is False
+    assert result["venues"]["okx"]["ready"] is False
+
+
+def test_no_ready_venues_keeps_execution_fail_closed(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
+    monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
+
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    manager = SimpleNamespace(_platform_brokers={}, eligible_brokers=set())
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
+
+    result = module.evaluate_all()
+
+    assert result["execution_ready"] is False
+    assert result["any_venue_ready"] is False
+    assert result["ready_venues"] == []
+    assert result["degraded_venues"] == ["kraken", "coinbase", "okx"]
+
+
+def test_writer_not_ready_keeps_execution_fail_closed(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
     monkeypatch.setattr(
         module,
-        "evaluate_all",
-        lambda: {
-            "marker": module.MARKER,
-            "timestamp": 1.0,
-            "pid": 1,
-            "writer_ready": True,
-            "capital_ready": True,
-            "any_venue_ready": False,
-            "all_venues_ready": False,
-            "execution_ready": False,
-            "three_venue_execution_ready": False,
-            "ready_venues": [],
-            "degraded_venues": ["kraken", "coinbase", "okx"],
-            "venues": {
-                venue: {
-                    "credentials_loaded": True,
-                    "authentication_succeeded": venue != "kraken",
-                    "balance_fetched": True,
-                    "market_metadata_loaded": True,
-                    "order_adapter_initialized": True,
-                    "venue_marked_ready": venue != "kraken",
-                    "eligible_for_execution": False,
-                    "spendable_quote": 0.0,
-                    "activation_state": "not_ready",
-                    "reason": "not_execution_eligible",
-                    "ready": False,
-                }
-                for venue in module.VENUES
-            },
-        },
+        "writer_authority_snapshot",
+        lambda **_kwargs: {"ready": False},
     )
-    monkeypatch.setattr(module, "_write_state", lambda payload: None)
-    monkeypatch.setattr(module, "_LAST_SIGNATURE", "")
 
-    module.publish_once(force=True)
+    kraken = FakeBroker(balance=116.09)
+    manager = SimpleNamespace(
+        _platform_brokers={"kraken": kraken},
+        eligible_brokers={kraken},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
 
-    assert os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] == "not_ready"
-    assert os.environ["NIJA_KRAKEN_TRADING_READY"] == "0"
-    assert os.environ["NIJA_KRAKEN_ACTIVATED"] == "0"
+    result = module.evaluate_all()
 
-
-def test_source_bootstrap_installs_definitive_verifier() -> None:
-    from pathlib import Path
-
-    root = Path(__file__).resolve().parents[2]
-    source = (root / "source_runtime_guard_bootstrap.py").read_text(encoding="utf-8")
-
-    assert '_install_required("three_venue_execution_readiness")' in source
-    assert 'NIJA_THREE_VENUE_STAGE_VERIFIER_INSTALLED' in source
-    assert 'three_venue_stage_verifier=installed' in source
+    assert result["writer_ready"] is False
+    assert result["execution_ready"] is False
 
 
-def test_ready_contract_contains_independent_summary_marker() -> None:
-    from pathlib import Path
+def test_unfunded_capital_keeps_execution_fail_closed(monkeypatch) -> None:
+    module = _module()
+    _set_credentials(monkeypatch)
+    _set_canonical_writer_ready(monkeypatch, module)
+    monkeypatch.delenv("CAPITAL_SYSTEM_READY", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_READY", raising=False)
 
-    root = Path(__file__).resolve().parents[2]
-    source = (root / "three_venue_execution_readiness.py").read_text(encoding="utf-8")
+    kraken = FakeBroker(balance=116.09)
+    manager = SimpleNamespace(
+        _platform_brokers={"kraken": kraken},
+        eligible_brokers={kraken},
+    )
+    broker_module = SimpleNamespace(BrokerType=FakeBrokerType)
+    monkeypatch.setattr(module, "_runtime", lambda: (broker_module, manager))
 
-    assert "BROKER_INDEPENDENT_EXECUTION_%s" in source
-    assert "THREE_VENUE_EXECUTION_%s" in source
-    assert "THREE_VENUE_STAGE venue=%s" in source
-    assert 'NIJA_THREE_VENUE_EXECUTION_READY' in source
-    assert 'NIJA_ANY_VENUE_EXECUTION_READY' in source
-    assert 'NIJA_EXECUTION_READY_VENUES' in source
-    assert 'ready_venues' in source
-    assert 'degraded_venues' in source
+    result = module.evaluate_all()
+
+    assert result["capital_ready"] is False
+    assert result["execution_ready"] is False

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -262,6 +262,7 @@ def test_publish_once_retains_independent_any_ready_semantics(monkeypatch, tmp_p
     assert os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] == "1"
     assert os.environ["NIJA_EXECUTION_READY_VENUES"] == "kraken"
     assert os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] == "coinbase,okx"
+    assert os.environ["NIJA_KRAKEN_SPENDABLE_QUOTE"] == "25.00000000"
 
 
 def test_okx_authenticated_snapshot_can_satisfy_balance_stage(monkeypatch) -> None:

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -6,13 +6,16 @@ canonical broker-startup convergence hook before importing ``main.py`` or the
 execute ``bot.__init__`` and load ``bot.bot_main`` before a late hook has a
 chance to wrap writer acquisition.
 
-The launcher does not acquire writer authority, connect brokers, synthesize
-capital, force activation, or submit orders. It installs the existing
-fail-closed startup, reconnect, capital-readiness, and production-corrective
-contracts before application imports.
+The launcher now also establishes the canonical writer before ``main.py`` runs
+its compatibility/runtime installer fanout. The acquisition is performed only
+through ``bot.bot_main._acquire_writer_authority_before_nonce()``, which keeps
+the existing exact Redis fencing/generation proof and fail-closed behavior. The
+final ``bot.bot`` handoff reuses the already-imported canonical module instead
+of executing it a second time under ``__main__``.
 """
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
 import os
@@ -23,6 +26,7 @@ from types import ModuleType
 from typing import Any
 
 MARKER = "20260807-canonical-runtime-launcher-v26-v44-v43-v42-v41-v40-v39-v38-v37-v18"
+WRITER_FIRST_MARKER = "20260809-canonical-writer-first-v59"
 ROOT = Path(__file__).resolve().parents[1]
 V24_PATH = ROOT / "bot" / "canonical_broker_startup_convergence_v24.py"
 V32_PATH = ROOT / "bot" / "runtime_execution_convergence_v32.py"
@@ -245,14 +249,134 @@ def install_canonical_startup_guard() -> ModuleType:
     return module
 
 
+def _release_early_writer(bot_main: ModuleType, *, reason: str) -> None:
+    release = getattr(bot_main, "_release_writer_authority", None)
+    if callable(release):
+        try:
+            release()
+        except Exception as exc:
+            LOGGER.warning(
+                "CANONICAL_EARLY_WRITER_RELEASE_FAILED marker=%s reason=%s err=%s:%s",
+                WRITER_FIRST_MARKER,
+                reason,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def _bootstrap_writer_first() -> tuple[ModuleType, ModuleType]:
+    """Import the canonical entrypoint and prove Redis writer authority first."""
+
+    bot_entry = importlib.import_module("bot.bot")
+    bot_main = importlib.import_module("bot.bot_main")
+    acquire = getattr(bot_main, "_acquire_writer_authority_before_nonce", None)
+    if not callable(acquire):
+        raise RuntimeError("canonical writer bootstrap function unavailable")
+
+    if not bool(acquire()):
+        error = str(getattr(bot_main, "_writer_authority_last_error", "") or "unknown")
+        raise RuntimeError(f"canonical writer bootstrap failed:{error}")
+
+    runtime = getattr(bot_main, "_writer_authority_runtime", None)
+    generation_text = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    try:
+        generation = int(generation_text or "0")
+    except (TypeError, ValueError):
+        generation = 0
+
+    exact_runtime = bool(
+        runtime is not None
+        and bool(getattr(runtime, "acquired", False))
+        and not bool(getattr(runtime, "lost", True))
+        and not bool(getattr(runtime, "_local_fallback", False))
+        and generation > 0
+        and token
+    )
+    if not exact_runtime:
+        _release_early_writer(bot_main, reason="runtime_lineage_incomplete")
+        raise RuntimeError(
+            "canonical writer bootstrap did not establish exact distributed lineage"
+        )
+
+    try:
+        authority = importlib.import_module("bot.execution_authority_context")
+        verify = getattr(authority, "assert_distributed_writer_authority", None)
+        if not callable(verify):
+            raise RuntimeError("distributed authority verifier unavailable")
+        verify()
+    except Exception:
+        _release_early_writer(bot_main, reason="exact_authority_reverify_failed")
+        raise
+
+    os.environ["NIJA_CANONICAL_WRITER_FIRST_V59_READY"] = "1"
+    LOGGER.critical(
+        "CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED marker=%s generation=%s "
+        "token_prefix=%s exact_redis_proof=true local_fallback=false "
+        "runtime_fanout_started=false",
+        WRITER_FIRST_MARKER,
+        generation,
+        token[:8],
+    )
+    return bot_entry, bot_main
+
+
+def _run_main_single_identity(bot_entry: ModuleType, bot_main: ModuleType) -> None:
+    """Run ``main.py`` while reusing the canonical ``bot.bot`` module once."""
+
+    original_run_module = runpy.run_module
+    handoff_started = False
+
+    def run_module_once(
+        mod_name: str,
+        init_globals: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        alter_sys: bool = False,
+    ) -> dict[str, Any]:
+        nonlocal handoff_started
+        if mod_name != "bot.bot":
+            return original_run_module(
+                mod_name,
+                init_globals=init_globals,
+                run_name=run_name,
+                alter_sys=alter_sys,
+            )
+
+        canonical = sys.modules.get("bot.bot")
+        if canonical is None or canonical is not bot_entry:
+            raise RuntimeError("canonical bot.bot module identity changed before handoff")
+        entry_main = getattr(canonical, "main", None)
+        if not callable(entry_main):
+            raise RuntimeError("canonical bot.bot main callable unavailable")
+
+        handoff_started = True
+        LOGGER.critical(
+            "CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF marker=%s "
+            "module=bot.bot reused_module=true run_name=%s",
+            WRITER_FIRST_MARKER,
+            run_name or "unset",
+        )
+        result = entry_main()
+        raise SystemExit(int(result or 0))
+
+    runpy.run_module = run_module_once
+    try:
+        runpy.run_path(str(MAIN_PATH), run_name="__main__")
+    finally:
+        runpy.run_module = original_run_module
+        if not handoff_started:
+            _release_early_writer(bot_main, reason="main_wrapper_failed_before_handoff")
+
+
 def main() -> int:
     os.environ["NIJA_DEFER_RUNTIME_SITE_HOOKS"] = "1"
     os.environ["NIJA_CANONICAL_ENTRYPOINT_FAST_PATH"] = "1"
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
     install_canonical_startup_guard()
+    bot_entry, bot_main = _bootstrap_writer_first()
     print("CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260807-canonical-fast-entrypoint-v44-v43-v42-v41-v40-v39-v38-v37-v18 package_hook_fanout=deferred", flush=True)
-    runpy.run_path(str(MAIN_PATH), run_name="__main__")
+    _run_main_single_identity(bot_entry, bot_main)
     return 0
 
 

--- a/scripts/render_entrypoint.sh
+++ b/scripts/render_entrypoint.sh
@@ -61,6 +61,7 @@ python3 -S -m py_compile \
     bot/stalled_writer_release_guard_v22.py \
     bot/writer_generation_handoff_v45_patch.py \
     bot/tests/test_writer_generation_handoff_v45.py \
+    bot/tests/test_canonical_writer_first_v59.py \
     scripts/canonical_runtime_launcher_v26.py \
     scripts/apply_canonical_launcher_v26.py \
     scripts/apply_writer_generation_handoff_v45.py \
@@ -75,8 +76,11 @@ fi
 grep -Fq 'DIRECT_CANONICAL_BROKER_PREBOOTSTRAP_V27_READY' bot/bot_main.py
 grep -Fq 'V45_PATH = ROOT / "bot" / "writer_generation_handoff_v45_patch.py"' scripts/canonical_runtime_launcher_v26.py
 grep -Fq '_install_writer_generation_handoff_v45()' scripts/canonical_runtime_launcher_v26.py
+grep -Fq 'CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED' scripts/canonical_runtime_launcher_v26.py
+grep -Fq 'CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF' scripts/canonical_runtime_launcher_v26.py
+grep -Fq 'NIJA_CANONICAL_WRITER_FIRST_V59_READY' scripts/canonical_runtime_launcher_v26.py
 
-echo "🧭 RENDER_ENTRYPOINT_CANONICAL_HANDOFF_READY marker=20260807-render-entrypoint-v45 launcher=canonical_runtime_launcher_v26 writer_generation_handoff=v45 direct_broker_prebootstrap=v27"
+echo "🧭 RENDER_ENTRYPOINT_CANONICAL_HANDOFF_READY marker=20260809-render-entrypoint-v59 launcher=canonical_runtime_launcher_v26 writer_generation_handoff=v45 writer_first=v59 single_identity=true direct_broker_prebootstrap=v27"
 unset NIJA_DEFER_RUNTIME_SITE_HOOKS
 
 exec bash scripts/production_bootstrap.sh "$@"

--- a/scripts/runtime_entrypoint_attestation.py
+++ b/scripts/runtime_entrypoint_attestation.py
@@ -3,8 +3,8 @@
 This script intentionally uses only the Python standard library and never imports the
 ``bot`` package. It is safe to run with ``python -S`` while runtime site hooks are
 deferred. The goal is to prove that the deployed image contains the canonical path
-and the current broker-prebootstrap and fill-confirmed exit safeguards before the
-live Python process starts.
+and the current broker-prebootstrap, writer-first, single-identity, and fill-confirmed
+exit safeguards before the live Python process starts.
 """
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-_MARKER = "20260723-runtime-entrypoint-attestation-v25"
+_MARKER = "20260809-runtime-entrypoint-attestation-v59"
 _CANONICAL_PATH = "main.py->bot.bot->bot.bot_main"
 _PLACEHOLDERS = {"", "unknown", "none", "null", "unset", "n/a", "na"}
 _PROVIDER_LITERAL = re.compile(
@@ -44,6 +44,11 @@ _CONTRACTS = (
             "NIJA_DEFER_RUNTIME_SITE_HOOKS",
             "NIJA_CANONICAL_ENTRYPOINT_FAST_PATH",
             "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED",
+            "CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED",
+            "CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF",
+            "NIJA_CANONICAL_WRITER_FIRST_V59_READY",
+            "exact_redis_proof=true",
+            "local_fallback=false",
         ),
     ),
     FileContract(

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -643,6 +643,19 @@ def publish_once(*, force: bool = False) -> dict[str, Any]:
     os.environ["NIJA_ANY_VENUE_EXECUTION_READY"] = "1" if enabled else "0"
     os.environ["NIJA_EXECUTION_READY_VENUES"] = ready_csv
     os.environ["NIJA_EXECUTION_DEGRADED_VENUES"] = degraded_csv
+
+    # Export the already-verified Kraken free quote snapshot for broker-independent
+    # readiness/diagnostics. This is telemetry only: no additional private Kraken
+    # request is made here and this value does not grant execution readiness.
+    try:
+        kraken_spendable = max(
+            0.0,
+            float(payload["venues"]["kraken"].get("spendable_quote", 0.0) or 0.0),
+        )
+    except (TypeError, ValueError, OverflowError, KeyError):
+        kraken_spendable = 0.0
+    os.environ["NIJA_KRAKEN_SPENDABLE_QUOTE"] = f"{kraken_spendable:.8f}"
+
     kraken_ready = bool(payload["venues"]["kraken"]["ready"])
     os.environ["NIJA_KRAKEN_ACTIVATION_STATE"] = "ready" if kraken_ready else "not_ready"
     os.environ["NIJA_KRAKEN_TRADING_READY"] = "1" if kraken_ready else "0"


### PR DESCRIPTION
## Purpose

Production after merge `2d618d22265304bdef99635d4117280ef4b97682` shows Kraken, Coinbase, and OKX all connected and capital-ready, while execution remains blocked because writer authority is still observed as generation `0` before the canonical writer bootstrap completes.

The same runtime also emits Python's warning that `bot.bot` is already present in `sys.modules` before `runpy.run_module("bot.bot", run_name="__main__")` executes it again. That creates two module execution identities around a startup path whose writer/runtime state is intentionally process-singleton.

## Root cause

`main.py` installs compatibility/runtime guards and monitors before its final `runpy` handoff into `bot.bot`. Those pre-handoff readers can inspect heartbeat/readiness state before `bot.bot_main.main()` reaches step 0 and establishes the Redis writer generation. The final `runpy.run_module(..., run_name="__main__")` can then execute `bot.bot` a second time even though the canonical `bot.bot` module is already imported.

This explains the observed combination of:

- all three brokers healthy and funded;
- `heartbeat_ts=0`, `generation=0`, `expected_generation_missing`;
- `writer_ready=False` with `capital_ready=True`;
- the `bot.bot found in sys.modules ... prior to execution` runtime warning.

## Fix — v59

- Establish writer authority in `scripts/canonical_runtime_launcher_v26.py` before `main.py` runs its runtime installer fanout.
- Use only the existing canonical `bot.bot_main._acquire_writer_authority_before_nonce()` path.
- Require a real acquired, non-lost, non-local-fallback runtime with a positive generation and fencing token.
- Re-run `assert_distributed_writer_authority()` before allowing the wrapper fanout to proceed.
- Release the early writer lease if the exact lineage proof or pre-handoff wrapper fails.
- Reuse the already-imported canonical `bot.bot` module at final handoff and call its exported `main()` once rather than re-executing the module under a second identity.
- Preserve the existing later `bot_main` writer-acquire call; it is idempotent and returns the already-acquired result rather than electing a second epoch.

## Safety

This change does **not** bypass Redis, synthesize a fencing token/generation, force `writer_ready`, change capital/risk/strategy gates, or weaken fail-closed behavior. Local writer fallback is explicitly rejected by v59. Any exact-proof failure releases the early authority and startup remains blocked.

All existing v45/v49 source-deployment patch anchors are preserved so the Render startup patch chain remains idempotent.

## Regression coverage

- writer bootstrap happens before the main runtime fanout;
- local fallback cannot satisfy v59;
- final `bot.bot` handoff reuses one canonical module identity and invokes `main()` exactly once;
- source markers attest exact Redis proof and single-identity handoff;
- canonical startup workflow compiles/runs the new v59 tests;
- runtime entrypoint attestation and Render entrypoint now require the v59 writer-first/single-identity markers.

## Expected production proof

Before broker/readiness fanout:

`CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED marker=20260809-canonical-writer-first-v59 generation=<positive> ... exact_redis_proof=true local_fallback=false runtime_fanout_started=false`

At final handoff:

`CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF marker=20260809-canonical-writer-first-v59 module=bot.bot reused_module=true`

Then heartbeat/readiness should report the same positive writer generation instead of `expected_generation=0`, and execution can proceed only after the existing downstream authority/capital/risk gates pass.