### PR TITLE
Converge writer heartbeat and Kraken recovery v80

### DIFF
--- a/bot/tests/test_writer_kraken_runtime_convergence_v80.py
+++ b/bot/tests/test_writer_kraken_runtime_convergence_v80.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+from unittest import mock
+
+
+class WriterKrakenConvergenceV80Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.writer_kraken_runtime_convergence_v80_patch")
+
+    def test_missing_runtime_uses_v77_reacquisition(self) -> None:
+        with mock.patch.object(self.mod.v77, "_runtime", return_value=(None, "entrypoint_runtime_unavailable")), \
+             mock.patch.object(self.mod, "_heartbeat_stale", return_value=(True, "heartbeat_stale")), \
+             mock.patch.object(self.mod.v77, "repair_or_reacquire", return_value=(True, 4001, "exact_owner_reconstituted")) as repair:
+            state = self.mod.reconcile_writer_once()
+        self.assertTrue(state["ok"])
+        self.assertEqual(state["generation"], 4001)
+        self.assertEqual(state["action"], "reconstituted_or_reacquired")
+        repair.assert_called_once()
+
+    def test_runtime_not_acquired_uses_canonical_reacquire(self) -> None:
+        runtime = mock.Mock(acquired=False, lost=False)
+        with mock.patch.object(self.mod.v77, "_runtime", return_value=(runtime, "")), \
+             mock.patch.object(self.mod, "_heartbeat_stale", return_value=(True, "heartbeat_stale")), \
+             mock.patch.object(self.mod.v77, "repair_or_reacquire", return_value=(True, 3424, "exact_owner_reconstituted")):
+            state = self.mod.reconcile_writer_once()
+        self.assertTrue(state["ok"])
+        self.assertFalse(state["acquired"])
+        self.assertTrue(state["heartbeat_stale"])
+
+    def test_writer_failure_blocks_kraken_recovery(self) -> None:
+        with mock.patch.object(self.mod, "reconcile_writer_once", return_value={"ok": False, "reason": "foreign_owner"}), \
+             mock.patch.object(self.mod.v44, "reconcile_once") as kraken:
+            state = self.mod.reconcile_kraken_once()
+        self.assertFalse(state["ok"])
+        self.assertIn("writer_not_ready", state["reason"])
+        kraken.assert_not_called()
+
+    def test_writer_success_allows_authenticated_kraken_recovery(self) -> None:
+        with mock.patch.object(self.mod, "reconcile_writer_once", return_value={"ok": True, "reason": "healthy"}), \
+             mock.patch.object(self.mod.v44, "reconcile_once", return_value={
+                 "ok": True,
+                 "connected": False,
+                 "action": "recovery_started",
+                 "reason": "disconnected_recovery_started",
+             }) as kraken:
+            state = self.mod.reconcile_kraken_once()
+        self.assertTrue(state["ok"])
+        self.assertEqual(state["action"], "recovery_started")
+        kraken.assert_called_once()
+
+    def test_healthy_writer_does_not_reacquire(self) -> None:
+        runtime = mock.Mock(acquired=True, lost=False)
+        with mock.patch.object(self.mod.v77, "_runtime", return_value=(runtime, "")), \
+             mock.patch.object(self.mod, "_heartbeat_stale", return_value=(False, "heartbeat_healthy")), \
+             mock.patch.object(self.mod.v77, "repair_or_reacquire") as repair:
+            state = self.mod.reconcile_writer_once()
+        self.assertTrue(state["ok"])
+        self.assertEqual(state["reason"], "writer_runtime_and_heartbeat_healthy")
+        repair.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/writer_kraken_runtime_convergence_v80_patch.py
+++ b/bot/writer_kraken_runtime_convergence_v80_patch.py
@@ -1,0 +1,178 @@
+"""Runtime convergence v80 for writer heartbeat and Kraken recovery.
+
+Production on eb2cb141 proved v78's slow-broker capital path but exposed two
+remaining liveness gaps:
+
+* the heartbeat generation could remain authoritative while the canonical
+  EntrypointWriterAuthority runtime reports ``acquired=False``; v42 then blocks
+  re-anchor with ``runtime_not_acquired``;
+* Kraken could remain configured/disconnected while Coinbase and OKX are ready.
+
+v80 composes the existing fail-closed authorities rather than inventing state.
+For writer recovery it invokes v77's exact-owner-or-canonical-reacquire path
+whenever heartbeat health is stale and the runtime is not acquired.  For Kraken
+it invokes v44's authenticated reconnect reconciler after writer convergence.
+No Redis lock, broker connection, balance, order or fill is fabricated.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import threading
+from typing import Any
+
+from bot import kraken_connection_convergence_v44_patch as v44
+from bot import writer_authority_reconstitution_v77_patch as v77
+
+LOGGER = logging.getLogger("nija.writer_kraken_runtime_convergence_v80")
+MARKER = "20260809-writer-kraken-runtime-convergence-v80"
+_LOCK = threading.RLock()
+_STOP = threading.Event()
+_STARTED = False
+_HOOK_FLAG = "_NIJA_WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALLED"
+
+
+def _heartbeat_stale() -> tuple[bool, str]:
+    """Use canonical heartbeat health when available; unknown remains fail-closed."""
+    try:
+        from bot import heartbeat_authority_single_source_patch as heartbeat
+        probe = getattr(heartbeat, "check_heartbeat", None)
+        if not callable(probe):
+            return True, "heartbeat_probe_unavailable"
+        result = probe(source="writer_kraken_v80")
+        if isinstance(result, tuple):
+            healthy = bool(result[0])
+        else:
+            healthy = bool(result)
+        return (not healthy), "heartbeat_stale" if not healthy else "heartbeat_healthy"
+    except Exception as exc:
+        return True, f"heartbeat_probe_error:{type(exc).__name__}:{exc}"
+
+
+def reconcile_writer_once() -> dict[str, Any]:
+    runtime, runtime_reason = v77._runtime()
+    acquired = bool(getattr(runtime, "acquired", False)) if runtime is not None else False
+    lost = bool(getattr(runtime, "lost", False)) if runtime is not None else False
+    stale, heartbeat_reason = _heartbeat_stale()
+    result: dict[str, Any] = {
+        "ok": False,
+        "acquired": acquired,
+        "lost": lost,
+        "heartbeat_stale": stale,
+        "action": "none",
+        "reason": runtime_reason or heartbeat_reason,
+    }
+    if acquired and not lost and not stale:
+        result.update(ok=True, reason="writer_runtime_and_heartbeat_healthy")
+        return result
+
+    ok, generation, reason = v77.repair_or_reacquire("writer_kraken_v80")
+    result.update(ok=bool(ok), generation=int(generation or 0), reason=str(reason or ""))
+    result["action"] = "reconstituted_or_reacquired" if ok else "fail_closed"
+    if ok:
+        LOGGER.critical(
+            "WRITER_V80_CONVERGED marker=%s generation=%s prior_acquired=%s prior_lost=%s prior_heartbeat_stale=%s",
+            MARKER,
+            generation,
+            str(acquired).lower(),
+            str(lost).lower(),
+            str(stale).lower(),
+        )
+    else:
+        LOGGER.warning(
+            "WRITER_V80_BLOCKED marker=%s reason=%s prior_acquired=%s prior_lost=%s heartbeat=%s fail_closed=true",
+            MARKER,
+            reason,
+            str(acquired).lower(),
+            str(lost).lower(),
+            heartbeat_reason,
+        )
+    return result
+
+
+def reconcile_kraken_once() -> dict[str, Any]:
+    writer = reconcile_writer_once()
+    if not writer.get("ok"):
+        return {
+            "ok": False,
+            "connected": False,
+            "action": "blocked",
+            "reason": f"writer_not_ready:{writer.get('reason')}",
+        }
+    state = dict(v44.reconcile_once() or {})
+    if state.get("connected"):
+        return state
+    if state.get("action") in {"recovery_started", "observe"}:
+        LOGGER.warning(
+            "KRAKEN_V80_RECOVERY_ACTIVE marker=%s action=%s reason=%s fabricated_connected=false",
+            MARKER,
+            state.get("action"),
+            state.get("reason"),
+        )
+    return state
+
+
+def reconcile_once() -> dict[str, Any]:
+    with _LOCK:
+        writer = reconcile_writer_once()
+        if not writer.get("ok"):
+            return {"writer": writer, "kraken": {"ok": False, "reason": "writer_not_ready"}}
+        kraken = dict(v44.reconcile_once() or {})
+        return {"writer": writer, "kraken": kraken}
+
+
+def _watchdog() -> None:
+    try:
+        interval = max(2.0, float(os.environ.get("NIJA_RUNTIME_CONVERGENCE_V80_POLL_S", "5") or "5"))
+    except (TypeError, ValueError):
+        interval = 5.0
+    last = ""
+    while not _STOP.wait(interval):
+        try:
+            state = reconcile_once()
+            writer = state.get("writer", {})
+            kraken = state.get("kraken", {})
+            signature = f"{writer.get('ok')}:{writer.get('reason')}:{kraken.get('connected')}:{kraken.get('reason')}"
+            if signature != last:
+                log = LOGGER.info if writer.get("ok") and kraken.get("connected") else LOGGER.warning
+                log(
+                    "RUNTIME_V80_STATE marker=%s writer_ok=%s writer_reason=%s kraken_connected=%s kraken_action=%s kraken_reason=%s",
+                    MARKER,
+                    str(bool(writer.get("ok"))).lower(),
+                    writer.get("reason"),
+                    str(bool(kraken.get("connected"))).lower(),
+                    kraken.get("action"),
+                    kraken.get("reason"),
+                )
+                last = signature
+        except Exception as exc:
+            LOGGER.warning("RUNTIME_V80_WATCHDOG_ERROR marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        v77.install_import_hook()
+        v44.install_import_hook()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="WriterKrakenRuntimeConvergenceV80", daemon=True).start()
+        setattr(builtins, _HOOK_FLAG, True)
+        os.environ["NIJA_WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALLED"] = "1"
+    try:
+        reconcile_once()
+    except Exception as exc:
+        LOGGER.warning("RUNTIME_V80_INITIAL_RECONCILE_FAILED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
+    LOGGER.critical(
+        "WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALLED marker=%s writer_exact_or_reacquire=true kraken_authenticated_recovery=true fail_closed=true",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "reconcile_once", "reconcile_writer_once", "reconcile_kraken_once"]

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -118,21 +118,10 @@ def _normalize_okx() -> None:
 
 
 def _normalize_coinbase_pem() -> None:
-    """Convert Coinbase PEM credential from escape-sequence form to true multiline.
-
-    Railway and other platforms encode newlines as the two-character sequence
-    ``\\n`` when storing multi-line secrets as env vars.  The Coinbase Advanced
-    Trade SDK (and the JWT signing code) require a real PEM with actual newline
-    characters.  This normalizes the env vars once at startup so every code
-    path that reads them gets a usable key without having to do its own
-    ``replace('\\\\n', '\\n')`` everywhere.
-    """
-    for name in ("COINBASE_API_SECRET", "COINBASE_PEM_CONTENT",
-                 "COINBASE_PLATFORM_API_SECRET", "COINBASE_ADVANCED_API_SECRET"):
+    for name in ("COINBASE_API_SECRET", "COINBASE_PEM_CONTENT", "COINBASE_PLATFORM_API_SECRET", "COINBASE_ADVANCED_API_SECRET"):
         raw = os.environ.get(name)
         if not raw:
             continue
-        # Convert literal \n (backslash-n, 2 chars) to a real newline.
         normalized = raw.replace("\\n", "\n").strip()
         if normalized != raw:
             os.environ[name] = normalized
@@ -220,6 +209,7 @@ def _runtime_defaults() -> None:
         "NIJA_STALE_LOCK_HEARTBEAT_THRESHOLD_S": "120",
         "NIJA_WRITER_LOCK_STALE_HEARTBEAT_THRESHOLD_S": "120",
         "NIJA_RAILWAY_STALE_LOCK_HEARTBEAT_THRESHOLD_S": "120",
+        "NIJA_RUNTIME_CONVERGENCE_V80_POLL_S": "5",
     }
     for key, value in defaults.items():
         os.environ.setdefault(key, value)
@@ -270,6 +260,10 @@ def _install_exchange_kill_switch_internal_reject_guard() -> None:
 
 def _install_kraken_ohlc_thread_guard() -> None:
     _install_patch_module(filename="kraken_ohlc_thread_guard_patch.py", module_name="nija_kraken_ohlc_thread_guard_patch", success_log="KRAKEN_OHLC_THREAD_GUARD_INSTALL_REQUESTED", error_prefix="Kraken OHLC thread guard")
+
+
+def _install_writer_kraken_runtime_convergence_v80() -> None:
+    _install_patch_module(filename="writer_kraken_runtime_convergence_v80_patch.py", module_name="nija_writer_kraken_runtime_convergence_v80_patch", success_log="WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALL_REQUESTED", error_prefix="Writer/Kraken runtime convergence v80")
 
 
 def _install_activation_snapshot_bridge() -> None:
@@ -385,6 +379,7 @@ _runtime_defaults()
 _install_stale_exchange_kill_switch_recovery()
 _install_exchange_kill_switch_internal_reject_guard()
 _install_kraken_ohlc_thread_guard()
+_install_writer_kraken_runtime_convergence_v80()
 _install_okx_min_notional_prefilter_repair()
 _install_okx_final_order_submission_bridge()
 _install_ecel_min_notional_rounding_repair()


### PR DESCRIPTION
## What changed

- add v80 runtime convergence for the production `runtime_not_acquired` writer-heartbeat state
- delegate writer repair to v77 exact-owner proof or canonical bounded reacquisition; never adopt a foreign Redis generation
- run Kraken authenticated reconnect convergence only after writer authority is proven
- install v80 from `sitecustomize.py` so recovery remains active after startup
- add regression coverage for missing/not-acquired writer runtime, fail-closed Kraken blocking, authenticated Kraken recovery, and healthy-writer no-op behavior

## Production evidence

The deployed `eb2cb141` runtime showed an authoritative generation with a stale heartbeat while v42 blocked re-anchor as `runtime_not_acquired`. In the same window Coinbase and OKX were ready while Kraken remained configured but disconnected. Coinbase's v78 slow-capital path completed successfully after ~195 seconds and is intentionally unchanged.

## Safety

- no Redis lock or generation is fabricated
- no broker connection state is fabricated
- no capital, order, fill, strategy, risk, or kill-switch gate is bypassed
- foreign/mismatched writer ownership remains fail-closed

## Validation

Focused regression tests are included in `bot/tests/test_writer_kraken_runtime_convergence_v80.py`. Full repository CI/security checks should run on this exact PR head before merge.