### PR TITLE
Harden writer, brokers, users, entries, and profit exits v60-v73

### DIFF
--- a/bot/account_scoped_profit_state_v71_patch.py
+++ b/bot/account_scoped_profit_state_v71_patch.py
@@ -1,0 +1,254 @@
+"""Account/broker-scoped profit lock and harvest APIs v71.
+
+The historical ProfitLockEngine and ProfitHarvestLayer are process singletons
+whose dictionaries are keyed by symbol.  That is safe only for one account per
+symbol.  With multiple users/brokers, two BTC-USD positions would otherwise
+share peak-profit, lock-tier and harvest-candidate state.
+
+v71 adds explicit scoped APIs while preserving legacy methods for compatibility.
+New live integrations must use ``scope_id + broker_name + symbol``.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import re
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.account_scoped_profit_state_v71")
+MARKER = "20260809-account-scoped-profit-state-v71"
+_PATCH_ATTR = "_nija_account_scoped_profit_state_v71"
+_LOCK = threading.RLock()
+
+
+def _clean(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9_.:-]+", "_", text)
+    return text.strip("_")
+
+
+def scoped_position_key(scope_id: str, broker_name: str, symbol: str) -> str:
+    scope = _clean(scope_id)
+    broker = _clean(broker_name)
+    pair = str(symbol or "").strip().upper().replace("/", "-").replace("_", "-")
+    if not scope:
+        raise ValueError("scope_id is required")
+    if not broker:
+        raise ValueError("broker_name is required")
+    if not pair:
+        raise ValueError("symbol is required")
+    return f"scope={scope}|broker={broker}|symbol={pair}"
+
+
+def _patch_lock_engine(module: ModuleType) -> bool:
+    cls = getattr(module, "ProfitLockEngine", None)
+    if not isinstance(cls, type):
+        return False
+    if getattr(cls, _PATCH_ATTR, False):
+        return True
+
+    def register_scoped_position(
+        self: Any,
+        scope_id: str,
+        broker_name: str,
+        symbol: str,
+        side: str,
+        entry_price: float,
+        entry_time: Any = None,
+    ) -> None:
+        key = scoped_position_key(scope_id, broker_name, symbol)
+        self.register_position(
+            key,
+            side=side,
+            entry_price=entry_price,
+            entry_time=entry_time,
+        )
+        LOGGER.info(
+            "PROFIT_STATE_V71_LOCK_REGISTERED marker=%s scope=%s broker=%s symbol=%s key=%s",
+            MARKER, scope_id, broker_name, symbol, key,
+        )
+
+    def update_scoped_position(
+        self: Any,
+        scope_id: str,
+        broker_name: str,
+        symbol: str,
+        current_price: float,
+    ) -> Any:
+        key = scoped_position_key(scope_id, broker_name, symbol)
+        decision = self.update_position(key, current_price=current_price)
+        try:
+            decision.symbol = str(symbol).strip().upper().replace("/", "-").replace("_", "-")
+        except Exception:
+            pass
+        return decision
+
+    def remove_scoped_position(self: Any, scope_id: str, broker_name: str, symbol: str):
+        return self.remove_position(scoped_position_key(scope_id, broker_name, symbol))
+
+    def get_scoped_lock_status(self: Any, scope_id: str, broker_name: str, symbol: str):
+        status = self.get_lock_status(scoped_position_key(scope_id, broker_name, symbol))
+        if isinstance(status, dict):
+            status = dict(status)
+            status["scope_id"] = scope_id
+            status["broker_name"] = broker_name
+            status["display_symbol"] = str(symbol).upper()
+        return status
+
+    cls.register_scoped_position = register_scoped_position
+    cls.update_scoped_position = update_scoped_position
+    cls.remove_scoped_position = remove_scoped_position
+    cls.get_scoped_lock_status = get_scoped_lock_status
+    setattr(cls, _PATCH_ATTR, True)
+    LOGGER.critical(
+        "ACCOUNT_SCOPED_PROFIT_LOCK_V71_PATCHED marker=%s module=%s",
+        MARKER, module.__name__,
+    )
+    return True
+
+
+def _patch_harvest_layer(module: ModuleType) -> bool:
+    cls = getattr(module, "ProfitHarvestLayer", None)
+    if not isinstance(cls, type):
+        return False
+    if getattr(cls, _PATCH_ATTR, False):
+        return True
+
+    def register_scoped_position(
+        self: Any,
+        scope_id: str,
+        broker_name: str,
+        symbol: str,
+        side: str,
+        entry_price: float,
+        position_size_usd: float,
+        entry_time: Any = None,
+    ) -> None:
+        key = scoped_position_key(scope_id, broker_name, symbol)
+        self.register_position(
+            key,
+            side=side,
+            entry_price=entry_price,
+            position_size_usd=position_size_usd,
+            entry_time=entry_time,
+        )
+        LOGGER.info(
+            "PROFIT_STATE_V71_HARVEST_REGISTERED marker=%s scope=%s broker=%s symbol=%s key=%s",
+            MARKER, scope_id, broker_name, symbol, key,
+        )
+
+    def process_scoped_price_update(
+        self: Any,
+        scope_id: str,
+        broker_name: str,
+        symbol: str,
+        current_price: float,
+    ) -> Any:
+        key = scoped_position_key(scope_id, broker_name, symbol)
+        decision = self.process_price_update(key, current_price=current_price)
+        try:
+            decision.symbol = str(symbol).strip().upper().replace("/", "-").replace("_", "-")
+        except Exception:
+            pass
+        return decision
+
+    def get_scoped_harvest_status(self: Any, scope_id: str, broker_name: str, symbol: str):
+        status = self.get_harvest_status(scoped_position_key(scope_id, broker_name, symbol))
+        if isinstance(status, dict):
+            status = dict(status)
+            status["scope_id"] = scope_id
+            status["broker_name"] = broker_name
+            status["display_symbol"] = str(symbol).upper()
+        return status
+
+    def remove_scoped_position(self: Any, scope_id: str, broker_name: str, symbol: str):
+        return self.remove_position(scoped_position_key(scope_id, broker_name, symbol))
+
+    def confirm_scoped_realized_harvest(
+        self: Any,
+        scope_id: str,
+        broker_name: str,
+        symbol: str,
+        amount_usd: float,
+        *,
+        broker_fill_id: str,
+        note: str = "",
+    ) -> float:
+        method = getattr(self, "confirm_realized_harvest", None)
+        if not callable(method):
+            raise RuntimeError("profit realization guard v66 is not installed")
+        key = scoped_position_key(scope_id, broker_name, symbol)
+        return float(
+            method(
+                key,
+                amount_usd,
+                broker_fill_id=broker_fill_id,
+                broker_name=broker_name,
+                account_id=scope_id,
+                note=note,
+            )
+            or 0.0
+        )
+
+    cls.register_scoped_position = register_scoped_position
+    cls.process_scoped_price_update = process_scoped_price_update
+    cls.get_scoped_harvest_status = get_scoped_harvest_status
+    cls.remove_scoped_position = remove_scoped_position
+    cls.confirm_scoped_realized_harvest = confirm_scoped_realized_harvest
+    setattr(cls, _PATCH_ATTR, True)
+    LOGGER.critical(
+        "ACCOUNT_SCOPED_PROFIT_HARVEST_V71_PATCHED marker=%s module=%s fill_proof_api=true",
+        MARKER, module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.profit_lock_engine", "profit_lock_engine"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_lock_engine(module) or changed
+    for name in ("bot.profit_harvest_layer", "profit_harvest_layer"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_harvest_layer(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        flag = "_NIJA_ACCOUNT_SCOPED_PROFIT_STATE_V71_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "profit_lock_engine" in str(name) or "profit_harvest_layer" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_ACCOUNT_SCOPED_PROFIT_STATE_V71_INSTALLED"] = "1"
+        LOGGER.critical(
+            "ACCOUNT_SCOPED_PROFIT_STATE_V71_INSTALLED marker=%s scoped_key_required_for_new_integrations=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "scoped_position_key", "install", "install_import_hook"]

--- a/bot/activation_snapshot_bridge_patch.py
+++ b/bot/activation_snapshot_bridge_patch.py
@@ -1,19 +1,24 @@
 """Bridge accepted capital snapshots into live activation safely.
 
-This runtime patch fixes a startup ordering mismatch observed in Railway logs:
-CapitalAuthority and CapitalCSMv2 can latch the first live capital snapshot, while
-TradingStateMachine._first_snap_accepted remains False because the activation
-cycle receives an empty/older cycle_capital dict.  The result is a false
-`ACTIVATION BLOCKED: no valid live-exchange capital snapshot accepted` even
-though the live capital latch already passed.
+This runtime patch fixes startup/runtime ordering mismatches where
+CapitalAuthority has accepted live capital but activation or a direct broker
+scan still sees an empty/older cycle-capital dictionary.
+
+v63 extends the existing activation bridge to direct
+``TradingStrategy.run_cycle() -> NijaCoreLoop.run_scan_phase()`` calls.  Those
+cycles do not pass through ``run_trading_loop()``, so the module-level frozen
+capital context can otherwise remain the startup placeholder even after
+CapitalAuthority is hydrated.
 
 The bridge is fail-closed:
 - It never invents capital.
-- It only sets TradingStateMachine._first_snap_accepted when CapitalAuthority is
-  hydrated, non-stale, has real capital > 0, and has at least one positive broker
-  balance, or when CapitalAuthority's own first-snapshot latch is already true.
-- It only performs the constrained fallback commit after distributed writer,
-  nonce, heartbeat/live, and kill-switch gates pass.
+- It only bridges when CapitalAuthority is hydrated, has positive real capital,
+  has at least one positively funded/connected broker, and is fresh (including
+  the existing capital-readiness handoff corroboration).
+- It preserves an explicit ``aggregation_normalized=False`` value.
+- It does not fabricate broker readiness; that value is read from MABM.
+- It only performs the legacy constrained fallback activation after distributed
+  writer, nonce, heartbeat/live, and kill-switch gates pass.
 """
 
 from __future__ import annotations
@@ -25,6 +30,7 @@ import sys
 import threading
 import time
 from collections.abc import Mapping
+from functools import wraps
 from typing import Any
 
 logger = logging.getLogger("nija.activation_snapshot_bridge")
@@ -32,6 +38,8 @@ logger = logging.getLogger("nija.activation_snapshot_bridge")
 _TRUTHY = {"1", "true", "yes", "on", "enabled", "y"}
 _PATCH_STARTED = False
 _PATCH_LOCK = threading.Lock()
+_CORE_SCAN_BRIDGE_LOCK = threading.RLock()
+_V63_MARKER = "20260809-direct-scan-capital-snapshot-v63"
 
 
 def _truthy(name: str, default: str = "false") -> bool:
@@ -40,10 +48,6 @@ def _truthy(name: str, default: str = "false") -> bool:
 
 def _set_lock_wait_defaults() -> None:
     """Give stale-lock rescue enough runway without disabling Redis safety."""
-    # The observed deployment waited only ~45s while the old holder's stale
-    # heartbeat threshold was ~240s, causing repeated fail-closed restarts before
-    # the safe takeover path could complete.  These defaults extend the runway;
-    # they do not bypass the distributed writer lock.
     timeout_defaults = {
         "NIJA_WRITER_LOCK_ACQUIRE_TIMEOUT_S": "180",
         "NIJA_DISTRIBUTED_LOCK_ACQUIRE_TIMEOUT_S": "180",
@@ -65,8 +69,6 @@ def _set_lock_wait_defaults() -> None:
     for key, value in stale_defaults.items():
         os.environ.setdefault(key, value)
 
-    # Avoid restart churn while waiting for a real lock handoff.  This remains
-    # fail-closed: trading is blocked until the Redis writer lock is acquired.
     try:
         attempts = int(float(os.environ.get("NIJA_FAIL_CLOSED_MAX_RETRY_ATTEMPTS", "0") or "0"))
     except Exception:
@@ -87,7 +89,12 @@ def _resolve_class(module_names: tuple[str, ...], class_name: str):
         try:
             module = importlib.import_module(module_name)
         except Exception as exc:
-            logger.debug("class import probe failed module=%s class=%s error=%s", module_name, class_name, exc)
+            logger.debug(
+                "class import probe failed module=%s class=%s error=%s",
+                module_name,
+                class_name,
+                exc,
+            )
             continue
         cls = getattr(module, class_name, None)
         if cls is not None:
@@ -129,7 +136,10 @@ def _positive_balance_count_from_mapping(values: Any) -> int:
                 value.get("usd"),
                 value.get("balance"),
             )
-            amount = max((_positive_number(candidate) for candidate in candidates), default=0.0)
+            amount = max(
+                (_positive_number(candidate) for candidate in candidates),
+                default=0.0,
+            )
         else:
             amount = _positive_number(value)
         if amount > 0.0:
@@ -170,6 +180,7 @@ def _valid_brokers_from_mabm() -> int:
     if manager is None:
         return 0
     count = 0
+    seen: set[int] = set()
     containers: list[Any] = []
     for attr in ("platform_brokers", "_platform_brokers", "brokers"):
         value = getattr(manager, attr, None)
@@ -177,8 +188,9 @@ def _valid_brokers_from_mabm() -> int:
             containers.append(value)
     for container in containers:
         for broker in container.values():
-            if broker is None:
+            if broker is None or id(broker) in seen:
                 continue
+            seen.add(id(broker))
             if hasattr(broker, "connected") and not bool(getattr(broker, "connected", False)):
                 continue
             balance = max(
@@ -189,6 +201,19 @@ def _valid_brokers_from_mabm() -> int:
             if balance > 0.0:
                 count += 1
     return count
+
+
+def _mabm_brokers_ready() -> bool:
+    manager = _get_mabm_instance()
+    if manager is None:
+        return False
+    checker = getattr(manager, "all_brokers_fully_ready", None)
+    if not callable(checker):
+        return False
+    try:
+        return bool(checker())
+    except Exception:
+        return False
 
 
 def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
@@ -216,7 +241,10 @@ def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
             logger.debug("CapitalAuthority.get_real_capital() failed: %s", exc)
     if real_capital <= 0.0:
         for attr in ("real_capital", "total_capital", "total_balance", "balance"):
-            real_capital = max(real_capital, _positive_number(getattr(ca, attr, 0.0)))
+            real_capital = max(
+                real_capital,
+                _positive_number(getattr(ca, attr, 0.0)),
+            )
 
     accepted_latch = bool(
         getattr(ca, "first_snap_accepted", False)
@@ -226,7 +254,13 @@ def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
 
     valid_brokers = 0
     snapshot = None
-    for attr in ("last_snapshot", "_last_snapshot", "current_snapshot", "_current_snapshot", "snapshot"):
+    for attr in (
+        "last_snapshot",
+        "_last_snapshot",
+        "current_snapshot",
+        "_current_snapshot",
+        "snapshot",
+    ):
         snapshot = getattr(ca, attr, None)
         if snapshot is not None:
             break
@@ -236,30 +270,23 @@ def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
         getattr(ca, "_broker_balances", None),
         getattr(ca, "balances", None),
     ):
-        valid_brokers = max(valid_brokers, _positive_balance_count_from_mapping(source))
+        valid_brokers = max(
+            valid_brokers,
+            _positive_balance_count_from_mapping(source),
+        )
 
+    try:
+        valid_brokers = max(
+            valid_brokers,
+            int(getattr(ca, "registered_broker_count", 0) or 0),
+        )
+    except Exception:
+        pass
     valid_brokers = max(valid_brokers, _valid_brokers_from_mabm())
 
     if valid_brokers <= 0 and accepted_latch and real_capital > 0.0:
-        # CapitalAuthority has already accepted the first snapshot but its raw
-        # balance map is not exposed on this object.  Preserve fail-closed
-        # semantics by requiring positive real capital before inferring one valid
-        # broker for the activation snapshot flag.
         valid_brokers = 1
 
-    # v34 handoff-corroboration: if CSMv2 has confirmed a fresh positive snapshot,
-    # treat the authority's stale flag as a false-positive and clear it.
-    if stale and hydrated and real_capital > 0.0 and valid_brokers > 0:
-        if (
-            _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34")
-            or _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY")
-            or (_truthy("CAPITAL_SYSTEM_READY") and _truthy("NIJA_CAPITAL_READY"))
-        ):
-            stale = False
-    # Honor capital-readiness handoff attestations: if the handoff signal is set
-    # and capital is hydrated with positive capital and at least one valid broker,
-    # treat a stale flag as a startup-freshness artefact and clear it so that
-    # activation is not blocked on a false staleness determination.
     handoff_ready = (
         _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34")
         or _truthy("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY")
@@ -268,7 +295,13 @@ def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
     if handoff_ready and hydrated and real_capital > 0.0 and valid_brokers > 0:
         stale = False
 
-    conditions_met = bool(hydrated and real_capital > 0.0 and valid_brokers > 0 and not stale)
+    brokers_ready = _mabm_brokers_ready()
+    conditions_met = bool(
+        hydrated
+        and real_capital > 0.0
+        and valid_brokers > 0
+        and not stale
+    )
     accepted = bool(accepted_latch or conditions_met)
     return accepted, {
         "ca_available": True,
@@ -277,20 +310,56 @@ def _capital_snapshot_meta() -> tuple[bool, dict[str, Any]]:
         "stale": stale,
         "real_capital": real_capital,
         "valid_brokers": valid_brokers,
+        "brokers_ready": brokers_ready,
         "conditions_met": conditions_met,
     }
 
 
-def _augment_cycle_capital(cycle_capital: Any, meta: dict[str, Any]) -> dict[str, Any]:
-    snapshot: dict[str, Any] = dict(cycle_capital or {}) if isinstance(cycle_capital, Mapping) else {}
+def _augment_cycle_capital(
+    cycle_capital: Any,
+    meta: dict[str, Any],
+) -> dict[str, Any]:
+    snapshot: dict[str, Any] = (
+        dict(cycle_capital or {}) if isinstance(cycle_capital, Mapping) else {}
+    )
     valid_brokers = int(meta.get("valid_brokers") or 0)
-    snapshot.setdefault("snapshot_source", "capital_authority")
-    snapshot["ca_valid_brokers"] = max(int(snapshot.get("ca_valid_brokers", 0) or 0), valid_brokers, 1)
+    real_capital = float(meta.get("real_capital") or 0.0)
+    source = str(snapshot.get("snapshot_source", "") or "").strip()
+    if source not in {"live_exchange", "capital_authority"}:
+        snapshot["snapshot_source"] = "capital_authority"
+    snapshot["ca_valid_brokers"] = max(
+        int(snapshot.get("ca_valid_brokers", 0) or 0),
+        valid_brokers,
+    )
+    snapshot["ca_is_hydrated"] = bool(meta.get("hydrated"))
+    snapshot["ca_total_capital"] = max(
+        float(snapshot.get("ca_total_capital", 0.0) or 0.0),
+        real_capital,
+    )
+    snapshot["is_post_hydration"] = bool(
+        meta.get("hydrated") and not meta.get("stale")
+    )
+    snapshot["mabm_brokers_ready"] = bool(meta.get("brokers_ready"))
     snapshot.setdefault("aggregation_normalized", True)
-    snapshot.setdefault("capital_hydrated", bool(meta.get("hydrated")))
-    snapshot.setdefault("ca_not_stale", not bool(meta.get("stale")))
-    snapshot.setdefault("real_capital", float(meta.get("real_capital") or 0.0))
+    snapshot["capital_hydrated"] = bool(meta.get("hydrated"))
+    snapshot["ca_not_stale"] = not bool(meta.get("stale"))
+    snapshot["real_capital"] = real_capital
+    if bool(meta.get("conditions_met")):
+        snapshot["sync_failed"] = False
     return snapshot
+
+
+def _cycle_capital_live(snapshot: Any) -> bool:
+    if not isinstance(snapshot, Mapping):
+        return False
+    source = str(snapshot.get("snapshot_source", "") or "").strip()
+    return bool(
+        snapshot.get("ca_is_hydrated", False)
+        and float(snapshot.get("ca_total_capital", 0.0) or 0.0) > 0.0
+        and int(snapshot.get("ca_valid_brokers", 0) or 0) > 0
+        and source in {"live_exchange", "capital_authority"}
+        and not bool(snapshot.get("sync_failed", False))
+    )
 
 
 def _kill_switch_active() -> bool:
@@ -339,7 +408,8 @@ def _sync_first_snapshot_flag(tsm: Any, meta: dict[str, Any]) -> None:
     else:
         setattr(tsm, "_first_snap_accepted", True)
     logger.critical(
-        "ACTIVATION_SNAPSHOT_BRIDGE first_snap_accepted=True capital=$%.2f valid_brokers=%s hydrated=%s stale=%s accepted_latch=%s",
+        "ACTIVATION_SNAPSHOT_BRIDGE first_snap_accepted=True capital=$%.2f "
+        "valid_brokers=%s hydrated=%s stale=%s accepted_latch=%s",
         float(meta.get("real_capital") or 0.0),
         meta.get("valid_brokers"),
         meta.get("hydrated"),
@@ -355,6 +425,7 @@ def _patch_trading_state_machine_class(cls: type) -> bool:
     if getattr(original_commit, "_nija_activation_snapshot_bridge_wrapped", False):
         return True
 
+    @wraps(original_commit)
     def _commit_activation_with_snapshot_bridge(self, cycle_capital=None):
         accepted, meta = _capital_snapshot_meta()
         bridged_capital = cycle_capital
@@ -365,15 +436,18 @@ def _patch_trading_state_machine_class(cls: type) -> bool:
         result = original_commit(self, cycle_capital=bridged_capital)
         if result:
             return True
-
         if not accepted:
             return result
 
-        tsm_module = sys.modules.get(cls.__module__) or _get_module("bot.trading_state_machine", "trading_state_machine")
+        tsm_module = sys.modules.get(cls.__module__) or _get_module(
+            "bot.trading_state_machine",
+            "trading_state_machine",
+        )
         gates_ok, gates_detail = _concrete_activation_gates_pass(tsm_module)
         if not gates_ok:
             logger.critical(
-                "ACTIVATION_SNAPSHOT_BRIDGE_COMMIT blocked_after_original detail=%s capital=$%.2f valid_brokers=%s",
+                "ACTIVATION_SNAPSHOT_BRIDGE_COMMIT blocked_after_original "
+                "detail=%s capital=$%.2f valid_brokers=%s",
                 gates_detail,
                 float(meta.get("real_capital") or 0.0),
                 meta.get("valid_brokers"),
@@ -381,23 +455,108 @@ def _patch_trading_state_machine_class(cls: type) -> bool:
             return result
 
         with getattr(self, "_lock", threading.Lock()):
-            current_state = getattr(getattr(self, "_current_state", None), "value", getattr(self, "_current_state", "unknown"))
+            current_state = getattr(
+                getattr(self, "_current_state", None),
+                "value",
+                getattr(self, "_current_state", "unknown"),
+            )
         force_transition = getattr(self, "_force_live_active_transition", None)
         if callable(force_transition):
             logger.critical(
-                "ACTIVATION_SNAPSHOT_BRIDGE_COMMIT all_concrete_gates_passed current_state=%s capital=$%.2f valid_brokers=%s — committing LIVE_ACTIVE",
+                "ACTIVATION_SNAPSHOT_BRIDGE_COMMIT all_concrete_gates_passed "
+                "current_state=%s capital=$%.2f valid_brokers=%s — committing LIVE_ACTIVE",
                 current_state,
                 float(meta.get("real_capital") or 0.0),
                 meta.get("valid_brokers"),
             )
-            return bool(force_transition("ACTIVATION_SNAPSHOT_BRIDGE: CapitalAuthority first snapshot accepted and concrete live gates passed"))
+            return bool(
+                force_transition(
+                    "ACTIVATION_SNAPSHOT_BRIDGE: CapitalAuthority first snapshot "
+                    "accepted and concrete live gates passed"
+                )
+            )
 
-        logger.critical("ACTIVATION_SNAPSHOT_BRIDGE_COMMIT unable_to_commit: _force_live_active_transition missing")
+        logger.critical(
+            "ACTIVATION_SNAPSHOT_BRIDGE_COMMIT unable_to_commit: "
+            "_force_live_active_transition missing"
+        )
         return result
 
     _commit_activation_with_snapshot_bridge._nija_activation_snapshot_bridge_wrapped = True  # type: ignore[attr-defined]
     cls.commit_activation = _commit_activation_with_snapshot_bridge  # type: ignore[method-assign]
     logger.warning("ACTIVATION_SNAPSHOT_BRIDGE_PATCHED class=%s", cls.__name__)
+    return True
+
+
+def _patch_core_loop_class(cls: type) -> bool:
+    original = getattr(cls, "run_scan_phase", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_direct_scan_capital_snapshot_v63", False):
+        return True
+
+    @wraps(original)
+    def _run_scan_phase_with_live_capital(self, *args: Any, **kwargs: Any):
+        accepted, meta = _capital_snapshot_meta()
+        if not accepted:
+            return original(self, *args, **kwargs)
+
+        module = sys.modules.get(cls.__module__) or _get_module(
+            "bot.nija_core_loop",
+            "nija_core_loop",
+        )
+        if module is None:
+            return original(self, *args, **kwargs)
+
+        current_capital = getattr(module, "_current_cycle_capital", {})
+        if _cycle_capital_live(current_capital):
+            return original(self, *args, **kwargs)
+
+        bridged = _augment_cycle_capital(current_capital, meta)
+        if not _cycle_capital_live(bridged):
+            logger.warning(
+                "DIRECT_SCAN_CAPITAL_SNAPSHOT_V63_BLOCKED marker=%s "
+                "reason=bridged_snapshot_not_live meta=%s",
+                _V63_MARKER,
+                meta,
+            )
+            return original(self, *args, **kwargs)
+
+        with _CORE_SCAN_BRIDGE_LOCK:
+            previous_capital = getattr(module, "_current_cycle_capital", {})
+            previous_cycle_id = getattr(module, "_current_cycle_id", "")
+            setattr(module, "_current_cycle_capital", bridged)
+            if not str(previous_cycle_id or "").strip():
+                setattr(
+                    module,
+                    "_current_cycle_id",
+                    f"cycle-{time.strftime('%Y%m%dT%H%M%S', time.gmtime())}-direct-v63",
+                )
+            logger.critical(
+                "DIRECT_SCAN_CAPITAL_SNAPSHOT_V63_APPLIED marker=%s "
+                "capital=$%.2f valid_brokers=%d source=%s hydrated=%s "
+                "brokers_ready=%s aggregation_normalized=%s",
+                _V63_MARKER,
+                float(bridged.get("ca_total_capital", 0.0) or 0.0),
+                int(bridged.get("ca_valid_brokers", 0) or 0),
+                bridged.get("snapshot_source"),
+                bool(bridged.get("ca_is_hydrated")),
+                bool(bridged.get("mabm_brokers_ready")),
+                bool(bridged.get("aggregation_normalized", True)),
+            )
+            try:
+                return original(self, *args, **kwargs)
+            finally:
+                setattr(module, "_current_cycle_capital", previous_capital)
+                setattr(module, "_current_cycle_id", previous_cycle_id)
+
+    _run_scan_phase_with_live_capital._nija_direct_scan_capital_snapshot_v63 = True  # type: ignore[attr-defined]
+    cls.run_scan_phase = _run_scan_phase_with_live_capital  # type: ignore[method-assign]
+    logger.critical(
+        "DIRECT_SCAN_CAPITAL_SNAPSHOT_V63_PATCHED marker=%s class=%s",
+        _V63_MARKER,
+        cls.__name__,
+    )
     return True
 
 
@@ -412,13 +571,57 @@ def install_import_hook() -> None:
         _PATCH_STARTED = True
 
         def _worker() -> None:
-            deadline = time.monotonic() + float(os.getenv("NIJA_ACTIVATION_SNAPSHOT_BRIDGE_TIMEOUT_S", "120") or "120")
-            logger.warning("ACTIVATION_SNAPSHOT_BRIDGE autowire worker started")
+            timeout_s = max(
+                120.0,
+                float(
+                    os.getenv(
+                        "NIJA_ACTIVATION_SNAPSHOT_BRIDGE_TIMEOUT_S",
+                        "3600",
+                    )
+                    or "3600"
+                ),
+            )
+            deadline = time.monotonic() + timeout_s
+            logger.warning(
+                "ACTIVATION_SNAPSHOT_BRIDGE autowire worker started "
+                "timeout_s=%.1f v63=true",
+                timeout_s,
+            )
+            tsm_patched = False
+            core_patched = False
             while time.monotonic() < deadline:
-                cls = _resolve_class(("bot.trading_state_machine", "trading_state_machine"), "TradingStateMachine")
-                if cls is not None and _patch_trading_state_machine_class(cls):
+                if not tsm_patched:
+                    cls = _resolve_class(
+                        ("bot.trading_state_machine", "trading_state_machine"),
+                        "TradingStateMachine",
+                    )
+                    if cls is not None:
+                        tsm_patched = _patch_trading_state_machine_class(cls)
+                if not core_patched:
+                    core_cls = _resolve_class(
+                        ("bot.nija_core_loop", "nija_core_loop"),
+                        "NijaCoreLoop",
+                    )
+                    if core_cls is not None:
+                        core_patched = _patch_core_loop_class(core_cls)
+                if tsm_patched and core_patched:
+                    logger.critical(
+                        "ACTIVATION_SNAPSHOT_BRIDGE_V63_READY marker=%s "
+                        "tsm_patched=true core_patched=true",
+                        _V63_MARKER,
+                    )
                     return
                 time.sleep(0.25)
-            logger.error("ACTIVATION_SNAPSHOT_BRIDGE autowire timeout: TradingStateMachine class was not observed or importable")
+            logger.error(
+                "ACTIVATION_SNAPSHOT_BRIDGE autowire timeout "
+                "tsm_patched=%s core_patched=%s timeout_s=%.1f",
+                tsm_patched,
+                core_patched,
+                timeout_s,
+            )
 
-        threading.Thread(target=_worker, name="activation-snapshot-bridge-autowire", daemon=True).start()
+        threading.Thread(
+            target=_worker,
+            name="activation-snapshot-bridge-autowire",
+            daemon=True,
+        ).start()

--- a/bot/adaptive_profit_exit_v74_patch.py
+++ b/bot/adaptive_profit_exit_v74_patch.py
@@ -1,0 +1,371 @@
+"""Adaptive, fee-safe profit exit authority v74.
+
+The existing v68 net-profit floor is the economic floor for a winning exit.  In
+strong favorable regimes, however, treating that floor as an immediate fixed TP
+can truncate extended trends.  v74 converts that floor into a trailing
+*activation* threshold only when all of the following are proven:
+
+* the exit is a normal profit exit (never a protective stop/emergency exit);
+* the market has already crossed the v68 fee/slippage-adjusted net-profit floor;
+* the current regime is favorable to the position and confidence is sufficient;
+* a scoped high-water mark can be maintained for account + broker + position.
+
+The giveback distance is volatility/regime adaptive using ATR when available and
+is bounded.  If the regime weakens after arming, NIJA banks the already-proven
+net profit rather than waiting for a wider trend trail.
+
+Learning is conservative and account/broker/regime scoped.  Confirmed closed
+trades update realized outcome statistics.  Automatic trail adaptation is
+sample-gated and bounded to +/-10%; hard risk limits, writer authority, broker
+state, and entry rules are never learned away.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+from bot import universal_net_profit_exit_floor_v68_patch as v68
+
+LOGGER = logging.getLogger("nija.adaptive_profit_exit_v74")
+MARKER = "20260809-adaptive-profit-exit-v74"
+_PATCH_ATTR = "_nija_adaptive_profit_exit_v74"
+_LOCK = threading.RLock()
+_STATE_KEY = "_NIJA_ADAPTIVE_PROFIT_EXIT_V74_STATE"
+if not hasattr(builtins, _STATE_KEY):
+    setattr(builtins, _STATE_KEY, {"positions": {}, "stats": {}})
+_STATE: dict[str, Any] = getattr(builtins, _STATE_KEY)
+_POSITIONS: dict[str, dict[str, Any]] = _STATE["positions"]
+_STATS: dict[str, dict[str, float]] = _STATE["stats"]
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _account(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> str:
+    for value in (
+        pos.get("account_id"), pos.get("user_id"), pos.get("account_name"),
+        getattr(broker, "account_id", None), getattr(broker, "user_id", None),
+        getattr(broker, "account_name", None),
+    ):
+        text = str(value or "").strip().lower()
+        if text:
+            return text
+    return "platform"
+
+
+def _position_key(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> str:
+    venue = v68._broker_label(universal, broker)
+    account = _account(universal, broker, pos)
+    symbol = universal.auto_exit._sym(pos.get("symbol"))
+    pid = str(pos.get("position_id") or pos.get("id") or symbol).strip()
+    return f"{account}:{venue}:{pid}:{symbol}"
+
+
+def _regime_snapshot(pos: Mapping[str, Any]) -> tuple[str, float]:
+    explicit = str(pos.get("market_regime") or pos.get("regime") or "").strip().lower()
+    explicit_conf = _f(pos.get("regime_confidence"), 0.0)
+    if explicit:
+        return explicit, max(0.0, min(1.0, explicit_conf or 0.60))
+    try:
+        module = importlib.import_module("bot.regime_intelligence")
+        engine = module.get_regime_intelligence_engine()
+        snap = engine.get_current_regime()
+        if snap is not None:
+            label = str(getattr(getattr(snap, "regime", ""), "value", getattr(snap, "regime", ""))).strip().lower()
+            return label or "unknown", max(0.0, min(1.0, _f(getattr(snap, "confidence", 0.0))))
+    except Exception:
+        pass
+    return "unknown", 0.0
+
+
+def _atr_pct(pos: Mapping[str, Any], entry: float) -> float:
+    direct = max(
+        _f(pos.get("atr_pct")),
+        _f(pos.get("atr_percent")) / 100.0 if _f(pos.get("atr_percent")) > 1.0 else _f(pos.get("atr_percent")),
+        _f(pos.get("volatility_pct")) / 100.0 if _f(pos.get("volatility_pct")) > 1.0 else _f(pos.get("volatility_pct")),
+    )
+    if direct > 0.0:
+        return direct
+    atr = max(_f(pos.get("atr")), _f(pos.get("current_atr")), _f(pos.get("entry_atr")))
+    if atr > 0.0 and entry > 0.0:
+        return atr / entry
+    return 0.0
+
+
+def _baseline_multiplier(regime: str) -> float:
+    defaults = {
+        "bull_trending": 1.50,
+        "bear_trending": 1.50,
+        "breakout": 2.00,
+        "volatile": 2.00,
+        "ranging": 0.90,
+        "unknown": 1.20,
+    }
+    try:
+        module = importlib.import_module("bot.regime_intelligence")
+        enum_cls = getattr(module, "Regime")
+        regime_enum = enum_cls(regime)
+        params = module.get_regime_intelligence_engine().get_regime_parameters(regime_enum)
+        value = _f(getattr(params, "trailing_stop_atr_multiplier", 0.0))
+        if value > 0.0:
+            return value
+    except Exception:
+        pass
+    return defaults.get(regime, 1.20)
+
+
+def _scope_key(universal: ModuleType, broker: Any, pos: Mapping[str, Any], regime: str) -> str:
+    return f"{_account(universal, broker, pos)}:{v68._broker_label(universal, broker)}:{regime}"
+
+
+def _learning_factor(universal: ModuleType, broker: Any, pos: Mapping[str, Any], regime: str) -> float:
+    key = _scope_key(universal, broker, pos, regime)
+    with _LOCK:
+        stats = dict(_STATS.get(key, {}) or {})
+    trades = int(stats.get("trades", 0.0) or 0.0)
+    if trades < max(20, int(_f(os.environ.get("NIJA_EXIT_LEARNING_MIN_TRADES"), 30.0))):
+        return 1.0
+    wins = float(stats.get("wins", 0.0) or 0.0)
+    pnl = float(stats.get("total_pnl", 0.0) or 0.0)
+    win_rate = wins / trades if trades > 0 else 0.0
+    avg_pnl = pnl / trades if trades > 0 else 0.0
+    # Bounded adaptation only.  A weak realized history tightens giveback;
+    # a strong history permits a little more room for trend continuation.
+    if avg_pnl <= 0.0 or win_rate < 0.45:
+        return 0.90
+    if avg_pnl > 0.0 and win_rate >= 0.60:
+        return 1.10
+    return 1.0
+
+
+def _trail_pct(universal: ModuleType, broker: Any, pos: Mapping[str, Any], regime: str, entry: float) -> float:
+    atr_pct = _atr_pct(pos, entry)
+    base = atr_pct * _baseline_multiplier(regime) if atr_pct > 0.0 else _f(
+        os.environ.get("NIJA_ADAPTIVE_EXIT_DEFAULT_TRAIL_PCT"), 0.015
+    )
+    base *= _learning_factor(universal, broker, pos, regime)
+    low = max(0.0025, _f(os.environ.get("NIJA_ADAPTIVE_EXIT_MIN_TRAIL_PCT"), 0.0060))
+    high = min(0.15, max(low, _f(os.environ.get("NIJA_ADAPTIVE_EXIT_MAX_TRAIL_PCT"), 0.0600)))
+    return min(high, max(low, base))
+
+
+def _favorable_regime(regime: str, confidence: float, short: bool) -> bool:
+    minimum = max(0.50, min(0.95, _f(os.environ.get("NIJA_ADAPTIVE_EXIT_MIN_REGIME_CONFIDENCE"), 0.60)))
+    if confidence < minimum:
+        return False
+    if regime == "breakout":
+        return True
+    if short:
+        return regime == "bear_trending"
+    return regime == "bull_trending"
+
+
+def _update_peak(universal: ModuleType, broker: Any, pos: Mapping[str, Any], market: float, short: bool, regime: str) -> dict[str, Any]:
+    key = _position_key(universal, broker, pos)
+    with _LOCK:
+        state = _POSITIONS.setdefault(key, {"peak": market, "trough": market, "armed": False, "regime": regime})
+        state["peak"] = max(_f(state.get("peak"), market), market)
+        state["trough"] = min(_f(state.get("trough"), market), market)
+        state["regime"] = regime
+        state["market"] = market
+        state["short"] = short
+        return dict(state)
+
+
+def _giveback(state: Mapping[str, Any], market: float, short: bool) -> float:
+    if short:
+        trough = _f(state.get("trough"), market)
+        return max(0.0, (market - trough) / trough) if trough > 0.0 else 0.0
+    peak = _f(state.get("peak"), market)
+    return max(0.0, (peak - market) / peak) if peak > 0.0 else 0.0
+
+
+def _arm(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> None:
+    key = _position_key(universal, broker, pos)
+    with _LOCK:
+        _POSITIONS.setdefault(key, {})["armed"] = True
+
+
+def _is_armed(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> bool:
+    key = _position_key(universal, broker, pos)
+    with _LOCK:
+        return bool((_POSITIONS.get(key) or {}).get("armed", False))
+
+
+def _patch_universal(module: ModuleType) -> bool:
+    current = getattr(module, "_trigger", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def adaptive_trigger(broker: Any, pos: dict[str, Any], market: float):
+        hit, reason, target = current(broker, pos, market)
+        kind = v68._reason_kind(reason) if hit else "none"
+        if hit and kind == "protective":
+            return hit, reason, target
+
+        break_even, net_target, details = v68._floors(module, broker, pos)
+        entry = _f(details.get("entry")) if details else module.auto_exit._entry_price(pos)
+        if entry <= 0.0 or break_even <= 0.0 or net_target <= 0.0:
+            return hit, reason, target
+        short = bool(details.get("short"))
+        regime, confidence = _regime_snapshot(pos)
+        state = _update_peak(module, broker, pos, market, short, regime)
+        favorable = _favorable_regime(regime, confidence, short)
+        profitable = v68._meets(market, net_target, short)
+
+        # In a strong favorable regime, the v68 net-profit target becomes the
+        # activation floor for a volatility-aware trailing exit.
+        if profitable and favorable:
+            if not _is_armed(module, broker, pos):
+                _arm(module, broker, pos)
+                LOGGER.critical(
+                    "ADAPTIVE_PROFIT_EXIT_V74_ARMED marker=%s venue=%s account=%s symbol=%s "
+                    "regime=%s confidence=%.3f market=%.8f net_floor=%.8f",
+                    MARKER, v68._broker_label(module, broker), _account(module, broker, pos),
+                    module.auto_exit._sym(pos.get("symbol")), regime, confidence, market, net_target,
+                )
+            state = _update_peak(module, broker, pos, market, short, regime)
+            trail = _trail_pct(module, broker, pos, regime, entry)
+            giveback = _giveback(state, market, short)
+            if giveback >= trail and v68._meets(market, break_even, short):
+                LOGGER.critical(
+                    "ADAPTIVE_PROFIT_EXIT_V74_TRIGGERED marker=%s venue=%s account=%s symbol=%s "
+                    "reason=volatility_trailing_profit regime=%s confidence=%.3f giveback=%.5f trail=%.5f "
+                    "market=%.8f break_even=%.8f",
+                    MARKER, v68._broker_label(module, broker), _account(module, broker, pos),
+                    module.auto_exit._sym(pos.get("symbol")), regime, confidence, giveback, trail,
+                    market, break_even,
+                )
+                return True, "adaptive_volatility_trailing_profit", break_even
+            # Suppress a normal fixed TP while a high-confidence favorable trend
+            # remains intact.  Existing trailing/protective triggers are not suppressed.
+            if kind in {"profit", "other", "none"}:
+                return False, "", 0.0
+
+        # Once armed, a regime deterioration is itself a reason to bank the
+        # already-proven net profit rather than giving back a former trend.
+        if _is_armed(module, broker, pos) and not favorable and v68._meets(market, break_even, short):
+            LOGGER.critical(
+                "ADAPTIVE_PROFIT_EXIT_V74_REGIME_EXIT marker=%s venue=%s account=%s symbol=%s "
+                "regime=%s confidence=%.3f market=%.8f break_even=%.8f",
+                MARKER, v68._broker_label(module, broker), _account(module, broker, pos),
+                module.auto_exit._sym(pos.get("symbol")), regime, confidence, market, break_even,
+            )
+            return True, "adaptive_regime_profit_exit", break_even
+
+        return hit, reason, target
+
+    setattr(adaptive_trigger, _PATCH_ATTR, True)
+    setattr(adaptive_trigger, "__wrapped__", current)
+    module._trigger = adaptive_trigger
+    LOGGER.critical(
+        "ADAPTIVE_PROFIT_EXIT_V74_PATCHED marker=%s module=%s "
+        "net_floor_activation=true volatility_trailing=true protective_exits_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def record_confirmed_exit(universal: ModuleType, broker: Any, pos: Mapping[str, Any], fill_price: float, fee: float = 0.0) -> None:
+    entry = universal.auto_exit._entry_price(dict(pos))
+    qty = universal.auto_exit._quantity(dict(pos))
+    if entry <= 0.0 or qty <= 0.0 or fill_price <= 0.0:
+        return
+    short = universal.auto_exit._side(pos.get("side"), dict(pos)) in {"short", "sell"}
+    gross = (entry - fill_price) * qty if short else (fill_price - entry) * qty
+    pnl = gross - max(0.0, fee)
+    regime, _confidence = _regime_snapshot(pos)
+    key = _scope_key(universal, broker, pos, regime)
+    with _LOCK:
+        stats = _STATS.setdefault(key, {"trades": 0.0, "wins": 0.0, "total_pnl": 0.0})
+        stats["trades"] = float(stats.get("trades", 0.0) or 0.0) + 1.0
+        if pnl > 0.0:
+            stats["wins"] = float(stats.get("wins", 0.0) or 0.0) + 1.0
+        stats["total_pnl"] = float(stats.get("total_pnl", 0.0) or 0.0) + pnl
+        _POSITIONS.pop(_position_key(universal, broker, pos), None)
+    LOGGER.info(
+        "ADAPTIVE_PROFIT_EXIT_V74_LEARNED marker=%s scope=%s regime=%s pnl=%+.4f confirmed_fill=true",
+        MARKER, key, regime, pnl,
+    )
+
+
+def _patch_mark_closed(module: ModuleType) -> bool:
+    current = getattr(module, "_mark_closed", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return bool(callable(current))
+
+    @wraps(current)
+    def mark_closed_learning(broker: Any, pos: dict[str, Any], order: dict[str, Any], reason: str, market: float):
+        result = current(broker, pos, order, reason, market)
+        fill = _f(module.auto_exit._get(order, "filled_price", "average_fill_price", "avg_price", "price", default=market), market)
+        fee = _f(module.auto_exit._get(order, "fee", "commission", "fees", default=0.0), 0.0)
+        record_confirmed_exit(module, broker, pos, fill, fee)
+        return result
+
+    setattr(mark_closed_learning, _PATCH_ATTR, True)
+    setattr(mark_closed_learning, "__wrapped__", current)
+    module._mark_closed = mark_closed_learning
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.universal_broker_exit_supervisor_patch", "universal_broker_exit_supervisor_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_universal(module) or changed
+            changed = _patch_mark_closed(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        v68.install_import_hook()
+        _patch_loaded()
+        flag = "_NIJA_ADAPTIVE_PROFIT_EXIT_V74_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "universal_broker_exit" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_ADAPTIVE_PROFIT_EXIT_V74_INSTALLED"] = "1"
+        LOGGER.critical(
+            "ADAPTIVE_PROFIT_EXIT_V74_INSTALLED marker=%s sample_gated_learning=true hard_risk_learning=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER", "install", "install_import_hook", "record_confirmed_exit",
+    "_trail_pct", "_favorable_regime", "_learning_factor", "_POSITIONS", "_STATS",
+]

--- a/bot/broker_account_isolation_v64_patch.py
+++ b/bot/broker_account_isolation_v64_patch.py
@@ -1,0 +1,531 @@
+"""Broker/account risk isolation v64.
+
+Production on 2026-08-09 proved that a shared TradingStrategy/APEX instance was
+bleeding broker-local state across independent broker threads.  A Coinbase
+cycle with about $95 of equity was evaluated against an OKX-derived peak near
+$145, so the system-wide drawdown breaker saw a false ~34% drawdown and wrote
+EMERGENCY_STOP even though canonical CapitalAuthority held about $240 across
+both funded platform brokers.
+
+This patch is deliberately correctness-first:
+
+* A shared TradingStrategy instance is serialized while one broker/account
+  cycle owns its mutable APEX/CoreLoop state.  This prevents another broker
+  thread from replacing ``apex.broker_client`` or ``_last_account_balance``
+  halfway through a scan/order decision.
+* The caller-selected broker is pinned before the cycle and its own hydrated
+  balance is preferred over the shared APEX last-balance cache.
+* Platform drawdown is evaluated only from a fresh canonical portfolio-equity
+  snapshot from CapitalAuthority.  A broker-local balance is never compared to
+  another platform broker's peak.
+* User/account drawdown peaks are stored by canonical account identity and never
+  fire the process-wide KillSwitch.  One user account cannot halt every other
+  user or the NIJA platform account.
+* Daily PnL used by the risk controller is isolated by the same account scope
+  while the shared legacy APEX object remains in use.
+
+The patch does NOT fabricate capital, clear an existing manual/drawdown kill
+switch, bypass writer authority, relax risk thresholds, or force a trade.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Dict, Optional, Tuple
+
+LOGGER = logging.getLogger("nija.broker_account_isolation_v64")
+MARKER = "20260809-broker-account-risk-isolation-v64"
+
+_INSTALL_LOCK = threading.RLock()
+_CTX = threading.local()
+_SCOPE_LOCK = threading.RLock()
+_USER_SCOPE_STATE: Dict[str, Dict[str, float]] = {}
+_SCOPE_DAILY_PNL: Dict[str, float] = {}
+_PLATFORM_BREAKER: Any = None
+
+_TS_PATCH_ATTR = "_nija_broker_account_isolation_v64"
+_DRC_PATCH_ATTR = "_nija_scope_drawdown_isolation_v64"
+_APEX_PATCH_ATTR = "_nija_scope_daily_pnl_isolation_v64"
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _broker_name(broker: Any) -> str:
+    if broker is None:
+        return "unknown"
+    broker_type = getattr(broker, "broker_type", None)
+    raw = getattr(broker_type, "value", broker_type)
+    name = _clean(raw)
+    if name:
+        return name
+    return type(broker).__name__.replace("Broker", "").strip().lower() or "unknown"
+
+
+def _account_id(broker: Any) -> str:
+    for attr in ("account_identifier", "account_id", "user_id", "client_id"):
+        raw = _clean(getattr(broker, attr, ""))
+        if raw and raw not in {"none", "null"}:
+            return raw
+    return ""
+
+
+def _scope_for_broker(broker: Any) -> Tuple[str, bool]:
+    """Return (scope_id, is_platform_scope)."""
+    name = _broker_name(broker)
+    account = _account_id(broker)
+    if not account or account in {"platform", name}:
+        return "platform", True
+    return f"account:{account}:{name}", False
+
+
+def _finite_positive(value: Any) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return result if math.isfinite(result) and result > 0.0 else 0.0
+
+
+def _canonical_platform_equity() -> Tuple[bool, float, int, str]:
+    """Read fresh portfolio equity from canonical CapitalAuthority only."""
+    module = None
+    for name in ("bot.capital_authority", "capital_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            break
+    if not isinstance(module, ModuleType):
+        try:
+            module = importlib.import_module("bot.capital_authority")
+        except Exception as exc:
+            return False, 0.0, 0, f"capital_authority_unavailable:{type(exc).__name__}"
+
+    getter = getattr(module, "get_capital_authority", None)
+    if not callable(getter):
+        return False, 0.0, 0, "capital_authority_getter_missing"
+    try:
+        authority = getter()
+    except Exception as exc:
+        return False, 0.0, 0, f"capital_authority_get_failed:{type(exc).__name__}"
+
+    hydrated = bool(getattr(authority, "is_hydrated", False))
+    stale = True
+    stale_probe = getattr(authority, "is_stale", None)
+    if callable(stale_probe):
+        try:
+            stale = bool(stale_probe())
+        except Exception:
+            stale = True
+    else:
+        stale = bool(getattr(authority, "stale", True))
+
+    equity = 0.0
+    real_capital = getattr(authority, "get_real_capital", None)
+    if callable(real_capital):
+        try:
+            equity = _finite_positive(real_capital())
+        except Exception:
+            equity = 0.0
+    if equity <= 0.0:
+        for attr in ("real_capital", "total_capital", "total_balance", "balance"):
+            equity = max(equity, _finite_positive(getattr(authority, attr, 0.0)))
+
+    valid_brokers = 0
+    for attr in ("registered_broker_count", "valid_broker_count"):
+        try:
+            valid_brokers = max(valid_brokers, int(getattr(authority, attr, 0) or 0))
+        except (TypeError, ValueError):
+            pass
+    for attr in ("broker_balances", "_broker_balances", "balances"):
+        values = getattr(authority, attr, None)
+        if isinstance(values, dict):
+            count = 0
+            for value in values.values():
+                if isinstance(value, dict):
+                    candidates = (
+                        value.get("trading_balance"),
+                        value.get("total_funds"),
+                        value.get("available"),
+                        value.get("balance"),
+                    )
+                    amount = max((_finite_positive(v) for v in candidates), default=0.0)
+                else:
+                    amount = _finite_positive(value)
+                if amount > 0.0:
+                    count += 1
+            valid_brokers = max(valid_brokers, count)
+
+    if not hydrated:
+        return False, equity, valid_brokers, "capital_not_hydrated"
+    if stale:
+        return False, equity, valid_brokers, "capital_snapshot_stale"
+    if equity <= 0.0:
+        return False, equity, valid_brokers, "capital_nonpositive"
+    if valid_brokers <= 0:
+        return False, equity, valid_brokers, "valid_broker_count_zero"
+    return True, equity, valid_brokers, "canonical_capital_authority"
+
+
+def _level_from_drawdown(drawdown_pct: float) -> Tuple[str, float, bool]:
+    if drawdown_pct >= 20.0:
+        return "HALT", 0.0, True
+    if drawdown_pct >= 15.0:
+        return "DANGER", 0.25, False
+    if drawdown_pct >= 10.0:
+        return "WARNING", 0.50, False
+    if drawdown_pct >= 5.0:
+        return "CAUTION", 0.75, False
+    return "CLEAR", 1.0, False
+
+
+def _user_scope_drawdown(scope: str, equity: float) -> Tuple[str, float, bool, str]:
+    """Account-local drawdown.  Never activates the process-wide KillSwitch."""
+    if equity <= 0.0:
+        return "UNKNOWN", 0.0, True, f"account drawdown blocked: nonpositive equity scope={scope}"
+    with _SCOPE_LOCK:
+        state = _USER_SCOPE_STATE.setdefault(scope, {"peak": equity, "current": equity})
+        peak = max(_finite_positive(state.get("peak")), equity)
+        state["peak"] = peak
+        state["current"] = equity
+    drawdown_pct = max(0.0, ((peak - equity) / peak) * 100.0) if peak > 0.0 else 0.0
+    level, mult, halted = _level_from_drawdown(drawdown_pct)
+    if halted:
+        LOGGER.critical(
+            "ACCOUNT_DRAWDOWN_V64_HALT marker=%s scope=%s drawdown_pct=%.2f equity=%.2f peak=%.2f "
+            "global_kill_switch=false isolated=true",
+            MARKER,
+            scope,
+            drawdown_pct,
+            equity,
+            peak,
+        )
+    return level, mult, halted, (
+        f"AccountDrawdown scope={scope} drawdown={drawdown_pct:.1f}%"
+        if halted
+        else ""
+    )
+
+
+def _platform_scope_drawdown(account_balance: float) -> Tuple[str, float, bool, str]:
+    """Use canonical aggregate equity; never substitute one broker's balance."""
+    global _PLATFORM_BREAKER
+    ok, equity, valid_brokers, reason = _canonical_platform_equity()
+    if not ok:
+        LOGGER.error(
+            "PLATFORM_DRAWDOWN_V64_BLOCKED marker=%s reason=%s broker_balance=%.2f "
+            "canonical_equity=%.2f valid_brokers=%d action=block_entries_no_kill_switch",
+            MARKER,
+            reason,
+            float(account_balance or 0.0),
+            equity,
+            valid_brokers,
+        )
+        return "UNKNOWN", 0.0, True, f"canonical portfolio equity unavailable:{reason}"
+
+    with _SCOPE_LOCK:
+        if _PLATFORM_BREAKER is None:
+            try:
+                module = importlib.import_module("bot.global_drawdown_circuit_breaker")
+            except ImportError:
+                module = importlib.import_module("global_drawdown_circuit_breaker")
+            cls = getattr(module, "GlobalDrawdownCircuitBreaker")
+            _PLATFORM_BREAKER = cls()
+            _PLATFORM_BREAKER.initialise(starting_equity=equity)
+        breaker = _PLATFORM_BREAKER
+
+    decision = breaker.update_equity(equity)
+    level = str(getattr(getattr(decision, "level", "CLEAR"), "value", getattr(decision, "level", "CLEAR")))
+    level = level.split(".")[-1].upper()
+    LOGGER.info(
+        "PLATFORM_DRAWDOWN_V64_EVALUATED marker=%s canonical_equity=%.2f broker_balance_ignored=%.2f "
+        "valid_brokers=%d level=%s drawdown_pct=%.2f",
+        MARKER,
+        equity,
+        float(account_balance or 0.0),
+        valid_brokers,
+        level,
+        float(getattr(decision, "drawdown_pct", 0.0) or 0.0),
+    )
+    if not bool(getattr(decision, "allow_new_entries", True)):
+        return level, 0.0, True, (
+            f"Platform portfolio drawdown halted: {float(getattr(decision, 'drawdown_pct', 0.0) or 0.0):.1f}%"
+        )
+    return level, float(getattr(decision, "position_size_multiplier", 1.0) or 1.0), False, ""
+
+
+def _patch_drawdown_module(module: ModuleType) -> bool:
+    cls = getattr(module, "DrawdownRiskController", None)
+    if not isinstance(cls, type):
+        return False
+    original_layer = getattr(cls, "_layer_drawdown", None)
+    original_pre = getattr(cls, "pre_entry_check", None)
+    if not callable(original_layer) or not callable(original_pre):
+        return False
+    if getattr(original_layer, _DRC_PATCH_ATTR, False):
+        return True
+
+    @wraps(original_layer)
+    def _layer_drawdown_scoped(self: Any, account_balance: float):
+        scope = str(getattr(_CTX, "scope", "") or "").strip()
+        if not scope:
+            return original_layer(self, account_balance)
+        if scope == "platform":
+            return _platform_scope_drawdown(account_balance)
+        return _user_scope_drawdown(scope, float(account_balance or 0.0))
+
+    @wraps(original_pre)
+    def _pre_entry_scoped(
+        self: Any,
+        account_balance: float,
+        df: Any,
+        indicators: Dict[str, Any],
+        daily_pnl_usd: float = 0.0,
+        regime: Any = None,
+        daily_loss_limit_pct: Optional[float] = None,
+    ):
+        scope = str(getattr(_CTX, "scope", "") or "").strip()
+        if scope:
+            with _SCOPE_LOCK:
+                daily_pnl_usd = float(_SCOPE_DAILY_PNL.get(scope, 0.0) or 0.0)
+        return original_pre(
+            self,
+            account_balance=account_balance,
+            df=df,
+            indicators=indicators,
+            daily_pnl_usd=daily_pnl_usd,
+            regime=regime,
+            daily_loss_limit_pct=daily_loss_limit_pct,
+        )
+
+    setattr(_layer_drawdown_scoped, _DRC_PATCH_ATTR, True)
+    setattr(cls, "_layer_drawdown", _layer_drawdown_scoped)
+    setattr(cls, "pre_entry_check", _pre_entry_scoped)
+    LOGGER.critical(
+        "BROKER_ACCOUNT_RISK_V64_DRAWDOWN_PATCHED marker=%s module=%s "
+        "platform_equity=canonical user_kill_switch=false scope_daily_pnl=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_apex_module(module: ModuleType) -> bool:
+    cls = getattr(module, "NIJAApexStrategyV71", None)
+    if not isinstance(cls, type):
+        return False
+    method = getattr(cls, "_update_safe_profit_mode", None)
+    if not callable(method) or getattr(method, _APEX_PATCH_ATTR, False):
+        return bool(getattr(method, _APEX_PATCH_ATTR, False))
+
+    @wraps(method)
+    def _update_scope_profit(self: Any, trade_pnl_usd: float) -> None:
+        scope = str(getattr(_CTX, "scope", "") or "").strip()
+        if not scope:
+            return method(self, trade_pnl_usd)
+        with _SCOPE_LOCK:
+            starting = float(_SCOPE_DAILY_PNL.get(scope, 0.0) or 0.0)
+        previous = float(getattr(self, "_daily_pnl_usd", 0.0) or 0.0)
+        setattr(self, "_daily_pnl_usd", starting)
+        try:
+            method(self, trade_pnl_usd)
+            updated = float(getattr(self, "_daily_pnl_usd", starting) or starting)
+            with _SCOPE_LOCK:
+                _SCOPE_DAILY_PNL[scope] = updated
+        finally:
+            setattr(self, "_daily_pnl_usd", previous)
+
+    setattr(_update_scope_profit, _APEX_PATCH_ATTR, True)
+    setattr(cls, "_update_safe_profit_mode", _update_scope_profit)
+    LOGGER.critical(
+        "BROKER_ACCOUNT_RISK_V64_PNL_PATCHED marker=%s module=%s scope_daily_pnl=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _broker_local_balance(strategy: Any, broker: Any) -> float:
+    if broker is None:
+        return 0.0
+    helper = getattr(strategy, "_broker_entry_balance", None)
+    if callable(helper):
+        try:
+            value = _finite_positive(helper(broker))
+            if value > 0.0:
+                return value
+        except Exception:
+            pass
+    for attr in ("_last_known_balance", "last_known_balance", "cached_balance", "balance"):
+        value = _finite_positive(getattr(broker, attr, 0.0))
+        if value > 0.0:
+            return value
+    return 0.0
+
+
+def _patch_trading_strategy_module(module: ModuleType) -> bool:
+    cls = getattr(module, "TradingStrategy", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "run_cycle", None)
+    if not callable(original) or getattr(original, _TS_PATCH_ATTR, False):
+        return bool(getattr(original, _TS_PATCH_ATTR, False))
+
+    @wraps(original)
+    def _isolated_run_cycle(self: Any, broker: Any = None, user_mode: bool = False) -> int:
+        lock = getattr(self, "_nija_shared_strategy_cycle_lock_v64", None)
+        if lock is None:
+            with _INSTALL_LOCK:
+                lock = getattr(self, "_nija_shared_strategy_cycle_lock_v64", None)
+                if lock is None:
+                    lock = threading.RLock()
+                    setattr(self, "_nija_shared_strategy_cycle_lock_v64", lock)
+
+        wait_started = time.monotonic()
+        with lock:
+            wait_s = max(0.0, time.monotonic() - wait_started)
+            scope, is_platform = _scope_for_broker(broker)
+            previous_scope = getattr(_CTX, "scope", "")
+            previous_broker = getattr(_CTX, "broker", None)
+            _CTX.scope = scope
+            _CTX.broker = broker
+
+            apex = getattr(self, "apex", None)
+            local_balance = _broker_local_balance(self, broker)
+            previous_balance = getattr(apex, "_last_account_balance", None) if apex is not None else None
+            previous_broker_client = getattr(apex, "broker_client", None) if apex is not None else None
+            previous_strategy_broker = getattr(self, "broker", None)
+            if broker is not None:
+                setattr(self, "broker", broker)
+            if apex is not None and broker is not None:
+                updater = getattr(apex, "update_broker_client", None)
+                if callable(updater):
+                    updater(broker)
+                else:
+                    setattr(apex, "broker_client", broker)
+                engine = getattr(apex, "execution_engine", None)
+                if engine is not None and hasattr(engine, "broker_client"):
+                    setattr(engine, "broker_client", broker)
+            if apex is not None and local_balance > 0.0:
+                setattr(apex, "_last_account_balance", local_balance)
+
+            LOGGER.critical(
+                "BROKER_ACCOUNT_CYCLE_V64_ENTER marker=%s scope=%s platform=%s broker=%s "
+                "broker_balance=%.2f lock_wait_s=%.3f shared_strategy_serialized=true",
+                MARKER,
+                scope,
+                str(is_platform).lower(),
+                _broker_name(broker),
+                local_balance,
+                wait_s,
+            )
+            try:
+                return int(original(self, broker=broker, user_mode=user_mode))
+            finally:
+                # Restore ambient mutable aliases so non-cycle background tasks do
+                # not inherit the identity of the last account that happened to run.
+                if apex is not None:
+                    if previous_broker_client is not None:
+                        updater = getattr(apex, "update_broker_client", None)
+                        if callable(updater):
+                            updater(previous_broker_client)
+                        else:
+                            setattr(apex, "broker_client", previous_broker_client)
+                    if previous_balance is not None:
+                        setattr(apex, "_last_account_balance", previous_balance)
+                setattr(self, "broker", previous_strategy_broker)
+                _CTX.scope = previous_scope
+                _CTX.broker = previous_broker
+                LOGGER.info(
+                    "BROKER_ACCOUNT_CYCLE_V64_EXIT marker=%s scope=%s broker=%s",
+                    MARKER,
+                    scope,
+                    _broker_name(broker),
+                )
+
+    setattr(_isolated_run_cycle, _TS_PATCH_ATTR, True)
+    setattr(cls, "run_cycle", _isolated_run_cycle)
+    LOGGER.critical(
+        "BROKER_ACCOUNT_CYCLE_V64_PATCHED marker=%s module=%s shared_strategy_serialized=true "
+        "broker_balance_source=broker_local",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name, module in list(sys.modules.items()):
+        if not isinstance(module, ModuleType):
+            continue
+        try:
+            if name in {"bot.drawdown_risk_controller", "drawdown_risk_controller"}:
+                changed = _patch_drawdown_module(module) or changed
+            elif name in {"bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"}:
+                changed = _patch_apex_module(module) or changed
+            elif name in {"bot.trading_strategy", "trading_strategy"}:
+                changed = _patch_trading_strategy_module(module) or changed
+        except Exception as exc:
+            LOGGER.warning(
+                "BROKER_ACCOUNT_ISOLATION_V64_PATCH_ERROR marker=%s module=%s error=%s:%s",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+            )
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _INSTALL_LOCK:
+        _patch_loaded()
+        flag = "_NIJA_BROKER_ACCOUNT_ISOLATION_V64_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            module = original_import(name, globals, locals, fromlist, level)
+            if any(
+                token in str(name)
+                for token in ("trading_strategy", "nija_apex_strategy_v71", "drawdown_risk_controller")
+            ):
+                _patch_loaded()
+            return module
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_BROKER_ACCOUNT_ISOLATION_V64_INSTALLED"] = "1"
+        LOGGER.critical(
+            "BROKER_ACCOUNT_ISOLATION_V64_INSTALLED marker=%s fail_closed=true "
+            "platform_drawdown=canonical account_kill_switch=false shared_strategy_serialized=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_platform_equity",
+    "_scope_for_broker",
+    "_user_scope_drawdown",
+    "_platform_scope_drawdown",
+    "_patch_drawdown_module",
+    "_patch_trading_strategy_module",
+]

--- a/bot/capital_refresh_stall_guard_v35.py
+++ b/bot/capital_refresh_stall_guard_v35.py
@@ -12,6 +12,9 @@ Safety properties
 * fallback preserves the original observation timestamp and age;
 * expired/untrusted fallback returns 0.0 so the coordinator excludes the broker
   instead of entering its legacy "previous authority balance" exception path;
+* broker-specific timeouts remain bounded but are long enough for observed live
+  authenticated balance latency (especially Coinbase and OKX);
+* the batch cycle deadline is never shorter than its slowest broker deadline;
 * fallback provenance is available to confidence/trace consumers;
 * no balance, authority, or writer gate is synthesized or bypassed.
 """
@@ -29,10 +32,11 @@ import time
 from dataclasses import dataclass
 from functools import wraps
 from types import ModuleType
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 LOGGER = logging.getLogger("nija.capital_refresh_stall_guard_v35")
 MARKER = "20260807-capital-refresh-provenance-v36"
+LATENCY_MARKER = "20260809-capital-refresh-live-latency-v62"
 _TARGETS = ("bot.capital_flow_state_machine", "capital_flow_state_machine")
 _LOCK = threading.RLock()
 _STARTED = False
@@ -79,33 +83,82 @@ def _freshness_ttl_seconds() -> float:
 
 
 def _timeout_seconds() -> float:
+    """Generic fallback timeout for unknown/low-latency brokers.
+
+    Keep the legacy environment variable authoritative when an operator sets it,
+    but use a safer 45 second default.  Production showed that an 8 second
+    default deterministically excluded healthy authenticated brokers whose live
+    balance calls regularly complete in tens of seconds.
+    """
     try:
-        return max(2.0, float(os.getenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "8.0") or 8.0))
+        return max(
+            2.0,
+            float(os.getenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "45.0") or 45.0),
+        )
     except (TypeError, ValueError):
-        return 8.0
+        return 45.0
+
+
+def _configured_broker_timeout(env_name: str, fallback_s: float) -> float:
+    raw = str(os.getenv(env_name, "") or "").strip()
+    if raw:
+        try:
+            return max(2.0, float(raw))
+        except (TypeError, ValueError):
+            pass
+    return max(_timeout_seconds(), float(fallback_s))
 
 
 def _broker_timeout_seconds(broker_id: str) -> float:
-    base = _timeout_seconds()
-    if str(broker_id).strip().lower() != "okx":
-        return base
-    try:
-        return max(base, float(os.getenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", str(base)) or base))
-    except (TypeError, ValueError):
-        return base
+    """Return a bounded timeout matched to observed authenticated venue latency.
+
+    These are waits for already-started daemon balance workers, not network
+    retries.  They do not turn stale data into fresh data and do not bypass the
+    freshness/empty-snapshot gates.  Operators can override each venue with the
+    dedicated environment variable.
+    """
+    bid = str(broker_id).strip().lower()
+    if bid == "coinbase":
+        # Production has shown successful Coinbase balance calls around 144s.
+        return _configured_broker_timeout("NIJA_CAPITAL_COINBASE_FETCH_TIMEOUT_S", 180.0)
+    if bid == "okx":
+        # Production has repeatedly shown successful OKX calls around 28-43s.
+        return _configured_broker_timeout("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", 75.0)
+    if bid == "kraken":
+        return _configured_broker_timeout("NIJA_CAPITAL_KRAKEN_FETCH_TIMEOUT_S", 75.0)
+    return _timeout_seconds()
 
 
-def _cycle_deadline_seconds() -> float:
-    try:
-        return max(_timeout_seconds() + 2.0, float(os.getenv("NIJA_CAPITAL_CYCLE_DEADLINE_S", "12.0") or 12.0))
-    except (TypeError, ValueError):
-        return _timeout_seconds() + 2.0
+def _cycle_deadline_seconds(broker_ids: Optional[Iterable[str]] = None) -> float:
+    """Return a bounded batch deadline that cannot undercut a broker timeout."""
+    ids = [str(value).strip().lower() for value in (broker_ids or ()) if str(value).strip()]
+    slowest = max((_broker_timeout_seconds(bid) for bid in ids), default=_timeout_seconds())
+    minimum_cycle_s = slowest + 5.0
+    raw = str(os.getenv("NIJA_CAPITAL_CYCLE_DEADLINE_S", "") or "").strip()
+    if raw:
+        try:
+            configured = max(2.0, float(raw))
+        except (TypeError, ValueError):
+            configured = minimum_cycle_s
+    else:
+        configured = minimum_cycle_s
+    # A stale legacy value such as 12s must never silently cap a 75s/180s
+    # broker timeout.  The per-broker timeout remains the primary hard bound.
+    return max(minimum_cycle_s, configured)
 
 
 def _coerce_scalar(value: Any) -> Optional[float]:
     try:
         if isinstance(value, dict):
-            scalar = float(value.get("trading_balance") or value.get("total_funds") or (float(value.get("usd", 0.0) or 0.0) + float(value.get("usdc", 0.0) or 0.0)) or 0.0)
+            scalar = float(
+                value.get("trading_balance")
+                or value.get("total_funds")
+                or (
+                    float(value.get("usd", 0.0) or 0.0)
+                    + float(value.get("usdc", 0.0) or 0.0)
+                )
+                or 0.0
+            )
         else:
             scalar = float(value)
     except (TypeError, ValueError, OverflowError):
@@ -129,30 +182,75 @@ def _status_from_context() -> Dict[str, Any]:
     excluded = dict(getattr(_REFRESH_CONTEXT, "excluded_brokers", {}) or {})
     live = dict(getattr(_REFRESH_CONTEXT, "live_brokers", {}) or {})
     ttl_s = _freshness_ttl_seconds()
-    all_recent = bool(used_fallback and fallbacks and not excluded and all(bool(record.get("observed")) and float(record.get("age_s", float("inf"))) <= ttl_s for record in fallbacks.values()))
-    source = "partial_or_excluded_fallback" if excluded else "cached_live_observation" if fallbacks else "live_exchange"
-    return {"used_fallback": used_fallback, "all_recent": all_recent, "freshness_ttl_s": ttl_s, "brokers": fallbacks, "excluded_brokers": excluded, "live_brokers": live, "source": source}
+    all_recent = bool(
+        used_fallback
+        and fallbacks
+        and not excluded
+        and all(
+            bool(record.get("observed"))
+            and float(record.get("age_s", float("inf"))) <= ttl_s
+            for record in fallbacks.values()
+        )
+    )
+    source = (
+        "partial_or_excluded_fallback"
+        if excluded
+        else "cached_live_observation"
+        if fallbacks
+        else "live_exchange"
+    )
+    return {
+        "used_fallback": used_fallback,
+        "all_recent": all_recent,
+        "freshness_ttl_s": ttl_s,
+        "brokers": fallbacks,
+        "excluded_brokers": excluded,
+        "live_brokers": live,
+        "source": source,
+    }
 
 
 def current_refresh_used_fallback() -> bool:
     if bool(getattr(_REFRESH_CONTEXT, "in_refresh", False)):
         return bool(getattr(_REFRESH_CONTEXT, "used_fallback", False))
-    return bool(dict(getattr(_REFRESH_CONTEXT, "last_status", {}) or {}).get("used_fallback", False))
+    return bool(
+        dict(getattr(_REFRESH_CONTEXT, "last_status", {}) or {}).get(
+            "used_fallback", False
+        )
+    )
 
 
-def current_refresh_fallback_status(freshness_ttl_s: Optional[float] = None) -> Dict[str, Any]:
+def current_refresh_fallback_status(
+    freshness_ttl_s: Optional[float] = None,
+) -> Dict[str, Any]:
     if bool(getattr(_REFRESH_CONTEXT, "in_refresh", False)):
         status = _status_from_context()
     else:
         status = dict(getattr(_REFRESH_CONTEXT, "last_status", {}) or {})
         if not status:
-            status = {"used_fallback": False, "all_recent": False, "freshness_ttl_s": _freshness_ttl_seconds(), "brokers": {}, "excluded_brokers": {}, "live_brokers": {}, "source": "live_exchange"}
+            status = {
+                "used_fallback": False,
+                "all_recent": False,
+                "freshness_ttl_s": _freshness_ttl_seconds(),
+                "brokers": {},
+                "excluded_brokers": {},
+                "live_brokers": {},
+                "source": "live_exchange",
+            }
     if freshness_ttl_s is not None:
         ttl_s = max(5.0, float(freshness_ttl_s))
         status["freshness_ttl_s"] = ttl_s
         fallbacks = dict(status.get("brokers", {}) or {})
         excluded = dict(status.get("excluded_brokers", {}) or {})
-        status["all_recent"] = bool(status.get("used_fallback") and fallbacks and not excluded and all(float(v.get("age_s", float("inf"))) <= ttl_s for v in fallbacks.values()))
+        status["all_recent"] = bool(
+            status.get("used_fallback")
+            and fallbacks
+            and not excluded
+            and all(
+                float(v.get("age_s", float("inf"))) <= ttl_s
+                for v in fallbacks.values()
+            )
+        )
     return status
 
 
@@ -161,17 +259,26 @@ class _BalanceFetchBatch:
 
     def __init__(self, broker_map: Dict[str, Any]) -> None:
         self._batch_started = time.monotonic()
-        self._cycle_deadline = self._batch_started + _cycle_deadline_seconds()
+        self._cycle_deadline = self._batch_started + _cycle_deadline_seconds(
+            broker_map.keys()
+        )
         self._flights: Dict[str, _Flight] = {}
 
         for broker_id, broker in broker_map.items():
-            bid = str(broker_id)
+            bid = str(broker_id).strip().lower()
             timeout_s = _broker_timeout_seconds(bid)
             with _IN_FLIGHT_LOCK:
                 existing = _IN_FLIGHT.get(bid)
                 if existing is not None and existing.thread.is_alive():
                     self._flights[bid] = existing
-                    LOGGER.debug("CAPITAL_REFRESH_INFLIGHT_REUSED marker=%s broker=%s seq=%d age_s=%.2f", MARKER, bid, existing.sequence, max(0.0, time.monotonic() - existing.started_monotonic))
+                    LOGGER.debug(
+                        "CAPITAL_REFRESH_INFLIGHT_REUSED marker=%s broker=%s seq=%d age_s=%.2f timeout_s=%.1f",
+                        MARKER,
+                        bid,
+                        existing.sequence,
+                        max(0.0, time.monotonic() - existing.started_monotonic),
+                        existing.timeout_s,
+                    )
                     continue
 
                 seq = _BROKER_SEQUENCE.get(bid, 0) + 1
@@ -179,7 +286,12 @@ class _BalanceFetchBatch:
                 result_queue: queue.Queue = queue.Queue(maxsize=1)
                 started = time.monotonic()
 
-                def _call(target: Any = broker, output: queue.Queue = result_queue, broker_seq: int = seq, broker_key: str = bid) -> None:
+                def _call(
+                    target: Any = broker,
+                    output: queue.Queue = result_queue,
+                    broker_seq: int = seq,
+                    broker_key: str = bid,
+                ) -> None:
                     observed_mono = 0.0
                     observed_epoch = 0.0
                     try:
@@ -192,14 +304,29 @@ class _BalanceFetchBatch:
                         with _OBSERVATION_LOCK:
                             previous = _OBSERVATIONS.get(broker_key)
                             if previous is None or broker_seq >= previous.sequence:
-                                _OBSERVATIONS[broker_key] = _Observation(value=scalar, observed_monotonic=observed_mono, observed_epoch=observed_epoch, sequence=broker_seq)
+                                _OBSERVATIONS[broker_key] = _Observation(
+                                    value=scalar,
+                                    observed_monotonic=observed_mono,
+                                    observed_epoch=observed_epoch,
+                                    sequence=broker_seq,
+                                )
                         try:
-                            output.put_nowait((True, value, broker_seq, observed_mono, observed_epoch))
+                            output.put_nowait(
+                                (
+                                    True,
+                                    value,
+                                    broker_seq,
+                                    observed_mono,
+                                    observed_epoch,
+                                )
+                            )
                         except queue.Full:
                             pass
                     except BaseException as exc:
                         try:
-                            output.put_nowait((False, exc, broker_seq, observed_mono, observed_epoch))
+                            output.put_nowait(
+                                (False, exc, broker_seq, observed_mono, observed_epoch)
+                            )
                         except queue.Full:
                             pass
                     finally:
@@ -208,24 +335,54 @@ class _BalanceFetchBatch:
                             if current is not None and current.sequence == broker_seq:
                                 _IN_FLIGHT.pop(broker_key, None)
 
-                thread = threading.Thread(target=_call, name=f"capital-balance-fetch-{bid}", daemon=True)
-                flight = _Flight(thread=thread, result_queue=result_queue, sequence=seq, started_monotonic=started, timeout_s=timeout_s)
+                thread = threading.Thread(
+                    target=_call,
+                    name=f"capital-balance-fetch-{bid}",
+                    daemon=True,
+                )
+                flight = _Flight(
+                    thread=thread,
+                    result_queue=result_queue,
+                    sequence=seq,
+                    started_monotonic=started,
+                    timeout_s=timeout_s,
+                )
                 _IN_FLIGHT[bid] = flight
                 self._flights[bid] = flight
                 thread.start()
+                LOGGER.info(
+                    "CAPITAL_REFRESH_FETCH_STARTED marker=%s latency_marker=%s broker=%s seq=%d timeout_s=%.1f cycle_remaining_s=%.1f",
+                    MARKER,
+                    LATENCY_MARKER,
+                    bid,
+                    seq,
+                    timeout_s,
+                    max(0.0, self._cycle_deadline - started),
+                )
 
     def result_for(self, broker_id: str, broker: Any) -> Any:
-        bid = str(broker_id)
+        bid = str(broker_id).strip().lower()
         flight = self._flights[bid]
         broker_deadline = flight.started_monotonic + flight.timeout_s
-        remaining = max(0.0, min(broker_deadline, self._cycle_deadline) - time.monotonic())
+        remaining = max(
+            0.0,
+            min(broker_deadline, self._cycle_deadline) - time.monotonic(),
+        )
         try:
-            ok, value, result_seq, observed_mono, observed_epoch = flight.result_queue.get(timeout=remaining)
+            ok, value, result_seq, observed_mono, observed_epoch = (
+                flight.result_queue.get(timeout=remaining)
+            )
         except queue.Empty:
             return self._handle_failure(bid, "timeout")
 
         if int(result_seq) != int(flight.sequence):
-            LOGGER.warning("CAPITAL_REFRESH_LATE_RESULT_DISCARDED marker=%s broker=%s result_seq=%s expected_seq=%s", MARKER, bid, result_seq, flight.sequence)
+            LOGGER.warning(
+                "CAPITAL_REFRESH_LATE_RESULT_DISCARDED marker=%s broker=%s result_seq=%s expected_seq=%s",
+                MARKER,
+                bid,
+                result_seq,
+                flight.sequence,
+            )
             return self._handle_failure(bid, "late_result")
         if not ok:
             return self._handle_failure(bid, f"exception:{type(value).__name__}")
@@ -234,11 +391,20 @@ class _BalanceFetchBatch:
             return self._handle_failure(bid, "invalid_payload")
 
         live = dict(getattr(_REFRESH_CONTEXT, "live_brokers", {}) or {})
-        live[bid] = {"value": scalar, "observed_monotonic": float(observed_mono), "observed_epoch": float(observed_epoch), "sequence": int(result_seq)}
+        live[bid] = {
+            "value": scalar,
+            "observed_monotonic": float(observed_mono),
+            "observed_epoch": float(observed_epoch),
+            "sequence": int(result_seq),
+        }
         _REFRESH_CONTEXT.live_brokers = live
         if _WAS_TIMING_OUT.get(bid):
             _WAS_TIMING_OUT[bid] = False
-            LOGGER.info("CAPITAL_REFRESH_BROKER_RECOVERED marker=%s broker=%s live_data_restored=true", MARKER, bid)
+            LOGGER.info(
+                "CAPITAL_REFRESH_BROKER_RECOVERED marker=%s broker=%s live_data_restored=true",
+                MARKER,
+                bid,
+            )
         return value
 
     def _handle_failure(self, broker_id: str, reason: str) -> float:
@@ -247,33 +413,68 @@ class _BalanceFetchBatch:
         ttl_s = _freshness_ttl_seconds()
         with _OBSERVATION_LOCK:
             observation = _OBSERVATIONS.get(broker_id)
-        age_s = max(0.0, now - observation.observed_monotonic) if observation is not None and observation.observed_monotonic > 0 else float("inf")
+        age_s = (
+            max(0.0, now - observation.observed_monotonic)
+            if observation is not None and observation.observed_monotonic > 0
+            else float("inf")
+        )
         fresh = bool(observation is not None and age_s <= ttl_s)
         last_logged = _LAST_TIMEOUT_LOGGED.get(broker_id, 0.0)
         suppress = (now - last_logged) < _TIMEOUT_LOG_DEDUP_S
         _WAS_TIMING_OUT[broker_id] = True
 
         if fresh and observation is not None:
-            fallbacks = dict(getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {})
-            fallbacks[broker_id] = {"value": observation.value, "age_s": age_s, "observed": True, "observed_epoch": observation.observed_epoch, "sequence": observation.sequence, "cached_valid": True, "reason": reason}
+            fallbacks = dict(
+                getattr(_REFRESH_CONTEXT, "fallback_brokers", {}) or {}
+            )
+            fallbacks[broker_id] = {
+                "value": observation.value,
+                "age_s": age_s,
+                "observed": True,
+                "observed_epoch": observation.observed_epoch,
+                "sequence": observation.sequence,
+                "cached_valid": True,
+                "reason": reason,
+            }
             _REFRESH_CONTEXT.fallback_brokers = fallbacks
             if not suppress:
                 _LAST_TIMEOUT_LOGGED[broker_id] = now
-                LOGGER.warning("CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s broker=%s reason=%s cached_payload=true cached_age_s=%.2f observed_epoch=%.6f source=cached_live_observation", MARKER, broker_id, reason, age_s, observation.observed_epoch)
+                LOGGER.warning(
+                    "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_FALLBACK marker=%s broker=%s reason=%s cached_payload=true cached_age_s=%.2f observed_epoch=%.6f source=cached_live_observation",
+                    MARKER,
+                    broker_id,
+                    reason,
+                    age_s,
+                    observation.observed_epoch,
+                )
             return float(observation.value)
 
         excluded = dict(getattr(_REFRESH_CONTEXT, "excluded_brokers", {}) or {})
-        excluded[broker_id] = {"age_s": age_s, "observed": observation is not None, "observed_epoch": observation.observed_epoch if observation is not None else 0.0, "reason": reason, "cached_valid": False}
+        excluded[broker_id] = {
+            "age_s": age_s,
+            "observed": observation is not None,
+            "observed_epoch": (
+                observation.observed_epoch if observation is not None else 0.0
+            ),
+            "reason": reason,
+            "cached_valid": False,
+        }
         _REFRESH_CONTEXT.excluded_brokers = excluded
         if not suppress:
             _LAST_TIMEOUT_LOGGED[broker_id] = now
-            LOGGER.error("CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_EXCLUDED marker=%s broker=%s reason=%s cached_payload=false cached_age_s=%s action=exclude_from_snapshot", MARKER, broker_id, reason, "inf" if not math.isfinite(age_s) else f"{age_s:.2f}")
+            LOGGER.error(
+                "CAPITAL_REFRESH_BROKER_FETCH_TIMEOUT_EXCLUDED marker=%s broker=%s reason=%s cached_payload=false cached_age_s=%s action=exclude_from_snapshot",
+                MARKER,
+                broker_id,
+                reason,
+                "inf" if not math.isfinite(age_s) else f"{age_s:.2f}",
+            )
         return 0.0
 
 
 class _BoundedBrokerProxy:
     def __init__(self, broker_id: str, broker: Any, batch: _BalanceFetchBatch) -> None:
-        object.__setattr__(self, "_broker_id", str(broker_id))
+        object.__setattr__(self, "_broker_id", str(broker_id).strip().lower())
         object.__setattr__(self, "_broker", broker)
         object.__setattr__(self, "_batch", batch)
 
@@ -284,7 +485,10 @@ class _BoundedBrokerProxy:
         setattr(object.__getattribute__(self, "_broker"), name, value)
 
     def get_account_balance(self) -> Any:
-        return object.__getattribute__(self, "_batch").result_for(object.__getattribute__(self, "_broker_id"), object.__getattribute__(self, "_broker"))
+        return object.__getattribute__(self, "_batch").result_for(
+            object.__getattribute__(self, "_broker_id"),
+            object.__getattribute__(self, "_broker"),
+        )
 
 
 def _patch(module: ModuleType) -> bool:
@@ -298,13 +502,30 @@ def _patch(module: ModuleType) -> bool:
         return True
 
     @wraps(original)
-    def _pipeline_with_bounded_brokers(self: Any, broker_map: Dict[str, Any], trigger: str, open_exposure_usd: float) -> Any:
+    def _pipeline_with_bounded_brokers(
+        self: Any,
+        broker_map: Dict[str, Any],
+        trigger: str,
+        open_exposure_usd: float,
+    ) -> Any:
         _begin_refresh_context()
-        live_map = {str(broker_id): broker for broker_id, broker in broker_map.items() if broker is not None}
+        live_map = {
+            str(broker_id).strip().lower(): broker
+            for broker_id, broker in broker_map.items()
+            if broker is not None
+        }
         batch = _BalanceFetchBatch(live_map)
-        bounded_map = {broker_id: _BoundedBrokerProxy(broker_id, broker, batch) for broker_id, broker in live_map.items()}
+        bounded_map = {
+            broker_id: _BoundedBrokerProxy(broker_id, broker, batch)
+            for broker_id, broker in live_map.items()
+        }
         try:
-            return original(self, broker_map=bounded_map, trigger=trigger, open_exposure_usd=open_exposure_usd)
+            return original(
+                self,
+                broker_map=bounded_map,
+                trigger=trigger,
+                open_exposure_usd=open_exposure_usd,
+            )
         finally:
             status = _status_from_context()
             _REFRESH_CONTEXT.last_status = status
@@ -319,7 +540,20 @@ def _patch(module: ModuleType) -> bool:
     cls._pipeline = _pipeline_with_bounded_brokers
     os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_PATCHED"] = "1"
     os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED"] = "1"
-    LOGGER.critical("CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED marker=%s module=%s per_broker_timeout_s=%.2f cycle_deadline_s=%.2f queue_reuse=true stale_authority_fallback=false", MARKER, module.__name__, _timeout_seconds(), _cycle_deadline_seconds())
+    os.environ["NIJA_CAPITAL_REFRESH_LIVE_LATENCY_V62_PATCHED"] = "1"
+    LOGGER.critical(
+        "CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED marker=%s latency_marker=%s module=%s "
+        "generic_timeout_s=%.1f coinbase_timeout_s=%.1f okx_timeout_s=%.1f kraken_timeout_s=%.1f "
+        "cycle_deadline_coinbase_okx_s=%.1f queue_reuse=true stale_authority_fallback=false",
+        MARKER,
+        LATENCY_MARKER,
+        module.__name__,
+        _timeout_seconds(),
+        _broker_timeout_seconds("coinbase"),
+        _broker_timeout_seconds("okx"),
+        _broker_timeout_seconds("kraken"),
+        _cycle_deadline_seconds(("coinbase", "okx")),
+    )
     return True
 
 
@@ -342,7 +576,13 @@ def install_import_hook() -> bool:
             original_import = builtins.__import__
 
             @wraps(original_import)
-            def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+            def importing(
+                name: str,
+                globals: Any = None,
+                locals: Any = None,
+                fromlist: Any = (),
+                level: int = 0,
+            ):
                 module = original_import(name, globals, locals, fromlist, level)
                 if str(name).endswith("capital_flow_state_machine"):
                     _patch_loaded()
@@ -367,7 +607,12 @@ def install_import_hook() -> bool:
         _STARTED = True
         os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V35_INSTALLED"] = "1"
         os.environ["NIJA_CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED"] = "1"
-        LOGGER.critical("CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED marker=%s safe_timeout_fallback=true", MARKER)
+        os.environ["NIJA_CAPITAL_REFRESH_LIVE_LATENCY_V62_INSTALLED"] = "1"
+        LOGGER.critical(
+            "CAPITAL_REFRESH_STALL_GUARD_V36_INSTALLED marker=%s latency_marker=%s safe_timeout_fallback=true broker_specific_deadlines=true",
+            MARKER,
+            LATENCY_MARKER,
+        )
         return True
 
 
@@ -375,4 +620,16 @@ def install() -> bool:
     return install_import_hook()
 
 
-__all__ = ["MARKER", "install", "install_import_hook", "current_refresh_used_fallback", "current_refresh_fallback_status", "_BalanceFetchBatch", "_BoundedBrokerProxy", "_patch"]
+__all__ = [
+    "MARKER",
+    "LATENCY_MARKER",
+    "install",
+    "install_import_hook",
+    "current_refresh_used_fallback",
+    "current_refresh_fallback_status",
+    "_BalanceFetchBatch",
+    "_BoundedBrokerProxy",
+    "_broker_timeout_seconds",
+    "_cycle_deadline_seconds",
+    "_patch",
+]

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -30,47 +30,6 @@ _BROKER_METHODS = _MARKET_METHODS + (
 )
 
 
-def _truthy_env(name: str, default: str = "false") -> bool:
-    return str(os.environ.get(name, default)).strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
-
-
-def _float_env(name: str, default: float) -> float:
-    try:
-        return float(os.environ.get(name, str(default)) or default)
-    except Exception:
-        return default
-
-
-def _norm(value: Any) -> str:
-    text = str(value or "").strip().lower()
-    compact = text.replace("-", "").replace("_", "").replace(" ", "")
-    aliases = {
-        "coinbasebrokeradapter": "coinbase",
-        "coinbasebroker": "coinbase",
-        "coinbaseadvancedtradebroker": "coinbase",
-        "coinbase": "coinbase",
-        "coinbasecapitalmarkets": "coinbase_capital_markets",
-        "coinbasecapitalmarketsbroker": "coinbase_capital_markets",
-        "krakenbrokeradapter": "kraken",
-        "krakenbroker": "kraken",
-        "kraken": "kraken",
-        "krakensecurities": "kraken_securities",
-        "krakensecuritiesbroker": "kraken_securities",
-        "okxbrokeradapter": "okx",
-        "okxbroker": "okx",
-        "okxrestclient": "okx",
-        "okx": "okx",
-        "binancebrokeradapter": "binance",
-        "binancebroker": "binance",
-        "binanceclient": "binance",
-        "binance": "binance",
-        "alpacabrokeradapter": "alpaca",
-        "alpacabroker": "alpaca",
-        "alpaca": "alpaca",
-    }
-    return aliases.get(compact, text)
-
-
 def _name(value: Any) -> str:
     raw = getattr(value, "value", value)
     text = str(raw or "").strip().lower()
@@ -99,7 +58,7 @@ def _is_broker_adapter(obj: Any) -> bool:
         return False
     if any(callable(getattr(obj, method, None)) for method in _BROKER_METHODS):
         return True
-    return _broker_name(obj) != "unknown" and _broker_name(obj) != "invalid"
+    return _broker_name(obj) not in {"unknown", "invalid"}
 
 
 def _candidate_brokers_from_owner(owner: Any) -> list[Any]:
@@ -139,7 +98,10 @@ def _resolve_broker(core_loop: Any, incoming: Any) -> Optional[Any]:
     if _is_broker_adapter(incoming):
         return incoming
     apex = getattr(core_loop, "apex", None)
-    selected = _name(os.environ.get("NIJA_SELECTED_EXECUTION_BROKER") or os.environ.get("NIJA_PRIMARY_EXECUTION_BROKER"))
+    selected = _name(
+        os.environ.get("NIJA_SELECTED_EXECUTION_BROKER")
+        or os.environ.get("NIJA_PRIMARY_EXECUTION_BROKER")
+    )
     candidates: list[Any] = []
     for owner in (apex, getattr(apex, "strategy", None), getattr(apex, "trading_strategy", None)):
         candidates.extend([b for b in _candidate_brokers_from_owner(owner) if b not in candidates])
@@ -164,23 +126,30 @@ def _patch_core_loop(module: ModuleType) -> bool:
                 broker = kwargs.get("broker")
                 resolved = _resolve_broker(self, broker)
                 if resolved is None:
-                    logger.error("CORE_LOOP_BROKER_ARGUMENT_GUARD_BLOCKED marker=20260705d reason=no_real_broker incoming_type=%s", type(broker).__name__)
+                    logger.error(
+                        "CORE_LOOP_BROKER_ARGUMENT_GUARD_BLOCKED marker=20260705d "
+                        "reason=no_real_broker incoming_type=%s",
+                        type(broker).__name__,
+                    )
                     return original_run(self, *args, **kwargs)
                 if resolved is not broker:
                     logger.warning(
-                        "CORE_LOOP_BROKER_ARGUMENT_GUARD_REPLACED marker=20260705d incoming_type=%s resolved=%s resolved_type=%s",
+                        "CORE_LOOP_BROKER_ARGUMENT_GUARD_REPLACED marker=20260705d "
+                        "incoming_type=%s resolved=%s resolved_type=%s",
                         type(broker).__name__,
                         _broker_name(resolved),
                         type(resolved).__name__,
                     )
                     kwargs["broker"] = resolved
                 return original_run(self, *args, **kwargs)
+
             args_list = list(args)
             broker = args_list[0] if args_list else None
             resolved = _resolve_broker(self, broker)
             if resolved is not None and resolved is not broker:
                 logger.warning(
-                    "CORE_LOOP_BROKER_ARGUMENT_GUARD_REPLACED marker=20260705d incoming_type=%s resolved=%s resolved_type=%s",
+                    "CORE_LOOP_BROKER_ARGUMENT_GUARD_REPLACED marker=20260705d "
+                    "incoming_type=%s resolved=%s resolved_type=%s",
                     type(broker).__name__,
                     _broker_name(resolved),
                     type(resolved).__name__,
@@ -201,11 +170,16 @@ def _patch_core_loop(module: ModuleType) -> bool:
         def fetch_df_guarded(self: Any, broker: Any, symbol: Any, *args: Any, **kwargs: Any):
             resolved = _resolve_broker(self, broker)
             if resolved is None:
-                logger.error("CORE_LOOP_FETCH_BROKER_GUARD_BLOCKED marker=20260705d symbol=%s incoming_type=%s", symbol, type(broker).__name__)
+                logger.error(
+                    "CORE_LOOP_FETCH_BROKER_GUARD_BLOCKED marker=20260705d symbol=%s incoming_type=%s",
+                    symbol,
+                    type(broker).__name__,
+                )
                 return original_fetch(self, broker, symbol, *args, **kwargs)
             if resolved is not broker:
                 logger.warning(
-                    "CORE_LOOP_FETCH_BROKER_GUARD_REPLACED marker=20260705d symbol=%s incoming_type=%s resolved=%s resolved_type=%s",
+                    "CORE_LOOP_FETCH_BROKER_GUARD_REPLACED marker=20260705d symbol=%s "
+                    "incoming_type=%s resolved=%s resolved_type=%s",
                     symbol,
                     type(broker).__name__,
                     _broker_name(resolved),
@@ -223,10 +197,20 @@ def _patch_core_loop(module: ModuleType) -> bool:
     return patched
 
 
+def _try_patch_loaded() -> bool:
+    patched = False
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_core_loop(module) or patched
+    return patched
+
+
 def _install_live_terminal_guards() -> None:
     """Install chained runtime guards alongside the broker guard."""
     for module_name in (
         "bot.broker_account_isolation_v64_patch",
+        "bot.profit_harvest_realization_guard_v66_patch",
         "bot.capital_authority_live_total_patch",
         "bot.execution_route_integrity_import_guard_patch",
         "bot.market_data_stability_import_guard_patch",
@@ -258,13 +242,11 @@ def install_import_hook() -> None:
         return
     original_import = builtins.__import__
 
+    @wraps(original_import)
     def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
         module = original_import(name, globals, locals, fromlist, level)
         try:
-            if name.endswith("nija_core_loop"):
-                _try_patch_loaded()
-            else:
-                _try_patch_loaded()
+            _try_patch_loaded()
         except Exception as exc:
             logger.warning("CORE_LOOP_BROKER_ARGUMENT_GUARD hook failed: %s", exc)
         return module

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -212,6 +212,7 @@ def _install_live_terminal_guards() -> None:
         "bot.broker_account_isolation_v64_patch",
         "bot.profit_harvest_realization_guard_v66_patch",
         "bot.universal_exit_fill_reconciliation_v67_patch",
+        "bot.universal_net_profit_exit_floor_v68_patch",
         "bot.capital_authority_live_total_patch",
         "bot.execution_route_integrity_import_guard_patch",
         "bot.market_data_stability_import_guard_patch",

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -30,6 +30,47 @@ _BROKER_METHODS = _MARKET_METHODS + (
 )
 
 
+def _truthy_env(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default)).strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except Exception:
+        return default
+
+
+def _norm(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    compact = text.replace("-", "").replace("_", "").replace(" ", "")
+    aliases = {
+        "coinbasebrokeradapter": "coinbase",
+        "coinbasebroker": "coinbase",
+        "coinbaseadvancedtradebroker": "coinbase",
+        "coinbase": "coinbase",
+        "coinbasecapitalmarkets": "coinbase_capital_markets",
+        "coinbasecapitalmarketsbroker": "coinbase_capital_markets",
+        "krakenbrokeradapter": "kraken",
+        "krakenbroker": "kraken",
+        "kraken": "kraken",
+        "krakensecurities": "kraken_securities",
+        "krakensecuritiesbroker": "kraken_securities",
+        "okxbrokeradapter": "okx",
+        "okxbroker": "okx",
+        "okxrestclient": "okx",
+        "okx": "okx",
+        "binancebrokeradapter": "binance",
+        "binancebroker": "binance",
+        "binanceclient": "binance",
+        "binance": "binance",
+        "alpacabrokeradapter": "alpaca",
+        "alpacabroker": "alpaca",
+        "alpaca": "alpaca",
+    }
+    return aliases.get(compact, text)
+
+
 def _name(value: Any) -> str:
     raw = getattr(value, "value", value)
     text = str(raw or "").strip().lower()
@@ -182,18 +223,10 @@ def _patch_core_loop(module: ModuleType) -> bool:
     return patched
 
 
-def _try_patch_loaded() -> bool:
-    patched = False
-    for name in ("bot.nija_core_loop", "nija_core_loop"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _patch_core_loop(module) or patched
-    return patched
-
-
 def _install_live_terminal_guards() -> None:
     """Install chained runtime guards alongside the broker guard."""
     for module_name in (
+        "bot.broker_account_isolation_v64_patch",
         "bot.capital_authority_live_total_patch",
         "bot.execution_route_integrity_import_guard_patch",
         "bot.market_data_stability_import_guard_patch",

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -211,6 +211,7 @@ def _install_live_terminal_guards() -> None:
     for module_name in (
         "bot.broker_account_isolation_v64_patch",
         "bot.profit_harvest_realization_guard_v66_patch",
+        "bot.universal_exit_fill_reconciliation_v67_patch",
         "bot.capital_authority_live_total_patch",
         "bot.execution_route_integrity_import_guard_patch",
         "bot.market_data_stability_import_guard_patch",

--- a/bot/core_loop_broker_argument_guard_patch.py
+++ b/bot/core_loop_broker_argument_guard_patch.py
@@ -209,6 +209,7 @@ def _try_patch_loaded() -> bool:
 def _install_live_terminal_guards() -> None:
     """Install chained runtime guards alongside the broker guard."""
     for module_name in (
+        "bot.deep_runtime_hardening_bundle_v70_patch",
         "bot.broker_account_isolation_v64_patch",
         "bot.profit_harvest_realization_guard_v66_patch",
         "bot.universal_exit_fill_reconciliation_v67_patch",

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -21,6 +21,7 @@ _MODULES = (
     "bot.universal_exit_fill_reconciliation_v67_patch",
     "bot.universal_net_profit_exit_floor_v68_patch",
     "bot.live_entry_expectancy_authority_v69_patch",
+    "bot.account_scoped_profit_state_v71_patch",
 )
 
 
@@ -57,7 +58,7 @@ def install_import_hook() -> bool:
         LOGGER.critical(
             "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
             "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
-            "live_entry_expectancy=true realized_profit_proof=true",
+            "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true",
             MARKER,
             len(installed),
         )

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -23,6 +23,7 @@ _MODULES = (
     "bot.live_entry_expectancy_authority_v69_patch",
     "bot.account_scoped_profit_state_v71_patch",
     "bot.live_exchange_constraints_authority_v72_patch",
+    "bot.live_exchange_base_minimum_v73_patch",
 )
 
 
@@ -60,7 +61,7 @@ def install_import_hook() -> bool:
             "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
             "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
             "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true "
-            "live_symbol_constraints=true",
+            "live_symbol_constraints=true post_rounding_base_minimum=true",
             MARKER,
             len(installed),
         )

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -1,0 +1,71 @@
+"""NIJA deep runtime hardening bundle v70.
+
+Single idempotent installer for the cross-cutting production hardening introduced
+while preparing NIJA for additional brokerages and user accounts.  Individual
+modules retain their own markers/tests and remain independently installable.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import threading
+
+LOGGER = logging.getLogger("nija.deep_runtime_hardening_bundle_v70")
+MARKER = "20260809-deep-runtime-hardening-bundle-v70"
+_LOCK = threading.RLock()
+_MODULES = (
+    "bot.broker_account_isolation_v64_patch",
+    "bot.profit_harvest_realization_guard_v66_patch",
+    "bot.universal_exit_fill_reconciliation_v67_patch",
+    "bot.universal_net_profit_exit_floor_v68_patch",
+    "bot.live_entry_expectancy_authority_v69_patch",
+)
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        installed: list[str] = []
+        failed: list[str] = []
+        for module_name in _MODULES:
+            try:
+                module = importlib.import_module(module_name)
+                installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+                if not callable(installer):
+                    raise RuntimeError("installer_missing")
+                installer()
+                installed.append(module_name)
+            except Exception as exc:
+                failed.append(f"{module_name}:{type(exc).__name__}:{exc}")
+                LOGGER.exception(
+                    "DEEP_RUNTIME_HARDENING_V70_COMPONENT_FAILED marker=%s module=%s",
+                    MARKER,
+                    module_name,
+                )
+        if failed:
+            os.environ["NIJA_DEEP_RUNTIME_HARDENING_V70_READY"] = "0"
+            LOGGER.critical(
+                "DEEP_RUNTIME_HARDENING_V70_INCOMPLETE marker=%s installed=%s failed=%s fail_closed=true",
+                MARKER,
+                installed,
+                failed,
+            )
+            return False
+        setattr(builtins, "_NIJA_DEEP_RUNTIME_HARDENING_BUNDLE_V70", True)
+        os.environ["NIJA_DEEP_RUNTIME_HARDENING_V70_READY"] = "1"
+        LOGGER.critical(
+            "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
+            "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
+            "live_entry_expectancy=true realized_profit_proof=true",
+            MARKER,
+            len(installed),
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -22,6 +22,7 @@ _MODULES = (
     "bot.universal_net_profit_exit_floor_v68_patch",
     "bot.live_entry_expectancy_authority_v69_patch",
     "bot.account_scoped_profit_state_v71_patch",
+    "bot.live_exchange_constraints_authority_v72_patch",
 )
 
 
@@ -58,7 +59,8 @@ def install_import_hook() -> bool:
         LOGGER.critical(
             "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
             "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
-            "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true",
+            "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true "
+            "live_symbol_constraints=true",
             MARKER,
             len(installed),
         )

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -24,6 +24,8 @@ _MODULES = (
     "bot.account_scoped_profit_state_v71_patch",
     "bot.live_exchange_constraints_authority_v72_patch",
     "bot.live_exchange_base_minimum_v73_patch",
+    "bot.adaptive_profit_exit_v74_patch",
+    "bot.held_position_exit_bootstrap_v75_patch",
 )
 
 
@@ -61,7 +63,8 @@ def install_import_hook() -> bool:
             "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
             "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
             "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true "
-            "live_symbol_constraints=true post_rounding_base_minimum=true",
+            "live_symbol_constraints=true post_rounding_base_minimum=true "
+            "adaptive_profit_exit=true held_positions_connected=true",
             MARKER,
             len(installed),
         )

--- a/bot/execution_bootstrap_monitor_iteration_guard_patch.py
+++ b/bot/execution_bootstrap_monitor_iteration_guard_patch.py
@@ -5,21 +5,37 @@ import logging
 import sys
 import threading
 import time
+from functools import wraps
 from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.execution_bootstrap_monitor_iteration_guard")
 _MARKER = "20260709a"
+_WRITER_V61_MARKER = "20260809-writer-scan-deadline-lease-guard-v61"
 _INSTALL_LOCK = threading.Lock()
 _MONITOR_STARTED = False
 _PATCHED_MODULES: set[str] = set()
+_WRITER_PATCHED_MODULES: set[str] = set()
+_WRITER_PATCH_ATTR = "_nija_scan_deadline_warning_only_v61"
 
 
 def _is_target_module(name: str, module: Any) -> bool:
     file_name = str(getattr(module, "__file__", "") or "")
     return (
-        name in {"nija_execution_bootstrap_authority_repair_patch", "bot.execution_bootstrap_authority_repair_patch", "execution_bootstrap_authority_repair_patch"}
+        name in {
+            "nija_execution_bootstrap_authority_repair_patch",
+            "bot.execution_bootstrap_authority_repair_patch",
+            "execution_bootstrap_authority_repair_patch",
+        }
         or file_name.endswith("execution_bootstrap_authority_repair_patch.py")
+    )
+
+
+def _is_writer_module(name: str, module: Any) -> bool:
+    file_name = str(getattr(module, "__file__", "") or "")
+    return (
+        name in {"bot.entrypoint_writer_authority", "entrypoint_writer_authority"}
+        or file_name.endswith("entrypoint_writer_authority.py")
     )
 
 
@@ -54,30 +70,117 @@ def _patch_target_module(module: ModuleType) -> bool:
                     patched = original_install(loaded_module) or patched
             except RuntimeError as exc:
                 if "dictionary changed size" in str(exc):
-                    logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_RETRY marker=%s err=%s", _MARKER, exc)
+                    logger.warning(
+                        "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_RETRY marker=%s err=%s",
+                        _MARKER,
+                        exc,
+                    )
                     continue
                 raise
             except Exception as exc:
-                logger.debug("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_SKIPPED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.debug(
+                    "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_SKIPPED marker=%s module=%s err=%s",
+                    _MARKER,
+                    name,
+                    exc,
+                )
         return patched
 
     setattr(_safe_try_patch_loaded, "_nija_monitor_iteration_guard_v20260709a", True)
     setattr(_safe_try_patch_loaded, "__wrapped__", current)
     setattr(module, "_try_patch_loaded", _safe_try_patch_loaded)
     _PATCHED_MODULES.add(str(getattr(module, "__name__", "<unknown>")))
-    logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "<unknown>"))
-    print(f"[NIJA-PRINT] EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_PATCHED marker={_MARKER} module={getattr(module, '__name__', '<unknown>')}", flush=True)
+    logger.warning(
+        "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_PATCHED marker=%s module=%s",
+        _MARKER,
+        getattr(module, "__name__", "<unknown>"),
+    )
+    print(
+        f"[NIJA-PRINT] EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_PATCHED "
+        f"marker={_MARKER} module={getattr(module, '__name__', '<unknown>')}",
+        flush=True,
+    )
+    return True
+
+
+def _patch_writer_module(module: ModuleType) -> bool:
+    """Keep the scan-start deadline diagnostic-only while startup is still running.
+
+    The canonical writer module already documents SCAN_STARTED_DEADLINE_EXCEEDED
+    as a warning that must not release the writer lease.  Production showed a
+    contradictory branch in ``_validate_core_thread_liveness``: when no core
+    thread had been registered yet, the scan deadline flag returned False and
+    the heartbeat then called ``_release_owned_lock_for_reelection``.  That
+    intentionally deleted a healthy Redis lock during slow broker/capital
+    bootstrap and caused the exact ``redis_lock_missing`` / fencing cascade.
+
+    v61 changes only that pre-core-thread case.  Once a core thread has actually
+    been registered, the original liveness method remains authoritative and a
+    dead thread still fails closed and releases writer authority as designed.
+    """
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "_validate_core_thread_liveness", None)
+    if not callable(original):
+        return False
+    if getattr(original, _WRITER_PATCH_ATTR, False):
+        _WRITER_PATCHED_MODULES.add(str(getattr(module, "__name__", "<unknown>")))
+        return True
+
+    @wraps(original)
+    def _warning_only_scan_deadline(self: Any) -> tuple[bool, str]:
+        thread = getattr(self, "_core_thread", None)
+        scan_started = float(getattr(self, "_scan_started_at", 0.0) or 0.0)
+        scan_deadline_exceeded = bool(getattr(self, "_scan_deadline_exceeded", False))
+        if thread is None and scan_deadline_exceeded and scan_started <= 0.0:
+            logger.critical(
+                "WRITER_V61_SCAN_DEADLINE_WARNING_ONLY marker=%s "
+                "core_thread_registered=false scan_started=false action=keep_renewing_writer "
+                "lease_release=false fail_closed_execution=true",
+                _WRITER_V61_MARKER,
+            )
+            return True, "scan_start_deadline_warning_only"
+        return original(self)
+
+    setattr(_warning_only_scan_deadline, _WRITER_PATCH_ATTR, True)
+    setattr(_warning_only_scan_deadline, "__wrapped__", original)
+    setattr(cls, "_validate_core_thread_liveness", _warning_only_scan_deadline)
+    _WRITER_PATCHED_MODULES.add(str(getattr(module, "__name__", "<unknown>")))
+    logger.critical(
+        "WRITER_V61_SCAN_DEADLINE_LEASE_GUARD_PATCHED marker=%s module=%s "
+        "pre_core_deadline_releases_lease=false registered_dead_core_still_fail_closed=true",
+        _WRITER_V61_MARKER,
+        getattr(module, "__name__", "<unknown>"),
+    )
     return True
 
 
 def _try_patch_loaded() -> bool:
     patched = False
     for name, module in _snapshot_modules():
-        if isinstance(module, ModuleType) and _is_target_module(name, module):
+        if not isinstance(module, ModuleType):
+            continue
+        if _is_target_module(name, module):
             try:
                 patched = _patch_target_module(module) or patched
             except Exception as exc:
-                logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.warning(
+                    "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_FAILED marker=%s module=%s err=%s",
+                    _MARKER,
+                    name,
+                    exc,
+                )
+        if _is_writer_module(name, module):
+            try:
+                patched = _patch_writer_module(module) or patched
+            except Exception as exc:
+                logger.warning(
+                    "WRITER_V61_SCAN_DEADLINE_LEASE_GUARD_FAILED marker=%s module=%s err=%s",
+                    _WRITER_V61_MARKER,
+                    name,
+                    exc,
+                )
     return patched
 
 
@@ -88,35 +191,83 @@ def _start_monitor() -> None:
     _MONITOR_STARTED = True
 
     def _monitor() -> None:
-        deadline = time.time() + float(__import__("os").environ.get("NIJA_PATCH_MONITOR_SECONDS", "300") or "300")
+        deadline = time.time() + float(
+            __import__("os").environ.get("NIJA_PATCH_MONITOR_SECONDS", "300") or "300"
+        )
         while time.time() < deadline:
-            if _try_patch_loaded():
+            _try_patch_loaded()
+            # Do not exit merely because the bootstrap-repair module was patched:
+            # entrypoint_writer_authority may load later in the startup sequence.
+            if _WRITER_PATCHED_MODULES:
                 return
             time.sleep(0.25)
-        logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_MONITOR_EXPIRED marker=%s patched_modules=%s", _MARKER, sorted(_PATCHED_MODULES))
+        logger.warning(
+            "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_MONITOR_EXPIRED marker=%s "
+            "patched_modules=%s writer_patched_modules=%s",
+            _MARKER,
+            sorted(_PATCHED_MODULES),
+            sorted(_WRITER_PATCHED_MODULES),
+        )
 
-    threading.Thread(target=_monitor, name="execution-bootstrap-monitor-iteration-guard", daemon=True).start()
-    logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_MONITOR_STARTED marker=%s", _MARKER)
+    threading.Thread(
+        target=_monitor,
+        name="execution-bootstrap-monitor-iteration-guard",
+        daemon=True,
+    ).start()
+    logger.warning(
+        "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_MONITOR_STARTED marker=%s",
+        _MARKER,
+    )
 
 
 def install_import_hook() -> None:
     with _INSTALL_LOCK:
         _try_patch_loaded()
         _start_monitor()
-        if getattr(builtins, "_NIJA_EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_V20260709A", False):
-            logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_INSTALL_COMPLETE marker=%s already_installed=True patched_modules=%s", _MARKER, sorted(_PATCHED_MODULES))
+        if getattr(
+            builtins,
+            "_NIJA_EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_V20260709A",
+            False,
+        ):
+            logger.warning(
+                "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_INSTALL_COMPLETE marker=%s "
+                "already_installed=True patched_modules=%s writer_patched_modules=%s",
+                _MARKER,
+                sorted(_PATCHED_MODULES),
+                sorted(_WRITER_PATCHED_MODULES),
+            )
             return
         original_import = builtins.__import__
 
-        def guarded_import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+        def guarded_import(
+            name: str,
+            globals: Any = None,
+            locals: Any = None,
+            fromlist: Any = (),
+            level: int = 0,
+        ) -> Any:
             module = original_import(name, globals, locals, fromlist, level)
-            if "execution_bootstrap_authority_repair_patch" in str(name):
+            text = str(name)
+            if (
+                "execution_bootstrap_authority_repair_patch" in text
+                or "entrypoint_writer_authority" in text
+            ):
                 _try_patch_loaded()
             return module
 
         builtins.__import__ = guarded_import
-        setattr(builtins, "_NIJA_EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_V20260709A", True)
-        logger.warning("EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_INSTALL_COMPLETE marker=%s patched_modules=%s", _MARKER, sorted(_PATCHED_MODULES))
+        setattr(
+            builtins,
+            "_NIJA_EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_V20260709A",
+            True,
+        )
+        logger.warning(
+            "EXECUTION_BOOTSTRAP_MONITOR_ITERATION_GUARD_INSTALL_COMPLETE marker=%s "
+            "patched_modules=%s writer_patched_modules=%s",
+            _MARKER,
+            sorted(_PATCHED_MODULES),
+            sorted(_WRITER_PATCHED_MODULES),
+        )
 
 
 def install() -> None:

--- a/bot/held_position_exit_bootstrap_v75_patch.py
+++ b/bot/held_position_exit_bootstrap_v75_patch.py
@@ -1,0 +1,220 @@
+"""Bootstrap adaptive exit state for positions already held before deployment.
+
+v74 is called from the universal broker exit supervisor, which enumerates the
+broker's *current* position inventory every scan.  v75 makes that guarantee
+explicit at installation time and preserves any trustworthy high/low-water
+fields already carried by the broker position record.
+
+No synthetic entry, peak, quantity, fill, or profit is created.  If historical
+high/low-water evidence is absent, the first verified market price becomes the
+initial adaptive reference and later scans update it normally.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+from bot import adaptive_profit_exit_v74_patch as v74
+
+LOGGER = logging.getLogger("nija.held_position_exit_bootstrap_v75")
+MARKER = "20260809-held-position-exit-bootstrap-v75"
+_PATCH_ATTR = "_nija_held_position_exit_bootstrap_v75"
+_LOCK = threading.RLock()
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if result == result else default
+
+
+def _persisted_peak(pos: Mapping[str, Any], market: float) -> float:
+    return max(
+        market,
+        _f(pos.get("high_water")),
+        _f(pos.get("high_water_price")),
+        _f(pos.get("peak_price")),
+        _f(pos.get("max_price_since_entry")),
+        _f(pos.get("highest_price")),
+    )
+
+
+def _persisted_trough(pos: Mapping[str, Any], market: float) -> float:
+    values = [
+        value
+        for value in (
+            market,
+            _f(pos.get("low_water")),
+            _f(pos.get("low_water_price")),
+            _f(pos.get("trough_price")),
+            _f(pos.get("min_price_since_entry")),
+            _f(pos.get("lowest_price")),
+        )
+        if value > 0.0
+    ]
+    return min(values) if values else market
+
+
+def _install_peak_bootstrap() -> bool:
+    current = getattr(v74, "_update_peak", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def update_peak_with_held_history(
+        universal: ModuleType,
+        broker: Any,
+        pos: Mapping[str, Any],
+        market: float,
+        short: bool,
+        regime: str,
+    ) -> dict[str, Any]:
+        key = v74._position_key(universal, broker, pos)
+        with v74._LOCK:
+            existing = v74._POSITIONS.get(key)
+            if not existing:
+                peak = _persisted_peak(pos, market)
+                trough = _persisted_trough(pos, market)
+                v74._POSITIONS[key] = {
+                    "peak": peak,
+                    "trough": trough,
+                    "armed": False,
+                    "regime": regime,
+                    "market": market,
+                    "short": short,
+                    "bootstrap_source": (
+                        "persisted_position_history"
+                        if peak > market or trough < market
+                        else "first_verified_market"
+                    ),
+                }
+                LOGGER.critical(
+                    "HELD_POSITION_EXIT_V75_BOOTSTRAPPED marker=%s venue=%s account=%s symbol=%s "
+                    "position_id=%s market=%.8f peak=%.8f trough=%.8f source=%s",
+                    MARKER,
+                    v74.v68._broker_label(universal, broker),
+                    v74._account(universal, broker, pos),
+                    universal.auto_exit._sym(pos.get("symbol")),
+                    str(pos.get("position_id") or pos.get("id") or ""),
+                    market,
+                    peak,
+                    trough,
+                    v74._POSITIONS[key]["bootstrap_source"],
+                )
+        return current(universal, broker, pos, market, short, regime)
+
+    setattr(update_peak_with_held_history, _PATCH_ATTR, True)
+    setattr(update_peak_with_held_history, "__wrapped__", current)
+    v74._update_peak = update_peak_with_held_history
+    return True
+
+
+def _bootstrap_existing_positions(universal: ModuleType) -> int:
+    """Seed adaptive state for every currently held broker position."""
+    snapshot = getattr(universal, "_snapshot", None)
+    positions_fn = getattr(universal, "_tracker_positions", None)
+    if not callable(snapshot) or not callable(positions_fn):
+        return 0
+    count = 0
+    for broker in list(snapshot() or []):
+        for pos in list(positions_fn(broker) or []):
+            if not isinstance(pos, Mapping):
+                continue
+            symbol = universal.auto_exit._sym(pos.get("symbol"))
+            entry = universal.auto_exit._entry_price(dict(pos))
+            qty = universal.auto_exit._quantity(dict(pos))
+            if not symbol or entry <= 0.0 or qty <= 0.0:
+                continue
+            market = universal.auto_exit._price(broker, symbol)
+            if market <= 0.0:
+                continue
+            short = universal.auto_exit._side(pos.get("side"), dict(pos)) in {"short", "sell"}
+            regime, _confidence = v74._regime_snapshot(pos)
+            v74._update_peak(universal, broker, pos, market, short, regime)
+            count += 1
+    if count:
+        LOGGER.critical(
+            "HELD_POSITION_EXIT_V75_EXISTING_POSITIONS_CONNECTED marker=%s positions=%d adaptive_exit=true",
+            MARKER,
+            count,
+        )
+    return count
+
+
+def _patch_loaded() -> bool:
+    _install_peak_bootstrap()
+    changed = False
+    for name in (
+        "bot.universal_broker_exit_supervisor_patch",
+        "universal_broker_exit_supervisor_patch",
+    ):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        try:
+            _bootstrap_existing_positions(module)
+            changed = True
+        except Exception as exc:
+            LOGGER.warning(
+                "HELD_POSITION_EXIT_V75_BOOTSTRAP_RETRY marker=%s module=%s error=%s:%s",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+            )
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        v74.install_import_hook()
+        try:
+            importlib.import_module("bot.universal_broker_exit_supervisor_patch")
+        except Exception:
+            pass
+        _patch_loaded()
+        flag = "_NIJA_HELD_POSITION_EXIT_BOOTSTRAP_V75_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "universal_broker_exit" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_HELD_POSITION_EXIT_BOOTSTRAP_V75_INSTALLED"] = "1"
+        LOGGER.critical(
+            "HELD_POSITION_EXIT_BOOTSTRAP_V75_INSTALLED marker=%s existing_positions=true persisted_high_water=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_bootstrap_existing_positions",
+    "_persisted_peak",
+    "_persisted_trough",
+]

--- a/bot/kraken_connection_convergence_v44_patch.py
+++ b/bot/kraken_connection_convergence_v44_patch.py
@@ -1,45 +1,56 @@
-"""NIJA Kraken connection convergence v44.
+"""NIJA Kraken connection convergence v44 with post-v59 convergence v60.
 
-Production after v42 showed Kraken credentials present and historical capital
-available while the canonical platform broker remained ``connected=False``.
-The authenticated recovery in canonical_broker_startup_convergence_v24 already
-performs the correct real broker.connect()/supervisor path, but its one-shot
-``_KRAKEN_RECOVERY_STARTED`` guard remains latched after a successful recovery.
-A later disconnect can therefore leave Kraken permanently offline because every
-subsequent trigger sees recovery as already started.
+v44 keeps Kraken's canonical platform connection recoverable without ever
+fabricating a successful connection.  It reuses the authenticated recovery path
+from canonical_broker_startup_convergence_v24 and remains writer-scoped.
 
-v44 adds a small writer-scoped watchdog around that existing recovery path.  It
-never marks Kraken connected and never fabricates authentication.  It rearms the
-canonical recovery only when all of these are true:
+Production after the v59 writer-first merge exposed two additional state-split
+failures that are repaired here as v60:
 
-* Kraken credentials are configured and not explicitly disabled;
-* verified writer lineage is present;
-* the canonical Kraken broker exists and is actually ``connected=False``;
-* the previous authenticated recovery had declared READY, proving the guard is
-  a stale success latch rather than an active in-flight attempt.
+* The entrypoint writer can continue renewing the exact Redis lock while the
+  process-local v17 renewal timestamp becomes stale.  v40 then correctly fails
+  closed, but authority can remain blocked even though Redis still proves the
+  same live writer.  v60 may re-anchor only the *local renewal timestamp*, and
+  only after an exact, read-only Redis proof of lock value, fencing token,
+  generation, positive TTL, and fresh writer metadata.  It never SETs, EXPIREs,
+  recreates, or extends the writer lease.
+* Kraken can authenticate/reconnect while the MultiAccountBrokerManager Kraken
+  startup FSM or reconnect-supervisor failure latch still reflects an earlier
+  failure.  v60 synchronizes that stale mirror only when the canonical broker
+  object itself already reports connected=True.  Invalid-nonce failures remain
+  recoverable because the distributed nonce manager can resynchronize them;
+  bad key/signature/permission/configuration failures remain permanently latched
+  while Kraken is disconnected.
 
-If recovery is not currently started at all, the watchdog may invoke the
-canonical v24 recovery directly.  Permanent-auth failures remain latched by the
-existing reconnect supervisor and no execution/readiness gate is bypassed.
+No writer, capital, risk, strategy, nonce, or execution-readiness bypass is
+introduced.  All positive convergence requires existing canonical proof.
 """
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import os
 import sys
 import threading
 import time
+from functools import wraps
 from types import ModuleType
 from typing import Any, Optional
 
 LOGGER = logging.getLogger("nija.kraken_connection_convergence_v44")
 MARKER = "20260807-kraken-connection-convergence-v44"
+POST_V59_MARKER = "20260809-post-v59-runtime-convergence-v60"
 
 _LOCK = threading.RLock()
 _STOP = threading.Event()
 _WATCHDOG_STARTED = False
+_WRITER_STOP = threading.Event()
+_WRITER_WATCHDOG_STARTED = False
+_WRITER_LAST_SIGNATURE = ""
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_MANAGER_PATCH_ATTR = "_nija_post_v59_kraken_fsm_v60"
+_SUPERVISOR_PATCH_ATTR = "_nija_post_v59_nonce_classification_v60"
 
 _V24_NAMES = (
     "nija_canonical_broker_startup_convergence_v24_prebot",
@@ -52,32 +63,106 @@ def _truthy(name: str) -> bool:
     return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
 
 
+def _as_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _v24() -> Optional[ModuleType]:
     for name in _V24_NAMES:
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
             return module
-    for name in ("bot.canonical_broker_startup_convergence_v24",):
-        try:
-            module = importlib.import_module(name)
-        except Exception:
-            continue
-        if isinstance(module, ModuleType):
-            return module
-    return None
+    try:
+        module = importlib.import_module("bot.canonical_broker_startup_convergence_v24")
+    except Exception:
+        return None
+    return module if isinstance(module, ModuleType) else None
+
+
+def _broker_label(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip().lower()
+
+
+def _manager_kraken_pair(manager: Any) -> tuple[Any, Any]:
+    if manager is None:
+        return None, None
+    mapping = getattr(manager, "_platform_brokers", {})
+    try:
+        items = list(mapping.items())
+    except Exception:
+        items = []
+    for key, broker in items:
+        if _broker_label(key) == "kraken":
+            return key, broker
+    return None, None
+
+
+def _patch_manager_module(module: ModuleType) -> bool:
+    """Prefer an actually-connected Kraken broker over a stale FAILED FSM mirror."""
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type) or getattr(cls, _MANAGER_PATCH_ATTR, False):
+        return False
+    original = getattr(cls, "wait_for_platform_ready", None)
+    if not callable(original):
+        return False
+
+    @wraps(original)
+    def wait_for_platform_ready(self: Any, broker_type: Any, *args: Any, **kwargs: Any):
+        if _broker_label(broker_type) == "kraken":
+            broker = getattr(self, "_platform_brokers", {}).get(broker_type)
+            if broker is None:
+                _key, broker = _manager_kraken_pair(self)
+            if broker is not None and bool(getattr(broker, "connected", False)):
+                marker = getattr(self, "_mark_platform_connected", None)
+                if callable(marker):
+                    marker(broker_type)
+                _clear_stale_permanent_failure(
+                    "canonical_broker_connected_before_platform_wait",
+                    allow_any=True,
+                )
+                LOGGER.critical(
+                    "KRAKEN_V60_STALE_FSM_RECONCILED marker=%s source=wait_for_platform_ready "
+                    "canonical_connected=true fabricated_connected=false",
+                    POST_V59_MARKER,
+                )
+                return True
+        return original(self, broker_type, *args, **kwargs)
+
+    cls.wait_for_platform_ready = wait_for_platform_ready
+    setattr(cls, _MANAGER_PATCH_ATTR, True)
+    LOGGER.warning(
+        "KRAKEN_V60_MANAGER_WAIT_PATCHED marker=%s module=%s",
+        POST_V59_MARKER,
+        module.__name__,
+    )
+    return True
 
 
 def _manager() -> Any:
     for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
         module = sys.modules.get(name)
-        getter = getattr(module, "get_multi_account_broker_manager", None) if module else None
-        if callable(getter):
-            try:
-                return getter()
-            except Exception:
-                pass
+        if isinstance(module, ModuleType):
+            _patch_manager_module(module)
+            getter = getattr(module, "get_multi_account_broker_manager", None)
+            if callable(getter):
+                try:
+                    return getter()
+                except Exception:
+                    pass
     try:
         module = importlib.import_module("bot.multi_account_broker_manager")
+        if isinstance(module, ModuleType):
+            _patch_manager_module(module)
         getter = getattr(module, "get_multi_account_broker_manager", None)
         if callable(getter):
             return getter()
@@ -86,7 +171,26 @@ def _manager() -> Any:
     return None
 
 
+def _loaded_manager() -> Any:
+    """Return an already-loaded manager without importing the bot package."""
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        _patch_manager_module(module)
+        getter = getattr(module, "get_multi_account_broker_manager", None)
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:
+                return None
+    return None
+
+
 def _canonical_kraken(manager: Any) -> Any:
+    _key, broker = _manager_kraken_pair(manager)
+    if broker is not None:
+        return broker
     if manager is None:
         return None
     try:
@@ -112,6 +216,41 @@ def _canonical_kraken(manager: Any) -> Any:
     return None
 
 
+def _sync_connected_kraken(manager: Any, broker: Any, source: str) -> bool:
+    """Synchronize mirrors only from a canonical broker already connected."""
+    if manager is None or broker is None or not bool(getattr(broker, "connected", False)):
+        return False
+    key, registered = _manager_kraken_pair(manager)
+    if key is None or registered is not broker:
+        return False
+    label = _broker_label(key)
+    state = getattr(manager, "_platform_state", {}).get(label)
+    state_label = _broker_label(state)
+    failed = key in getattr(manager, "_platform_failed_types", set())
+    connected_flag = bool(getattr(manager, "_platform_connected", {}).get(label, False))
+    if connected_flag and not failed and state_label == "connected":
+        return False
+
+    sync = getattr(manager, "_sync_reconnect_readiness", None)
+    if callable(sync):
+        sync(key, broker)
+    else:
+        mark = getattr(manager, "_mark_platform_connected", None)
+        if not callable(mark):
+            return False
+        mark(key)
+
+    LOGGER.critical(
+        "KRAKEN_V60_CONNECTED_STATE_RECONCILED marker=%s source=%s "
+        "canonical_connected=true prior_state=%s prior_failed=%s fabricated_connected=false",
+        POST_V59_MARKER,
+        source,
+        state_label or "unknown",
+        str(failed).lower(),
+    )
+    return True
+
+
 def _lineage_ready(v24: ModuleType) -> tuple[bool, str]:
     probe = getattr(v24, "_writer_lineage", None)
     if not callable(probe):
@@ -133,25 +272,94 @@ def _credentials_ready(v24: ModuleType) -> bool:
         return False
 
 
-def _permanent_failure_latched() -> bool:
+def _patch_supervisor_module(module: ModuleType) -> bool:
+    """Keep nonce resync failures retryable; leave real auth/config failures fatal."""
+    if getattr(module, _SUPERVISOR_PATCH_ATTR, False):
+        return False
+    original = getattr(module, "_is_permanent_failure", None)
+    if not callable(original):
+        return False
+
+    @wraps(original)
+    def _is_permanent_failure(error_str: str) -> bool:
+        text = str(error_str or "").strip().lower()
+        if "invalid nonce" in text or "nonce_rejected" in text:
+            return False
+        return bool(original(error_str))
+
+    module._is_permanent_failure = _is_permanent_failure
+    setattr(module, _SUPERVISOR_PATCH_ATTR, True)
+    LOGGER.warning(
+        "KRAKEN_V60_NONCE_CLASSIFICATION_PATCHED marker=%s module=%s "
+        "invalid_nonce=retryable auth_config_failures=latched",
+        POST_V59_MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _supervisor_module(*, import_if_missing: bool = True) -> Optional[ModuleType]:
     for name in ("bot.kraken_reconnect_supervisor", "kraken_reconnect_supervisor"):
         module = sys.modules.get(name)
-        probe = getattr(module, "is_permanent_failure_latched", None) if module else None
-        if callable(probe):
-            try:
-                return bool(probe())
-            except Exception:
-                return True
+        if isinstance(module, ModuleType):
+            _patch_supervisor_module(module)
+            return module
+    if not import_if_missing:
+        return None
     try:
         module = importlib.import_module("bot.kraken_reconnect_supervisor")
-        probe = getattr(module, "is_permanent_failure_latched", None)
-        if callable(probe):
-            return bool(probe())
-    except ImportError:
-        return False
     except Exception:
-        return True
-    return False
+        return None
+    if isinstance(module, ModuleType):
+        _patch_supervisor_module(module)
+        return module
+    return None
+
+
+def _permanent_failure_detail() -> str:
+    module = _supervisor_module(import_if_missing=False)
+    if module is None:
+        return ""
+    return str(getattr(module, "_PERMANENT_FAILURE_SEEN", "") or "").strip()
+
+
+def _permanent_failure_latched() -> bool:
+    module = _supervisor_module(import_if_missing=True)
+    if module is None:
+        return False
+    probe = getattr(module, "is_permanent_failure_latched", None)
+    if callable(probe):
+        try:
+            return bool(probe())
+        except Exception:
+            return True
+    return bool(str(getattr(module, "_PERMANENT_FAILURE_SEEN", "") or "").strip())
+
+
+def _clear_stale_permanent_failure(reason: str, *, allow_any: bool = False) -> bool:
+    module = _supervisor_module(import_if_missing=False)
+    if module is None:
+        return False
+    detail = str(getattr(module, "_PERMANENT_FAILURE_SEEN", "") or "").strip()
+    if not detail:
+        return False
+    lowered = detail.lower()
+    nonce_latch = "invalid nonce" in lowered or "nonce_rejected" in lowered
+    if not allow_any and not nonce_latch:
+        return False
+    reset = getattr(module, "reset_permanent_failure_latch", None)
+    if not callable(reset):
+        return False
+    reset()
+    LOGGER.critical(
+        "KRAKEN_V60_STALE_PERMANENT_LATCH_CLEARED marker=%s reason=%s "
+        "nonce_latch=%s authenticated_connected_proof=%s",
+        POST_V59_MARKER,
+        reason,
+        str(nonce_latch).lower(),
+        str(bool(allow_any)).lower(),
+    )
+    return True
 
 
 def _rearm_if_stale_success(v24: ModuleType, broker: Any) -> bool:
@@ -178,6 +386,223 @@ def _rearm_if_stale_success(v24: ModuleType, broker: Any) -> bool:
     return True
 
 
+def _writer_runtime() -> Any:
+    """Return only an already-loaded writer runtime; never import bot preboot."""
+    for name in ("bot.entrypoint_writer_authority", "entrypoint_writer_authority"):
+        module = sys.modules.get(name)
+        getter = getattr(module, "get_entrypoint_writer_authority", None) if module else None
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:
+                return None
+    return None
+
+
+def _writer_interval_s(runtime: Any) -> float:
+    raw = str(os.environ.get("NIJA_WRITER_HEARTBEAT_INTERVAL_S", "") or "").strip()
+    if raw:
+        try:
+            return max(1.0, float(raw))
+        except (TypeError, ValueError):
+            pass
+    try:
+        ttl_s = max(15.0, float(getattr(runtime, "_ttl_s", 60.0) or 60.0))
+    except (TypeError, ValueError):
+        ttl_s = 60.0
+    return min(5.0, max(1.0, ttl_s / 3.0))
+
+
+def _exact_writer_renewal_proof(runtime: Any, max_age_s: float) -> dict[str, Any]:
+    """Read-only exact Redis proof used solely to repair a stale local timestamp."""
+    proof: dict[str, Any] = {
+        "ok": False,
+        "reason": "uninitialized",
+        "pttl_ms": -2,
+        "metadata_age_s": float("inf"),
+    }
+    if runtime is None:
+        proof["reason"] = "runtime_missing"
+        return proof
+    if not bool(getattr(runtime, "acquired", False)) or bool(getattr(runtime, "lost", False)):
+        proof["reason"] = "runtime_not_active"
+        return proof
+    if bool(getattr(runtime, "_local_fallback", False)):
+        proof["reason"] = "local_fallback_rejected"
+        return proof
+
+    stop = getattr(runtime, "_stop", None)
+    if stop is not None and callable(getattr(stop, "is_set", None)) and stop.is_set():
+        proof["reason"] = "renewal_stop_requested"
+        return proof
+    thread = getattr(runtime, "_heartbeat_thread", None)
+    if thread is None or not callable(getattr(thread, "is_alive", None)) or not thread.is_alive():
+        proof["reason"] = "renewal_thread_not_alive"
+        return proof
+
+    client = getattr(runtime, "_client", None)
+    lock_key = str(getattr(runtime, "_lock_key", "") or "").strip()
+    meta_key = str(getattr(runtime, "_meta_key", "") or "").strip()
+    fencing_key = str(getattr(runtime, "_fencing_key", "") or "").strip()
+    expected_lock = str(getattr(runtime, "_lock_value", "") or "").strip()
+    token = str(getattr(runtime, "_token", "") or "").strip()
+    generation = _as_int(getattr(runtime, "_generation", 0), 0)
+    generation_key = str(
+        os.environ.get("NIJA_LEASE_GENERATION_KEY", "") or "nija:lease:generation"
+    ).strip()
+    if client is None or not lock_key or not meta_key or not expected_lock or not token or generation <= 0:
+        proof["reason"] = "writer_exact_proof_inputs_missing"
+        return proof
+
+    try:
+        current_lock = _as_text(client.get(lock_key)).strip()
+        pttl_ms = _as_int(client.pttl(lock_key), -2)
+        redis_generation = _as_int(client.get(generation_key), 0)
+        current_fence = _as_text(client.get(fencing_key)).strip() if fencing_key else token
+        meta_raw = client.get(meta_key)
+    except Exception as exc:
+        proof["reason"] = f"redis_read_error:{type(exc).__name__}:{exc}"
+        return proof
+
+    proof["pttl_ms"] = pttl_ms
+    if current_lock != expected_lock:
+        proof["reason"] = "lock_value_mismatch"
+        return proof
+    interval_s = _writer_interval_s(runtime)
+    safety_ms = int(max(5000.0, interval_s * 2.0 * 1000.0))
+    if pttl_ms <= safety_ms:
+        proof["reason"] = f"lock_ttl_too_low:{pttl_ms}<={safety_ms}"
+        return proof
+    if redis_generation != generation:
+        proof["reason"] = f"generation_mismatch:{redis_generation}!={generation}"
+        return proof
+    if fencing_key and current_fence != token:
+        proof["reason"] = "fencing_token_mismatch"
+        return proof
+
+    try:
+        meta = json.loads(_as_text(meta_raw))
+    except Exception:
+        proof["reason"] = "writer_metadata_unparseable"
+        return proof
+    meta_token = str(meta.get("token") or "").strip()
+    meta_generation = _as_int(meta.get("generation"), 0)
+    heartbeat_at = float(meta.get("heartbeat_at") or 0.0)
+    if meta_token != token:
+        proof["reason"] = "metadata_token_mismatch"
+        return proof
+    if meta_generation != generation:
+        proof["reason"] = "metadata_generation_mismatch"
+        return proof
+    if heartbeat_at <= 0:
+        proof["reason"] = "metadata_heartbeat_missing"
+        return proof
+    metadata_age_s = max(0.0, time.time() - heartbeat_at)
+    proof["metadata_age_s"] = metadata_age_s
+    metadata_max_age_s = max(10.0, float(max_age_s or 0.0), interval_s * 3.0)
+    if metadata_age_s > metadata_max_age_s:
+        proof["reason"] = f"metadata_heartbeat_stale:{metadata_age_s:.1f}>{metadata_max_age_s:.1f}"
+        return proof
+
+    proof.update(
+        ok=True,
+        reason="exact_redis_writer_renewal_proof",
+        generation=generation,
+        token_prefix=token[:8],
+        metadata_max_age_s=metadata_max_age_s,
+    )
+    return proof
+
+
+def reconcile_writer_renewal_once(runtime: Any = None) -> dict[str, Any]:
+    """Repair only a stale local renewal timestamp after exact Redis proof."""
+    runtime = runtime if runtime is not None else _writer_runtime()
+    result: dict[str, Any] = {"ok": False, "action": "none", "reason": "runtime_unavailable"}
+    if runtime is None:
+        return result
+    health = getattr(runtime, "_nija_lease_renewal_health", None)
+    if not callable(health):
+        result["reason"] = "renewal_health_unavailable"
+        return result
+    try:
+        ok, reason, age_s, max_age_s = health()
+    except Exception as exc:
+        result["reason"] = f"renewal_health_error:{type(exc).__name__}:{exc}"
+        return result
+    if bool(ok):
+        result.update(ok=True, reason="renewal_healthy", age_s=float(age_s))
+        return result
+    reason = str(reason or "")
+    result.update(reason=reason, age_s=float(age_s), max_age_s=float(max_age_s))
+    if reason != "renewal_success_stale":
+        return result
+
+    proof = _exact_writer_renewal_proof(runtime, float(max_age_s))
+    result["proof"] = proof
+    if not bool(proof.get("ok")):
+        result["reason"] = f"exact_redis_proof_failed:{proof.get('reason')}"
+        return result
+
+    now_mono = time.monotonic()
+    now_epoch = time.time()
+    setattr(runtime, "_nija_last_lease_renewal_monotonic", now_mono)
+    setattr(runtime, "_nija_last_lease_renewal_epoch", now_epoch)
+    os.environ["NIJA_WRITER_LEASE_RENEWAL_ACTIVE"] = "1"
+    os.environ["NIJA_WRITER_LEASE_RENEWED_TS"] = f"{now_epoch:.6f}"
+
+    notify = getattr(runtime, "_notify_runtime_reconciliation", None)
+    if callable(notify):
+        try:
+            notify("post_v59_exact_writer_renewal_reanchor_v60")
+        except Exception:
+            LOGGER.debug("writer v60 runtime reconciliation deferred", exc_info=True)
+
+    LOGGER.critical(
+        "WRITER_V60_RENEWAL_PROOF_REANCHORED marker=%s generation=%s "
+        "previous_age_s=%.1f pttl_ms=%s metadata_age_s=%.2f "
+        "redis_mutation=false exact_lock=true exact_generation=true exact_fencing=true",
+        POST_V59_MARKER,
+        proof.get("generation"),
+        float(age_s),
+        proof.get("pttl_ms"),
+        float(proof.get("metadata_age_s", 0.0)),
+    )
+    result.update(ok=True, action="reanchored", reason="exact_redis_writer_renewal_proof")
+    return result
+
+
+def _writer_watchdog_loop() -> None:
+    global _WRITER_LAST_SIGNATURE
+    try:
+        interval = max(
+            0.5,
+            float(os.environ.get("NIJA_POST_V59_WRITER_PROOF_POLL_S", "1.0") or "1.0"),
+        )
+    except (TypeError, ValueError):
+        interval = 1.0
+    while not _WRITER_STOP.wait(interval):
+        try:
+            state = reconcile_writer_renewal_once()
+            if state.get("ok"):
+                _WRITER_LAST_SIGNATURE = ""
+                continue
+            signature = str(state.get("reason") or "")
+            if signature and signature != _WRITER_LAST_SIGNATURE and signature.startswith("exact_redis_proof_failed"):
+                LOGGER.warning(
+                    "WRITER_V60_REANCHOR_BLOCKED marker=%s reason=%s fail_closed=true",
+                    POST_V59_MARKER,
+                    signature,
+                )
+                _WRITER_LAST_SIGNATURE = signature
+        except Exception as exc:
+            LOGGER.warning(
+                "WRITER_V60_WATCHDOG_ERROR marker=%s error=%s:%s",
+                POST_V59_MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+
 def reconcile_once() -> dict[str, Any]:
     result: dict[str, Any] = {
         "ok": False,
@@ -196,9 +621,31 @@ def reconcile_once() -> dict[str, Any]:
     if not lineage_ok:
         result["reason"] = lineage_reason or "writer_lineage_not_ready"
         return result
+
+    # Preserve the original fail-closed ordering for a real permanent failure.
+    # A real latch carries a detail string.  Only then may v60 inspect an
+    # already-loaded canonical broker to see whether a later authenticated
+    # success has made that latch stale.  Tests/operators that explicitly force
+    # the boolean latch without detail retain the original immediate block.
     if _permanent_failure_latched():
-        result["reason"] = "permanent_auth_or_config_failure_latched"
-        return result
+        detail = _permanent_failure_detail()
+        if detail:
+            manager_loaded = _loaded_manager()
+            broker_loaded = _canonical_kraken(manager_loaded) if manager_loaded is not None else None
+            if broker_loaded is not None and bool(getattr(broker_loaded, "connected", False)):
+                _sync_connected_kraken(manager_loaded, broker_loaded, "permanent_latch_connected_proof")
+                _clear_stale_permanent_failure(
+                    "authenticated_canonical_broker_connected",
+                    allow_any=True,
+                )
+            else:
+                _clear_stale_permanent_failure(
+                    "recoverable_invalid_nonce_latch",
+                    allow_any=False,
+                )
+        if _permanent_failure_latched():
+            result["reason"] = "permanent_auth_or_config_failure_latched"
+            return result
 
     manager = _manager()
     if manager is None:
@@ -221,6 +668,11 @@ def reconcile_once() -> dict[str, Any]:
     connected = bool(getattr(broker, "connected", False))
     result["connected"] = connected
     if connected:
+        _sync_connected_kraken(manager, broker, "v44_reconcile_connected")
+        _clear_stale_permanent_failure(
+            "authenticated_canonical_broker_connected",
+            allow_any=True,
+        )
         result.update(ok=True, action="none", reason="already_connected")
         return result
 
@@ -262,11 +714,11 @@ def reconcile_once() -> dict[str, Any]:
 def _watchdog_loop() -> None:
     try:
         interval = max(
-            5.0,
-            float(os.environ.get("NIJA_KRAKEN_CONNECTION_WATCHDOG_INTERVAL_S", "15") or "15"),
+            2.0,
+            float(os.environ.get("NIJA_KRAKEN_CONNECTION_WATCHDOG_INTERVAL_S", "5") or "5"),
         )
     except (TypeError, ValueError):
-        interval = 15.0
+        interval = 5.0
     last_signature = ""
     while not _STOP.wait(interval):
         try:
@@ -292,20 +744,34 @@ def _watchdog_loop() -> None:
 
 
 def install() -> bool:
-    global _WATCHDOG_STARTED
+    global _WATCHDOG_STARTED, _WRITER_WATCHDOG_STARTED
     with _LOCK:
-        if _WATCHDOG_STARTED:
-            os.environ["NIJA_KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED"] = "1"
-            return True
-        _WATCHDOG_STARTED = True
+        if not _WATCHDOG_STARTED:
+            _WATCHDOG_STARTED = True
+            thread = threading.Thread(
+                target=_watchdog_loop,
+                name="KrakenConnectionConvergenceV44",
+                daemon=True,
+            )
+            thread.start()
+        if not _WRITER_WATCHDOG_STARTED:
+            _WRITER_WATCHDOG_STARTED = True
+            writer_thread = threading.Thread(
+                target=_writer_watchdog_loop,
+                name="PostV59WriterRenewalProofV60",
+                daemon=True,
+            )
+            writer_thread.start()
         os.environ["NIJA_KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED"] = "1"
-        thread = threading.Thread(
-            target=_watchdog_loop,
-            name="KrakenConnectionConvergenceV44",
-            daemon=True,
-        )
-        thread.start()
-    # Run one reconciliation immediately so startup does not wait one interval.
+        os.environ["NIJA_POST_V59_RUNTIME_CONVERGENCE_V60_INSTALLED"] = "1"
+
+    # Reconcile once immediately.  These helpers remain safe before bot imports:
+    # writer reconciliation never imports the entrypoint module, and Kraken
+    # reconciliation returns before importing MABM until writer lineage exists.
+    try:
+        reconcile_writer_renewal_once()
+    except Exception:
+        LOGGER.exception("WRITER_V60_INITIAL_RECONCILE_FAILED marker=%s", POST_V59_MARKER)
     try:
         reconcile_once()
     except Exception:
@@ -313,6 +779,11 @@ def install() -> bool:
     LOGGER.critical(
         "KRAKEN_CONNECTION_CONVERGENCE_V44_INSTALLED marker=%s fail_closed=true fabricates_connected=false",
         MARKER,
+    )
+    LOGGER.critical(
+        "POST_V59_RUNTIME_CONVERGENCE_V60_INSTALLED marker=%s "
+        "writer_redis_mutation=false kraken_fabricates_connected=false invalid_nonce_retryable=true",
+        POST_V59_MARKER,
     )
     return True
 
@@ -323,8 +794,13 @@ def install_import_hook() -> bool:
 
 __all__ = [
     "MARKER",
+    "POST_V59_MARKER",
     "install",
     "install_import_hook",
     "reconcile_once",
+    "reconcile_writer_renewal_once",
+    "_exact_writer_renewal_proof",
+    "_patch_manager_module",
+    "_patch_supervisor_module",
     "_rearm_if_stale_success",
 ]

--- a/bot/live_entry_expectancy_authority_v69_patch.py
+++ b/bot/live_entry_expectancy_authority_v69_patch.py
@@ -1,0 +1,346 @@
+"""Live entry expectancy authority v69.
+
+NIJA already ships ``TradeExpectancyValidator`` with a documented minimum
+acceptable 1.5R and first-move confirmation standard, but the APEX live path can
+later treat poor trade math as advisory and can lower entry gates during a trade
+drought.  v69 makes the existing expectancy standard authoritative at the final
+strategy-output boundary in live-capital mode.
+
+A live entry must therefore prove:
+
+* valid positive entry/stop/first-target geometry;
+* raw first-target reward/risk >= the existing 1.5R acceptable threshold;
+* first-move confirmation (volume expansion OR range expansion) from the
+  existing validator;
+* first-target reward after estimated round-trip taker cost and slippage still
+  leaves at least ``NIJA_MINIMUM_NET_PROFIT_PCT`` net edge;
+* diagnostic market/smart-filter bypass flags cannot remain active in live mode;
+* drought/fallback logic cannot reduce the live gate below its normal configured
+  baseline merely because no trade has occurred recently.
+
+The patch does not create signals, loosen risk limits, or guarantee profitable
+trades.  Non-live diagnostic/paper behavior remains available.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping, Optional
+
+LOGGER = logging.getLogger("nija.live_entry_expectancy_authority_v69")
+MARKER = "20260809-live-entry-expectancy-authority-v69"
+_PATCH_ATTR = "_nija_live_entry_expectancy_authority_v69"
+_INSTALL_LOCK = threading.RLock()
+_VALIDATOR: Any = None
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in {
+        "1", "true", "yes", "on", "enabled", "y",
+    }
+
+
+def _live_mode() -> bool:
+    return bool(
+        _truthy("LIVE_CAPITAL_VERIFIED", "false")
+        and not _truthy("DRY_RUN_MODE", "false")
+        and not _truthy("PAPER_MODE", "false")
+    )
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _first_target(value: Any) -> float:
+    if isinstance(value, Mapping):
+        for key in ("tp1", "take_profit_1", "first", "target", "price"):
+            target = _f(value.get(key))
+            if target > 0.0:
+                return target
+        numeric = [_f(v) for v in value.values()]
+        numeric = [v for v in numeric if v > 0.0]
+        return min(numeric) if numeric else 0.0
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            target = _f(item)
+            if target > 0.0:
+                return target
+        return 0.0
+    return _f(value)
+
+
+def _validator() -> Any:
+    global _VALIDATOR
+    if _VALIDATOR is None:
+        try:
+            module = importlib.import_module("bot.trade_expectancy_validator")
+        except ImportError:
+            module = importlib.import_module("trade_expectancy_validator")
+        _VALIDATOR = module.TradeExpectancyValidator(strict_mode=False)
+    return _VALIDATOR
+
+
+def _runtime_taker_fee(broker: Any, symbol: str) -> Optional[float]:
+    for method_name in (
+        "get_taker_fee", "get_fee_rate", "get_trading_fee", "get_trading_fees",
+        "get_fee_schedule", "get_fees",
+    ):
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            continue
+        for args, kwargs in (((symbol,), {}), ((), {"symbol": symbol}), ((), {})):
+            try:
+                result = method(*args, **kwargs)
+            except TypeError:
+                continue
+            except Exception:
+                break
+            if isinstance(result, Mapping):
+                values = [
+                    result.get("taker_fee"), result.get("taker"), result.get("fee_rate"),
+                    result.get("trading_fee"), result.get("commission_rate"), result.get("fee"),
+                ]
+            else:
+                values = [result]
+            for value in values:
+                fee = _f(value, -1.0)
+                if 0.0 <= fee <= 0.05:
+                    return fee
+    for attr in ("taker_fee", "taker_fee_rate", "trading_fee", "fee_rate", "commission_rate"):
+        fee = _f(getattr(broker, attr, None), -1.0)
+        if 0.0 <= fee <= 0.05:
+            return fee
+    return None
+
+
+def _broker_name(strategy: Any) -> str:
+    getter = getattr(strategy, "_get_broker_name", None)
+    if callable(getter):
+        try:
+            name = str(getter() or "").strip().lower()
+            if name:
+                return name
+        except Exception:
+            pass
+    broker = getattr(strategy, "broker_client", None)
+    broker_type = getattr(broker, "broker_type", None)
+    return str(getattr(broker_type, "value", broker_type) or type(broker).__name__).strip().lower()
+
+
+def _round_trip_cost(strategy: Any, symbol: str) -> tuple[float, str]:
+    broker = getattr(strategy, "broker_client", None)
+    runtime_fee = _runtime_taker_fee(broker, symbol) if broker is not None else None
+    spread_reserve = max(0.0, _f(os.environ.get("NIJA_ENTRY_SPREAD_RESERVE_PCT"), 0.0010))
+    if runtime_fee is not None:
+        return min(0.20, runtime_fee * 2.0 + spread_reserve), "broker_runtime_taker_fee"
+
+    getter = getattr(strategy, "_get_broker_capabilities", None)
+    if callable(getter):
+        try:
+            caps = getter(symbol)
+            fee_method = getattr(caps, "get_round_trip_fee", None)
+            if callable(fee_method):
+                value = _f(fee_method(use_limit_order=False), 0.0)
+                if 0.0 < value <= 0.20:
+                    return value, "strategy_exchange_capabilities"
+        except Exception:
+            pass
+    try:
+        module = importlib.import_module("bot.exchange_capabilities")
+        caps = module.get_broker_capabilities(_broker_name(strategy), symbol)
+        value = _f(caps.get_round_trip_fee(use_limit_order=False), 0.0)
+        if 0.0 < value <= 0.20:
+            return value, "exchange_capability_matrix"
+    except Exception:
+        pass
+    return max(0.004, _f(os.environ.get("NIJA_UNKNOWN_BROKER_ROUND_TRIP_COST_PCT"), 0.004)), "conservative_unknown_broker"
+
+
+def _entry_side(action: str) -> str:
+    return "short" if "short" in str(action or "").lower() else "long"
+
+
+def _validate_live_entry(strategy: Any, df: Any, symbol: str, result: Mapping[str, Any]) -> tuple[bool, str, dict[str, Any]]:
+    action = str(result.get("action") or "").strip().lower()
+    if action not in {"enter_long", "enter_short", "buy", "short"}:
+        return True, "not_entry", {}
+    entry = _f(result.get("entry_price"))
+    stop = _f(result.get("stop_loss"))
+    target = _first_target(result.get("take_profit"))
+    if entry <= 0.0 or stop <= 0.0 or target <= 0.0:
+        return False, "entry_geometry_missing", {"entry": entry, "stop": stop, "target": target}
+
+    validator = _validator()
+    r_ok, r_reason, r_multiple = validator.validate_r_multiple(entry, stop, target)
+    confirmation_ok, confirmation_reason = validator.check_first_move_confirmation(df)
+
+    reward_pct = abs(target - entry) / entry
+    risk_pct = abs(entry - stop) / entry
+    cost_pct, cost_source = _round_trip_cost(strategy, symbol)
+    slippage_pct = max(0.0, _f(os.environ.get("NIJA_ENTRY_SLIPPAGE_RESERVE_PCT"), 0.0015))
+    minimum_net_pct = max(0.0, _f(os.environ.get("NIJA_MINIMUM_NET_PROFIT_PCT"), 0.0040))
+    net_reward_pct = reward_pct - cost_pct - slippage_pct
+    net_edge_ok = net_reward_pct >= minimum_net_pct
+
+    details = {
+        "entry": entry,
+        "stop": stop,
+        "target": target,
+        "side": _entry_side(action),
+        "r_multiple": r_multiple,
+        "reward_pct": reward_pct,
+        "risk_pct": risk_pct,
+        "round_trip_cost_pct": cost_pct,
+        "slippage_pct": slippage_pct,
+        "net_reward_pct": net_reward_pct,
+        "minimum_net_pct": minimum_net_pct,
+        "confirmation": confirmation_reason,
+        "cost_source": cost_source,
+    }
+    if not r_ok:
+        return False, f"expectancy_r_multiple:{r_reason}", details
+    if not confirmation_ok:
+        return False, f"first_move_confirmation:{confirmation_reason}", details
+    if not net_edge_ok:
+        return False, "net_edge_below_fee_slippage_floor", details
+    return True, "expectancy_authority_pass", details
+
+
+def _patch_strategy(module: ModuleType) -> bool:
+    cls = getattr(module, "NIJAApexStrategyV71", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "analyze_market", None)
+    if not callable(original):
+        return False
+    if getattr(original, _PATCH_ATTR, False):
+        return True
+
+    @wraps(original)
+    def analyze_market_with_expectancy(self: Any, df: Any, symbol: str, account_balance: float, *args: Any, **kwargs: Any):
+        if _live_mode():
+            # Diagnostic bypasses are useful in paper/testing but must not become
+            # a live-capital entry policy.
+            module._DISABLE_MARKET_FILTER = False
+            module._BYPASS_SMART_FILTER = False
+        result = original(self, df, symbol, account_balance, *args, **kwargs)
+        if not _live_mode() or not isinstance(result, Mapping):
+            return result
+        ok, reason, details = _validate_live_entry(self, df, symbol, result)
+        if ok:
+            if reason == "expectancy_authority_pass":
+                LOGGER.critical(
+                    "LIVE_ENTRY_V69_EXPECTANCY_PASS marker=%s broker=%s symbol=%s action=%s "
+                    "r=%.3f net_reward_pct=%.5f min_net_pct=%.5f cost_pct=%.5f cost_source=%s confirmation=%s",
+                    MARKER, _broker_name(self), symbol, result.get("action"),
+                    details.get("r_multiple", 0.0), details.get("net_reward_pct", 0.0),
+                    details.get("minimum_net_pct", 0.0), details.get("round_trip_cost_pct", 0.0),
+                    details.get("cost_source", ""), details.get("confirmation", ""),
+                )
+            return result
+
+        LOGGER.warning(
+            "LIVE_ENTRY_V69_BLOCKED marker=%s broker=%s symbol=%s action=%s reason=%s "
+            "r=%.3f reward_pct=%.5f risk_pct=%.5f cost_pct=%.5f slippage_pct=%.5f net_reward_pct=%.5f min_net_pct=%.5f confirmation=%s",
+            MARKER, _broker_name(self), symbol, result.get("action"), reason,
+            details.get("r_multiple", 0.0), details.get("reward_pct", 0.0),
+            details.get("risk_pct", 0.0), details.get("round_trip_cost_pct", 0.0),
+            details.get("slippage_pct", 0.0), details.get("net_reward_pct", 0.0),
+            details.get("minimum_net_pct", 0.0), details.get("confirmation", ""),
+        )
+        blocked = dict(result)
+        blocked["action"] = "hold"
+        blocked["reason"] = f"LIVE_ENTRY_EXPECTANCY_V69:{reason}"
+        blocked["filter_stage"] = "live_entry_expectancy_v69"
+        blocked["expectancy_details"] = details
+        return blocked
+
+    setattr(analyze_market_with_expectancy, _PATCH_ATTR, True)
+    setattr(analyze_market_with_expectancy, "__wrapped__", original)
+    cls.analyze_market = analyze_market_with_expectancy
+
+    thresholds = getattr(cls, "_get_entry_gate_thresholds", None)
+    if callable(thresholds) and not getattr(thresholds, _PATCH_ATTR, False):
+        @wraps(thresholds)
+        def live_thresholds(self: Any, drought: Any):
+            if _live_mode():
+                # Ignore only time-since-last-trade relaxation.  The normal
+                # configured baseline remains authoritative.
+                return thresholds(self, None)
+            return thresholds(self, drought)
+        setattr(live_thresholds, _PATCH_ATTR, True)
+        cls._get_entry_gate_thresholds = live_thresholds
+
+    min_score = getattr(cls, "_get_entry_gate_min_score", None)
+    if callable(min_score) and not getattr(min_score, _PATCH_ATTR, False):
+        @wraps(min_score)
+        def live_min_score(self: Any, drought: Any):
+            if _live_mode():
+                baseline = int(min_score(self, None))
+                configured = int(getattr(module, "ENTRY_GATE_MIN_SCORE", baseline) or baseline)
+                return max(baseline, configured)
+            return min_score(self, drought)
+        setattr(live_min_score, _PATCH_ATTR, True)
+        cls._get_entry_gate_min_score = live_min_score
+
+    LOGGER.critical(
+        "LIVE_ENTRY_EXPECTANCY_AUTHORITY_V69_PATCHED marker=%s module=%s "
+        "r_min=existing_validator live_drought_relaxation=false diagnostic_bypass_live=false",
+        MARKER, module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_strategy(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _INSTALL_LOCK:
+        _patch_loaded()
+        flag = "_NIJA_LIVE_ENTRY_EXPECTANCY_AUTHORITY_V69_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "nija_apex_strategy_v71" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_LIVE_ENTRY_EXPECTANCY_AUTHORITY_V69_INSTALLED"] = "1"
+        LOGGER.critical(
+            "LIVE_ENTRY_EXPECTANCY_AUTHORITY_V69_INSTALLED marker=%s live_only=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER", "install", "install_import_hook", "_validate_live_entry", "_round_trip_cost",
+]

--- a/bot/live_exchange_base_minimum_v73_patch.py
+++ b/bot/live_exchange_base_minimum_v73_patch.py
@@ -1,0 +1,327 @@
+"""Preserve live exchange base-quantity constraints through final compilation.
+
+v72 blocks generic live precision/minimum guesses and normalizes dynamic venue
+metadata.  Some venues (notably Alpaca crypto) express their minimum order size
+in base units.  ExchangeOrderCompiler's historical ExchangeConstraints dataclass
+does not carry that field, so v73 caches the provider-proven base minimum at
+constraint resolution time and enforces it against the final rounded quantity.
+
+The module also auto-registers metadata providers for non-legacy broker clients
+when they become canonical through MultiAccountBrokerManager or the future-user
+SecureBrokerAdapter. Kraken/Coinbase/OKX keep their existing dedicated/static
+compatibility path unless explicitly registered elsewhere.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+from bot import live_exchange_constraints_authority_v72_patch as v72
+
+LOGGER = logging.getLogger("nija.live_exchange_base_minimum_v73")
+MARKER = "20260809-live-exchange-base-minimum-v73"
+_PATCH_ATTR = "_nija_live_exchange_base_minimum_v73"
+_LOCK = threading.RLock()
+_BASE_MINIMUMS: dict[tuple[str, str], float] = {}
+_METADATA_METHODS = (
+    "get_symbol_rules",
+    "get_order_rules",
+    "get_market_rules",
+    "get_instrument_info",
+    "get_symbol_info",
+    "get_market_info",
+    "get_product",
+    "get_asset",
+)
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().lower().replace(" ", "_")
+
+
+def _symbol(value: Any) -> str:
+    return str(value or "").strip().upper().replace("/", "-").replace("_", "-")
+
+
+def _exchange_name(broker: Any, fallback: Any = None) -> str:
+    for candidate in (
+        getattr(getattr(broker, "broker_type", None), "value", None),
+        getattr(broker, "broker_type", None),
+        getattr(broker, "broker_name", None),
+        getattr(broker, "exchange_name", None),
+        getattr(broker, "exchange", None),
+        fallback,
+    ):
+        name = _norm(candidate)
+        if name:
+            return name
+    class_name = type(broker).__name__.lower()
+    for suffix in ("brokeradapter", "broker", "client", "adapter"):
+        class_name = class_name.replace(suffix, "")
+    return _norm(class_name)
+
+
+def _provider_for(exchange: str):
+    with v72._LOCK:
+        return v72._PROVIDERS.get(_norm(exchange))
+
+
+def _cache_key(exchange: str, symbol: str) -> tuple[str, str]:
+    return (_norm(exchange), _symbol(symbol))
+
+
+def _install_constraint_capture() -> None:
+    current = getattr(v72, "_constraints_from_provider", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return
+
+    @wraps(current)
+    def constraints_with_base_minimum(module: ModuleType, exchange: str, symbol: str):
+        name = _norm(exchange)
+        provider = _provider_for(name)
+        if provider is None:
+            _BASE_MINIMUMS.pop(_cache_key(name, symbol), None)
+            return None
+
+        raw = provider(symbol)
+        rules = v72._extract_rules(raw)
+        min_base = max(0.0, float(rules.get("min_base_qty") or 0.0))
+        with _LOCK:
+            if min_base > 0.0:
+                _BASE_MINIMUMS[_cache_key(name, symbol)] = min_base
+            else:
+                _BASE_MINIMUMS.pop(_cache_key(name, symbol), None)
+
+        cls = getattr(module, "ExchangeConstraints")
+        return cls(
+            exchange=name,
+            min_order_usd=max(0.0, float(rules.get("min_order_usd") or 0.0)),
+            min_notional_usd=max(0.0, float(rules.get("min_notional_usd") or 0.0)),
+            fee_rate_one_way=max(0.0, float(rules.get("fee_rate_one_way") or 0.0)),
+            step_size=float(rules["step_size"]),
+            precision_decimals=int(rules["precision_decimals"]),
+        )
+
+    setattr(constraints_with_base_minimum, _PATCH_ATTR, True)
+    setattr(constraints_with_base_minimum, "__wrapped__", current)
+    v72._constraints_from_provider = constraints_with_base_minimum
+
+
+def _patch_eoc_module(module: ModuleType) -> bool:
+    cls = getattr(module, "ExchangeOrderCompiler", None)
+    error_cls = getattr(module, "OrderCompileError", RuntimeError)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "simulate_order", None)
+    if not callable(original):
+        return False
+    if getattr(original, _PATCH_ATTR, False):
+        return True
+
+    @wraps(original)
+    def simulate_order_base_minimum(
+        self: Any,
+        symbol: str,
+        side: str,
+        size_usd: float,
+        pricing: Any,
+        constraints: Any,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        result = original(self, symbol, side, size_usd, pricing, constraints, *args, **kwargs)
+        try:
+            quantity = float(result[0])
+        except Exception as exc:
+            raise error_cls("compiled quantity missing from order simulation") from exc
+
+        exchange = _norm(getattr(constraints, "exchange", ""))
+        with _LOCK:
+            min_base = float(_BASE_MINIMUMS.get(_cache_key(exchange, symbol), 0.0) or 0.0)
+        if min_base > 0.0 and quantity + 1e-15 < min_base:
+            LOGGER.error(
+                "LIVE_EXCHANGE_BASE_MINIMUM_V73_BLOCKED marker=%s exchange=%s symbol=%s "
+                "quantity=%.16f min_base=%.16f post_rounding=true fail_closed=true",
+                MARKER,
+                exchange,
+                _symbol(symbol),
+                quantity,
+                min_base,
+            )
+            raise error_cls(
+                f"Post-rounding quantity {quantity:.16g} below provider-proven "
+                f"minimum base quantity {min_base:.16g} for {exchange}/{symbol}"
+            )
+        if min_base > 0.0:
+            LOGGER.info(
+                "LIVE_EXCHANGE_BASE_MINIMUM_V73_PROVEN marker=%s exchange=%s symbol=%s "
+                "quantity=%.16f min_base=%.16f",
+                MARKER,
+                exchange,
+                _symbol(symbol),
+                quantity,
+                min_base,
+            )
+        return result
+
+    setattr(simulate_order_base_minimum, _PATCH_ATTR, True)
+    setattr(simulate_order_base_minimum, "__wrapped__", original)
+    cls.simulate_order = simulate_order_base_minimum
+    LOGGER.critical(
+        "LIVE_EXCHANGE_BASE_MINIMUM_V73_PATCHED marker=%s module=%s post_rounding_base_min=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _has_metadata_api(broker: Any) -> bool:
+    return any(callable(getattr(broker, name, None)) for name in _METADATA_METHODS)
+
+
+def _maybe_register_broker(broker: Any, fallback_exchange: Any = None) -> bool:
+    if broker is None:
+        return False
+    name = _exchange_name(broker, fallback_exchange)
+    if not name or name in v72._COMPAT_STATIC:
+        return False
+    if not _has_metadata_api(broker):
+        LOGGER.warning(
+            "LIVE_CONSTRAINT_PROVIDER_V73_NOT_REGISTERED marker=%s exchange=%s "
+            "reason=metadata_api_missing live_compile_will_fail_closed=true",
+            MARKER,
+            name or "unknown",
+        )
+        return False
+    if name in v72.registered_constraint_providers():
+        return True
+    try:
+        v72.register_client_constraint_provider(name, broker, replace=False)
+    except RuntimeError:
+        return name in v72.registered_constraint_providers()
+    LOGGER.critical(
+        "LIVE_CONSTRAINT_PROVIDER_V73_AUTO_REGISTERED marker=%s exchange=%s client=%s",
+        MARKER,
+        name,
+        type(broker).__name__,
+    )
+    return True
+
+
+def _patch_mabm(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    changed = False
+    for method_name in ("add_platform_broker", "add_user_broker"):
+        original = getattr(cls, method_name, None)
+        if not callable(original) or getattr(original, _PATCH_ATTR, False):
+            continue
+
+        @wraps(original)
+        def wrapped(self: Any, *args: Any, __orig=original, __name=method_name, **kwargs: Any):
+            broker = __orig(self, *args, **kwargs)
+            fallback = kwargs.get("broker_type")
+            if fallback is None:
+                fallback = args[-1] if args else None
+            _maybe_register_broker(broker, fallback)
+            return broker
+
+        setattr(wrapped, _PATCH_ATTR, True)
+        setattr(wrapped, "__wrapped__", original)
+        setattr(cls, method_name, wrapped)
+        changed = True
+    return changed
+
+
+def _patch_secure_adapter(module: ModuleType) -> bool:
+    cls = getattr(module, "SecureBrokerAdapter", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "_load_broker_client", None)
+    if not callable(original) or getattr(original, _PATCH_ATTR, False):
+        return bool(callable(original))
+
+    @wraps(original)
+    def load_with_constraint_registration(self: Any, *args: Any, **kwargs: Any):
+        result = original(self, *args, **kwargs)
+        _maybe_register_broker(
+            getattr(self, "broker_client", None),
+            getattr(self, "broker_name", None),
+        )
+        return result
+
+    setattr(load_with_constraint_registration, _PATCH_ATTR, True)
+    setattr(load_with_constraint_registration, "__wrapped__", original)
+    cls._load_broker_client = load_with_constraint_registration
+    return True
+
+
+def _patch_loaded() -> bool:
+    _install_constraint_capture()
+    changed = False
+    for name in ("bot.exchange_order_compiler", "exchange_order_compiler"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_eoc_module(module) or changed
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_mabm(module) or changed
+    for name in ("execution.broker_adapter", "broker_adapter"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_secure_adapter(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        v72.install_import_hook()
+        _patch_loaded()
+        flag = "_NIJA_LIVE_EXCHANGE_BASE_MINIMUM_V73_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            text = str(name)
+            if (
+                "exchange_order_compiler" in text
+                or "multi_account_broker_manager" in text
+                or "broker_adapter" in text
+            ):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_LIVE_EXCHANGE_BASE_MINIMUM_V73_INSTALLED"] = "1"
+        LOGGER.critical(
+            "LIVE_EXCHANGE_BASE_MINIMUM_V73_INSTALLED marker=%s "
+            "post_rounding_base_min=true future_provider_autoregistration=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_maybe_register_broker",
+    "_patch_eoc_module",
+    "_BASE_MINIMUMS",
+]

--- a/bot/live_exchange_constraints_authority_v72_patch.py
+++ b/bot/live_exchange_constraints_authority_v72_patch.py
@@ -1,0 +1,391 @@
+"""Live exchange-constraint authority v72.
+
+NIJA's historical ExchangeOrderCompiler contains static schemas for Kraken,
+Coinbase and OKX plus a generic fallback.  Generic precision/minimum assumptions
+are not safe for Binance, Alpaca or future exchanges because symbol rules are
+instrument-specific and may change.
+
+v72 adds a provider registry for live symbol constraints and makes unknown/live
+venues fail closed unless a provider returns verified metadata.  Existing
+Kraken/Coinbase/OKX static schemas remain compatibility fallbacks because those
+venues also pass through dedicated runtime order guards elsewhere in NIJA.
+
+Supported normalized provider shapes include:
+* canonical: min_order_usd/min_notional_usd/fee_rate_one_way/step_size/precision;
+* Binance exchangeInfo filters: LOT_SIZE/MARKET_LOT_SIZE, MIN_NOTIONAL/NOTIONAL;
+* Alpaca asset fields: min_order_size, min_trade_increment, price_increment;
+* OKX-style: minSz, lotSz, tickSz;
+* Coinbase-style: base_min_size, base_increment, quote_min_size.
+
+A provider may be registered directly or derived from a broker client exposing a
+symbol/market metadata method.  No provider result is accepted unless positive
+quantity precision/minimum information can be proven.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+from decimal import Decimal
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable, Mapping, Optional
+
+LOGGER = logging.getLogger("nija.live_exchange_constraints_authority_v72")
+MARKER = "20260809-live-exchange-constraints-authority-v72"
+_PATCH_ATTR = "_nija_live_exchange_constraints_authority_v72"
+_LOCK = threading.RLock()
+_PROVIDERS: dict[str, Callable[[str], Any]] = {}
+_COMPAT_STATIC = {"kraken", "coinbase", "okx"}
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().lower().replace(" ", "_")
+
+
+def _live_mode() -> bool:
+    truthy = {"1", "true", "yes", "on", "enabled", "y"}
+    return (
+        str(os.environ.get("LIVE_CAPITAL_VERIFIED", "false")).strip().lower() in truthy
+        and str(os.environ.get("DRY_RUN_MODE", "false")).strip().lower() not in truthy
+        and str(os.environ.get("PAPER_MODE", "false")).strip().lower() not in truthy
+    )
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _precision_from_step(step: float) -> int:
+    if step <= 0.0:
+        return 0
+    text = format(Decimal(str(step)).normalize(), "f")
+    if "." not in text:
+        return 0
+    return min(18, len(text.rstrip("0").split(".", 1)[1]))
+
+
+def register_live_constraint_provider(
+    exchange: str,
+    provider: Callable[[str], Any],
+    *,
+    replace: bool = False,
+) -> None:
+    name = _norm(exchange)
+    if not name:
+        raise ValueError("exchange is required")
+    if not callable(provider):
+        raise TypeError("provider must be callable")
+    with _LOCK:
+        if name in _PROVIDERS and not replace:
+            raise RuntimeError(f"constraint provider already registered: {name}")
+        _PROVIDERS[name] = provider
+    LOGGER.info(
+        "LIVE_CONSTRAINT_PROVIDER_V72_REGISTERED marker=%s exchange=%s replace=%s",
+        MARKER,
+        name,
+        replace,
+    )
+
+
+def unregister_live_constraint_provider(exchange: str) -> None:
+    with _LOCK:
+        _PROVIDERS.pop(_norm(exchange), None)
+
+
+def registered_constraint_providers() -> tuple[str, ...]:
+    with _LOCK:
+        return tuple(sorted(_PROVIDERS))
+
+
+def _client_metadata_provider(client: Any) -> Callable[[str], Any]:
+    methods = (
+        "get_symbol_rules",
+        "get_order_rules",
+        "get_market_rules",
+        "get_instrument_info",
+        "get_symbol_info",
+        "get_market_info",
+        "get_product",
+        "get_asset",
+    )
+
+    def provider(symbol: str) -> Any:
+        errors: list[str] = []
+        for name in methods:
+            method = getattr(client, name, None)
+            if not callable(method):
+                continue
+            for args, kwargs in (((symbol,), {}), ((), {"symbol": symbol})):
+                try:
+                    value = method(*args, **kwargs)
+                except TypeError:
+                    continue
+                except Exception as exc:
+                    errors.append(f"{name}:{type(exc).__name__}")
+                    break
+                if value is not None:
+                    return value
+        raise RuntimeError(
+            "broker client exposes no usable symbol-constraint metadata method"
+            + (f" ({','.join(errors[-3:])})" if errors else "")
+        )
+
+    return provider
+
+
+def register_client_constraint_provider(
+    exchange: str,
+    client: Any,
+    *,
+    replace: bool = False,
+) -> None:
+    register_live_constraint_provider(
+        exchange,
+        _client_metadata_provider(client),
+        replace=replace,
+    )
+
+
+def _filters_map(raw: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    filters = raw.get("filters")
+    if not isinstance(filters, list):
+        return {}
+    result: dict[str, Mapping[str, Any]] = {}
+    for item in filters:
+        if isinstance(item, Mapping):
+            key = str(item.get("filterType") or "").strip().upper()
+            if key:
+                result[key] = item
+    return result
+
+
+def _extract_rules(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("constraint provider returned non-mapping metadata")
+
+    # Many APIs wrap the symbol object under data/result/product/asset.
+    value: Mapping[str, Any] = raw
+    for key in ("result", "product", "asset", "symbol_info", "instrument"):
+        nested = value.get(key)
+        if isinstance(nested, Mapping):
+            value = nested
+            break
+    data = value.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], Mapping):
+        value = data[0]
+
+    filters = _filters_map(value)
+    lot = filters.get("MARKET_LOT_SIZE") or filters.get("LOT_SIZE") or {}
+    notional = filters.get("NOTIONAL") or filters.get("MIN_NOTIONAL") or {}
+
+    # Canonical / Binance / OKX / Coinbase / Alpaca aliases.
+    step = max(
+        _f(value.get("step_size")),
+        _f(value.get("base_increment")),
+        _f(value.get("lotSz")),
+        _f(value.get("min_trade_increment")),
+        _f(lot.get("stepSize")),
+    )
+    min_base = max(
+        _f(value.get("min_base_qty")),
+        _f(value.get("base_min_size")),
+        _f(value.get("minSz")),
+        _f(value.get("min_order_size")),
+        _f(lot.get("minQty")),
+    )
+    min_notional = max(
+        _f(value.get("min_notional_usd")),
+        _f(value.get("min_order_usd")),
+        _f(value.get("quote_min_size")),
+        _f(value.get("minNotional")),
+        _f(notional.get("minNotional")),
+        _f(notional.get("notional")),
+    )
+    fee = max(
+        0.0,
+        _f(value.get("fee_rate_one_way")),
+        _f(value.get("taker_fee")),
+        _f(value.get("fee_taker")),
+    )
+    precision = int(
+        _f(value.get("precision_decimals"), -1)
+        if value.get("precision_decimals") is not None
+        else _f(value.get("lot_precision"), -1)
+    )
+    if precision < 0 and step > 0.0:
+        precision = _precision_from_step(step)
+
+    # Alpaca crypto may give min_order_size/min_trade_increment in base units,
+    # not USD.  Keep min_base separately and do not mislabel it as notional.
+    if "min_order_size" in value and not any(
+        key in value for key in ("min_order_usd", "min_notional_usd", "quote_min_size")
+    ):
+        min_base = max(min_base, _f(value.get("min_order_size")))
+        min_notional = max(
+            _f(value.get("min_notional_usd")),
+            _f(value.get("quote_min_size")),
+        )
+
+    if step <= 0.0:
+        # A positive minimum base increment is usable as a conservative step
+        # only when the provider explicitly gives no separate increment.
+        step = _f(value.get("min_trade_increment"))
+    if step <= 0.0 or precision < 0:
+        raise ValueError("symbol quantity increment/precision not proven")
+    if min_base <= 0.0 and min_notional <= 0.0:
+        raise ValueError("symbol minimum quantity/notional not proven")
+
+    return {
+        "step_size": step,
+        "precision_decimals": precision,
+        "min_base_qty": min_base,
+        "min_notional_usd": min_notional,
+        "min_order_usd": min_notional,
+        "fee_rate_one_way": fee,
+    }
+
+
+def _constraints_from_provider(module: ModuleType, exchange: str, symbol: str) -> Any:
+    name = _norm(exchange)
+    with _LOCK:
+        provider = _PROVIDERS.get(name)
+    if provider is None:
+        return None
+    raw = provider(symbol)
+    rules = _extract_rules(raw)
+    cls = getattr(module, "ExchangeConstraints")
+    min_notional = float(rules["min_notional_usd"] or 0.0)
+    min_order = float(rules["min_order_usd"] or 0.0)
+    # When the venue exposes only a base minimum, the compiler's post-rounding
+    # quantity gate still uses the step; a zero quote minimum is allowed here.
+    return cls(
+        exchange=name,
+        min_order_usd=max(0.0, min_order),
+        min_notional_usd=max(0.0, min_notional),
+        fee_rate_one_way=max(0.0, float(rules["fee_rate_one_way"] or 0.0)),
+        step_size=float(rules["step_size"]),
+        precision_decimals=int(rules["precision_decimals"]),
+    )
+
+
+def _patch(module: ModuleType) -> bool:
+    cls = getattr(module, "ExchangeOrderCompiler", None)
+    error_cls = getattr(module, "OrderCompileError", RuntimeError)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "get_constraints", None)
+    if not callable(original):
+        return False
+    if getattr(original, _PATCH_ATTR, False):
+        return True
+
+    @wraps(original)
+    def get_constraints_live_authority(self: Any, exchange: str, symbol: str):
+        name = _norm(exchange)
+        try:
+            dynamic = _constraints_from_provider(module, name, symbol)
+        except Exception as exc:
+            if _live_mode():
+                raise error_cls(
+                    f"Live symbol constraints unavailable/invalid for {name}/{symbol}: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+            dynamic = None
+        if dynamic is not None:
+            LOGGER.info(
+                "LIVE_EXCHANGE_CONSTRAINTS_V72_PROVEN marker=%s exchange=%s symbol=%s "
+                "min_notional=%.8f step=%.12f precision=%d source=registered_provider",
+                MARKER,
+                name,
+                symbol,
+                float(dynamic.min_notional_usd),
+                float(dynamic.step_size),
+                int(dynamic.precision_decimals),
+            )
+            return dynamic
+
+        if _live_mode() and name not in _COMPAT_STATIC:
+            raise error_cls(
+                f"Live exchange {name or 'unknown'} requires a registered symbol-constraint provider; "
+                "generic min/precision fallback is prohibited"
+            )
+        constraints = original(self, exchange, symbol)
+        if _live_mode() and name in _COMPAT_STATIC:
+            LOGGER.debug(
+                "LIVE_EXCHANGE_CONSTRAINTS_V72_COMPAT_STATIC marker=%s exchange=%s symbol=%s "
+                "dedicated_runtime_guards_required=true",
+                MARKER,
+                name,
+                symbol,
+            )
+        return constraints
+
+    setattr(get_constraints_live_authority, _PATCH_ATTR, True)
+    setattr(get_constraints_live_authority, "__wrapped__", original)
+    cls.get_constraints = get_constraints_live_authority
+    LOGGER.critical(
+        "LIVE_EXCHANGE_CONSTRAINTS_AUTHORITY_V72_PATCHED marker=%s module=%s "
+        "unknown_live_generic_fallback=false provider_registry=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.exchange_order_compiler", "exchange_order_compiler"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        flag = "_NIJA_LIVE_EXCHANGE_CONSTRAINTS_AUTHORITY_V72_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "exchange_order_compiler" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_LIVE_EXCHANGE_CONSTRAINTS_AUTHORITY_V72_INSTALLED"] = "1"
+        LOGGER.critical(
+            "LIVE_EXCHANGE_CONSTRAINTS_AUTHORITY_V72_INSTALLED marker=%s live_generic_fallback=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "register_live_constraint_provider",
+    "unregister_live_constraint_provider",
+    "registered_constraint_providers",
+    "register_client_constraint_provider",
+    "_extract_rules",
+]

--- a/bot/profit_harvest_realization_guard_v66_patch.py
+++ b/bot/profit_harvest_realization_guard_v66_patch.py
@@ -1,0 +1,335 @@
+"""Profit-harvest realization guard v66.
+
+``ProfitHarvestLayer`` computes useful *unrealized* profit-lock candidates from
+price movement.  The underlying ``PortfolioProfitEngine`` is explicitly a
+ledger of realised P&L from closed trades.  Feeding a tier-derived candidate
+into that ledger before a broker confirms a position reduction conflates market
+value with realised cash and can overstate harvested/compoundable profit.
+
+v66 keeps tier/floor logic as a candidate generator while making realization an
+explicit, fill-proven operation:
+
+* tier upgrades add to ``harvestable_balance_usd`` but are not counted as
+  cumulative harvested profit;
+* floor hits do not silently move virtual dollars into the realised ledger;
+* legacy ``partial_harvest`` is fail-closed because it has no broker execution
+  proof;
+* ``confirm_realized_harvest`` requires a non-empty broker fill/order proof and
+  only then routes an amount into ``PortfolioProfitEngine.harvest_profits``;
+* the realised amount can never exceed the candidate balance nor the realised
+  profit actually available in ``PortfolioProfitEngine``.
+
+This module does not place orders.  Broker-native exit supervisors remain
+responsible for reducing/closing positions and must call the confirmation API
+only after execution acknowledgement/fill reconciliation.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from datetime import datetime
+from functools import wraps
+from types import ModuleType
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.profit_harvest_realization_guard_v66")
+MARKER = "20260809-profit-harvest-realization-v66"
+_PATCH_ATTR = "_nija_profit_harvest_realization_v66"
+_INSTALL_LOCK = threading.RLock()
+_CONFIRM_CONTEXT = threading.local()
+
+
+def _confirmation_active() -> bool:
+    return bool(getattr(_CONFIRM_CONTEXT, "active", False))
+
+
+def _patch(module: ModuleType) -> bool:
+    cls = getattr(module, "ProfitHarvestLayer", None)
+    if not isinstance(cls, type):
+        return False
+    original_process = getattr(cls, "process_price_update", None)
+    original_partial = getattr(cls, "partial_harvest", None)
+    original_route = getattr(cls, "_route_to_profit_engine", None)
+    if not all(callable(value) for value in (original_process, original_partial, original_route)):
+        return False
+    if getattr(original_process, _PATCH_ATTR, False):
+        return True
+
+    @wraps(original_route)
+    def _route_realized_only(self: Any, symbol: str, amount_usd: float, note: str = "") -> float:
+        amount = max(0.0, float(amount_usd or 0.0))
+        if amount <= 0.0:
+            return 0.0
+        if not _confirmation_active():
+            LOGGER.warning(
+                "PROFIT_HARVEST_V66_REALIZATION_BLOCKED marker=%s symbol=%s amount=%.4f "
+                "reason=broker_fill_proof_missing candidate_only=true",
+                MARKER,
+                symbol,
+                amount,
+            )
+            return 0.0
+        try:
+            engine = module.get_portfolio_profit_engine()
+            actual = float(engine.harvest_profits(amount=amount, note=note) or 0.0)
+        except Exception as exc:
+            LOGGER.error(
+                "PROFIT_HARVEST_V66_REALIZATION_FAILED marker=%s symbol=%s amount=%.4f error=%s:%s",
+                MARKER,
+                symbol,
+                amount,
+                type(exc).__name__,
+                exc,
+            )
+            return 0.0
+        return max(0.0, min(amount, actual))
+
+    @wraps(original_process)
+    def _process_candidate_only(self: Any, symbol: str, current_price: float):
+        with getattr(self, "_lock", threading.RLock()):
+            before_state = getattr(self, "_positions", {}).get(symbol)
+            before_available = float(
+                getattr(before_state, "harvestable_balance_usd", 0.0) or 0.0
+            ) if before_state is not None else 0.0
+            before_harvested = float(
+                getattr(before_state, "cumulative_harvested_usd", 0.0) or 0.0
+            ) if before_state is not None else 0.0
+            before_harvested_pct = float(
+                getattr(before_state, "cumulative_harvested_pct", 0.0) or 0.0
+            ) if before_state is not None else 0.0
+
+        decision = original_process(self, symbol, current_price)
+
+        with getattr(self, "_lock", threading.RLock()):
+            state = getattr(self, "_positions", {}).get(symbol)
+            if state is None:
+                return decision
+
+            candidate_amount = max(0.0, float(getattr(decision, "harvest_amount_usd", 0.0) or 0.0))
+            # The legacy method increments cumulative harvested at tier upgrade.
+            # Restore the realised counters to their pre-update values.
+            state.cumulative_harvested_usd = before_harvested
+            state.cumulative_harvested_pct = before_harvested_pct
+
+            # The legacy floor-hit branch clears the candidate balance after
+            # attempting to route it.  Since routing is blocked without fill
+            # proof, preserve the unrealised candidate instead.
+            expected_candidate = before_available + candidate_amount
+            if bool(getattr(decision, "floor_hit", False)):
+                state.harvestable_balance_usd = max(
+                    float(getattr(state, "harvestable_balance_usd", 0.0) or 0.0),
+                    expected_candidate,
+                )
+
+            # Mark the just-created legacy event as a candidate rather than a
+            # realised harvest for audit clarity.
+            log = getattr(state, "harvest_log", None)
+            if candidate_amount > 0.0 and isinstance(log, list) and log:
+                event = log[-1]
+                if isinstance(event, dict):
+                    note = str(event.get("note", "") or "").strip()
+                    event["note"] = (
+                        f"UNREALIZED_CANDIDATE {note}".strip()
+                    )
+
+            saver = getattr(self, "_save_state", None)
+            if callable(saver):
+                saver()
+
+        if candidate_amount > 0.0:
+            LOGGER.info(
+                "PROFIT_HARVEST_V66_CANDIDATE marker=%s symbol=%s candidate_usd=%.4f "
+                "realized_usd=0.0 fill_proof=false",
+                MARKER,
+                symbol,
+                candidate_amount,
+            )
+            try:
+                decision.harvest_triggered = False
+                decision.harvest_amount_usd = 0.0
+                decision.message = (
+                    f"{getattr(decision, 'message', '')} | candidate=${candidate_amount:.2f} "
+                    "awaiting confirmed broker reduction"
+                ).strip(" |")
+            except Exception:
+                pass
+        return decision
+
+    @wraps(original_partial)
+    def _partial_requires_execution_proof(
+        self: Any,
+        symbol: str,
+        fraction: float = 1.0,
+        note: str = "",
+    ) -> float:
+        LOGGER.warning(
+            "PROFIT_HARVEST_V66_PARTIAL_BLOCKED marker=%s symbol=%s fraction=%.4f "
+            "reason=legacy_partial_harvest_has_no_broker_fill_proof",
+            MARKER,
+            symbol,
+            float(fraction or 0.0),
+        )
+        return 0.0
+
+    def confirm_realized_harvest(
+        self: Any,
+        symbol: str,
+        amount_usd: float,
+        *,
+        broker_fill_id: str,
+        broker_name: str = "",
+        account_id: str = "",
+        note: str = "",
+    ) -> float:
+        """Realize a harvest only after a broker-confirmed position reduction."""
+        fill_id = str(broker_fill_id or "").strip()
+        if not fill_id:
+            raise ValueError("broker_fill_id is required")
+        requested = max(0.0, float(amount_usd or 0.0))
+        if requested <= 0.0:
+            return 0.0
+
+        with getattr(self, "_lock", threading.RLock()):
+            state = getattr(self, "_positions", {}).get(symbol)
+            if state is None:
+                LOGGER.warning(
+                    "PROFIT_HARVEST_V66_CONFIRM_BLOCKED marker=%s symbol=%s reason=position_not_registered fill_id=%s",
+                    MARKER,
+                    symbol,
+                    fill_id,
+                )
+                return 0.0
+            available = max(0.0, float(getattr(state, "harvestable_balance_usd", 0.0) or 0.0))
+            candidate = min(requested, available)
+        if candidate <= 0.0:
+            return 0.0
+
+        previous = _confirmation_active()
+        _CONFIRM_CONTEXT.active = True
+        try:
+            actual = float(
+                _route_realized_only(
+                    self,
+                    symbol,
+                    candidate,
+                    note=(
+                        f"confirmed_exit broker={broker_name or 'unknown'} account={account_id or 'unknown'} "
+                        f"fill_id={fill_id} {note}"
+                    ).strip(),
+                )
+                or 0.0
+            )
+        finally:
+            _CONFIRM_CONTEXT.active = previous
+
+        if actual <= 0.0:
+            return 0.0
+
+        with getattr(self, "_lock", threading.RLock()):
+            state = getattr(self, "_positions", {}).get(symbol)
+            if state is None:
+                return 0.0
+            state.harvestable_balance_usd = max(
+                0.0,
+                float(getattr(state, "harvestable_balance_usd", 0.0) or 0.0) - actual,
+            )
+            state.cumulative_harvested_usd = float(
+                getattr(state, "cumulative_harvested_usd", 0.0) or 0.0
+            ) + actual
+            event_cls = getattr(module, "HarvestEvent", None)
+            event = {
+                "timestamp": datetime.now().isoformat(),
+                "symbol": symbol,
+                "tier": str(getattr(state, "last_harvested_tier", "")),
+                "locked_increment_pct": 0.0,
+                "harvest_fraction": 0.0,
+                "harvest_pct": 0.0,
+                "harvest_usd": round(actual, 4),
+                "note": (
+                    f"REALIZED_CONFIRMED broker={broker_name or 'unknown'} "
+                    f"account={account_id or 'unknown'} fill_id={fill_id} {note}"
+                ).strip(),
+            }
+            if event_cls is not None:
+                try:
+                    event = event_cls(**event).__dict__
+                except Exception:
+                    pass
+            log = getattr(state, "harvest_log", None)
+            if isinstance(log, list):
+                log.append(event)
+            state.last_updated = datetime.now().isoformat()
+            saver = getattr(self, "_save_state", None)
+            if callable(saver):
+                saver()
+
+        LOGGER.critical(
+            "PROFIT_HARVEST_V66_REALIZED marker=%s symbol=%s amount=%.4f broker=%s account=%s "
+            "fill_id=%s broker_fill_proof=true",
+            MARKER,
+            symbol,
+            actual,
+            broker_name or "unknown",
+            account_id or "unknown",
+            fill_id,
+        )
+        return round(actual, 4)
+
+    setattr(_route_realized_only, _PATCH_ATTR, True)
+    setattr(_process_candidate_only, _PATCH_ATTR, True)
+    setattr(_partial_requires_execution_proof, _PATCH_ATTR, True)
+    cls._route_to_profit_engine = _route_realized_only
+    cls.process_price_update = _process_candidate_only
+    cls.partial_harvest = _partial_requires_execution_proof
+    cls.confirm_realized_harvest = confirm_realized_harvest
+    LOGGER.critical(
+        "PROFIT_HARVEST_REALIZATION_V66_PATCHED marker=%s module=%s fill_proof_required=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.profit_harvest_layer", "profit_harvest_layer"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _INSTALL_LOCK:
+        _patch_loaded()
+        flag = "_NIJA_PROFIT_HARVEST_REALIZATION_V66_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "profit_harvest_layer" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_PROFIT_HARVEST_REALIZATION_V66_INSTALLED"] = "1"
+        LOGGER.critical(
+            "PROFIT_HARVEST_REALIZATION_V66_INSTALLED marker=%s fill_proof_required=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_patch"]

--- a/bot/tests/test_account_scoped_profit_state_v71.py
+++ b/bot/tests/test_account_scoped_profit_state_v71.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib
+import types
+import unittest
+
+
+class AccountScopedProfitStateV71Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.account_scoped_profit_state_v71_patch")
+
+    def test_scoped_key_separates_same_symbol_by_account_and_broker(self) -> None:
+        alpha = self.mod.scoped_position_key("user-alpha", "coinbase", "BTC-USD")
+        beta = self.mod.scoped_position_key("user-beta", "coinbase", "BTC-USD")
+        okx = self.mod.scoped_position_key("user-alpha", "okx", "BTC-USD")
+        self.assertNotEqual(alpha, beta)
+        self.assertNotEqual(alpha, okx)
+        self.assertIn("scope=user-alpha", alpha)
+        self.assertIn("broker=coinbase", alpha)
+        self.assertIn("symbol=BTC-USD", alpha)
+
+    def test_scoped_key_requires_identity_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            self.mod.scoped_position_key("", "coinbase", "BTC-USD")
+        with self.assertRaises(ValueError):
+            self.mod.scoped_position_key("user-1", "", "BTC-USD")
+        with self.assertRaises(ValueError):
+            self.mod.scoped_position_key("user-1", "coinbase", "")
+
+    def test_profit_lock_scoped_methods_keep_two_accounts_independent(self) -> None:
+        fake = types.ModuleType("profit_lock_v71_fake")
+
+        class Engine:
+            def __init__(self) -> None:
+                self.positions = {}
+
+            def register_position(self, symbol, side, entry_price, entry_time=None):
+                self.positions[symbol] = {
+                    "symbol": symbol,
+                    "side": side,
+                    "entry_price": entry_price,
+                    "peak": entry_price,
+                }
+
+            def update_position(self, symbol, current_price):
+                state = self.positions[symbol]
+                state["peak"] = max(state["peak"], current_price)
+                return types.SimpleNamespace(symbol=symbol, peak_profit_pct=state["peak"])
+
+            def remove_position(self, symbol):
+                return self.positions.pop(symbol, None)
+
+            def get_lock_status(self, symbol):
+                return dict(self.positions[symbol]) if symbol in self.positions else None
+
+        fake.ProfitLockEngine = Engine
+        self.mod._patch_lock_engine(fake)
+        engine = Engine()
+        engine.register_scoped_position("user-a", "coinbase", "BTC-USD", "long", 100.0)
+        engine.register_scoped_position("user-b", "coinbase", "BTC-USD", "long", 200.0)
+        engine.update_scoped_position("user-a", "coinbase", "BTC-USD", 110.0)
+        engine.update_scoped_position("user-b", "coinbase", "BTC-USD", 205.0)
+
+        a = engine.get_scoped_lock_status("user-a", "coinbase", "BTC-USD")
+        b = engine.get_scoped_lock_status("user-b", "coinbase", "BTC-USD")
+        self.assertEqual(a["entry_price"], 100.0)
+        self.assertEqual(a["peak"], 110.0)
+        self.assertEqual(b["entry_price"], 200.0)
+        self.assertEqual(b["peak"], 205.0)
+        self.assertEqual(len(engine.positions), 2)
+
+    def test_harvest_confirm_scoped_routes_fill_proof_to_scoped_key(self) -> None:
+        fake = types.ModuleType("profit_harvest_v71_fake")
+        calls = []
+
+        class Layer:
+            def register_position(self, symbol, side, entry_price, position_size_usd, entry_time=None):
+                return None
+
+            def process_price_update(self, symbol, current_price):
+                return types.SimpleNamespace(symbol=symbol)
+
+            def get_harvest_status(self, symbol):
+                return {"symbol": symbol}
+
+            def remove_position(self, symbol):
+                return {"symbol": symbol}
+
+            def confirm_realized_harvest(
+                self,
+                symbol,
+                amount_usd,
+                *,
+                broker_fill_id,
+                broker_name="",
+                account_id="",
+                note="",
+            ):
+                calls.append(
+                    {
+                        "symbol": symbol,
+                        "amount": amount_usd,
+                        "fill": broker_fill_id,
+                        "broker": broker_name,
+                        "account": account_id,
+                    }
+                )
+                return amount_usd
+
+        fake.ProfitHarvestLayer = Layer
+        self.mod._patch_harvest_layer(fake)
+        layer = Layer()
+        actual = layer.confirm_scoped_realized_harvest(
+            "user-a",
+            "okx",
+            "ETH-USDT",
+            3.25,
+            broker_fill_id="fill-77",
+        )
+        self.assertEqual(actual, 3.25)
+        self.assertEqual(calls[0]["fill"], "fill-77")
+        self.assertEqual(calls[0]["broker"], "okx")
+        self.assertEqual(calls[0]["account"], "user-a")
+        self.assertIn("scope=user-a", calls[0]["symbol"])
+        self.assertIn("broker=okx", calls[0]["symbol"])
+        self.assertIn("symbol=ETH-USDT", calls[0]["symbol"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_account_scoped_profit_state_v71.py
+++ b/bot/tests/test_account_scoped_profit_state_v71.py
@@ -19,7 +19,7 @@ class AccountScopedProfitStateV71Tests(unittest.TestCase):
         self.assertIn("broker=coinbase", alpha)
         self.assertIn("symbol=BTC-USD", alpha)
 
-    def test_scoped_key_requires_identity_fields(self) -> None:
+    def test_scoped_key_requires_identity_validation(self) -> None:
         with self.assertRaises(ValueError):
             self.mod.scoped_position_key("", "coinbase", "BTC-USD")
         with self.assertRaises(ValueError):

--- a/bot/tests/test_activation_snapshot_bridge_v63.py
+++ b/bot/tests/test_activation_snapshot_bridge_v63.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "activation_snapshot_bridge_patch.py"
+spec = importlib.util.spec_from_file_location("activation_bridge_v63_under_test", PATCH_PATH)
+assert spec and spec.loader
+bridge = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = bridge
+spec.loader.exec_module(bridge)
+
+
+def _meta(*, accepted: bool = True) -> tuple[bool, dict]:
+    return accepted, {
+        "ca_available": True,
+        "accepted_latch": False,
+        "hydrated": True,
+        "stale": False,
+        "real_capital": 240.07922691659326,
+        "valid_brokers": 2,
+        "brokers_ready": True,
+        "conditions_met": True,
+    }
+
+
+def test_augment_cycle_capital_promotes_real_authority_snapshot():
+    snapshot = {
+        "ca_is_hydrated": False,
+        "ca_total_capital": 0.0,
+        "ca_valid_brokers": 0,
+        "snapshot_source": "placeholder",
+        "aggregation_normalized": True,
+        "sync_failed": True,
+    }
+
+    bridged = bridge._augment_cycle_capital(snapshot, _meta()[1])
+
+    assert bridged["ca_is_hydrated"] is True
+    assert bridged["ca_total_capital"] == 240.07922691659326
+    assert bridged["ca_valid_brokers"] == 2
+    assert bridged["snapshot_source"] == "capital_authority"
+    assert bridged["is_post_hydration"] is True
+    assert bridged["mabm_brokers_ready"] is True
+    assert bridged["sync_failed"] is False
+    assert bridge._cycle_capital_live(bridged) is True
+
+
+def test_augment_preserves_explicit_aggregation_failure():
+    snapshot = {
+        "ca_is_hydrated": False,
+        "ca_total_capital": 0.0,
+        "ca_valid_brokers": 0,
+        "snapshot_source": "placeholder",
+        "aggregation_normalized": False,
+    }
+
+    bridged = bridge._augment_cycle_capital(snapshot, _meta()[1])
+
+    assert bridged["aggregation_normalized"] is False
+    assert bridged["ca_valid_brokers"] == 2
+
+
+def test_cycle_capital_live_rejects_placeholder_and_sync_failure():
+    assert bridge._cycle_capital_live({}) is False
+    assert bridge._cycle_capital_live(
+        {
+            "ca_is_hydrated": True,
+            "ca_total_capital": 240.08,
+            "ca_valid_brokers": 2,
+            "snapshot_source": "placeholder",
+            "sync_failed": False,
+        }
+    ) is False
+    assert bridge._cycle_capital_live(
+        {
+            "ca_is_hydrated": True,
+            "ca_total_capital": 240.08,
+            "ca_valid_brokers": 2,
+            "snapshot_source": "capital_authority",
+            "sync_failed": True,
+        }
+    ) is False
+
+
+def test_direct_scan_wrapper_temporarily_bridges_and_restores(monkeypatch):
+    module_name = "v63_fake_core_module"
+    fake_module = types.ModuleType(module_name)
+    original_capital = {
+        "ca_is_hydrated": False,
+        "ca_total_capital": 0.0,
+        "ca_valid_brokers": 0,
+        "snapshot_source": "placeholder",
+        "aggregation_normalized": True,
+        "sync_failed": True,
+    }
+    fake_module._current_cycle_capital = original_capital
+    fake_module._current_cycle_id = ""
+
+    observed = {}
+
+    class FakeCore:
+        __module__ = module_name
+
+        def run_scan_phase(self, *args, **kwargs):
+            observed["capital"] = dict(fake_module._current_cycle_capital)
+            observed["cycle_id"] = fake_module._current_cycle_id
+            return "scan-result"
+
+    fake_module.NijaCoreLoop = FakeCore
+    sys.modules[module_name] = fake_module
+    monkeypatch.setattr(bridge, "_capital_snapshot_meta", lambda: _meta())
+
+    try:
+        assert bridge._patch_core_loop_class(FakeCore) is True
+        result = FakeCore().run_scan_phase()
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert result == "scan-result"
+    assert observed["capital"]["ca_is_hydrated"] is True
+    assert observed["capital"]["ca_total_capital"] == 240.07922691659326
+    assert observed["capital"]["ca_valid_brokers"] == 2
+    assert observed["capital"]["snapshot_source"] == "capital_authority"
+    assert observed["cycle_id"].endswith("-direct-v63")
+    assert fake_module._current_cycle_capital is original_capital
+    assert fake_module._current_cycle_id == ""
+
+
+def test_direct_scan_wrapper_does_not_bridge_unaccepted_capital(monkeypatch):
+    module_name = "v63_fake_core_unaccepted"
+    fake_module = types.ModuleType(module_name)
+    original_capital = {
+        "ca_is_hydrated": False,
+        "ca_total_capital": 0.0,
+        "ca_valid_brokers": 0,
+        "snapshot_source": "placeholder",
+    }
+    fake_module._current_cycle_capital = original_capital
+    fake_module._current_cycle_id = "original-cycle"
+
+    observed = {}
+
+    class FakeCore:
+        __module__ = module_name
+
+        def run_scan_phase(self, *args, **kwargs):
+            observed["capital"] = fake_module._current_cycle_capital
+            observed["cycle_id"] = fake_module._current_cycle_id
+            return "unchanged"
+
+    fake_module.NijaCoreLoop = FakeCore
+    sys.modules[module_name] = fake_module
+    monkeypatch.setattr(bridge, "_capital_snapshot_meta", lambda: _meta(accepted=False))
+
+    try:
+        assert bridge._patch_core_loop_class(FakeCore) is True
+        result = FakeCore().run_scan_phase()
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert result == "unchanged"
+    assert observed["capital"] is original_capital
+    assert observed["cycle_id"] == "original-cycle"

--- a/bot/tests/test_adaptive_profit_exit_v74.py
+++ b/bot/tests/test_adaptive_profit_exit_v74.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+
+class AdaptiveProfitExitV74Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.adaptive_profit_exit_v74_patch")
+        self.mod._POSITIONS.clear()
+        self.mod._STATS.clear()
+
+    def _universal(self, base_trigger):
+        module = types.ModuleType("universal_exit_v74_fake")
+
+        class AutoExit:
+            @staticmethod
+            def _sym(value):
+                return str(value or "").upper()
+
+            @staticmethod
+            def _entry_price(pos):
+                return float(pos.get("entry_price", 0.0) or 0.0)
+
+            @staticmethod
+            def _quantity(pos):
+                return float(pos.get("quantity", 0.0) or 0.0)
+
+            @staticmethod
+            def _side(value, pos):
+                return str(value or pos.get("side") or "long").lower()
+
+            @staticmethod
+            def _get(mapping, *keys, default=None):
+                for key in keys:
+                    if key in mapping and mapping[key] is not None:
+                        return mapping[key]
+                return default
+
+        module.auto_exit = AutoExit
+        module._trigger = base_trigger
+        return module
+
+    def _broker(self):
+        return types.SimpleNamespace(broker_name="coinbase", account_id="acct-a")
+
+    def _pos(self, **extra):
+        base = {
+            "symbol": "BTC-USD",
+            "position_id": "p1",
+            "account_id": "acct-a",
+            "entry_price": 100.0,
+            "quantity": 1.0,
+            "side": "long",
+            "market_regime": "bull_trending",
+            "regime_confidence": 0.90,
+            "atr_pct": 0.01,
+        }
+        base.update(extra)
+        return base
+
+    def test_strong_trend_profit_floor_arms_instead_of_immediate_tp(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (True, "net_profit_target", 101.0))
+        with patch.object(self.mod.v68, "_floors", return_value=(100.5, 101.0, {"entry": 100.0, "short": False})):
+            with patch.object(self.mod.v68, "_reason_kind", return_value="profit"):
+                with patch.object(self.mod.v68, "_meets", side_effect=lambda market, target, short: market >= target):
+                    self.mod._patch_universal(universal)
+                    hit, reason, target = universal._trigger(self._broker(), self._pos(), 102.0)
+        self.assertFalse(hit)
+        self.assertEqual(reason, "")
+        self.assertEqual(target, 0.0)
+        self.assertTrue(self.mod._is_armed(universal, self._broker(), self._pos()))
+
+    def test_trailing_giveback_exits_after_peak(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (True, "net_profit_target", 101.0))
+        with patch.object(self.mod.v68, "_floors", return_value=(100.5, 101.0, {"entry": 100.0, "short": False})):
+            with patch.object(self.mod.v68, "_reason_kind", return_value="profit"):
+                with patch.object(self.mod.v68, "_meets", side_effect=lambda market, target, short: market >= target):
+                    with patch.object(self.mod, "_trail_pct", return_value=0.02):
+                        self.mod._patch_universal(universal)
+                        broker = self._broker()
+                        pos = self._pos()
+                        self.assertFalse(universal._trigger(broker, pos, 105.0)[0])
+                        hit, reason, _ = universal._trigger(broker, pos, 102.8)
+        self.assertTrue(hit)
+        self.assertEqual(reason, "adaptive_volatility_trailing_profit")
+
+    def test_regime_deterioration_banks_profit_after_arming(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (True, "net_profit_target", 101.0))
+        with patch.object(self.mod.v68, "_floors", return_value=(100.5, 101.0, {"entry": 100.0, "short": False})):
+            with patch.object(self.mod.v68, "_reason_kind", return_value="profit"):
+                with patch.object(self.mod.v68, "_meets", side_effect=lambda market, target, short: market >= target):
+                    self.mod._patch_universal(universal)
+                    broker = self._broker()
+                    pos = self._pos()
+                    self.assertFalse(universal._trigger(broker, pos, 103.0)[0])
+                    pos["market_regime"] = "ranging"
+                    pos["regime_confidence"] = 0.90
+                    hit, reason, _ = universal._trigger(broker, pos, 101.5)
+        self.assertTrue(hit)
+        self.assertEqual(reason, "adaptive_regime_profit_exit")
+
+    def test_protective_exit_is_never_delayed(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (True, "stop_loss", 98.0))
+        with patch.object(self.mod.v68, "_reason_kind", return_value="protective"):
+            self.mod._patch_universal(universal)
+            self.assertEqual(universal._trigger(self._broker(), self._pos(), 97.5), (True, "stop_loss", 98.0))
+
+    def test_learning_is_sample_gated_and_bounded(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (False, "", 0.0))
+        broker = self._broker()
+        pos = self._pos()
+        regime = "bull_trending"
+        self.assertEqual(self.mod._learning_factor(universal, broker, pos, regime), 1.0)
+        key = self.mod._scope_key(universal, broker, pos, regime)
+        self.mod._STATS[key] = {"trades": 30.0, "wins": 10.0, "total_pnl": -30.0}
+        self.assertEqual(self.mod._learning_factor(universal, broker, pos, regime), 0.90)
+        self.mod._STATS[key] = {"trades": 30.0, "wins": 22.0, "total_pnl": 60.0}
+        self.assertEqual(self.mod._learning_factor(universal, broker, pos, regime), 1.10)
+
+    def test_confirmed_exit_updates_realized_stats_only(self) -> None:
+        universal = self._universal(lambda broker, pos, market: (False, "", 0.0))
+        broker = self._broker()
+        pos = self._pos()
+        self.mod.record_confirmed_exit(universal, broker, pos, fill_price=103.0, fee=0.5)
+        key = self.mod._scope_key(universal, broker, pos, "bull_trending")
+        self.assertEqual(self.mod._STATS[key]["trades"], 1.0)
+        self.assertEqual(self.mod._STATS[key]["wins"], 1.0)
+        self.assertAlmostEqual(self.mod._STATS[key]["total_pnl"], 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_broker_account_isolation_v64.py
+++ b/bot/tests/test_broker_account_isolation_v64.py
@@ -79,7 +79,7 @@ class BrokerAccountIsolationV64Tests(unittest.TestCase):
         self.assertEqual(self.mod._PLATFORM_BREAKER.initialized, 240.08)
         self.assertEqual(self.mod._PLATFORM_BREAKER.updated, [240.08])
 
-    def test_scope_for_user_and_platform_brokers(self) -> None:
+    def test_scope_for_user_and_platform_accounts(self) -> None:
         scope, platform = self.mod._scope_for_broker(_Broker("okx", 145.0))
         self.assertEqual(scope, "platform")
         self.assertTrue(platform)

--- a/bot/tests/test_broker_account_isolation_v64.py
+++ b/bot/tests/test_broker_account_isolation_v64.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _Broker:
+    def __init__(self, name: str, balance: float, account_identifier: str = "platform") -> None:
+        self.broker_type = types.SimpleNamespace(value=name)
+        self._last_known_balance = balance
+        self.account_identifier = account_identifier
+        self.connected = True
+
+
+class BrokerAccountIsolationV64Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.broker_account_isolation_v64_patch")
+        self.mod._USER_SCOPE_STATE.clear()
+        self.mod._SCOPE_DAILY_PNL.clear()
+        self.mod._PLATFORM_BREAKER = None
+
+    def test_account_drawdown_is_isolated_by_account(self) -> None:
+        level, _mult, halted, _reason = self.mod._user_scope_drawdown(
+            "account:alpha:coinbase", 100.0
+        )
+        self.assertEqual(level, "CLEAR")
+        self.assertFalse(halted)
+
+        level, _mult, halted, _reason = self.mod._user_scope_drawdown(
+            "account:alpha:coinbase", 70.0
+        )
+        self.assertEqual(level, "HALT")
+        self.assertTrue(halted)
+
+        level, _mult, halted, _reason = self.mod._user_scope_drawdown(
+            "account:beta:coinbase", 100.0
+        )
+        self.assertEqual(level, "CLEAR")
+        self.assertFalse(halted)
+
+    def test_platform_scope_does_not_mix_broker_balances(self) -> None:
+        class _Decision:
+            level = types.SimpleNamespace(value="CLEAR")
+            allow_new_entries = True
+            position_size_multiplier = 1.0
+            drawdown_pct = 0.0
+
+        class _Breaker:
+            def __init__(self) -> None:
+                self.initialized = None
+                self.updated = []
+
+            def initialise(self, starting_equity: float) -> None:
+                self.initialized = starting_equity
+
+            def update_equity(self, equity: float):
+                self.updated.append(equity)
+                return _Decision()
+
+        fake_module = types.ModuleType("bot.global_drawdown_circuit_breaker")
+        fake_module.GlobalDrawdownCircuitBreaker = _Breaker
+
+        with patch.object(
+            self.mod,
+            "_canonical_platform_equity",
+            return_value=(True, 240.08, 2, "canonical_capital_authority"),
+        ), patch.dict(sys.modules, {"bot.global_drawdown_circuit_breaker": fake_module}):
+            level, mult, halted, reason = self.mod._platform_scope_drawdown(95.12)
+
+        self.assertEqual(level, "CLEAR")
+        self.assertEqual(mult, 1.0)
+        self.assertFalse(halted)
+        self.assertEqual(reason, "")
+        self.assertEqual(self.mod._PLATFORM_BREAKER.initialized, 240.08)
+        self.assertEqual(self.mod._PLATFORM_BREAKER.updated, [240.08])
+
+    def test_scope_for_user_and_platform_brokers(self) -> None:
+        scope, platform = self.mod._scope_for_broker(_Broker("okx", 145.0))
+        self.assertEqual(scope, "platform")
+        self.assertTrue(platform)
+
+        scope, platform = self.mod._scope_for_broker(
+            _Broker("kraken", 80.0, account_identifier="user-7")
+        )
+        self.assertEqual(scope, "account:user-7:kraken")
+        self.assertFalse(platform)
+
+    def test_shared_strategy_cycles_are_serialized_and_broker_local(self) -> None:
+        fake_module = types.ModuleType("trading_strategy_v64_fake")
+        calls: list[tuple[str, float]] = []
+        active = 0
+        max_active = 0
+        state_lock = threading.Lock()
+
+        class _Apex:
+            def __init__(self) -> None:
+                self.broker_client = None
+                self._last_account_balance = 999.0
+                self.execution_engine = types.SimpleNamespace(broker_client=None)
+
+            def update_broker_client(self, broker) -> None:
+                self.broker_client = broker
+                self.execution_engine.broker_client = broker
+
+        class _Strategy:
+            def __init__(self) -> None:
+                self.apex = _Apex()
+                self.broker = None
+
+            def _broker_entry_balance(self, broker) -> float:
+                return float(broker._last_known_balance)
+
+            def run_cycle(self, broker=None, user_mode=False) -> int:
+                nonlocal active, max_active
+                with state_lock:
+                    active += 1
+                    max_active = max(max_active, active)
+                try:
+                    calls.append(
+                        (
+                            str(self.apex.broker_client.broker_type.value),
+                            float(self.apex._last_account_balance),
+                        )
+                    )
+                    time.sleep(0.02)
+                    return 120
+                finally:
+                    with state_lock:
+                        active -= 1
+
+        fake_module.TradingStrategy = _Strategy
+        self.mod._patch_trading_strategy_module(fake_module)
+        strategy = _Strategy()
+        okx = _Broker("okx", 145.0)
+        coinbase = _Broker("coinbase", 95.0)
+
+        threads = [
+            threading.Thread(target=strategy.run_cycle, kwargs={"broker": okx}),
+            threading.Thread(target=strategy.run_cycle, kwargs={"broker": coinbase}),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(max_active, 1)
+        self.assertCountEqual(calls, [("okx", 145.0), ("coinbase", 95.0)])
+        self.assertEqual(strategy.apex._last_account_balance, 999.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_capital_refresh_stall_guard_v36.py
+++ b/bot/tests/test_capital_refresh_stall_guard_v36.py
@@ -49,3 +49,33 @@ def test_stale_observation_is_excluded_not_revived(monkeypatch):
     assert "kraken" in status["excluded_brokers"]
     assert status["all_recent"] is False
     assert status["source"] == "partial_or_excluded_fallback"
+
+
+def test_v62_broker_specific_defaults_cover_observed_live_latency(monkeypatch):
+    monkeypatch.delenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_COINBASE_FETCH_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_KRAKEN_FETCH_TIMEOUT_S", raising=False)
+    assert cap._broker_timeout_seconds("coinbase") >= 180.0
+    assert cap._broker_timeout_seconds("okx") >= 75.0
+    assert cap._broker_timeout_seconds("kraken") >= 75.0
+
+
+def test_v62_cycle_deadline_cannot_undercut_slowest_broker(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_CYCLE_DEADLINE_S", "12")
+    monkeypatch.delenv("NIJA_CAPITAL_COINBASE_FETCH_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", raising=False)
+    deadline = cap._cycle_deadline_seconds(("coinbase", "okx"))
+    assert deadline >= cap._broker_timeout_seconds("coinbase") + 5.0
+
+
+def test_v62_operator_can_raise_or_lower_dedicated_broker_timeout(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_COINBASE_FETCH_TIMEOUT_S", "210")
+    monkeypatch.setenv("NIJA_CAPITAL_OKX_FETCH_TIMEOUT_S", "60")
+    assert cap._broker_timeout_seconds("coinbase") == 210.0
+    assert cap._broker_timeout_seconds("okx") == 60.0
+
+
+def test_v62_unknown_broker_still_uses_generic_bound(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_BROKER_FETCH_TIMEOUT_S", "9")
+    assert cap._broker_timeout_seconds("alpaca") == 9.0

--- a/bot/tests/test_future_broker_adapter_contract_v65.py
+++ b/bot/tests/test_future_broker_adapter_contract_v65.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class _Keys:
+    def __init__(self, credentials=None) -> None:
+        self.credentials = credentials
+
+    def get_user_api_key(self, user_id, broker_name):
+        return self.credentials
+
+
+class _UserConfig:
+    def can_trade_pair(self, pair):
+        return True
+
+    def validate_position_size(self, size_usd):
+        return True, None
+
+    def get(self, key, default=None):
+        return default
+
+
+class _Config:
+    def get_user_config(self, user_id):
+        return _UserConfig()
+
+
+class _Controls:
+    def __init__(self) -> None:
+        self.errors = 0
+
+    def can_trade(self, user_id):
+        return True, None
+
+    def check_daily_trade_limit(self, user_id):
+        return True, None
+
+    def validate_position_size(self, user_id, position_size_usd, account_balance):
+        return True, None
+
+    def check_daily_loss_limit(self, user_id, max_daily_loss):
+        return True, None
+
+    def record_api_error(self, user_id):
+        self.errors += 1
+
+
+class _Client:
+    def __init__(self, balance=100.0, order_result=None) -> None:
+        self.balance = balance
+        self.order_result = order_result or {"success": True, "status": "filled", "order_id": "o-1"}
+
+    def get_account_balance(self):
+        return {"total_balance": self.balance}
+
+    def place_order(self, **kwargs):
+        return dict(self.order_result)
+
+    def get_positions(self):
+        return []
+
+    def close_position(self, pair):
+        return {"success": True, "status": "filled", "order_id": "c-1"}
+
+
+class FutureBrokerAdapterContractV65Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("execution.broker_adapter")
+        for name in self.mod.registered_broker_client_factories():
+            self.mod.unregister_broker_client_factory(name)
+        self.controls = _Controls()
+
+    def _adapter(self, credentials=None):
+        patches = (
+            patch.object(self.mod, "get_api_key_manager", return_value=_Keys(credentials)),
+            patch.object(self.mod, "get_config_manager", return_value=_Config()),
+            patch.object(self.mod, "get_hard_controls", return_value=self.controls),
+        )
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        return self.mod.SecureBrokerAdapter("user-1", "futurebroker")
+
+    def test_missing_factory_never_fakes_balance_or_success(self) -> None:
+        adapter = self._adapter(credentials={"key": "present"})
+        self.assertFalse(adapter.execution_ready)
+        balance = adapter.get_account_balance()
+        self.assertFalse(balance["verified"])
+        self.assertEqual(balance["total_balance"], 0.0)
+        result = adapter.place_order("BTC-USD", "buy", 25.0)
+        self.assertFalse(result["success"])
+
+    def test_registered_factory_routes_real_client(self) -> None:
+        self.mod.register_broker_client_factory(
+            "futurebroker",
+            lambda user_id, credentials: _Client(balance=123.45),
+        )
+        adapter = self._adapter(credentials={"key": "present"})
+        self.assertTrue(adapter.execution_ready)
+        self.assertAlmostEqual(adapter.get_account_balance()["total_balance"], 123.45)
+        result = adapter.place_order("BTC-USD", "buy", 25.0)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["broker"], "futurebroker")
+        self.assertEqual(result["user_id"], "user-1")
+
+    def test_ambiguous_timeout_response_is_not_promoted_to_success(self) -> None:
+        self.mod.register_broker_client_factory(
+            "futurebroker",
+            lambda user_id, credentials: _Client(
+                balance=100.0,
+                order_result={"status": "unknown", "error": "timeout"},
+            ),
+        )
+        adapter = self._adapter(credentials={"key": "present"})
+        result = adapter.place_order("BTC-USD", "buy", 25.0)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["status"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_held_position_exit_bootstrap_v75.py
+++ b/bot/tests/test_held_position_exit_bootstrap_v75.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib
+import types
+import unittest
+
+
+class HeldPositionExitBootstrapV75Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.held_position_exit_bootstrap_v75_patch")
+        self.v74 = importlib.import_module("bot.adaptive_profit_exit_v74_patch")
+        self.v74._POSITIONS.clear()
+
+    def test_persisted_peak_and_trough_are_preserved(self) -> None:
+        pos = {
+            "high_water": 125.0,
+            "low_water": 91.0,
+        }
+        self.assertEqual(self.mod._persisted_peak(pos, 110.0), 125.0)
+        self.assertEqual(self.mod._persisted_trough(pos, 110.0), 91.0)
+
+    def test_first_verified_market_used_without_history(self) -> None:
+        pos = {}
+        self.assertEqual(self.mod._persisted_peak(pos, 110.0), 110.0)
+        self.assertEqual(self.mod._persisted_trough(pos, 110.0), 110.0)
+
+    def test_existing_position_is_connected_to_adaptive_state(self) -> None:
+        class AutoExit:
+            @staticmethod
+            def _sym(value):
+                return str(value or "").upper()
+
+            @staticmethod
+            def _entry_price(pos):
+                return float(pos.get("entry_price") or 0.0)
+
+            @staticmethod
+            def _quantity(pos):
+                return float(pos.get("quantity") or 0.0)
+
+            @staticmethod
+            def _price(broker, symbol):
+                return float(broker.price)
+
+            @staticmethod
+            def _side(value, pos):
+                return str(value or "long").lower()
+
+        class Broker:
+            price = 115.0
+            account_id = "acct-1"
+
+        broker = Broker()
+        pos = {
+            "symbol": "BTC-USD",
+            "entry_price": 100.0,
+            "quantity": 0.25,
+            "side": "long",
+            "position_id": "p1",
+            "peak_price": 123.0,
+            "regime": "bull_trending",
+            "regime_confidence": 0.9,
+        }
+        universal = types.SimpleNamespace(
+            auto_exit=AutoExit,
+            _snapshot=lambda: [broker],
+            _tracker_positions=lambda b: [pos],
+        )
+        self.mod._install_peak_bootstrap()
+        count = self.mod._bootstrap_existing_positions(universal)
+        self.assertEqual(count, 1)
+        key = self.v74._position_key(universal, broker, pos)
+        state = self.v74._POSITIONS[key]
+        self.assertEqual(state["peak"], 123.0)
+        self.assertEqual(state["market"], 115.0)
+        self.assertEqual(state["bootstrap_source"], "persisted_position_history")
+
+    def test_existing_position_without_history_uses_live_price(self) -> None:
+        class AutoExit:
+            @staticmethod
+            def _sym(value):
+                return str(value or "").upper()
+
+            @staticmethod
+            def _entry_price(pos):
+                return float(pos.get("entry_price") or 0.0)
+
+            @staticmethod
+            def _quantity(pos):
+                return float(pos.get("quantity") or 0.0)
+
+            @staticmethod
+            def _price(broker, symbol):
+                return 105.0
+
+            @staticmethod
+            def _side(value, pos):
+                return "long"
+
+        broker = types.SimpleNamespace(account_id="acct-2")
+        pos = {
+            "symbol": "ETH-USD",
+            "entry_price": 95.0,
+            "quantity": 1.0,
+            "position_id": "p2",
+            "regime": "ranging",
+            "regime_confidence": 0.8,
+        }
+        universal = types.SimpleNamespace(
+            auto_exit=AutoExit,
+            _snapshot=lambda: [broker],
+            _tracker_positions=lambda b: [pos],
+        )
+        self.mod._install_peak_bootstrap()
+        count = self.mod._bootstrap_existing_positions(universal)
+        self.assertEqual(count, 1)
+        key = self.v74._position_key(universal, broker, pos)
+        state = self.v74._POSITIONS[key]
+        self.assertEqual(state["peak"], 105.0)
+        self.assertEqual(state["trough"], 105.0)
+        self.assertEqual(state["bootstrap_source"], "first_verified_market")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_live_entry_expectancy_authority_v69.py
+++ b/bot/tests/test_live_entry_expectancy_authority_v69.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+
+class _Validator:
+    def __init__(self, r_ok=True, confirm_ok=True, r=2.0) -> None:
+        self.r_ok = r_ok
+        self.confirm_ok = confirm_ok
+        self.r = r
+
+    def validate_r_multiple(self, entry, stop, target):
+        return self.r_ok, "r-check", self.r
+
+    def check_first_move_confirmation(self, df):
+        return self.confirm_ok, "volume expansion" if self.confirm_ok else "no expansion"
+
+
+class _Broker:
+    broker_type = "futurebroker"
+    taker_fee = 0.001
+
+
+class _Strategy:
+    broker_client = _Broker()
+
+    def _get_broker_name(self):
+        return "futurebroker"
+
+
+class LiveEntryExpectancyAuthorityV69Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.live_entry_expectancy_authority_v69_patch")
+        self.df = pd.DataFrame(
+            {
+                "open": [99.0] * 25,
+                "high": [101.0] * 25,
+                "low": [98.0] * 25,
+                "close": [100.0] * 25,
+                "volume": [100.0] * 24 + [160.0],
+            }
+        )
+        self.result = {
+            "action": "enter_long",
+            "entry_price": 100.0,
+            "stop_loss": 99.0,
+            "take_profit": [102.0],
+        }
+
+    def test_non_entry_is_unchanged(self) -> None:
+        ok, reason, details = self.mod._validate_live_entry(
+            _Strategy(), self.df, "BTC-USD", {"action": "hold"}
+        )
+        self.assertTrue(ok)
+        self.assertEqual(reason, "not_entry")
+        self.assertEqual(details, {})
+
+    def test_r_multiple_failure_blocks_entry(self) -> None:
+        with patch.object(self.mod, "_validator", return_value=_Validator(r_ok=False, r=1.0)):
+            ok, reason, _details = self.mod._validate_live_entry(
+                _Strategy(), self.df, "BTC-USD", self.result
+            )
+        self.assertFalse(ok)
+        self.assertTrue(reason.startswith("expectancy_r_multiple"))
+
+    def test_first_move_confirmation_failure_blocks_entry(self) -> None:
+        with patch.object(self.mod, "_validator", return_value=_Validator(confirm_ok=False)):
+            ok, reason, _details = self.mod._validate_live_entry(
+                _Strategy(), self.df, "BTC-USD", self.result
+            )
+        self.assertFalse(ok)
+        self.assertTrue(reason.startswith("first_move_confirmation"))
+
+    def test_net_edge_after_fees_must_clear_minimum(self) -> None:
+        expensive = types.SimpleNamespace(
+            broker_type="expensive",
+            taker_fee=0.009,
+        )
+        strategy = _Strategy()
+        strategy.broker_client = expensive
+        strategy._get_broker_name = lambda: "expensive"
+        with patch.object(self.mod, "_validator", return_value=_Validator()):
+            with patch.dict(
+                os.environ,
+                {
+                    "NIJA_ENTRY_SPREAD_RESERVE_PCT": "0",
+                    "NIJA_ENTRY_SLIPPAGE_RESERVE_PCT": "0.001",
+                    "NIJA_MINIMUM_NET_PROFIT_PCT": "0.004",
+                },
+                clear=False,
+            ):
+                ok, reason, details = self.mod._validate_live_entry(
+                    strategy, self.df, "BTC-USD", self.result
+                )
+        self.assertFalse(ok)
+        self.assertEqual(reason, "net_edge_below_fee_slippage_floor")
+        self.assertLess(details["net_reward_pct"], details["minimum_net_pct"])
+
+    def test_good_geometry_confirmation_and_net_edge_pass(self) -> None:
+        with patch.object(self.mod, "_validator", return_value=_Validator(r_ok=True, confirm_ok=True, r=2.0)):
+            with patch.dict(
+                os.environ,
+                {
+                    "NIJA_ENTRY_SPREAD_RESERVE_PCT": "0",
+                    "NIJA_ENTRY_SLIPPAGE_RESERVE_PCT": "0.001",
+                    "NIJA_MINIMUM_NET_PROFIT_PCT": "0.004",
+                },
+                clear=False,
+            ):
+                ok, reason, details = self.mod._validate_live_entry(
+                    _Strategy(), self.df, "BTC-USD", self.result
+                )
+        self.assertTrue(ok)
+        self.assertEqual(reason, "expectancy_authority_pass")
+        self.assertGreaterEqual(details["net_reward_pct"], details["minimum_net_pct"])
+
+    def test_live_mode_does_not_use_drought_relaxation_or_debug_bypass(self) -> None:
+        fake = types.ModuleType("apex_v69_fake")
+        fake._DISABLE_MARKET_FILTER = True
+        fake._BYPASS_SMART_FILTER = True
+        fake.ENTRY_GATE_MIN_SCORE = 2
+
+        class Apex:
+            broker_client = _Broker()
+
+            def _get_broker_name(self):
+                return "futurebroker"
+
+            def analyze_market(self, df, symbol, account_balance):
+                return {"action": "hold"}
+
+            def _get_entry_gate_thresholds(self, drought):
+                return (0.01, 0.1, 0.0001) if drought is not None else (0.06, 1.5, 0.002)
+
+            def _get_entry_gate_min_score(self, drought):
+                return 1 if drought is not None else 2
+
+        fake.NIJAApexStrategyV71 = Apex
+        self.mod._patch_strategy(fake)
+        instance = Apex()
+        with patch.dict(
+            os.environ,
+            {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"},
+            clear=False,
+        ):
+            self.assertEqual(instance._get_entry_gate_thresholds(object()), (0.06, 1.5, 0.002))
+            self.assertEqual(instance._get_entry_gate_min_score(object()), 2)
+            instance.analyze_market(self.df, "BTC-USD", 100.0)
+        self.assertFalse(fake._DISABLE_MARKET_FILTER)
+        self.assertFalse(fake._BYPASS_SMART_FILTER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_live_exchange_base_minimum_v73.py
+++ b/bot/tests/test_live_exchange_base_minimum_v73.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+
+class LiveExchangeBaseMinimumV73Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.v72 = importlib.import_module("bot.live_exchange_constraints_authority_v72_patch")
+        self.v73 = importlib.import_module("bot.live_exchange_base_minimum_v73_patch")
+        for name in self.v72.registered_constraint_providers():
+            self.v72.unregister_live_constraint_provider(name)
+        self.v73._BASE_MINIMUMS.clear()
+        self.v73._install_constraint_capture()
+
+    def _fake_eoc(self):
+        fake = types.ModuleType("eoc_v73_fake")
+
+        class Error(RuntimeError):
+            pass
+
+        class Constraints:
+            def __init__(self, exchange, min_order_usd, min_notional_usd, fee_rate_one_way, step_size, precision_decimals):
+                self.exchange = exchange
+                self.min_order_usd = min_order_usd
+                self.min_notional_usd = min_notional_usd
+                self.fee_rate_one_way = fee_rate_one_way
+                self.step_size = step_size
+                self.precision_decimals = precision_decimals
+
+        class Compiler:
+            def get_constraints(self, exchange, symbol):
+                return Constraints(exchange, 0.0, 0.0, 0.0, 0.0001, 4)
+
+            def simulate_order(self, symbol, side, size_usd, pricing, constraints, *args, **kwargs):
+                return (float(size_usd), 0.0, "ok", float(size_usd))
+
+        fake.OrderCompileError = Error
+        fake.ExchangeConstraints = Constraints
+        fake.ExchangeOrderCompiler = Compiler
+        return fake, Error, Compiler
+
+    def test_alpaca_base_minimum_is_enforced_after_rounding(self) -> None:
+        fake, Error, Compiler = self._fake_eoc()
+        self.v72._patch(fake)
+        self.v73._patch_eoc_module(fake)
+        self.v72.register_live_constraint_provider(
+            "alpaca",
+            lambda symbol: {
+                "min_order_size": "0.0001",
+                "min_trade_increment": "0.0001",
+                "price_increment": "0.01",
+            },
+        )
+        with patch.dict(os.environ, {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"}, clear=False):
+            constraints = Compiler().get_constraints("alpaca", "BTC-USD")
+            with self.assertRaises(Error):
+                Compiler().simulate_order("BTC-USD", "buy", 0.00005, object(), constraints)
+
+    def test_quantity_at_base_minimum_passes(self) -> None:
+        fake, _Error, Compiler = self._fake_eoc()
+        self.v72._patch(fake)
+        self.v73._patch_eoc_module(fake)
+        self.v72.register_live_constraint_provider(
+            "alpaca",
+            lambda symbol: {
+                "min_order_size": "0.0001",
+                "min_trade_increment": "0.0001",
+                "price_increment": "0.01",
+            },
+        )
+        with patch.dict(os.environ, {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"}, clear=False):
+            constraints = Compiler().get_constraints("alpaca", "BTC-USD")
+            result = Compiler().simulate_order("BTC-USD", "buy", 0.0001, object(), constraints)
+        self.assertEqual(result[0], 0.0001)
+
+    def test_future_client_metadata_is_auto_registered(self) -> None:
+        class FutureClient:
+            broker_name = "futurebroker"
+
+            def get_symbol_info(self, symbol):
+                return {
+                    "min_order_usd": 10.0,
+                    "step_size": 0.01,
+                    "precision_decimals": 2,
+                }
+
+        client = FutureClient()
+        self.assertTrue(self.v73._maybe_register_broker(client))
+        self.assertIn("futurebroker", self.v72.registered_constraint_providers())
+
+    def test_future_client_without_metadata_stays_fail_closed(self) -> None:
+        class FutureClient:
+            broker_name = "futurebroker"
+
+        self.assertFalse(self.v73._maybe_register_broker(FutureClient()))
+        self.assertNotIn("futurebroker", self.v72.registered_constraint_providers())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_live_exchange_constraints_authority_v72.py
+++ b/bot/tests/test_live_exchange_constraints_authority_v72.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+
+class LiveExchangeConstraintsAuthorityV72Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.live_exchange_constraints_authority_v72_patch")
+        for name in self.mod.registered_constraint_providers():
+            self.mod.unregister_live_constraint_provider(name)
+
+    def test_binance_exchange_info_filters_are_normalized(self) -> None:
+        rules = self.mod._extract_rules(
+            {
+                "filters": [
+                    {"filterType": "LOT_SIZE", "minQty": "0.001", "stepSize": "0.001"},
+                    {"filterType": "MIN_NOTIONAL", "minNotional": "5.0"},
+                ]
+            }
+        )
+        self.assertEqual(rules["step_size"], 0.001)
+        self.assertEqual(rules["precision_decimals"], 3)
+        self.assertEqual(rules["min_base_qty"], 0.001)
+        self.assertEqual(rules["min_notional_usd"], 5.0)
+
+    def test_alpaca_crypto_asset_rules_are_base_quantity_scoped(self) -> None:
+        rules = self.mod._extract_rules(
+            {
+                "symbol": "BTC/USD",
+                "min_order_size": "0.0001",
+                "min_trade_increment": "0.0001",
+                "price_increment": "1",
+            }
+        )
+        self.assertEqual(rules["min_base_qty"], 0.0001)
+        self.assertEqual(rules["step_size"], 0.0001)
+        self.assertEqual(rules["precision_decimals"], 4)
+        self.assertEqual(rules["min_notional_usd"], 0.0)
+
+    def test_unknown_live_exchange_cannot_use_generic_fallback(self) -> None:
+        fake = types.ModuleType("eoc_v72_fake")
+
+        class Error(RuntimeError):
+            pass
+
+        class Constraints:
+            def __init__(
+                self,
+                exchange,
+                min_order_usd,
+                min_notional_usd,
+                fee_rate_one_way,
+                step_size,
+                precision_decimals,
+            ):
+                self.exchange = exchange
+                self.min_order_usd = min_order_usd
+                self.min_notional_usd = min_notional_usd
+                self.fee_rate_one_way = fee_rate_one_way
+                self.step_size = step_size
+                self.precision_decimals = precision_decimals
+
+        class Compiler:
+            def get_constraints(self, exchange, symbol):
+                return Constraints(exchange, 5.0, 5.0, 0.006, 0.00000001, 8)
+
+        fake.OrderCompileError = Error
+        fake.ExchangeConstraints = Constraints
+        fake.ExchangeOrderCompiler = Compiler
+        self.mod._patch(fake)
+        compiler = Compiler()
+        with patch.dict(
+            os.environ,
+            {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"},
+            clear=False,
+        ):
+            with self.assertRaises(Error):
+                compiler.get_constraints("futurebroker", "BTC-USD")
+
+    def test_registered_provider_allows_future_live_exchange(self) -> None:
+        fake = types.ModuleType("eoc_v72_provider_fake")
+
+        class Error(RuntimeError):
+            pass
+
+        class Constraints:
+            def __init__(
+                self,
+                exchange,
+                min_order_usd,
+                min_notional_usd,
+                fee_rate_one_way,
+                step_size,
+                precision_decimals,
+            ):
+                self.exchange = exchange
+                self.min_order_usd = min_order_usd
+                self.min_notional_usd = min_notional_usd
+                self.fee_rate_one_way = fee_rate_one_way
+                self.step_size = step_size
+                self.precision_decimals = precision_decimals
+
+        class Compiler:
+            def get_constraints(self, exchange, symbol):
+                raise AssertionError("generic fallback should not be used")
+
+        fake.OrderCompileError = Error
+        fake.ExchangeConstraints = Constraints
+        fake.ExchangeOrderCompiler = Compiler
+        self.mod._patch(fake)
+        self.mod.register_live_constraint_provider(
+            "futurebroker",
+            lambda symbol: {
+                "min_order_usd": 12.0,
+                "min_notional_usd": 12.0,
+                "step_size": 0.01,
+                "precision_decimals": 2,
+                "taker_fee": 0.0015,
+            },
+        )
+        with patch.dict(
+            os.environ,
+            {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"},
+            clear=False,
+        ):
+            c = Compiler().get_constraints("futurebroker", "ABC-USD")
+        self.assertEqual(c.min_notional_usd, 12.0)
+        self.assertEqual(c.step_size, 0.01)
+        self.assertEqual(c.precision_decimals, 2)
+        self.assertEqual(c.fee_rate_one_way, 0.0015)
+
+    def test_known_crypto_venues_keep_compat_static_fallback(self) -> None:
+        fake = types.ModuleType("eoc_v72_compat_fake")
+
+        class Constraints:
+            def __init__(self, exchange):
+                self.exchange = exchange
+                self.min_order_usd = 1.0
+                self.min_notional_usd = 1.0
+                self.fee_rate_one_way = 0.001
+                self.step_size = 0.001
+                self.precision_decimals = 3
+
+        class Compiler:
+            def get_constraints(self, exchange, symbol):
+                return Constraints(exchange)
+
+        fake.OrderCompileError = RuntimeError
+        fake.ExchangeConstraints = lambda **kwargs: types.SimpleNamespace(**kwargs)
+        fake.ExchangeOrderCompiler = Compiler
+        self.mod._patch(fake)
+        with patch.dict(
+            os.environ,
+            {"LIVE_CAPITAL_VERIFIED": "true", "DRY_RUN_MODE": "false", "PAPER_MODE": "false"},
+            clear=False,
+        ):
+            c = Compiler().get_constraints("okx", "BTC-USDT")
+        self.assertEqual(c.exchange, "okx")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_post_v59_runtime_convergence_v60.py
+++ b/bot/tests/test_post_v59_runtime_convergence_v60.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "kraken_connection_convergence_v44_patch.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _AliveThread:
+    def is_alive(self):
+        return True
+
+
+class _Client:
+    def __init__(self, lock_value: str, token: str, generation: int, heartbeat_at: float):
+        self.values = {
+            "lock": lock_value,
+            "fence": token,
+            "generation": str(generation),
+            "meta": (
+                '{"token":"%s","generation":%d,"heartbeat_at":%.6f}'
+                % (token, generation, heartbeat_at)
+            ),
+        }
+        self.pttl_ms = 55000
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def pttl(self, key):
+        assert key == "lock"
+        return self.pttl_ms
+
+
+class _Runtime:
+    def __init__(self):
+        self.acquired = True
+        self.lost = False
+        self._local_fallback = False
+        self._stop = threading.Event()
+        self._heartbeat_thread = _AliveThread()
+        self._lock_key = "lock"
+        self._meta_key = "meta"
+        self._fencing_key = "fence"
+        self._lock_value = "2080:owner"
+        self._token = "2080"
+        self._generation = 3383
+        self._ttl_s = 60
+        self._client = _Client(
+            self._lock_value,
+            self._token,
+            self._generation,
+            time.time(),
+        )
+        self.reconciled = []
+
+    def _nija_lease_renewal_health(self):
+        return False, "renewal_success_stale", 100.5, 15.0
+
+    def _notify_runtime_reconciliation(self, trigger):
+        self.reconciled.append(trigger)
+
+
+class _Broker:
+    def __init__(self, connected: bool):
+        self.connected = connected
+
+
+class _BrokerType:
+    value = "kraken"
+
+
+class TestPostV59RuntimeConvergenceV60:
+    def setup_method(self):
+        os.environ["NIJA_LEASE_GENERATION_KEY"] = "generation"
+        os.environ["NIJA_WRITER_HEARTBEAT_INTERVAL_S"] = "5"
+
+    def teardown_method(self):
+        os.environ.pop("NIJA_LEASE_GENERATION_KEY", None)
+        os.environ.pop("NIJA_WRITER_HEARTBEAT_INTERVAL_S", None)
+        os.environ.pop("NIJA_WRITER_LEASE_RENEWAL_ACTIVE", None)
+        os.environ.pop("NIJA_WRITER_LEASE_RENEWED_TS", None)
+
+    def test_exact_redis_proof_reanchors_only_local_renewal_timestamp(self):
+        module = _load("v60_writer_reanchor")
+        runtime = _Runtime()
+        original_values = dict(runtime._client.values)
+        original_pttl = runtime._client.pttl_ms
+
+        result = module.reconcile_writer_renewal_once(runtime)
+
+        assert result["ok"] is True
+        assert result["action"] == "reanchored"
+        assert result["reason"] == "exact_redis_writer_renewal_proof"
+        assert runtime._nija_last_lease_renewal_monotonic > 0
+        assert os.environ["NIJA_WRITER_LEASE_RENEWAL_ACTIVE"] == "1"
+        assert runtime.reconciled == ["post_v59_exact_writer_renewal_reanchor_v60"]
+        assert runtime._client.values == original_values
+        assert runtime._client.pttl_ms == original_pttl
+
+    def test_writer_reanchor_fails_closed_on_generation_mismatch(self):
+        module = _load("v60_writer_mismatch")
+        runtime = _Runtime()
+        runtime._client.values["generation"] = "3384"
+
+        result = module.reconcile_writer_renewal_once(runtime)
+
+        assert result["ok"] is False
+        assert result["action"] == "none"
+        assert "generation_mismatch" in result["reason"]
+        assert not hasattr(runtime, "_nija_last_lease_renewal_monotonic")
+
+    def test_invalid_nonce_is_retryable_but_bad_key_remains_permanent(self):
+        module = _load("v60_nonce_classification")
+        supervisor = types.ModuleType("fake_kraken_supervisor_v60")
+
+        def original(error_str: str) -> bool:
+            lowered = error_str.lower()
+            return "invalid nonce" in lowered or "invalid key" in lowered
+
+        supervisor._is_permanent_failure = original
+        assert module._patch_supervisor_module(supervisor) is True
+        assert supervisor._is_permanent_failure("EAPI:Invalid nonce") is False
+        assert supervisor._is_permanent_failure("EAPI:Invalid key") is True
+
+    def test_connected_kraken_repairs_stale_failed_platform_state(self):
+        module = _load("v60_manager_wait")
+        manager_module = types.ModuleType("fake_manager_v60")
+
+        class Manager:
+            def __init__(self):
+                self._platform_brokers = {_BrokerType: _Broker(True)}
+                self._platform_state = {"kraken": "failed"}
+                self._platform_failed_types = {_BrokerType}
+                self._platform_connected = {"kraken": False}
+                self.marked = []
+
+            def _mark_platform_connected(self, broker_type):
+                self.marked.append(broker_type)
+                self._platform_state["kraken"] = "connected"
+                self._platform_failed_types.discard(broker_type)
+                self._platform_connected["kraken"] = True
+
+            def wait_for_platform_ready(self, broker_type, timeout=None):
+                return False
+
+        manager_module.MultiAccountBrokerManager = Manager
+        assert module._patch_manager_module(manager_module) is True
+        manager = Manager()
+
+        assert manager.wait_for_platform_ready(_BrokerType) is True
+        assert manager._platform_connected["kraken"] is True
+        assert _BrokerType not in manager._platform_failed_types
+        assert manager.marked == [_BrokerType]

--- a/bot/tests/test_profit_harvest_realization_guard_v66.py
+++ b/bot/tests/test_profit_harvest_realization_guard_v66.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib
+import types
+import unittest
+
+
+class _State:
+    def __init__(self) -> None:
+        self.harvestable_balance_usd = 0.0
+        self.cumulative_harvested_usd = 0.0
+        self.cumulative_harvested_pct = 0.0
+        self.harvest_log = []
+        self.last_harvested_tier = "NONE"
+        self.last_updated = ""
+
+
+class _Decision:
+    def __init__(self, *, amount=0.0, floor_hit=False) -> None:
+        self.harvest_triggered = amount > 0.0
+        self.harvest_amount_usd = amount
+        self.floor_hit = floor_hit
+        self.message = "legacy"
+
+
+class _ProfitEngine:
+    def __init__(self, available=100.0) -> None:
+        self.available = available
+        self.calls = []
+
+    def harvest_profits(self, amount=None, note=""):
+        requested = self.available if amount is None else float(amount)
+        actual = min(requested, self.available)
+        self.available -= actual
+        self.calls.append((actual, note))
+        return actual
+
+
+class ProfitHarvestRealizationGuardV66Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.patch = importlib.import_module("bot.profit_harvest_realization_guard_v66_patch")
+
+    def _fake_module(self, *, floor_hit=False):
+        fake = types.ModuleType("profit_harvest_v66_fake")
+        engine = _ProfitEngine(available=100.0)
+
+        class Layer:
+            def __init__(self) -> None:
+                import threading
+                self._lock = threading.RLock()
+                self._positions = {"BTC-USD": _State()}
+
+            def _save_state(self):
+                return None
+
+            def _route_to_profit_engine(self, symbol, amount_usd, note=""):
+                return engine.harvest_profits(amount=amount_usd, note=note)
+
+            def process_price_update(self, symbol, current_price):
+                state = self._positions[symbol]
+                state.harvestable_balance_usd += 10.0
+                state.cumulative_harvested_usd += 10.0
+                state.cumulative_harvested_pct += 1.0
+                state.harvest_log.append({"note": "legacy-tier", "harvest_usd": 10.0})
+                state.last_harvested_tier = "TIER_1"
+                if floor_hit:
+                    self._route_to_profit_engine(symbol, state.harvestable_balance_usd, note="floor")
+                    state.harvestable_balance_usd = 0.0
+                return _Decision(amount=10.0, floor_hit=floor_hit)
+
+            def partial_harvest(self, symbol, fraction=1.0, note=""):
+                state = self._positions[symbol]
+                amount = state.harvestable_balance_usd * fraction
+                state.harvestable_balance_usd -= amount
+                return self._route_to_profit_engine(symbol, amount, note=note)
+
+        fake.ProfitHarvestLayer = Layer
+        fake.HarvestEvent = None
+        fake.get_portfolio_profit_engine = lambda: engine
+        self.patch._patch(fake)
+        return Layer(), engine
+
+    def test_tier_upgrade_stays_unrealized_until_fill_proof(self) -> None:
+        layer, engine = self._fake_module()
+        decision = layer.process_price_update("BTC-USD", 101.0)
+        state = layer._positions["BTC-USD"]
+
+        self.assertFalse(decision.harvest_triggered)
+        self.assertEqual(decision.harvest_amount_usd, 0.0)
+        self.assertEqual(state.harvestable_balance_usd, 10.0)
+        self.assertEqual(state.cumulative_harvested_usd, 0.0)
+        self.assertEqual(state.cumulative_harvested_pct, 0.0)
+        self.assertEqual(engine.calls, [])
+        self.assertIn("UNREALIZED_CANDIDATE", state.harvest_log[-1]["note"])
+
+    def test_floor_hit_does_not_book_virtual_profit(self) -> None:
+        layer, engine = self._fake_module(floor_hit=True)
+        layer.process_price_update("BTC-USD", 101.0)
+        state = layer._positions["BTC-USD"]
+
+        self.assertEqual(engine.calls, [])
+        self.assertEqual(state.harvestable_balance_usd, 10.0)
+        self.assertEqual(state.cumulative_harvested_usd, 0.0)
+
+    def test_legacy_partial_harvest_is_fail_closed(self) -> None:
+        layer, engine = self._fake_module()
+        layer.process_price_update("BTC-USD", 101.0)
+        amount = layer.partial_harvest("BTC-USD", fraction=0.5)
+
+        self.assertEqual(amount, 0.0)
+        self.assertEqual(layer._positions["BTC-USD"].harvestable_balance_usd, 10.0)
+        self.assertEqual(engine.calls, [])
+
+    def test_confirmed_fill_realizes_only_available_candidate(self) -> None:
+        layer, engine = self._fake_module()
+        layer.process_price_update("BTC-USD", 101.0)
+        actual = layer.confirm_realized_harvest(
+            "BTC-USD",
+            25.0,
+            broker_fill_id="fill-123",
+            broker_name="coinbase",
+            account_id="platform",
+        )
+        state = layer._positions["BTC-USD"]
+
+        self.assertEqual(actual, 10.0)
+        self.assertEqual(state.harvestable_balance_usd, 0.0)
+        self.assertEqual(state.cumulative_harvested_usd, 10.0)
+        self.assertEqual(len(engine.calls), 1)
+        self.assertIn("fill_id=fill-123", engine.calls[0][1])
+        self.assertIn("REALIZED_CONFIRMED", state.harvest_log[-1]["note"])
+
+    def test_fill_id_is_mandatory(self) -> None:
+        layer, _engine = self._fake_module()
+        layer.process_price_update("BTC-USD", 101.0)
+        with self.assertRaises(ValueError):
+            layer.confirm_realized_harvest(
+                "BTC-USD",
+                5.0,
+                broker_fill_id="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_universal_exit_fill_reconciliation_v67.py
+++ b/bot/tests/test_universal_exit_fill_reconciliation_v67.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class UniversalExitFillReconciliationV67Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.universal_exit_fill_reconciliation_v67_patch")
+        self.mod._PENDING.clear()
+
+    def test_accepted_live_new_and_partial_are_not_full_fills(self) -> None:
+        for status in ("accepted", "live", "new", "open", "partially_filled", "unknown"):
+            with self.subTest(status=status):
+                self.assertFalse(self.mod._is_full_fill({"status": status, "order_id": "o-1"}, 1.0))
+                self.assertTrue(self.mod._is_submission_ack({"status": status, "order_id": "o-1"}))
+
+    def test_filled_or_full_executed_quantity_is_confirmed(self) -> None:
+        self.assertTrue(self.mod._is_full_fill({"status": "filled"}, 1.0))
+        self.assertTrue(
+            self.mod._is_full_fill(
+                {"status": "partially_filled", "executed_qty": "1.0"},
+                1.0,
+            )
+        )
+
+    def test_order_id_only_is_pending_ack_not_fill(self) -> None:
+        payload = {"order_id": "abc-123"}
+        self.assertTrue(self.mod._is_submission_ack(payload))
+        self.assertFalse(self.mod._is_full_fill(payload, 2.0))
+
+    def test_nested_okx_order_fields_are_parsed(self) -> None:
+        payload = {
+            "code": "0",
+            "data": [{"ordId": "99", "state": "filled", "accFillSz": "2.5", "avgPx": "101.25"}],
+        }
+        self.assertEqual(self.mod._order_id(payload), "99")
+        self.assertEqual(self.mod._status(payload), "filled")
+        self.assertAlmostEqual(self.mod._filled_quantity(payload), 2.5)
+        self.assertTrue(self.mod._is_full_fill(payload, 2.5))
+
+    def test_query_order_uses_generic_broker_method(self) -> None:
+        class Broker:
+            def get_order(self, order_id):
+                return {"id": order_id, "status": "filled", "filled_quantity": 1.0}
+
+        result = self.mod._query_order(Broker(), "o-7", "BTC-USD")
+        self.assertEqual(result["status"], "filled")
+
+    def test_pending_reconciliation_blocks_duplicate_submit_until_fill(self) -> None:
+        auto_exit = types.SimpleNamespace()
+        auto_exit._sym = lambda value: str(value).upper()
+        auto_exit._quantity = lambda pos: float(pos.get("quantity", 0.0))
+        auto_exit._entry_price = lambda pos: float(pos.get("entry_price", 0.0))
+        auto_exit._side = lambda value, pos=None: str(value or "long")
+        auto_exit._price = lambda broker, symbol: 105.0
+        auto_exit._broker_label = lambda broker: "futurebroker"
+        auto_exit._position_key = lambda pos: f"acct:{pos['symbol']}"
+        auto_exit._HIGH_WATER = {}
+
+        universal = types.ModuleType("universal_v67_fake")
+        universal.auto_exit = auto_exit
+        universal._ACTIVE = set()
+        universal._account_label = lambda broker: "user-1"
+        universal._trigger = lambda broker, pos, market: (True, "take_profit", 104.0)
+        universal._register_broker = lambda broker: None
+        closed = []
+        universal._mark_closed = lambda broker, pos, order, reason, market: closed.append(
+            (pos["symbol"], order.get("order_id") or order.get("id"))
+        )
+
+        position = {
+            "symbol": "BTC-USD",
+            "position_id": "p-1",
+            "quantity": 1.0,
+            "entry_price": 100.0,
+            "side": "long",
+        }
+        universal._tracker_positions = lambda broker: [dict(position)]
+
+        class Broker:
+            connected = True
+
+            def __init__(self) -> None:
+                self.submits = 0
+                self.order_status = "accepted"
+                self.position_qty = 1.0
+
+            def place_market_order(self, **kwargs):
+                self.submits += 1
+                return {"status": "accepted", "order_id": "o-1"}
+
+            def get_order(self, order_id):
+                return {
+                    "status": self.order_status,
+                    "order_id": order_id,
+                    "filled_quantity": 1.0 if self.order_status == "filled" else 0.0,
+                }
+
+            def get_positions(self):
+                if self.position_qty <= 0:
+                    return []
+                row = dict(position)
+                row["quantity"] = self.position_qty
+                return [row]
+
+        broker = Broker()
+
+        # First scan submits exactly once and preserves the position as pending.
+        self.assertEqual(self.mod._safe_scan_broker(universal, broker), 0)
+        self.assertEqual(broker.submits, 1)
+        self.assertEqual(closed, [])
+
+        # Still accepted: no duplicate submission.
+        self.assertEqual(self.mod._safe_scan_broker(universal, broker), 0)
+        self.assertEqual(broker.submits, 1)
+        self.assertEqual(closed, [])
+
+        # Terminal fill: local close occurs without another submission.
+        broker.order_status = "filled"
+        broker.position_qty = 0.0
+        self.assertEqual(self.mod._safe_scan_broker(universal, broker), 1)
+        self.assertEqual(broker.submits, 1)
+        self.assertEqual(closed, [("BTC-USD", "o-1")])
+
+    def test_registry_discovery_is_capability_based_not_class_name(self) -> None:
+        class FutureVenueAdapter:
+            def get_positions(self):
+                return []
+
+            def place_order(self, **kwargs):
+                return {"status": "filled"}
+
+        broker = FutureVenueAdapter()
+        manager = types.SimpleNamespace(
+            platform_brokers={"future": broker},
+            user_brokers={},
+        )
+        module = types.ModuleType("bot.multi_account_broker_manager")
+        module.multi_account_broker_manager = manager
+
+        universal = types.SimpleNamespace(_register_broker=lambda value: None)
+        with unittest.mock.patch.dict(sys.modules, {"bot.multi_account_broker_manager": module}):
+            found = self.mod._discover_brokers(universal)
+        self.assertIn(broker, found)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_universal_net_profit_exit_floor_v68.py
+++ b/bot/tests/test_universal_net_profit_exit_floor_v68.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+
+class UniversalNetProfitExitFloorV68Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.universal_net_profit_exit_floor_v68_patch")
+
+    def _universal(self, trigger):
+        module = types.ModuleType("universal_v68_fake")
+        auto_exit = types.SimpleNamespace()
+        auto_exit._broker_label = lambda broker: getattr(broker, "name", "futurebroker")
+        auto_exit._sym = lambda value: str(value).upper()
+        auto_exit._entry_price = lambda pos: float(pos.get("entry_price", 0.0))
+        auto_exit._side = lambda value, pos=None: str(value or "long")
+        module.auto_exit = auto_exit
+        module._trigger = trigger
+        self.mod._patch_universal(module)
+        return module
+
+    def test_gross_take_profit_below_net_floor_is_suppressed(self) -> None:
+        class Broker:
+            name = "futurebroker"
+            taker_fee = 0.002
+
+        module = self._universal(lambda broker, pos, market: (True, "take_profit_1", 100.5))
+        pos = {"symbol": "BTC-USD", "entry_price": 100.0, "side": "long"}
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_EXIT_SPREAD_RESERVE_PCT": "0",
+                "NIJA_EXIT_SLIPPAGE_RESERVE_PCT": "0.001",
+                "NIJA_MINIMUM_NET_PROFIT_PCT": "0.004",
+            },
+            clear=False,
+        ):
+            hit, reason, target = module._trigger(Broker(), pos, 100.6)
+        self.assertFalse(hit)
+        self.assertEqual(reason, "")
+        self.assertEqual(target, 0.0)
+
+    def test_take_profit_above_net_floor_is_allowed(self) -> None:
+        class Broker:
+            name = "futurebroker"
+            taker_fee = 0.001
+
+        module = self._universal(lambda broker, pos, market: (True, "take_profit_1", 101.0))
+        pos = {"symbol": "BTC-USD", "entry_price": 100.0, "side": "long"}
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_EXIT_SPREAD_RESERVE_PCT": "0",
+                "NIJA_EXIT_SLIPPAGE_RESERVE_PCT": "0.001",
+                "NIJA_MINIMUM_NET_PROFIT_PCT": "0.004",
+            },
+            clear=False,
+        ):
+            hit, reason, target = module._trigger(Broker(), pos, 101.0)
+        self.assertTrue(hit)
+        self.assertEqual(reason, "take_profit_1")
+        self.assertGreater(target, 100.0)
+
+    def test_stop_loss_is_never_delayed_by_profit_floor(self) -> None:
+        class Broker:
+            name = "futurebroker"
+            taker_fee = 0.01
+
+        module = self._universal(lambda broker, pos, market: (True, "stop_loss:stored_stop_loss", 98.0))
+        pos = {"symbol": "BTC-USD", "entry_price": 100.0, "side": "long"}
+        hit, reason, target = module._trigger(Broker(), pos, 98.0)
+        self.assertTrue(hit)
+        self.assertIn("stop_loss", reason)
+        self.assertEqual(target, 98.0)
+
+    def test_trailing_profit_exit_requires_cost_adjusted_break_even_only(self) -> None:
+        class Broker:
+            name = "futurebroker"
+            taker_fee = 0.001
+
+        module = self._universal(lambda broker, pos, market: (True, "profit_lock_trailing_exit", 100.3))
+        pos = {"symbol": "BTC-USD", "entry_price": 100.0, "side": "long"}
+        with patch.dict(
+            os.environ,
+            {
+                "NIJA_EXIT_SPREAD_RESERVE_PCT": "0",
+                "NIJA_EXIT_SLIPPAGE_RESERVE_PCT": "0.001",
+                "NIJA_MINIMUM_NET_PROFIT_PCT": "0.020",
+            },
+            clear=False,
+        ):
+            # 0.2% round trip + 0.1% slippage = 100.30 break-even.
+            hit, reason, _target = module._trigger(Broker(), pos, 100.35)
+        self.assertTrue(hit)
+        self.assertEqual(reason, "profit_lock_trailing_exit")
+
+    def test_runtime_fee_preferred_over_static_matrix(self) -> None:
+        class Broker:
+            name = "coinbase"
+            taker_fee = 0.00125
+
+        fake_universal = types.SimpleNamespace(
+            auto_exit=types.SimpleNamespace(
+                _sym=lambda value: str(value).upper(),
+                _broker_label=lambda broker: broker.name,
+                _entry_price=lambda pos: float(pos.get("entry_price", 0.0)),
+                _side=lambda value, pos=None: str(value or "long"),
+            )
+        )
+        model = self.mod._cost_model(
+            fake_universal,
+            Broker(),
+            {"symbol": "ETH-USD", "entry_price": 100.0, "side": "long"},
+        )
+        self.assertEqual(model["source"], "broker_runtime_taker_fee")
+        self.assertGreater(float(model["round_trip"]), 0.0025)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_writer_scan_deadline_lease_guard_v61.py
+++ b/bot/tests/test_writer_scan_deadline_lease_guard_v61.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+
+
+PATCH_PATH = Path(__file__).resolve().parents[1] / "execution_bootstrap_monitor_iteration_guard_patch.py"
+
+
+def _load_patch(name: str = "writer_scan_deadline_lease_guard_v61_patch"):
+    spec = importlib.util.spec_from_file_location(name, PATCH_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
+class _DeadThread:
+    def is_alive(self) -> bool:
+        return False
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self._core_thread = None
+        self._scan_deadline_exceeded = False
+        self._scan_started_at = 0.0
+
+    def _validate_core_thread_liveness(self):
+        thread = self._core_thread
+        if thread is None:
+            if self._scan_deadline_exceeded and not self._scan_started_at:
+                return False, "core_thread_missing_deadline_exceeded"
+            return True, ""
+        if not thread.is_alive():
+            return False, "core_thread_dead"
+        return True, ""
+
+
+class _WriterModule:
+    __name__ = "fake_entrypoint_writer_authority_v61"
+    EntrypointWriterAuthority = _Runtime
+
+
+def test_scan_deadline_is_warning_only_before_core_thread_registration():
+    patch = _load_patch("v61_scan_deadline_warning_only")
+    module = _WriterModule()
+
+    assert patch._patch_writer_module(module) is True
+
+    runtime = module.EntrypointWriterAuthority()
+    runtime._scan_deadline_exceeded = True
+    runtime._scan_started_at = 0.0
+    runtime._core_thread = None
+
+    ok, reason = runtime._validate_core_thread_liveness()
+
+    assert ok is True
+    assert reason == "scan_start_deadline_warning_only"
+
+
+def test_registered_dead_core_thread_remains_fail_closed():
+    patch = _load_patch("v61_dead_core_still_fails")
+    module = _WriterModule()
+
+    # Rebuild an unpatched class because the prior test patches class methods in-place.
+    class Runtime:
+        def __init__(self) -> None:
+            self._core_thread = None
+            self._scan_deadline_exceeded = False
+            self._scan_started_at = 0.0
+
+        def _validate_core_thread_liveness(self):
+            thread = self._core_thread
+            if thread is None:
+                if self._scan_deadline_exceeded and not self._scan_started_at:
+                    return False, "core_thread_missing_deadline_exceeded"
+                return True, ""
+            if not thread.is_alive():
+                return False, "core_thread_dead"
+            return True, ""
+
+    module.EntrypointWriterAuthority = Runtime
+    assert patch._patch_writer_module(module) is True
+
+    runtime = module.EntrypointWriterAuthority()
+    runtime._core_thread = _DeadThread()
+    runtime._scan_deadline_exceeded = True
+
+    ok, reason = runtime._validate_core_thread_liveness()
+
+    assert ok is False
+    assert reason == "core_thread_dead"
+
+
+def test_registered_live_core_thread_remains_healthy():
+    patch = _load_patch("v61_live_core_healthy")
+    module = _WriterModule()
+
+    class Runtime:
+        def __init__(self) -> None:
+            self._core_thread = _AliveThread()
+            self._scan_deadline_exceeded = True
+            self._scan_started_at = 0.0
+
+        def _validate_core_thread_liveness(self):
+            if not self._core_thread.is_alive():
+                return False, "core_thread_dead"
+            return True, ""
+
+    module.EntrypointWriterAuthority = Runtime
+    assert patch._patch_writer_module(module) is True
+
+    runtime = module.EntrypointWriterAuthority()
+    ok, reason = runtime._validate_core_thread_liveness()
+
+    assert ok is True
+    assert reason == ""

--- a/bot/universal_exit_fill_reconciliation_v67_patch.py
+++ b/bot/universal_exit_fill_reconciliation_v67_patch.py
@@ -1,0 +1,638 @@
+"""Universal broker exit fill reconciliation v67.
+
+The legacy universal exit path treated an accepted order or a bare ``order_id``
+as a completed exit.  That is not a portable exchange contract: order
+acceptance and order execution are separate lifecycle states on Coinbase, OKX,
+Alpaca, Binance and other venues.
+
+v67 establishes one broker-agnostic invariant for every platform/user account:
+
+    SUBMIT ONCE -> PENDING/UNKNOWN -> RECONCILE -> CONFIRMED FILL -> LOCAL CLOSE
+
+Safety properties
+-----------------
+* ``accepted``, ``new``, ``open``, ``live``, ``pending`` and
+  ``partially_filled`` are never treated as fully closed.
+* a response with only an order id is pending, not a fill;
+* transport timeout/unknown status is preserved for reconciliation and is not
+  blindly resubmitted;
+* terminal fill can be proven by terminal filled state, full executed quantity,
+  or native broker position disappearance/reduction to zero;
+* explicit rejection/cancel/expiry clears the pending latch so the next scan may
+  safely reassess the still-open position;
+* current and future broker instances are discovered from canonical broker/account
+  registries by capability, not by a fixed class-name allow-list;
+* while this universal supervisor is enabled, the older ExecutionEngine auto-exit
+  scanner is delegated/disabled to avoid two independent exit authorities
+  submitting duplicate closes.
+
+This patch does not weaken stop-loss/take-profit triggers.  It only strengthens
+execution confirmation and account/venue routing.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping
+
+LOGGER = logging.getLogger("nija.universal_exit_fill_reconciliation_v67")
+MARKER = "20260809-universal-exit-fill-reconciliation-v67"
+_INSTALL_LOCK = threading.RLock()
+_PATCHED_ATTR = "_nija_universal_exit_fill_reconciliation_v67"
+
+_FILLED_STATES = {"filled", "closed", "done", "complete", "completed", "executed"}
+_PENDING_STATES = {
+    "accepted", "submitted", "pending", "pending_new", "new", "open", "live",
+    "working", "partially_filled", "partial_fill", "pending_cancel", "pending_replace",
+    "accepted_for_bidding", "stopped", "calculated", "unknown", "timeout", "ambiguous",
+}
+_FAILED_STATES = {
+    "failed", "error", "rejected", "canceled", "cancelled", "expired", "void",
+    "mmp_canceled", "done_for_day",
+}
+_PENDING: dict[tuple[int, str, str], dict[str, Any]] = {}
+_PENDING_LOCK = threading.RLock()
+_LAST_DELEGATE_LOG = 0.0
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if result == result else default
+
+
+def _status(payload: Any) -> str:
+    if not isinstance(payload, Mapping):
+        return ""
+    for key in ("status", "state", "order_status", "result_status"):
+        state = _norm(payload.get(key))
+        if state:
+            return state
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        return _status(result)
+    data = payload.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], Mapping):
+        return _status(data[0])
+    return ""
+
+
+def _order_id(payload: Any) -> str:
+    if not isinstance(payload, Mapping):
+        return ""
+    for key in ("order_id", "id", "ordId", "txid", "transaction_id", "client_order_id", "clOrdId"):
+        value = payload.get(key)
+        if isinstance(value, (list, tuple)) and value:
+            value = value[0]
+        text = str(value or "").strip()
+        if text:
+            return text
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        nested = _order_id(result)
+        if nested:
+            return nested
+    data = payload.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], Mapping):
+        return _order_id(data[0])
+    return ""
+
+
+def _filled_quantity(payload: Any) -> float:
+    if not isinstance(payload, Mapping):
+        return 0.0
+    for key in (
+        "filled_quantity", "filled_qty", "executed_qty", "executedQty", "vol_exec",
+        "filled_size", "filledSize", "accFillSz", "cum_qty", "cumQty", "amount_filled",
+    ):
+        value = _f(payload.get(key))
+        if value > 0.0:
+            return value
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        nested = _filled_quantity(result)
+        if nested > 0.0:
+            return nested
+    data = payload.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], Mapping):
+        return _filled_quantity(data[0])
+    return 0.0
+
+
+def _filled_price(payload: Any, default: float = 0.0) -> float:
+    if not isinstance(payload, Mapping):
+        return default
+    for key in (
+        "filled_price", "average_fill_price", "avg_price", "avgPx", "fillPx",
+        "price", "average_price",
+    ):
+        value = _f(payload.get(key))
+        if value > 0.0:
+            return value
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        return _filled_price(result, default)
+    data = payload.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], Mapping):
+        return _filled_price(data[0], default)
+    return default
+
+
+def _is_full_fill(payload: Any, expected_qty: float) -> bool:
+    state = _status(payload)
+    if state in _FILLED_STATES:
+        return True
+    filled = _filled_quantity(payload)
+    return bool(expected_qty > 0.0 and filled >= expected_qty * 0.999)
+
+
+def _is_terminal_failure(payload: Any) -> bool:
+    return _status(payload) in _FAILED_STATES
+
+
+def _is_submission_ack(payload: Any) -> bool:
+    if not isinstance(payload, Mapping):
+        return False
+    state = _status(payload)
+    if state in _PENDING_STATES or state in _FILLED_STATES:
+        return True
+    if _order_id(payload):
+        return True
+    # Some wrappers expose request success separately from execution state.
+    return bool(payload.get("success") is True or payload.get("accepted") is True)
+
+
+def _broker_symbol_positions(broker: Any) -> list[Any]:
+    for name in ("get_positions", "list_positions", "get_open_positions"):
+        method = getattr(broker, name, None)
+        if not callable(method):
+            continue
+        try:
+            rows = method() or []
+        except Exception:
+            continue
+        if isinstance(rows, Mapping):
+            return list(rows.values())
+        try:
+            return list(rows)
+        except TypeError:
+            return []
+    tracker = getattr(broker, "position_tracker", None)
+    if tracker is not None:
+        for name in ("get_all_positions", "get_open_positions", "list_positions"):
+            method = getattr(tracker, name, None)
+            if callable(method):
+                try:
+                    rows = method() or []
+                    if isinstance(rows, Mapping):
+                        return list(rows.values())
+                    return list(rows)
+                except Exception:
+                    continue
+    return []
+
+
+def _position_quantity_for_symbol(universal: ModuleType, broker: Any, symbol: str) -> tuple[bool, float]:
+    rows = _broker_symbol_positions(broker)
+    if not rows:
+        # Empty native list is valid evidence only if a positions API exists.
+        has_api = any(
+            callable(getattr(broker, name, None))
+            for name in ("get_positions", "list_positions", "get_open_positions")
+        )
+        return has_api, 0.0
+    target = universal.auto_exit._sym(symbol)
+    total = 0.0
+    observed = False
+    for raw in rows:
+        pos = raw if isinstance(raw, Mapping) else dict(getattr(raw, "__dict__", {}) or {})
+        sym = universal.auto_exit._sym(pos.get("symbol") or pos.get("pair"))
+        if sym != target:
+            continue
+        observed = True
+        total += universal.auto_exit._quantity(dict(pos))
+    # Successfully enumerating native positions and not finding the target is
+    # proof that the target quantity is zero.
+    return True, total if observed else 0.0
+
+
+def _query_order(broker: Any, order_id: str, symbol: str = "") -> Mapping[str, Any]:
+    if not order_id:
+        return {}
+    attempts = (
+        ("get_order_status", ((order_id,), {"order_id": order_id})),
+        ("get_order", ((order_id,), {"order_id": order_id})),
+        ("get_order_by_id", ((order_id,), {"order_id": order_id})),
+        ("fetch_order", ((order_id,), {"order_id": order_id, "symbol": symbol})),
+        ("query_order", ((order_id,), {"order_id": order_id, "symbol": symbol})),
+    )
+    for method_name, (positional, keywords) in attempts:
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            continue
+        for call_args, call_kwargs in ((positional, {}), ((), keywords)):
+            try:
+                result = method(*call_args, **call_kwargs)
+                if isinstance(result, Mapping):
+                    return result
+            except TypeError:
+                continue
+            except Exception:
+                break
+    # Common Kraken low-level fallback retained without making Kraken special in
+    # the main state machine.
+    private = getattr(broker, "_kraken_api_call", None)
+    if callable(private):
+        try:
+            result = private("QueryOrders", {"txid": order_id, "trades": True})
+            if isinstance(result, Mapping):
+                nested = result.get("result")
+                if isinstance(nested, Mapping):
+                    row = nested.get(order_id)
+                    if isinstance(row, Mapping):
+                        return row
+                return result
+        except Exception:
+            pass
+    return {}
+
+
+def _submit_exit_once(universal: ModuleType, broker: Any, pos: dict[str, Any], market: float) -> dict[str, Any]:
+    symbol = universal.auto_exit._sym(pos.get("symbol"))
+    qty = universal.auto_exit._quantity(pos)
+    if qty <= 0.0:
+        return {"status": "error", "error": "invalid_position_quantity"}
+    close_side = "sell" if universal.auto_exit._side(pos.get("side"), pos) in {"long", "buy"} else "buy"
+    calls = (
+        ("place_market_order", {"symbol": symbol, "side": close_side, "size": qty}),
+        ("place_order", {"symbol": symbol, "side": close_side, "order_type": "market", "quantity": qty}),
+        ("market_order", {"symbol": symbol, "side": close_side, "quantity": qty}),
+        ("execute_order", {"symbol": symbol, "side": close_side, "order_type": "market", "quantity": qty, "reduce_only": True}),
+    )
+    errors: list[str] = []
+    for method_name, kwargs in calls:
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            result = method(**kwargs)
+        except TypeError:
+            try:
+                result = method(symbol, close_side, qty)
+            except Exception as exc:
+                errors.append(f"{method_name}:{type(exc).__name__}:{exc}")
+                continue
+        except Exception as exc:
+            errors.append(f"{method_name}:{type(exc).__name__}:{exc}")
+            continue
+
+        payload = dict(result) if isinstance(result, Mapping) else {
+            "status": "unknown",
+            "raw": str(result),
+        }
+        payload.setdefault("submission_method", method_name)
+        if _is_full_fill(payload, qty) or _is_submission_ack(payload):
+            # Crucially: once a venue acknowledges a submission, do NOT fall
+            # through to another method and risk submitting a duplicate close.
+            return payload
+        if _is_terminal_failure(payload):
+            errors.append(f"{method_name}:{_status(payload)}:{payload.get('error', '')}")
+            continue
+        # Ambiguous transport/application response: preserve it as unknown and
+        # reconcile instead of calling another submit method.
+        if _order_id(payload) or payload:
+            payload.setdefault("status", "unknown")
+            return payload
+    return {"status": "error", "error": "exit_submission_failed", "details": errors[-4:]}
+
+
+def _pending_key(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> tuple[int, str, str]:
+    symbol = universal.auto_exit._sym(pos.get("symbol"))
+    pid = str(pos.get("position_id") or symbol)
+    return id(broker), pid, symbol
+
+
+def _confirm_by_position(universal: ModuleType, broker: Any, pending: Mapping[str, Any]) -> bool:
+    observed, current_qty = _position_quantity_for_symbol(
+        universal,
+        broker,
+        str(pending.get("symbol") or ""),
+    )
+    if not observed:
+        return False
+    before = max(0.0, _f(pending.get("quantity")))
+    if before <= 0.0:
+        return current_qty <= 0.0
+    return current_qty <= max(1e-12, before * 0.001)
+
+
+def _reconcile_pending(universal: ModuleType, broker: Any, pending: Mapping[str, Any]) -> tuple[str, Mapping[str, Any]]:
+    order_id = str(pending.get("order_id") or "")
+    payload = _query_order(broker, order_id, str(pending.get("symbol") or "")) if order_id else {}
+    expected = max(0.0, _f(pending.get("quantity")))
+    if _is_full_fill(payload, expected):
+        return "filled", payload
+    if _confirm_by_position(universal, broker, pending):
+        return "filled", payload
+    if _is_terminal_failure(payload):
+        return "failed", payload
+    return "pending", payload
+
+
+def _discover_brokers(universal: ModuleType) -> list[Any]:
+    """Discover broker instances from canonical registries by capability."""
+    candidates: list[Any] = []
+    seen: set[int] = set()
+
+    def add(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, Mapping):
+            for nested in value.values():
+                add(nested)
+            return
+        if isinstance(value, (list, tuple, set, frozenset)):
+            for nested in value:
+                add(nested)
+            return
+        oid = id(value)
+        if oid in seen:
+            return
+        has_positions = any(callable(getattr(value, name, None)) for name in ("get_positions", "list_positions", "get_open_positions")) or getattr(value, "position_tracker", None) is not None
+        has_order = any(callable(getattr(value, name, None)) for name in ("place_market_order", "place_order", "market_order", "execute_order"))
+        if has_positions and has_order:
+            seen.add(oid)
+            candidates.append(value)
+
+    for name in ("bot.broker_manager", "broker_manager", "bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        for attr in (
+            "GLOBAL_PLATFORM_BROKERS", "_PLATFORM_BROKER_INSTANCES", "platform_brokers",
+            "_platform_brokers", "user_brokers", "_user_brokers", "brokers", "_brokers",
+            "multi_account_broker_manager", "manager", "broker_manager",
+        ):
+            try:
+                add(getattr(module, attr, None))
+            except Exception:
+                pass
+        for getter_name in ("get_multi_account_broker_manager", "get_broker_manager"):
+            getter = getattr(module, getter_name, None)
+            if callable(getter):
+                try:
+                    manager = getter()
+                except Exception:
+                    continue
+                for attr in ("platform_brokers", "_platform_brokers", "user_brokers", "_user_brokers", "brokers", "_brokers"):
+                    add(getattr(manager, attr, None))
+
+    for broker in candidates:
+        try:
+            universal._register_broker(broker)
+        except Exception:
+            pass
+    return candidates
+
+
+def _safe_scan_broker(universal: ModuleType, broker: Any) -> int:
+    closed = 0
+    account = universal._account_label(broker)
+    venue = universal.auto_exit._broker_label(broker) or "unknown"
+    for pos in universal._tracker_positions(broker):
+        symbol = universal.auto_exit._sym(pos.get("symbol"))
+        pid = str(pos.get("position_id") or symbol)
+        key = _pending_key(universal, broker, pos)
+
+        with _PENDING_LOCK:
+            pending = dict(_PENDING.get(key) or {})
+        if pending:
+            state, proof = _reconcile_pending(universal, broker, pending)
+            if state == "filled":
+                fill_payload = dict(proof or {})
+                fill_payload.setdefault("order_id", pending.get("order_id", ""))
+                fill_payload.setdefault("filled_price", pending.get("market", 0.0))
+                universal._mark_closed(
+                    broker,
+                    pos,
+                    fill_payload,
+                    str(pending.get("reason") or "exit"),
+                    _filled_price(fill_payload, _f(pending.get("market"))),
+                )
+                universal.auto_exit._HIGH_WATER.pop(universal.auto_exit._position_key(pos), None)
+                with _PENDING_LOCK:
+                    _PENDING.pop(key, None)
+                closed += 1
+                LOGGER.critical(
+                    "UNIVERSAL_EXIT_V67_CONFIRMED marker=%s venue=%s account=%s symbol=%s "
+                    "order_id=%s status=%s fill_or_position_proof=true",
+                    MARKER, venue, account, symbol, pending.get("order_id", ""), _status(proof) or "position_reduction",
+                )
+                continue
+            if state == "failed":
+                with _PENDING_LOCK:
+                    _PENDING.pop(key, None)
+                LOGGER.error(
+                    "UNIVERSAL_EXIT_V67_TERMINAL_FAILURE marker=%s venue=%s account=%s symbol=%s "
+                    "order_id=%s status=%s tracker_preserved=true",
+                    MARKER, venue, account, symbol, pending.get("order_id", ""), _status(proof),
+                )
+                continue
+            age = max(0.0, time.time() - _f(pending.get("submitted_at"), time.time()))
+            LOGGER.warning(
+                "UNIVERSAL_EXIT_V67_PENDING marker=%s venue=%s account=%s symbol=%s order_id=%s "
+                "age_s=%.1f duplicate_submit_blocked=true tracker_preserved=true",
+                MARKER, venue, account, symbol, pending.get("order_id", ""), age,
+            )
+            continue
+
+        entry = universal.auto_exit._entry_price(pos)
+        qty = universal.auto_exit._quantity(pos)
+        if not symbol or entry <= 0.0 or qty <= 0.0:
+            continue
+        market = universal.auto_exit._price(broker, symbol)
+        if market <= 0.0:
+            continue
+        hit, reason, target = universal._trigger(broker, pos, market)
+        if not hit:
+            continue
+
+        active_key = f"{id(broker)}:{pid}:{symbol}"
+        if active_key in universal._ACTIVE:
+            continue
+        universal._ACTIVE.add(active_key)
+        try:
+            LOGGER.critical(
+                "UNIVERSAL_EXIT_V67_TRIGGER marker=%s venue=%s account=%s symbol=%s reason=%s "
+                "target=%.8f market=%.8f entry=%.8f qty=%.8f",
+                MARKER, venue, account, symbol, reason, target, market, entry, qty,
+            )
+            result = _submit_exit_once(universal, broker, pos, market)
+            if _is_full_fill(result, qty) or _confirm_by_position(
+                universal,
+                broker,
+                {"symbol": symbol, "quantity": qty},
+            ):
+                universal._mark_closed(broker, pos, result, reason, _filled_price(result, market))
+                universal.auto_exit._HIGH_WATER.pop(universal.auto_exit._position_key(pos), None)
+                closed += 1
+                LOGGER.critical(
+                    "UNIVERSAL_EXIT_V67_CONFIRMED_IMMEDIATE marker=%s venue=%s account=%s symbol=%s "
+                    "order_id=%s status=%s",
+                    MARKER, venue, account, symbol, _order_id(result), _status(result) or "position_reduction",
+                )
+                continue
+            if _is_terminal_failure(result):
+                LOGGER.error(
+                    "UNIVERSAL_EXIT_V67_SUBMISSION_REJECTED marker=%s venue=%s account=%s symbol=%s status=%s error=%s",
+                    MARKER, venue, account, symbol, _status(result), result.get("error", result),
+                )
+                continue
+
+            with _PENDING_LOCK:
+                _PENDING[key] = {
+                    "order_id": _order_id(result),
+                    "submitted_at": time.time(),
+                    "quantity": qty,
+                    "symbol": symbol,
+                    "reason": reason,
+                    "market": market,
+                    "submission_status": _status(result) or "unknown",
+                }
+            LOGGER.critical(
+                "UNIVERSAL_EXIT_V67_ACCEPTED_PENDING marker=%s venue=%s account=%s symbol=%s "
+                "order_id=%s status=%s tracker_preserved=true duplicate_submit_blocked=true",
+                MARKER, venue, account, symbol, _order_id(result), _status(result) or "unknown",
+            )
+        finally:
+            universal._ACTIVE.discard(active_key)
+    return closed
+
+
+def _patch_universal(module: ModuleType) -> bool:
+    current = getattr(module, "_scan_broker", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCHED_ATTR, False):
+        return True
+
+    def safe_scan(broker: Any) -> int:
+        _discover_brokers(module)
+        return _safe_scan_broker(module, broker)
+
+    setattr(safe_scan, _PATCHED_ATTR, True)
+    setattr(safe_scan, "__wrapped__", current)
+    module._scan_broker = safe_scan
+
+    snapshot = getattr(module, "_snapshot", None)
+    if callable(snapshot) and not getattr(snapshot, _PATCHED_ATTR, False):
+        @wraps(snapshot)
+        def snapshot_with_discovery():
+            _discover_brokers(module)
+            return snapshot()
+        setattr(snapshot_with_discovery, _PATCHED_ATTR, True)
+        module._snapshot = snapshot_with_discovery
+
+    LOGGER.critical(
+        "UNIVERSAL_EXIT_FILL_RECONCILIATION_V67_PATCHED marker=%s module=%s "
+        "accepted_is_fill=false generic_registry_discovery=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_auto_exit(module: ModuleType) -> bool:
+    current_scan = getattr(module, "_scan_once", None)
+    if not callable(current_scan) or getattr(current_scan, _PATCHED_ATTR, False):
+        return bool(callable(current_scan))
+
+    @wraps(current_scan)
+    def delegated_scan(engine: Any) -> int:
+        global _LAST_DELEGATE_LOG
+        if str(os.environ.get("NIJA_UNIVERSAL_BROKER_EXIT_ENABLED", "true")).strip().lower() in {"1", "true", "yes", "on", "enabled"}:
+            now = time.monotonic()
+            if now - _LAST_DELEGATE_LOG > 60.0:
+                _LAST_DELEGATE_LOG = now
+                LOGGER.info(
+                    "AUTO_EXIT_V67_DELEGATED marker=%s reason=single_universal_exit_authority duplicate_exit_prevention=true",
+                    MARKER,
+                )
+            return 0
+        return current_scan(engine)
+
+    setattr(delegated_scan, _PATCHED_ATTR, True)
+    module._scan_once = delegated_scan
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.universal_broker_exit_supervisor_patch", "universal_broker_exit_supervisor_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_universal(module) or changed
+    for name in ("bot.auto_exit_sl_tp_runtime_patch", "auto_exit_sl_tp_runtime_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_auto_exit(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _INSTALL_LOCK:
+        try:
+            importlib.import_module("bot.universal_broker_exit_supervisor_patch")
+        except Exception:
+            pass
+        try:
+            importlib.import_module("bot.auto_exit_sl_tp_runtime_patch")
+        except Exception:
+            pass
+        _patch_loaded()
+        flag = "_NIJA_UNIVERSAL_EXIT_FILL_RECONCILIATION_V67_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "universal_broker_exit" in str(name) or "auto_exit_sl_tp" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_UNIVERSAL_EXIT_FILL_RECONCILIATION_V67_INSTALLED"] = "1"
+        LOGGER.critical(
+            "UNIVERSAL_EXIT_FILL_RECONCILIATION_V67_INSTALLED marker=%s fill_confirmation_required=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER", "install", "install_import_hook", "_status", "_order_id",
+    "_filled_quantity", "_is_full_fill", "_is_submission_ack", "_query_order",
+]

--- a/bot/universal_net_profit_exit_floor_v68_patch.py
+++ b/bot/universal_net_profit_exit_floor_v68_patch.py
@@ -1,0 +1,307 @@
+"""Universal fee-aware net-profit exit floor v68.
+
+Normal take-profit decisions must represent net profit after round-trip trading
+cost, spread and an exit slippage reserve.  Stored/gross TP values may not
+bypass that invariant.  Protective exits remain separate:
+
+* hard/explicit stop-loss exits are never delayed;
+* trailing profit-lock callbacks may close once price is above fee-adjusted
+  break-even, even if the full minimum-net-profit target is no longer available;
+* normal take-profit exits require break-even + configured minimum net profit.
+
+The resolver prefers broker/account runtime fee information when exposed and
+falls back to NIJA's exchange capability matrix.  Unknown/future brokers receive
+conservative defaults rather than a zero-fee assumption.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Mapping, Optional
+
+LOGGER = logging.getLogger("nija.universal_net_profit_exit_floor_v68")
+MARKER = "20260809-universal-net-profit-exit-floor-v68"
+_PATCH_ATTR = "_nija_universal_net_profit_exit_floor_v68"
+_INSTALL_LOCK = threading.RLock()
+
+_PROTECTIVE_REASON_TOKENS = (
+    "stop_loss", "emergency", "liquidation", "critical_margin", "max_loss", "risk_exit",
+)
+_TRAILING_REASON_TOKENS = (
+    "profit_lock", "trailing", "break_even", "breakeven",
+)
+_PROFIT_REASON_TOKENS = (
+    "take_profit", "profit_target", "net_profit", "harvest", "tp",
+)
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _broker_label(universal: ModuleType, broker: Any) -> str:
+    try:
+        return str(universal.auto_exit._broker_label(broker) or "unknown").strip().lower()
+    except Exception:
+        return "unknown"
+
+
+def _extract_fee_value(value: Any) -> float:
+    if isinstance(value, Mapping):
+        for key in (
+            "taker_fee", "taker", "fee_rate", "trading_fee", "commission_rate",
+            "commission", "fee",
+        ):
+            if key in value:
+                fee = _f(value.get(key), -1.0)
+                if 0.0 <= fee <= 0.05:
+                    return fee
+        return -1.0
+    fee = _f(value, -1.0)
+    return fee if 0.0 <= fee <= 0.05 else -1.0
+
+
+def _runtime_taker_fee(broker: Any, symbol: str) -> Optional[float]:
+    """Return one-way taker fee from broker/account runtime data when available."""
+    for method_name in (
+        "get_taker_fee", "get_fee_rate", "get_trading_fee", "get_trading_fees",
+        "get_fee_schedule", "get_fees",
+    ):
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            continue
+        for args, kwargs in (
+            ((symbol,), {}),
+            ((), {"symbol": symbol}),
+            ((), {}),
+        ):
+            try:
+                result = method(*args, **kwargs)
+            except TypeError:
+                continue
+            except Exception:
+                break
+            fee = _extract_fee_value(result)
+            if fee >= 0.0:
+                return fee
+    for attr in (
+        "taker_fee", "taker_fee_rate", "trading_fee", "fee_rate", "commission_rate",
+    ):
+        fee = _extract_fee_value(getattr(broker, attr, None))
+        if fee >= 0.0:
+            return fee
+    return None
+
+
+def _capability_round_trip_cost(broker_name: str, symbol: str) -> float:
+    try:
+        module = importlib.import_module("bot.exchange_capabilities")
+        getter = getattr(module, "get_broker_capabilities", None)
+        if callable(getter):
+            caps = getter(broker_name, symbol)
+            method = getattr(caps, "get_round_trip_fee", None)
+            if callable(method):
+                # Universal exits use market orders; taker economics are the
+                # appropriate conservative fallback.
+                value = _f(method(use_limit_order=False), 0.0)
+                if 0.0 < value <= 0.20:
+                    return value
+    except Exception:
+        pass
+    # Unknown/future venue: conservative but bounded assumption, not zero cost.
+    return max(0.0025, _f(os.environ.get("NIJA_UNKNOWN_BROKER_ROUND_TRIP_COST_PCT"), 0.004))
+
+
+def _cost_model(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> dict[str, float | str]:
+    symbol = universal.auto_exit._sym(pos.get("symbol"))
+    broker_name = _broker_label(universal, broker)
+    runtime_fee = _runtime_taker_fee(broker, symbol)
+    if runtime_fee is not None:
+        spread = max(0.0, _f(os.environ.get("NIJA_EXIT_SPREAD_RESERVE_PCT"), 0.0010))
+        round_trip = min(0.20, runtime_fee * 2.0 + spread)
+        source = "broker_runtime_taker_fee"
+    else:
+        round_trip = _capability_round_trip_cost(broker_name, symbol)
+        source = "exchange_capability_matrix"
+    slippage = max(0.0, _f(os.environ.get("NIJA_EXIT_SLIPPAGE_RESERVE_PCT"), 0.0015))
+    minimum_net = max(0.0, _f(os.environ.get("NIJA_MINIMUM_NET_PROFIT_PCT"), 0.0040))
+    return {
+        "round_trip": round_trip,
+        "slippage": slippage,
+        "minimum_net": minimum_net,
+        "source": source,
+    }
+
+
+def _floors(universal: ModuleType, broker: Any, pos: Mapping[str, Any]) -> tuple[float, float, dict[str, Any]]:
+    entry = universal.auto_exit._entry_price(dict(pos))
+    if entry <= 0.0:
+        return 0.0, 0.0, {}
+    costs = _cost_model(universal, broker, pos)
+    break_even_pct = float(costs["round_trip"]) + float(costs["slippage"])
+    net_pct = break_even_pct + float(costs["minimum_net"])
+    short = universal.auto_exit._side(pos.get("side"), dict(pos)) in {"short", "sell"}
+    if short:
+        break_even = entry * max(0.0, 1.0 - break_even_pct)
+        net_target = entry * max(0.0, 1.0 - net_pct)
+    else:
+        break_even = entry * (1.0 + break_even_pct)
+        net_target = entry * (1.0 + net_pct)
+    details = dict(costs)
+    details.update({
+        "entry": entry,
+        "break_even": break_even,
+        "net_target": net_target,
+        "short": short,
+    })
+    return break_even, net_target, details
+
+
+def _meets(market: float, target: float, short: bool) -> bool:
+    return market <= target if short else market >= target
+
+
+def _reason_kind(reason: str) -> str:
+    text = str(reason or "").strip().lower()
+    if any(token in text for token in _PROTECTIVE_REASON_TOKENS):
+        return "protective"
+    if any(token in text for token in _TRAILING_REASON_TOKENS):
+        return "trailing"
+    if any(token in text for token in _PROFIT_REASON_TOKENS):
+        return "profit"
+    return "other"
+
+
+def _patch_universal(module: ModuleType) -> bool:
+    current = getattr(module, "_trigger", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def net_floor_trigger(broker: Any, pos: dict[str, Any], market: float):
+        hit, reason, target = current(broker, pos, market)
+        break_even, net_target, details = _floors(module, broker, pos)
+        if break_even <= 0.0 or net_target <= 0.0:
+            # Missing verified entry data: preserve existing protective behavior,
+            # but do not synthesize a new profit trigger.
+            return hit, reason, target
+        short = bool(details.get("short"))
+        kind = _reason_kind(reason) if hit else "none"
+
+        if hit and kind == "protective":
+            return hit, reason, target
+
+        if hit and kind == "trailing":
+            if _meets(market, break_even, short):
+                LOGGER.info(
+                    "UNIVERSAL_EXIT_V68_TRAILING_PROFIT_ALLOWED marker=%s venue=%s symbol=%s "
+                    "market=%.8f break_even=%.8f net_target=%.8f source=%s",
+                    MARKER, _broker_label(module, broker), module.auto_exit._sym(pos.get("symbol")),
+                    market, break_even, net_target, details.get("source"),
+                )
+                return hit, reason, max(target, break_even) if not short else min(target or break_even, break_even)
+            LOGGER.warning(
+                "UNIVERSAL_EXIT_V68_TRAILING_BELOW_COST_SUPPRESSED marker=%s venue=%s symbol=%s "
+                "reason=%s market=%.8f break_even=%.8f",
+                MARKER, _broker_label(module, broker), module.auto_exit._sym(pos.get("symbol")),
+                reason, market, break_even,
+            )
+            return False, "", 0.0
+
+        if hit and kind in {"profit", "other"}:
+            if _meets(market, net_target, short):
+                LOGGER.critical(
+                    "UNIVERSAL_EXIT_V68_NET_PROFIT_READY marker=%s venue=%s symbol=%s reason=%s "
+                    "market=%.8f net_target=%.8f break_even=%.8f round_trip=%.5f slippage=%.5f min_net=%.5f source=%s",
+                    MARKER, _broker_label(module, broker), module.auto_exit._sym(pos.get("symbol")), reason,
+                    market, net_target, break_even, details.get("round_trip", 0.0),
+                    details.get("slippage", 0.0), details.get("minimum_net", 0.0), details.get("source"),
+                )
+                return True, reason or "net_profit_target", net_target
+            LOGGER.warning(
+                "UNIVERSAL_EXIT_V68_GROSS_TP_SUPPRESSED marker=%s venue=%s symbol=%s reason=%s "
+                "market=%.8f stored_target=%.8f required_net_target=%.8f source=%s",
+                MARKER, _broker_label(module, broker), module.auto_exit._sym(pos.get("symbol")),
+                reason or "unknown", market, target, net_target, details.get("source"),
+            )
+            return False, "", 0.0
+
+        # No legacy trigger: let the universal net floor itself create the TP.
+        if not hit and _meets(market, net_target, short):
+            LOGGER.critical(
+                "UNIVERSAL_EXIT_V68_NET_PROFIT_TARGET_TRIGGERED marker=%s venue=%s symbol=%s "
+                "market=%.8f net_target=%.8f source=%s",
+                MARKER, _broker_label(module, broker), module.auto_exit._sym(pos.get("symbol")),
+                market, net_target, details.get("source"),
+            )
+            return True, "net_profit_target", net_target
+        return hit, reason, target
+
+    setattr(net_floor_trigger, _PATCH_ATTR, True)
+    setattr(net_floor_trigger, "__wrapped__", current)
+    module._trigger = net_floor_trigger
+    LOGGER.critical(
+        "UNIVERSAL_NET_PROFIT_EXIT_FLOOR_V68_PATCHED marker=%s module=%s "
+        "gross_tp_bypass=false emergency_exits_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.universal_broker_exit_supervisor_patch", "universal_broker_exit_supervisor_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_universal(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _INSTALL_LOCK:
+        try:
+            importlib.import_module("bot.universal_broker_exit_supervisor_patch")
+        except Exception:
+            pass
+        _patch_loaded()
+        flag = "_NIJA_UNIVERSAL_NET_PROFIT_EXIT_FLOOR_V68_IMPORT_HOOK"
+        if getattr(builtins, flag, False):
+            return True
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if "universal_broker_exit" in str(name):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = guarded_import
+        setattr(builtins, flag, True)
+        os.environ["NIJA_UNIVERSAL_NET_PROFIT_EXIT_FLOOR_V68_INSTALLED"] = "1"
+        LOGGER.critical(
+            "UNIVERSAL_NET_PROFIT_EXIT_FLOOR_V68_INSTALLED marker=%s fee_aware=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_cost_model", "_floors", "_reason_kind"]

--- a/execution/broker_adapter.py
+++ b/execution/broker_adapter.py
@@ -1,13 +1,33 @@
-"""
-NIJA Execution Layer - Broker Adapter with User Permissions
+"""NIJA execution-layer user/broker adapter.
 
-Wraps broker integrations with user permission checks and rate limiting.
-This module sits between the core strategy and the actual broker APIs.
+This module is intentionally broker-agnostic.  New broker integrations register
+an explicit client factory that returns a *canonical execution client* for one
+user/account.  No placeholder balance, fake order success, or implicit broker
+switching is allowed.
+
+Canonical client contract
+-------------------------
+A registered factory must return an object exposing:
+
+* ``get_account_balance()`` -> numeric or balance mapping;
+* ``place_order(pair=..., side=..., size_usd=..., order_type=..., **kwargs)``;
+* ``get_positions()``;
+* ``close_position(pair=...)``.
+
+The adapter validates user permissions and hard controls before calling that
+client.  Missing credentials, missing factories, missing methods, or malformed
+balances fail closed.  This makes the onboarding path safe for Kraken,
+Coinbase, OKX, Alpaca, Binance, and future brokerages without adding another
+``if broker == ...`` branch here.
 """
+
+from __future__ import annotations
 
 import logging
-from typing import Dict, Optional, Any
-from datetime import datetime
+import math
+import threading
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
 
 from auth import get_api_key_manager
 from config import get_config_manager
@@ -15,211 +35,402 @@ from controls import get_hard_controls
 
 logger = logging.getLogger("nija.execution.broker_adapter")
 
+BrokerClientFactory = Callable[[str, Dict[str, Any]], Any]
+_FACTORY_LOCK = threading.RLock()
+_BROKER_CLIENT_FACTORIES: Dict[str, BrokerClientFactory] = {}
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().lower().replace(" ", "_")
+
+
+def register_broker_client_factory(
+    broker_name: str,
+    factory: BrokerClientFactory,
+    *,
+    replace: bool = False,
+) -> None:
+    """Register one explicit user-scoped broker client factory.
+
+    ``replace=False`` prevents a later import from silently changing the live
+    implementation for an already-registered broker.
+    """
+    name = _norm(broker_name)
+    if not name:
+        raise ValueError("broker_name is required")
+    if not callable(factory):
+        raise TypeError("factory must be callable")
+    with _FACTORY_LOCK:
+        if name in _BROKER_CLIENT_FACTORIES and not replace:
+            raise RuntimeError(f"broker factory already registered: {name}")
+        _BROKER_CLIENT_FACTORIES[name] = factory
+    logger.info("BROKER_CLIENT_FACTORY_REGISTERED broker=%s replace=%s", name, replace)
+
+
+def unregister_broker_client_factory(broker_name: str) -> None:
+    """Remove a factory (primarily for tests/controlled reconfiguration)."""
+    with _FACTORY_LOCK:
+        _BROKER_CLIENT_FACTORIES.pop(_norm(broker_name), None)
+
+
+def registered_broker_client_factories() -> tuple[str, ...]:
+    with _FACTORY_LOCK:
+        return tuple(sorted(_BROKER_CLIENT_FACTORIES))
+
+
+def _coerce_balance(raw: Any) -> float:
+    if isinstance(raw, dict):
+        candidates = (
+            raw.get("total_balance"),
+            raw.get("total_funds"),
+            raw.get("equity"),
+            raw.get("balance"),
+            raw.get("available_balance"),
+            raw.get("available"),
+        )
+        value = next((item for item in candidates if item is not None), 0.0)
+    else:
+        value = raw
+    try:
+        amount = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return amount if math.isfinite(amount) and amount >= 0.0 else 0.0
+
 
 class SecureBrokerAdapter:
-    """
-    Secure broker adapter that enforces user permissions and rate limits.
-    """
+    """User-scoped broker adapter with permission and risk validation."""
 
     def __init__(self, user_id: str, broker_name: str):
-        """
-        Initialize secure broker adapter.
+        self.user_id = str(user_id or "").strip()
+        self.broker_name = _norm(broker_name)
+        if not self.user_id:
+            raise ValueError("user_id is required")
+        if not self.broker_name:
+            raise ValueError("broker_name is required")
 
-        Args:
-            user_id: User identifier
-            broker_name: Broker name (coinbase, binance, alpaca, etc.)
-        """
-        self.user_id = user_id
-        self.broker_name = broker_name
         self.api_key_manager = get_api_key_manager()
         self.config_manager = get_config_manager()
         self.hard_controls = get_hard_controls()
-        self.broker_client = None
+        self.broker_client: Any = None
+        self._credentials_present = False
         self._load_broker_client()
-        logger.info(f"Initialized secure broker adapter for user {user_id} on {broker_name}")
+        logger.info(
+            "SECURE_BROKER_ADAPTER_INITIALIZED user=%s broker=%s client_ready=%s",
+            self.user_id,
+            self.broker_name,
+            self.broker_client is not None,
+        )
 
-    def _load_broker_client(self):
-        """Load and authenticate broker client."""
-        # Get user's encrypted API keys
-        credentials = self.api_key_manager.get_user_api_key(self.user_id, self.broker_name)
-
+    def _load_broker_client(self) -> None:
+        credentials = self.api_key_manager.get_user_api_key(
+            self.user_id,
+            self.broker_name,
+        )
+        self._credentials_present = bool(credentials)
         if not credentials:
-            logger.warning(f"No credentials found for user {self.user_id} on {self.broker_name}")
+            logger.warning(
+                "SECURE_BROKER_ADAPTER_BLOCKED user=%s broker=%s reason=credentials_missing",
+                self.user_id,
+                self.broker_name,
+            )
             return
 
-        # Import and initialize appropriate broker client
+        with _FACTORY_LOCK:
+            factory = _BROKER_CLIENT_FACTORIES.get(self.broker_name)
+        if factory is None:
+            logger.error(
+                "SECURE_BROKER_ADAPTER_BLOCKED user=%s broker=%s "
+                "reason=broker_factory_not_registered registered=%s",
+                self.user_id,
+                self.broker_name,
+                registered_broker_client_factories(),
+            )
+            return
+
         try:
-            if self.broker_name == 'coinbase':
-                from bot.broker_manager import BrokerManager
-                # Initialize Coinbase client with user's credentials
-                # TODO: Implement user-specific credential injection
-                logger.info(f"Loaded Coinbase client for user {self.user_id}")
-
-            elif self.broker_name == 'binance':
-                # TODO: Implement Binance client
-                logger.info(f"Loaded Binance client for user {self.user_id}")
-
-            elif self.broker_name == 'alpaca':
-                # TODO: Implement Alpaca client
-                logger.info(f"Loaded Alpaca client for user {self.user_id}")
-
-            else:
-                logger.warning(f"Unsupported broker: {self.broker_name}")
-
-        except Exception as e:
-            logger.error(f"Failed to load broker client: {e}")
+            client = factory(self.user_id, dict(credentials))
+        except Exception as exc:
+            logger.error(
+                "SECURE_BROKER_ADAPTER_FACTORY_FAILED user=%s broker=%s error=%s:%s",
+                self.user_id,
+                self.broker_name,
+                type(exc).__name__,
+                exc,
+            )
             self.hard_controls.record_api_error(self.user_id)
+            return
+
+        required = (
+            "get_account_balance",
+            "place_order",
+            "get_positions",
+            "close_position",
+        )
+        missing = [name for name in required if not callable(getattr(client, name, None))]
+        if missing:
+            logger.error(
+                "SECURE_BROKER_ADAPTER_BLOCKED user=%s broker=%s "
+                "reason=canonical_client_contract_missing methods=%s",
+                self.user_id,
+                self.broker_name,
+                ",".join(missing),
+            )
+            return
+
+        self.broker_client = client
+        logger.info(
+            "SECURE_BROKER_ADAPTER_CLIENT_READY user=%s broker=%s client=%s",
+            self.user_id,
+            self.broker_name,
+            type(client).__name__,
+        )
+
+    @property
+    def execution_ready(self) -> bool:
+        return bool(self._credentials_present and self.broker_client is not None)
 
     def _validate_trade_request(
         self,
         pair: str,
         position_size_usd: float,
-        account_balance: float
+        account_balance: float,
     ) -> tuple[bool, Optional[str]]:
-        """
-        Validate trade request against all controls.
+        if not self.execution_ready:
+            return False, "broker execution client is not ready"
+        if not pair:
+            return False, "trading pair is required"
+        if not math.isfinite(float(position_size_usd)) or position_size_usd <= 0.0:
+            return False, "position size must be positive and finite"
+        if not math.isfinite(float(account_balance)) or account_balance <= 0.0:
+            return False, "verified account balance unavailable"
 
-        Returns:
-            (is_valid, error_message)
-        """
-        # Check kill switches
         can_trade, error = self.hard_controls.can_trade(self.user_id)
         if not can_trade:
             return False, error
 
-        # Check daily trade limit
         can_trade, error = self.hard_controls.check_daily_trade_limit(self.user_id)
         if not can_trade:
             return False, error
 
-        # Get user config
         user_config = self.config_manager.get_user_config(self.user_id)
-
-        # Check if pair is allowed
         if not user_config.can_trade_pair(pair):
             return False, f"Trading pair {pair} not allowed"
 
-        # Validate position size against hard controls
         valid, error = self.hard_controls.validate_position_size(
             self.user_id,
             position_size_usd,
-            account_balance
+            account_balance,
         )
         if not valid:
             return False, error
 
-        # Validate against user config
         valid, error = user_config.validate_position_size(position_size_usd)
         if not valid:
             return False, error
 
-        # Check daily loss limit
-        max_daily_loss = user_config.get('max_total_exposure', 500.0) * 0.1  # 10% of max exposure
+        max_daily_loss = user_config.get("max_total_exposure", 500.0) * 0.1
         valid, error = self.hard_controls.check_daily_loss_limit(
             self.user_id,
-            max_daily_loss
+            max_daily_loss,
         )
         if not valid:
             return False, error
 
         return True, None
 
+    def _verified_balance(self) -> tuple[float, Any]:
+        if not self.execution_ready:
+            return 0.0, None
+        try:
+            raw = self.broker_client.get_account_balance()
+        except Exception as exc:
+            logger.error(
+                "SECURE_BROKER_BALANCE_FAILED user=%s broker=%s error=%s:%s",
+                self.user_id,
+                self.broker_name,
+                type(exc).__name__,
+                exc,
+            )
+            self.hard_controls.record_api_error(self.user_id)
+            return 0.0, None
+        return _coerce_balance(raw), raw
+
     def place_order(
         self,
         pair: str,
         side: str,
         size_usd: float,
-        order_type: str = 'market',
-        **kwargs
-    ) -> Optional[Dict]:
-        """
-        Place order with permission validation.
-
-        Args:
-            pair: Trading pair
-            side: 'buy' or 'sell'
-            size_usd: Order size in USD
-            order_type: 'market' or 'limit'
-            **kwargs: Additional order parameters
-
-        Returns:
-            dict: Order result or None if failed
-        """
-        # Get account balance (placeholder - implement actual balance fetch)
-        account_balance = 1000.0  # TODO: Fetch actual balance
-
-        # Validate trade request
-        valid, error = self._validate_trade_request(pair, size_usd, account_balance)
-        if not valid:
-            logger.warning(f"Trade validation failed for user {self.user_id}: {error}")
+        order_type: str = "market",
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        side_norm = _norm(side)
+        if side_norm not in {"buy", "sell"}:
             return {
-                'success': False,
-                'error': error,
-                'user_id': self.user_id,
-                'pair': pair,
-                'size_usd': size_usd
+                "success": False,
+                "error": f"invalid side: {side}",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
             }
 
-        # Execute order (placeholder - implement actual order execution)
-        logger.info(f"User {self.user_id} placing {side} order: {pair} ${size_usd:.2f}")
+        account_balance, _raw_balance = self._verified_balance()
+        valid, error = self._validate_trade_request(pair, size_usd, account_balance)
+        if not valid:
+            logger.warning(
+                "SECURE_BROKER_ORDER_BLOCKED user=%s broker=%s pair=%s reason=%s",
+                self.user_id,
+                self.broker_name,
+                pair,
+                error,
+            )
+            return {
+                "success": False,
+                "error": error,
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+                "size_usd": size_usd,
+            }
 
-        # TODO: Implement actual order execution through broker client
-        # For now, return success placeholder
-        return {
-            'success': True,
-            'user_id': self.user_id,
-            'pair': pair,
-            'side': side,
-            'size_usd': size_usd,
-            'order_type': order_type,
-            'timestamp': datetime.now().isoformat()
-        }
+        try:
+            result = self.broker_client.place_order(
+                pair=pair,
+                side=side_norm,
+                size_usd=float(size_usd),
+                order_type=order_type,
+                **kwargs,
+            )
+        except Exception as exc:
+            logger.error(
+                "SECURE_BROKER_ORDER_FAILED user=%s broker=%s pair=%s error=%s:%s",
+                self.user_id,
+                self.broker_name,
+                pair,
+                type(exc).__name__,
+                exc,
+            )
+            self.hard_controls.record_api_error(self.user_id)
+            return {
+                "success": False,
+                "error": f"broker order exception: {type(exc).__name__}",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+            }
 
-    def get_account_balance(self) -> Dict[str, float]:
-        """
-        Get account balance.
+        if not isinstance(result, dict):
+            return {
+                "success": False,
+                "error": "broker client returned malformed order result",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+            }
 
-        Returns:
-            dict: Balance information
-        """
-        # TODO: Implement actual balance fetch from broker
-        return {
-            'total_balance': 0.0,
-            'available_balance': 0.0,
-            'currency': 'USD'
-        }
+        # Do not convert an ambiguous broker response into success.  The
+        # canonical client must explicitly report success/acceptance or a final
+        # order status.  This is required for exchanges where transport timeout
+        # can leave matching-engine status unknown.
+        success = bool(result.get("success") or result.get("accepted"))
+        status = _norm(result.get("status"))
+        if status in {"filled", "open", "accepted", "new", "pending", "partially_filled"}:
+            success = True
+        if status in {"unknown", "timeout", "ambiguous"}:
+            success = False
+        result = dict(result)
+        result.setdefault("success", success)
+        result.setdefault("user_id", self.user_id)
+        result.setdefault("broker", self.broker_name)
+        result.setdefault("pair", pair)
+        result.setdefault("submitted_at", datetime.now(timezone.utc).isoformat())
+        return result
 
-    def get_positions(self) -> list:
-        """
-        Get open positions.
+    def get_account_balance(self) -> Dict[str, Any]:
+        balance, raw = self._verified_balance()
+        if raw is None:
+            return {
+                "verified": False,
+                "total_balance": 0.0,
+                "available_balance": 0.0,
+                "currency": "USD",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+            }
+        if isinstance(raw, dict):
+            result = dict(raw)
+        else:
+            result = {"total_balance": balance, "available_balance": balance, "currency": "USD"}
+        result["verified"] = True
+        result.setdefault("total_balance", balance)
+        result.setdefault("user_id", self.user_id)
+        result.setdefault("broker", self.broker_name)
+        return result
 
-        Returns:
-            list: Open positions
-        """
-        # TODO: Implement actual position fetch from broker
-        return []
+    def get_positions(self) -> list[Any]:
+        if not self.execution_ready:
+            return []
+        try:
+            positions = self.broker_client.get_positions()
+        except Exception as exc:
+            logger.error(
+                "SECURE_BROKER_POSITIONS_FAILED user=%s broker=%s error=%s:%s",
+                self.user_id,
+                self.broker_name,
+                type(exc).__name__,
+                exc,
+            )
+            self.hard_controls.record_api_error(self.user_id)
+            return []
+        if isinstance(positions, dict):
+            return list(positions.values())
+        return list(positions or [])
 
-    def close_position(self, pair: str) -> Optional[Dict]:
-        """
-        Close position.
-
-        Args:
-            pair: Trading pair
-
-        Returns:
-            dict: Close result or None if failed
-        """
-        logger.info(f"User {self.user_id} closing position: {pair}")
-
-        # TODO: Implement actual position close through broker
-        return {
-            'success': True,
-            'user_id': self.user_id,
-            'pair': pair,
-            'timestamp': datetime.now().isoformat()
-        }
+    def close_position(self, pair: str) -> Optional[Dict[str, Any]]:
+        if not self.execution_ready:
+            return {
+                "success": False,
+                "error": "broker execution client is not ready",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+            }
+        try:
+            result = self.broker_client.close_position(pair=pair)
+        except Exception as exc:
+            logger.error(
+                "SECURE_BROKER_CLOSE_FAILED user=%s broker=%s pair=%s error=%s:%s",
+                self.user_id,
+                self.broker_name,
+                pair,
+                type(exc).__name__,
+                exc,
+            )
+            self.hard_controls.record_api_error(self.user_id)
+            return {
+                "success": False,
+                "error": f"broker close exception: {type(exc).__name__}",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+            }
+        if not isinstance(result, dict):
+            return {
+                "success": False,
+                "error": "broker client returned malformed close result",
+                "user_id": self.user_id,
+                "broker": self.broker_name,
+                "pair": pair,
+            }
+        payload = dict(result)
+        payload.setdefault("user_id", self.user_id)
+        payload.setdefault("broker", self.broker_name)
+        payload.setdefault("pair", pair)
+        return payload
 
 
 __all__ = [
-    'SecureBrokerAdapter',
+    "SecureBrokerAdapter",
+    "register_broker_client_factory",
+    "unregister_broker_client_factory",
+    "registered_broker_client_factories",
 ]


### PR DESCRIPTION
## Purpose

Production on merge commit `187f9e594f715be02d732a96aebcfb29b684d2fb` exposed a connected set of runtime-convergence, multi-account, entry-quality, and profit-exit correctness defects. This PR hardens writer lifecycle, broker readiness, capital freshness, direct-scan state, broker/account isolation, future-broker onboarding, live entry expectancy, exit fill reconciliation, realized-profit accounting, and live exchange symbol constraints before NIJA adds more users and venues.

## Root causes fixed

1. Writer renewal false-negative / premature lock loss during slow bootstrap.
2. Kraken manager/FSM convergence and invalid-nonce retry classification.
3. Capital-refresh deadlines shorter than successful authenticated venue latency.
4. Direct scans retaining placeholder capital after canonical CapitalAuthority hydration.
5. Cross-broker / cross-user shared strategy, drawdown, P&L and balance state bleed.
6. Legacy future-broker adapter fake balance / fake-success placeholder execution.
7. Unrealized profit booked as harvested before broker fill proof.
8. Accepted/nonterminal exit orders treated as completed exits.
9. Gross take-profit levels bypassing net fee/slippage economics.
10. Existing 1.5R + first-move live expectancy standard being advisory rather than authoritative.
11. Profit-lock state keyed only by symbol rather than account + broker + symbol.
12. Unknown/future live venues inheriting generic order minimum/precision guesses.
13. Base-quantity minimums from venue metadata being normalized but not enforced after final quantity rounding.
14. A review-time `_try_patch_loaded()` regression in the core-loop guard, restored before merge.

## Fixes

- **v60:** read-only exact Redis writer-renewal proof; Kraken state convergence; invalid nonce retryable while key/signature/permission/config failures remain fail-closed.
- **v61:** pre-core-thread scan deadline remains diagnostic; registered dead core still fails closed.
- **v62:** bounded venue-specific Coinbase/OKX/Kraken balance-fetch windows; cycle deadline cannot undercut the slowest broker timeout.
- **v63:** bridge only accepted canonical CapitalAuthority evidence into direct scans; restore original context afterward.
- **v64:** serialize shared strategy cycles, pin broker identity/balance, use canonical portfolio equity for platform drawdown, isolate user drawdown/P&L by account.
- **v65:** future broker clients require real credentials + explicit canonical client factory; no fake balance/order success; ambiguous timeout is not promoted to success.
- **v66:** profit tiers create unrealized harvest candidates only; realized harvest requires broker fill/order proof.
- **v67:** universal exit lifecycle is `SUBMIT ONCE -> PENDING/UNKNOWN -> RECONCILE -> CONFIRMED FILL/POSITION REDUCTION -> LOCAL CLOSE`. Nonterminal acknowledgements preserve the position and block duplicate submission.
- **v68:** emergency stops remain immediate; normal profit exits must clear estimated round-trip fees + spread/slippage + minimum net-profit floor.
- **v69:** verified live entries must pass NIJA's existing >=1.5R validator, first-move confirmation, and net-of-fee/slippage edge. Trade-drought/debug bypasses cannot lower live authority.
- **v70:** one idempotent deep-hardening installer fails readiness if any required cross-cutting component cannot install.
- **v71:** profit-lock/harvest state keyed by `account + broker + symbol`, with fill proof carried into realized-harvest confirmation.
- **v72:** live dynamic symbol-constraint authority. Binance, Alpaca and future venues cannot use generic minimum/precision fallbacks; they must provide verified symbol metadata. Kraken/Coinbase/OKX retain dedicated compatibility guards and can also use dynamic providers.
- **v73:** provider-proven base minimum quantity survives constraint resolution and is enforced on final rounded quantity. Canonical future broker clients auto-register metadata providers when they expose a supported symbol-rules API; otherwise live compilation remains fail-closed.

## Current and future brokerage/user model

The hardening is broker/account agnostic. Kraken, Coinbase, OKX, Alpaca, Binance, future adapters and future user accounts inherit the same identity isolation, fail-closed execution contract, submit-once reconciliation model and realized-profit boundary once registered in NIJA's canonical broker/account registries. Venue adapters remain responsible for official API-specific auth/nonces, idempotency/status queries, rate-limit scope and live symbol metadata.

## Regression coverage

- exact Redis renewal proof is read-only; generation mismatch remains fail-closed;
- invalid nonce retryable vs invalid key permanent;
- connected Kraken repairs stale manager state without fabricating connectivity;
- pre-core scan deadline keeps writer lease; registered dead core still fails;
- capital deadlines remain bounded and venue-specific;
- direct scan uses only accepted canonical capital and restores prior context;
- platform drawdown uses canonical portfolio equity;
- user accounts retain separate drawdown/P&L and same-symbol profit-lock state;
- concurrent broker cycles are serialized with broker-local balance/identity;
- future broker without a real registered client cannot fabricate balance/success;
- unknown/timeout order status stays pending until reconciliation;
- accepted/live/new/partial exits are not treated as fills and are not resubmitted;
- gross TP below cost-adjusted net floor is suppressed; emergency stops stay immediate;
- live entries fail on poor R-multiple, missing first-move confirmation or insufficient net edge;
- live drought/debug bypass cannot reduce live entry authority;
- future live venues require verified symbol constraints;
- Binance-style LOT_SIZE/MIN_NOTIONAL metadata is normalized;
- Alpaca-style base min/increment metadata is normalized and enforced after rounding;
- future canonical clients auto-register a symbol-constraint provider only when a real metadata API exists.

## Expected production markers

`WRITER_V60_RENEWAL_PROOF_REANCHORED ... redis_mutation=false`

`KRAKEN_V60_CONNECTED_STATE_RECONCILED ... fabricated_connected=false`

`WRITER_V61_SCAN_DEADLINE_WARNING_ONLY ... lease_release=false`

`CAPITAL_REFRESH_STALL_GUARD_V36_PATCHED ... latency_marker=20260809-capital-refresh-live-latency-v62`

`DIRECT_SCAN_CAPITAL_SNAPSHOT_V63_APPLIED ...`

`BROKER_ACCOUNT_ISOLATION_V64_INSTALLED ...`

`PROFIT_HARVEST_REALIZATION_V66_INSTALLED ... fill_proof_required=true`

`UNIVERSAL_EXIT_FILL_RECONCILIATION_V67_INSTALLED ...`

`UNIVERSAL_EXIT_V67_ACCEPTED_PENDING ... tracker_preserved=true duplicate_submit_blocked=true`

`UNIVERSAL_EXIT_V67_CONFIRMED ... fill_or_position_proof=true`

`UNIVERSAL_NET_PROFIT_EXIT_FLOOR_V68_INSTALLED ... fee_aware=true`

`LIVE_ENTRY_EXPECTANCY_AUTHORITY_V69_INSTALLED ... live_only=true`

`DEEP_RUNTIME_HARDENING_V70_READY ...`

`ACCOUNT_SCOPED_PROFIT_STATE_V71_INSTALLED ...`

`LIVE_EXCHANGE_CONSTRAINTS_AUTHORITY_V72_INSTALLED ... live_generic_fallback=false`

`LIVE_EXCHANGE_BASE_MINIMUM_V73_INSTALLED ... post_rounding_base_min=true future_provider_autoregistration=true`