### PR TITLE
Repair writer reconstitution and slow broker capital refresh

### DIFF
--- a/bot/capital_refresh_live_continuity_v78_patch.py
+++ b/bot/capital_refresh_live_continuity_v78_patch.py
@@ -1,0 +1,153 @@
+"""Slow-broker capital refresh continuity v78.
+
+A healthy Coinbase authenticated balance read has been observed taking longer
+than the historical 180 second capital-refresh deadline.  v37 correctly refuses
+to reuse an observation after the normal freshness TTL, but the short live-fetch
+deadline can therefore collapse a healthy multi-broker snapshot to one venue.
+
+v78 changes the *live request budget*, not the capital freshness contract:
+* increase the bounded per-broker/cycle fetch budget to a configurable 420s;
+* reuse a still-running in-flight request within that bounded cycle rather than
+  starting a second request;
+* preserve v37's existing fresh-observation fallback exactly as-is;
+* never convert timeout to zero unless both live fetch and fresh fallback fail;
+* never extend the freshness TTL or authorize trading from stale balances.
+
+The guard remains fail closed after the extended bounded deadline.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.capital_refresh_live_continuity_v78")
+MARKER = "20260809-capital-refresh-live-continuity-v78"
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_capital_refresh_live_continuity_v78"
+_HOOK_FLAG = "_NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_IMPORT_HOOK"
+_GUARD_NAMES = (
+    "nija_capital_refresh_stall_guard_v35_prebot",
+    "bot.capital_refresh_stall_guard_v35",
+    "capital_refresh_stall_guard_v35",
+)
+
+
+def fetch_budget_seconds() -> float:
+    try:
+        value = float(os.environ.get("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", "420") or 420.0)
+    except (TypeError, ValueError):
+        value = 420.0
+    return max(180.0, min(600.0, value))
+
+
+def _patch_guard(module: ModuleType) -> bool:
+    batch_cls = getattr(module, "_BalanceFetchBatch", None)
+    if not isinstance(batch_cls, type):
+        return False
+    original_init = getattr(batch_cls, "__init__", None)
+    if not callable(original_init):
+        return False
+    if getattr(original_init, _PATCH_ATTR, False):
+        return True
+
+    @wraps(original_init)
+    def init_v78(self: Any, broker_map: dict[str, Any]) -> None:
+        budget = fetch_budget_seconds()
+        # v35/v36 read their timeout configuration while constructing the batch.
+        # Set only the dedicated capital-refresh variable and restore the caller's
+        # environment immediately after construction.
+        key = "NIJA_CAPITAL_REFRESH_BROKER_TIMEOUT_SECONDS"
+        previous = os.environ.get(key)
+        try:
+            os.environ[key] = str(budget)
+            original_init(self, broker_map)
+        finally:
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
+
+        # Some historical guard revisions materialize timeout values before
+        # consulting the environment. Raise only values that are clearly the
+        # old <=180s default; never shorten a stricter operator configuration.
+        for flight in dict(getattr(self, "_flights", {}) or {}).values():
+            try:
+                current = float(getattr(flight, "timeout_s", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                current = 0.0
+            if current <= 180.0:
+                try:
+                    setattr(flight, "timeout_s", budget)
+                except Exception:
+                    pass
+        try:
+            cycle_started = float(getattr(self, "_cycle_started", 0.0) or 0.0)
+            cycle_deadline = float(getattr(self, "_cycle_deadline", 0.0) or 0.0)
+            if cycle_started > 0.0 and cycle_deadline - cycle_started <= 180.0:
+                setattr(self, "_cycle_deadline", cycle_started + budget)
+        except Exception:
+            pass
+        LOGGER.info(
+            "CAPITAL_REFRESH_V78_BATCH_BUDGET marker=%s budget_s=%.1f brokers=%s freshness_ttl_unchanged=true",
+            MARKER,
+            budget,
+            sorted(str(name).lower() for name in broker_map),
+        )
+
+    setattr(init_v78, _PATCH_ATTR, True)
+    setattr(init_v78, "__wrapped__", original_init)
+    batch_cls.__init__ = init_v78
+    LOGGER.critical(
+        "CAPITAL_REFRESH_V78_GUARD_PATCHED marker=%s module=%s max_budget_s=600 stale_fallback_extension=false",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _GUARD_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_guard(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if "capital_refresh_stall_guard_v35" in str(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+        os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] = "1"
+        LOGGER.critical(
+            "CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED marker=%s budget_s=%.1f freshness_ttl_unchanged=true",
+            MARKER,
+            fetch_budget_seconds(),
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "fetch_budget_seconds", "install", "install_import_hook"]

--- a/bot/deep_runtime_hardening_bundle_v70_patch.py
+++ b/bot/deep_runtime_hardening_bundle_v70_patch.py
@@ -1,7 +1,7 @@
 """NIJA deep runtime hardening bundle v70.
 
 Single idempotent installer for the cross-cutting production hardening introduced
-while preparing NIJA for additional brokerages and user accounts.  Individual
+while preparing NIJA for additional brokerages and user accounts. Individual
 modules retain their own markers/tests and remain independently installable.
 """
 from __future__ import annotations
@@ -26,6 +26,8 @@ _MODULES = (
     "bot.live_exchange_base_minimum_v73_patch",
     "bot.adaptive_profit_exit_v74_patch",
     "bot.held_position_exit_bootstrap_v75_patch",
+    "bot.writer_authority_reconstitution_v77_patch",
+    "bot.capital_refresh_live_continuity_v78_patch",
 )
 
 
@@ -63,8 +65,8 @@ def install_import_hook() -> bool:
             "DEEP_RUNTIME_HARDENING_V70_READY marker=%s components=%d "
             "broker_account_isolation=true exit_fill_confirmation=true net_profit_floor=true "
             "live_entry_expectancy=true realized_profit_proof=true account_scoped_profit_state=true "
-            "live_symbol_constraints=true post_rounding_base_minimum=true "
-            "adaptive_profit_exit=true held_positions_connected=true",
+            "live_symbol_constraints=true post_rounding_base_minimum=true adaptive_profit_exit=true "
+            "held_positions_connected=true writer_reconstitution=true slow_broker_capital_continuity=true",
             MARKER,
             len(installed),
         )

--- a/bot/tests/test_capital_refresh_live_continuity_v78.py
+++ b/bot/tests/test_capital_refresh_live_continuity_v78.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+
+
+class CapitalRefreshLiveContinuityV78Tests(unittest.TestCase):
+    def setUp(self):
+        self.mod = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        self.previous = os.environ.get("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS")
+
+    def tearDown(self):
+        if self.previous is None:
+            os.environ.pop("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", None)
+        else:
+            os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = self.previous
+
+    def test_default_budget_exceeds_observed_180_second_timeout(self):
+        os.environ.pop("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", None)
+        self.assertEqual(self.mod.fetch_budget_seconds(), 420.0)
+
+    def test_budget_is_bounded(self):
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "9999"
+        self.assertEqual(self.mod.fetch_budget_seconds(), 600.0)
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "10"
+        self.assertEqual(self.mod.fetch_budget_seconds(), 180.0)
+
+    def test_patch_extends_old_batch_deadline_without_touching_freshness(self):
+        fake = types.ModuleType("capital_guard_v78_fake")
+
+        class Flight:
+            def __init__(self):
+                self.timeout_s = 180.0
+
+        class Batch:
+            def __init__(self, broker_map):
+                self._cycle_started = 1000.0
+                self._cycle_deadline = 1180.0
+                self._flights = {name: Flight() for name in broker_map}
+
+        fake._BalanceFetchBatch = Batch
+        fake._freshness_ttl_seconds = lambda: 120.0
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "420"
+        self.assertTrue(self.mod._patch_guard(fake))
+        batch = Batch({"coinbase": object(), "okx": object()})
+        self.assertEqual(batch._flights["coinbase"].timeout_s, 420.0)
+        self.assertEqual(batch._cycle_deadline, 1420.0)
+        self.assertEqual(fake._freshness_ttl_seconds(), 120.0)
+
+    def test_operator_larger_timeout_is_not_shortened(self):
+        fake = types.ModuleType("capital_guard_v78_large_fake")
+
+        class Flight:
+            def __init__(self):
+                self.timeout_s = 500.0
+
+        class Batch:
+            def __init__(self, broker_map):
+                self._cycle_started = 1000.0
+                self._cycle_deadline = 1500.0
+                self._flights = {name: Flight() for name in broker_map}
+
+        fake._BalanceFetchBatch = Batch
+        self.mod._patch_guard(fake)
+        batch = Batch({"coinbase": object()})
+        self.assertEqual(batch._flights["coinbase"].timeout_s, 500.0)
+        self.assertEqual(batch._cycle_deadline, 1500.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_writer_authority_reconstitution_v77.py
+++ b/bot/tests/test_writer_authority_reconstitution_v77.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib
+import os
+import types
+import unittest
+
+
+class FakeRedis:
+    def __init__(self, lock_key: str, lock_value: str, generation: int, pttl: int = 60000):
+        self.values = {lock_key: lock_value, "nija:lease:generation": str(generation)}
+        self.lock_key = lock_key
+        self._pttl = pttl
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def pttl(self, key):
+        return self._pttl if key == self.lock_key else -2
+
+
+class WriterAuthorityReconstitutionV77Tests(unittest.TestCase):
+    def setUp(self):
+        self.mod = importlib.import_module("bot.writer_authority_reconstitution_v77_patch")
+        self.saved = {key: os.environ.get(key) for key in (
+            "NIJA_WRITER_LEASE_ACQUIRED",
+            "NIJA_WRITER_LEASE_GENERATION",
+            "NIJA_WRITER_GENERATION",
+            "NIJA_WRITER_FENCING_TOKEN",
+            "NIJA_LEASE_GENERATION_KEY",
+        )}
+
+    def tearDown(self):
+        for key, value in self.saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def runtime(self, generation=3405, lock_value="owner-abc", token="fence-3405", pttl=60000):
+        lock_key = "nija:writer:lock"
+        return types.SimpleNamespace(
+            acquired=True,
+            lost=False,
+            _local_fallback=False,
+            _generation=generation,
+            _token=token,
+            _lock_key=lock_key,
+            _lock_value=lock_value,
+            _client=FakeRedis(lock_key, lock_value, generation, pttl),
+        )
+
+    def test_exact_owner_proof_uses_runtime_and_redis_not_env_generation(self):
+        os.environ["NIJA_WRITER_LEASE_GENERATION"] = "0"
+        os.environ.pop("NIJA_WRITER_LEASE_ACQUIRED", None)
+        proof, reason = self.mod.exact_owner_proof(self.runtime())
+        self.assertIsNotNone(proof)
+        self.assertEqual(proof["generation"], 3405)
+        self.assertEqual(reason, "exact_runtime_redis_owner")
+
+    def test_foreign_redis_lock_is_never_adopted(self):
+        runtime = self.runtime()
+        runtime._client.values[runtime._lock_key] = "different-owner"
+        proof, reason = self.mod.exact_owner_proof(runtime)
+        self.assertIsNone(proof)
+        self.assertEqual(reason, "redis_lock_owner_mismatch")
+
+    def test_generation_mismatch_is_never_adopted(self):
+        runtime = self.runtime()
+        runtime._client.values["nija:lease:generation"] = "3406"
+        proof, reason = self.mod.exact_owner_proof(runtime)
+        self.assertIsNone(proof)
+        self.assertIn("redis_generation_mismatch", reason)
+
+    def test_expired_lock_is_never_reconstituted(self):
+        proof, reason = self.mod.exact_owner_proof(self.runtime(pttl=0))
+        self.assertIsNone(proof)
+        self.assertIn("ttl_not_positive", reason)
+
+    def test_publish_repairs_complete_local_lineage_after_proof(self):
+        runtime = self.runtime()
+        proof, _ = self.mod.exact_owner_proof(runtime)
+        self.mod._ensure_renewal_worker = lambda _runtime: None
+        self.mod._refresh_canonical_heartbeat = lambda generation, source: True
+        ok, generation, reason = self.mod.publish_local_lineage(proof, "unit")
+        self.assertTrue(ok)
+        self.assertEqual(generation, 3405)
+        self.assertEqual(reason, "exact_owner_reconstituted")
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_ACQUIRED"], "1")
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_GENERATION"], "3405")
+        self.assertEqual(os.environ["NIJA_WRITER_GENERATION"], "3405")
+        self.assertEqual(os.environ["NIJA_WRITER_FENCING_TOKEN"], "fence-3405")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/writer_authority_reconstitution_v77_patch.py
+++ b/bot/writer_authority_reconstitution_v77_patch.py
@@ -1,0 +1,335 @@
+"""Writer authority reconstitution v77.
+
+Production after the v59 hardening showed a circular recovery failure: Redis and
+the canonical EntrypointWriterAuthority could still describe the current writer
+lineage while process-local environment aliases had fallen back to generation 0
+/ missing lease flags.  v42 correctly refused to re-anchor because its expected
+generation is sourced from those local aliases.
+
+v77 breaks that loop without trusting Redis generation by itself.
+
+Safe paths
+----------
+1. Exact-owner reconstitution: only when the canonical EntrypointWriterAuthority
+   runtime is acquired/not-lost and Redis proves the runtime's exact lock value,
+   fencing generation and positive TTL do we republish process-local aliases.
+2. Bounded reacquisition: if exact-owner proof is unavailable, delegate to the
+   existing canonical ``_acquire_writer_authority_before_nonce`` path.  That
+   path remains responsible for lock acquisition/fencing and can fail closed.
+
+v77 never rewrites the Redis lock, never copies a foreign Redis generation into
+local state, and never clears kill-switch/risk/readiness gates.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.writer_authority_reconstitution_v77")
+MARKER = "20260809-writer-authority-reconstitution-v77"
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_writer_authority_reconstitution_v77"
+_HOOK_FLAG = "_NIJA_WRITER_AUTHORITY_RECONSTITUTION_V77_IMPORT_HOOK"
+_ENTRYPOINT_NAMES = ("bot.entrypoint_writer_authority", "entrypoint_writer_authority")
+_V42_NAMES = (
+    "nija_heartbeat_authority_reanchor_v42_prebot",
+    "bot.heartbeat_authority_reanchor_v42_patch",
+    "heartbeat_authority_reanchor_v42_patch",
+)
+_SINGLE_SOURCE_NAMES = (
+    "bot.heartbeat_authority_single_source_patch",
+    "heartbeat_authority_single_source_patch",
+)
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _integer(value: Any, default: int = 0) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _runtime() -> tuple[Any, str]:
+    seen: set[int] = set()
+    for name in _ENTRYPOINT_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if not callable(getter):
+            continue
+        try:
+            runtime = getter()
+        except Exception as exc:
+            return None, f"runtime_getter_error:{type(exc).__name__}:{exc}"
+        if runtime is not None:
+            return runtime, ""
+    return None, "entrypoint_runtime_unavailable"
+
+
+def _generation_key() -> str:
+    return str(os.environ.get("NIJA_LEASE_GENERATION_KEY", "") or "nija:lease:generation").strip()
+
+
+def exact_owner_proof(runtime: Any = None) -> tuple[Optional[dict[str, Any]], str]:
+    """Prove canonical runtime ownership without relying on local env aliases."""
+    if runtime is None:
+        runtime, error = _runtime()
+        if runtime is None:
+            return None, error
+    if bool(getattr(runtime, "_local_fallback", False)):
+        return None, "local_fallback_rejected"
+    if not bool(getattr(runtime, "acquired", False)):
+        return None, "runtime_not_acquired"
+    if bool(getattr(runtime, "lost", False)):
+        return None, "runtime_marked_lost"
+
+    generation = _integer(getattr(runtime, "_generation", 0))
+    token = str(getattr(runtime, "_token", "") or "").strip()
+    lock_key = str(getattr(runtime, "_lock_key", "") or "").strip()
+    lock_value = str(getattr(runtime, "_lock_value", "") or "").strip()
+    client = getattr(runtime, "_client", None)
+    if generation <= 0:
+        return None, "runtime_generation_missing"
+    if not token:
+        return None, "runtime_fencing_token_missing"
+    if client is None or not lock_key or not lock_value:
+        return None, "runtime_redis_identity_missing"
+
+    try:
+        redis_lock = _text(client.get(lock_key)).strip()
+        redis_generation = _integer(client.get(_generation_key()), 0)
+        pttl = _integer(client.pttl(lock_key), -2)
+    except Exception as exc:
+        return None, f"redis_proof_error:{type(exc).__name__}:{exc}"
+
+    if redis_lock != lock_value:
+        return None, "redis_lock_owner_mismatch" if redis_lock else "redis_lock_missing"
+    if redis_generation != generation:
+        return None, f"redis_generation_mismatch:{redis_generation}!={generation}"
+    if pttl <= 0:
+        return None, f"redis_lock_ttl_not_positive:{pttl}"
+
+    return {
+        "runtime": runtime,
+        "generation": generation,
+        "token": token,
+        "lock_key": lock_key,
+        "lock_value": lock_value,
+        "pttl_ms": pttl,
+    }, "exact_runtime_redis_owner"
+
+
+def _ensure_renewal_worker(runtime: Any) -> None:
+    health = getattr(runtime, "_nija_lease_renewal_health", None)
+    starter = getattr(runtime, "_start_heartbeat", None)
+    if not callable(health) or not callable(starter):
+        return
+    try:
+        ok, reason, _age, _limit = health()
+    except Exception:
+        return
+    if ok or str(reason or "") not in {
+        "renewal_thread_missing",
+        "renewal_thread_not_alive",
+        "renewal_success_uninitialized",
+    }:
+        return
+    try:
+        starter()
+    except Exception as exc:
+        LOGGER.warning(
+            "WRITER_V77_RENEWAL_RESTART_FAILED marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def _refresh_canonical_heartbeat(generation: int, source: str) -> bool:
+    for name in _SINGLE_SOURCE_NAMES:
+        module = sys.modules.get(name)
+        refresh = getattr(module, "refresh_heartbeat", None) if isinstance(module, ModuleType) else None
+        if not callable(refresh):
+            continue
+        try:
+            return float(refresh(source=f"writer_v77:{source}", generation=generation) or 0.0) > 0.0
+        except Exception:
+            return False
+    return False
+
+
+def publish_local_lineage(proof: dict[str, Any], source: str) -> tuple[bool, int, str]:
+    """Republish process-local aliases after exact owner proof only."""
+    generation = int(proof["generation"])
+    token = str(proof["token"])
+    runtime = proof["runtime"]
+    before = {
+        "lease_flag": os.environ.get("NIJA_WRITER_LEASE_ACQUIRED", ""),
+        "lease_generation": os.environ.get("NIJA_WRITER_LEASE_GENERATION", ""),
+        "generation": os.environ.get("NIJA_WRITER_GENERATION", ""),
+        "token": os.environ.get("NIJA_WRITER_FENCING_TOKEN", ""),
+    }
+    value = str(generation)
+    os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "1"
+    os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "1"
+    os.environ["NIJA_WRITER_LEASE_GENERATION"] = value
+    os.environ["NIJA_WRITER_GENERATION"] = value
+    os.environ["NIJA_WRITER_LEASE_GENERATION_LAST"] = value
+    os.environ["NIJA_WRITER_LEASE_GENERATION_EXPECTED"] = value
+    os.environ["NIJA_WRITER_FENCING_TOKEN"] = token
+    _ensure_renewal_worker(runtime)
+    heartbeat_refreshed = _refresh_canonical_heartbeat(generation, source)
+    LOGGER.critical(
+        "WRITER_V77_LOCAL_LINEAGE_RECONSTITUTED marker=%s source=%s generation=%d "
+        "pttl_ms=%s redis_mutation=false exact_owner=true heartbeat_refreshed=%s before=%s",
+        MARKER,
+        source,
+        generation,
+        proof.get("pttl_ms", -2),
+        str(heartbeat_refreshed).lower(),
+        before,
+    )
+    return True, generation, "exact_owner_reconstituted"
+
+
+def _canonical_reacquire(source: str) -> tuple[bool, int, str]:
+    """Delegate fresh acquisition to the existing canonical writer bootstrap."""
+    try:
+        bot_main = importlib.import_module("bot.bot_main")
+    except Exception as exc:
+        return False, 0, f"bot_main_import_error:{type(exc).__name__}:{exc}"
+    acquire = getattr(bot_main, "_acquire_writer_authority_before_nonce", None)
+    if not callable(acquire):
+        return False, 0, "canonical_acquire_unavailable"
+    try:
+        acquired = bool(acquire())
+    except Exception as exc:
+        return False, 0, f"canonical_acquire_error:{type(exc).__name__}:{exc}"
+    if not acquired:
+        return False, 0, str(getattr(bot_main, "_writer_authority_last_error", "") or "canonical_acquire_failed")
+
+    runtime = getattr(bot_main, "_writer_authority_runtime", None)
+    proof, reason = exact_owner_proof(runtime)
+    if proof is None:
+        return False, 0, f"post_acquire_proof_failed:{reason}"
+    LOGGER.critical(
+        "WRITER_V77_FRESH_REACQUISITION_PROVEN marker=%s source=%s generation=%s pttl_ms=%s",
+        MARKER,
+        source,
+        proof["generation"],
+        proof["pttl_ms"],
+    )
+    return publish_local_lineage(proof, f"{source}:fresh_reacquire")
+
+
+def repair_or_reacquire(source: str = "runtime") -> tuple[bool, int, str]:
+    """Restore local identity from proof, otherwise use bounded canonical acquisition."""
+    with _LOCK:
+        proof, reason = exact_owner_proof()
+        if proof is not None:
+            return publish_local_lineage(proof, source)
+        LOGGER.warning(
+            "WRITER_V77_EXACT_OWNER_PROOF_UNAVAILABLE marker=%s source=%s reason=%s action=canonical_reacquire",
+            MARKER,
+            source,
+            reason,
+        )
+        return _canonical_reacquire(source)
+
+
+def _patch_v42(module: ModuleType) -> bool:
+    current = getattr(module, "_attempt_reanchor", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def attempt_reanchor_v77(source: str):
+        expected = _integer(
+            os.environ.get("NIJA_WRITER_LEASE_GENERATION", "")
+            or os.environ.get("NIJA_WRITER_GENERATION", "")
+            or 0
+        )
+        lease_flag = str(os.environ.get("NIJA_WRITER_LEASE_ACQUIRED", "") or "").strip().lower()
+        if expected <= 0 or lease_flag not in {"1", "true", "yes", "on", "enabled", "y"}:
+            ok, generation, reason = repair_or_reacquire(f"v42:{source}")
+            if not ok:
+                LOGGER.warning(
+                    "WRITER_V77_PRE_REANCHOR_BLOCKED marker=%s source=%s reason=%s generation=%s",
+                    MARKER,
+                    source,
+                    reason,
+                    generation,
+                )
+        return current(source)
+
+    setattr(attempt_reanchor_v77, _PATCH_ATTR, True)
+    setattr(attempt_reanchor_v77, "__wrapped__", current)
+    module._attempt_reanchor = attempt_reanchor_v77
+    LOGGER.critical("WRITER_V77_V42_PATCHED marker=%s module=%s", MARKER, module.__name__)
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _V42_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_v42(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                module = original_import(name, globals, locals, fromlist, level)
+                if "heartbeat_authority_reanchor_v42" in str(name):
+                    _patch_loaded()
+                return module
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+        os.environ["NIJA_WRITER_AUTHORITY_RECONSTITUTION_V77_INSTALLED"] = "1"
+        LOGGER.critical(
+            "WRITER_AUTHORITY_RECONSTITUTION_V77_INSTALLED marker=%s exact_owner_only=true bounded_reacquire=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "exact_owner_proof",
+    "publish_local_lineage",
+    "repair_or_reacquire",
+    "install",
+    "install_import_hook",
+]


### PR DESCRIPTION
## What changed

- Adds **v77 writer-authority reconstitution**. If process-local writer aliases disappear while the canonical runtime still owns the exact Redis lock/generation, NIJA restores the local lease/generation/fencing aliases only after exact lock-value, generation, and positive-TTL proof. If exact ownership cannot be proven, it delegates to the existing canonical bounded writer acquisition path instead of adopting Redis state.
- Adds **v78 capital-refresh live continuity**. The bounded live broker balance budget defaults to 420s (hard capped at 600s) to cover the observed Coinbase >180s authenticated read while leaving the existing capital freshness TTL unchanged. Stale balances are not granted a longer validity window.
- Wires v77/v78 into the existing deep runtime hardening bundle.
- Adds focused regression tests for generation=0 local-state recovery, foreign-lock/generation/expired-TTL rejection, and slow-broker timeout budget/freshness separation.

## Production failures addressed

1. Redis/canonical writer runtime held generation while local process aliases fell back to generation 0, causing `expected_generation_missing`, writer-authority pending, and nonce readiness failure.
2. Coinbase remained connected/trading-ready but a 180s balance fetch timeout excluded it from the capital snapshot and collapsed canonical capital to OKX-only.

## Safety invariants

- No blind Redis generation adoption.
- No Redis lock mutation by v77.
- Exact runtime + Redis owner proof is required before local writer state is restored.
- Fresh reacquisition uses the existing canonical writer authority path.
- v78 does **not** extend capital freshness TTL and does not turn stale balances into trading authority.
- Existing fail-closed behavior remains after the bounded request deadline.

## Verification requested

CI should run the new focused tests plus the existing full CI/security matrix. Production proof after merge should show sustained writer generation/renewal, `authority_ready=true`, `nonce_ready=true`, all configured brokers trading-ready, and Coinbase remaining in the canonical capital picture during slow but successful balance reads.