### PR TITLE
Fix writer recovery epoch and core thread convergence v81

### DIFF
--- a/bot/tests/test_writer_recovery_epoch_core_v81.py
+++ b/bot/tests/test_writer_recovery_epoch_core_v81.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+
+class WriterRecoveryEpochCoreV81Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.writer_recovery_epoch_core_v81_patch")
+        self.saved = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.saved)
+
+    def test_secondary_loss_is_recoverable_only_during_primary_epoch(self) -> None:
+        self.assertTrue(self.mod.recoverable_reason("lock_missing_and_fencing_token_mismatch"))
+        self.assertTrue(
+            self.mod.recoverable_reason("heartbeat_grace_expired:runtime_already_lost")
+        )
+        os.environ["NIJA_WRITER_RECOVERY_EPOCH_TS"] = str(time.time() - 1000.0)
+        self.assertFalse(
+            self.mod.recoverable_reason("heartbeat_grace_expired:runtime_already_lost")
+        )
+
+    def test_arbitrary_heartbeat_failure_remains_terminal(self) -> None:
+        os.environ.pop("NIJA_WRITER_RECOVERY_EPOCH_REASON", None)
+        os.environ.pop("NIJA_WRITER_RECOVERY_EPOCH_TS", None)
+        self.assertFalse(self.mod.recoverable_reason("heartbeat_grace_expired:redis_timeout"))
+        self.assertFalse(self.mod.recoverable_reason("manual_stop"))
+        self.assertFalse(self.mod.recoverable_reason("core_thread_not_alive"))
+
+    def test_existing_live_core_is_registered_not_restarted(self) -> None:
+        class Runtime:
+            acquired = True
+            lost = False
+            _core_thread = None
+
+            def __init__(self) -> None:
+                self.registered = None
+
+            def register_core_thread(self, thread):
+                self.registered = thread
+
+            def record_scan_started(self):
+                return None
+
+        stop = threading.Event()
+        thread = threading.Thread(target=lambda: stop.wait(2.0), name="real-core", daemon=True)
+        thread.start()
+        runtime = Runtime()
+        bot_main = types.ModuleType("bot.bot_main")
+        bot_main._core_loop_thread = thread
+        bot_main._startup_complete = True
+        bot_main._shutdown_event = threading.Event()
+
+        with mock.patch.object(self.mod, "_bot_main", return_value=bot_main), mock.patch.object(
+            self.mod, "_runtime", return_value=runtime
+        ), mock.patch.object(self.mod, "_canonical_strategy") as strategy:
+            ok, reason = self.mod.repair_core_thread_once()
+
+        stop.set()
+        thread.join(timeout=2.0)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "existing_live_thread")
+        self.assertIs(runtime.registered, thread)
+        strategy.assert_not_called()
+
+    def test_dead_core_restarts_only_from_canonical_strategy(self) -> None:
+        class Runtime:
+            acquired = True
+            lost = False
+            _core_thread = None
+
+            def __init__(self) -> None:
+                self.registered = None
+
+            def register_core_thread(self, thread):
+                self.registered = thread
+
+            def record_scan_started(self):
+                return None
+
+        class Strategy:
+            def run_cycle(self):
+                return None
+
+        runtime = Runtime()
+        bot_main = types.ModuleType("bot.bot_main")
+        bot_main._core_loop_thread = None
+        bot_main._startup_complete = True
+        bot_main._shutdown_event = threading.Event()
+        stop = threading.Event()
+        created = []
+
+        def starter(strategy):
+            self.assertIsInstance(strategy, Strategy)
+            thread = threading.Thread(target=lambda: stop.wait(2.0), name="restarted-core", daemon=True)
+            thread.start()
+            created.append(thread)
+            return thread
+
+        engine = types.ModuleType("bot.nija_core_loop")
+        engine.start_trading_engine = starter
+        original = sys.modules.get("bot.nija_core_loop")
+        sys.modules["bot.nija_core_loop"] = engine
+        try:
+            with mock.patch.object(self.mod, "_bot_main", return_value=bot_main), mock.patch.object(
+                self.mod, "_runtime", return_value=runtime
+            ), mock.patch.object(self.mod, "_canonical_strategy", return_value=Strategy()):
+                ok, reason = self.mod.repair_core_thread_once()
+        finally:
+            stop.set()
+            for thread in created:
+                thread.join(timeout=2.0)
+            if original is None:
+                sys.modules.pop("bot.nija_core_loop", None)
+            else:
+                sys.modules["bot.nija_core_loop"] = original
+
+        self.assertTrue(ok)
+        self.assertEqual(reason, "canonical_strategy_restart")
+        self.assertIs(runtime.registered, created[0])
+        self.assertIs(bot_main._core_loop_thread, created[0])
+
+    def test_no_restart_without_writer_authority(self) -> None:
+        runtime = types.SimpleNamespace(acquired=False, lost=True, _core_thread=None)
+        bot_main = types.ModuleType("bot.bot_main")
+        bot_main._core_loop_thread = None
+        bot_main._startup_complete = True
+        bot_main._shutdown_event = threading.Event()
+        with mock.patch.object(self.mod, "_bot_main", return_value=bot_main), mock.patch.object(
+            self.mod, "_runtime", return_value=runtime
+        ):
+            ok, reason = self.mod.repair_core_thread_once()
+        self.assertFalse(ok)
+        self.assertEqual(reason, "writer_not_acquired")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/writer_recovery_epoch_core_v81_patch.py
+++ b/bot/writer_recovery_epoch_core_v81_patch.py
@@ -1,0 +1,391 @@
+"""Writer recovery epoch + real core-thread convergence v81.
+
+Production on merge 4f758f3e showed two coupled liveness defects after a
+recoverable distributed writer loss:
+
+* v48 correctly marked the runtime lost for
+  ``lock_missing_and_fencing_token_mismatch``.  While v39 was already performing
+  bounded fresh-epoch recovery, the old heartbeat loop returned
+  ``runtime_already_lost`` and the grace wrapper later emitted
+  ``heartbeat_grace_expired:runtime_already_lost``.  v46 classified that
+  secondary symptom as non-recoverable, allowing one incident to be reclassified
+  as terminal during its own recovery window.
+* after a successful fresh generation and broker recovery, activation remained
+  ``LIVE_PENDING_CONFIRMATION`` because ``NIJA_CORE_THREAD_ALIVE`` was false.
+  The runtime can have a valid canonical TradingStrategy while the original core
+  thread reference is stale/dead.  v81 only reuses a genuinely alive core thread
+  or restarts the engine from the already-published canonical strategy, verifies
+  the returned thread is alive, and registers that exact thread with the writer.
+
+Safety invariants:
+* no Redis lock/token/generation is created or inferred by this module;
+* arbitrary heartbeat failures remain non-recoverable;
+* dead core-thread evidence is never converted to a synthetic alive flag;
+* restart requires an acquired/non-lost writer, completed startup, a canonical
+  published strategy, and no live registered core thread;
+* all existing risk, emergency-stop, capital, broker and execution gates remain
+  authoritative.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.writer_recovery_epoch_core_v81")
+MARKER = "20260809-writer-recovery-epoch-core-v81"
+_PATCH_ATTR = "_nija_writer_recovery_epoch_core_v81"
+_LOCK = threading.RLock()
+_RESTART_LOCK = threading.Lock()
+_STOP = threading.Event()
+_STARTED = False
+
+_PRIMARY_TOKENS = (
+    "lock_missing_and_fencing_token_mismatch",
+    "writer_lock_released_for_reelection:authority_invariant_violated:",
+)
+_SECONDARY_REASON = "heartbeat_grace_expired:runtime_already_lost"
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        result = float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return result if result == result else default
+
+
+def _thread_alive(thread: Any) -> bool:
+    if thread is None or not callable(getattr(thread, "is_alive", None)):
+        return False
+    try:
+        return bool(thread.is_alive())
+    except Exception:
+        return False
+
+
+def _primary_recoverable(reason: str) -> bool:
+    text = str(reason or "")
+    if "core_thread_" in text:
+        return False
+    return any(token in text for token in _PRIMARY_TOKENS)
+
+
+def _record_epoch(reason: str) -> None:
+    if not _primary_recoverable(reason):
+        return
+    os.environ["NIJA_WRITER_RECOVERY_EPOCH_REASON"] = str(reason)
+    os.environ["NIJA_WRITER_RECOVERY_EPOCH_TS"] = str(time.time())
+
+
+def _epoch_window_s() -> float:
+    # v39's normal recovery window plus enough room for the heartbeat grace
+    # callback to observe the same incident.  Bounded by 10 minutes.
+    base = max(5.0, _f(os.environ.get("NIJA_WRITER_REELECTION_MAX_S"), 120.0))
+    grace = max(1.0, _f(os.environ.get("NIJA_WRITER_LOSS_GRACE_S"), 12.0))
+    return min(600.0, base + grace + 15.0)
+
+
+def _secondary_is_same_epoch(reason: str) -> bool:
+    if str(reason or "") != _SECONDARY_REASON:
+        return False
+    primary = str(os.environ.get("NIJA_WRITER_RECOVERY_EPOCH_REASON", "") or "")
+    if not _primary_recoverable(primary):
+        return False
+    started = _f(os.environ.get("NIJA_WRITER_RECOVERY_EPOCH_TS"), 0.0)
+    if started <= 0.0:
+        return False
+    age = max(0.0, time.time() - started)
+    return age <= _epoch_window_s()
+
+
+def recoverable_reason(reason: str) -> bool:
+    text = str(reason or "")
+    if _primary_recoverable(text):
+        _record_epoch(text)
+        return True
+    if _secondary_is_same_epoch(text):
+        LOGGER.warning(
+            "WRITER_V81_SECONDARY_LOSS_PRESERVED marker=%s reason=%s primary=%s age_s=%.1f",
+            MARKER,
+            text,
+            os.environ.get("NIJA_WRITER_RECOVERY_EPOCH_REASON", ""),
+            max(0.0, time.time() - _f(os.environ.get("NIJA_WRITER_RECOVERY_EPOCH_TS"), time.time())),
+        )
+        return True
+    return False
+
+
+def _patch_recovery_predicates() -> bool:
+    changed = False
+    targets = (
+        ("bot.production_readiness_v39_patch", "_recoverable_writer_loss"),
+        ("bot.writer_reelection_loss_reason_v46_patch", "_safe_recoverable_reason"),
+    )
+    for module_name, attr in targets:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        current = getattr(module, attr, None)
+        if not callable(current) or getattr(current, _PATCH_ATTR, False):
+            continue
+
+        @wraps(current)
+        def wrapped(reason: str, __current=current):
+            if bool(__current(reason)):
+                if _primary_recoverable(reason):
+                    _record_epoch(str(reason))
+                return True
+            return recoverable_reason(str(reason))
+
+        setattr(wrapped, _PATCH_ATTR, True)
+        setattr(wrapped, "__wrapped__", current)
+        setattr(module, attr, wrapped)
+        changed = True
+        LOGGER.critical(
+            "WRITER_V81_RECOVERY_PREDICATE_PATCHED marker=%s module=%s attr=%s",
+            MARKER,
+            module_name,
+            attr,
+        )
+    return changed
+
+
+def _runtime() -> Any:
+    try:
+        module = importlib.import_module("bot.entrypoint_writer_authority")
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        return getter() if callable(getter) else None
+    except Exception:
+        return None
+
+
+def _bot_main() -> ModuleType | None:
+    module = sys.modules.get("bot.bot_main")
+    if isinstance(module, ModuleType):
+        return module
+    try:
+        module = importlib.import_module("bot.bot_main")
+    except Exception:
+        return None
+    return module if isinstance(module, ModuleType) else None
+
+
+def _live_core_thread(bot_main: ModuleType | None, runtime: Any) -> Any:
+    for thread in (
+        getattr(bot_main, "_core_loop_thread", None) if bot_main is not None else None,
+        getattr(runtime, "_core_thread", None) if runtime is not None else None,
+    ):
+        if _thread_alive(thread):
+            return thread
+    return None
+
+
+def _canonical_strategy() -> Any:
+    try:
+        module = importlib.import_module("bot.strategy_publication_patch")
+    except Exception:
+        return None
+    strategy = getattr(module, "_PUBLISHED", None)
+    if strategy is not None and callable(getattr(strategy, "run_cycle", None)):
+        return strategy
+    finder = getattr(module, "_existing", None)
+    class_reader = getattr(module, "_strategy_class", None)
+    if callable(finder):
+        try:
+            cls = class_reader() if callable(class_reader) else None
+            strategy = finder(cls)
+        except Exception:
+            strategy = None
+    return strategy if strategy is not None and callable(getattr(strategy, "run_cycle", None)) else None
+
+
+def _register_real_core(bot_main: ModuleType, runtime: Any, thread: Any, source: str) -> bool:
+    if not _thread_alive(thread):
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        return False
+    setattr(bot_main, "_core_loop_thread", thread)
+    register = getattr(runtime, "register_core_thread", None)
+    if not callable(register):
+        return False
+    register(thread)
+    if not _thread_alive(thread):
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        return False
+    os.environ["NIJA_CORE_THREAD_ALIVE"] = "1"
+    record = getattr(runtime, "record_scan_started", None)
+    if callable(record):
+        try:
+            record()
+        except Exception:
+            pass
+    LOGGER.critical(
+        "WRITER_V81_CORE_THREAD_BOUND marker=%s source=%s thread=%s ident=%s alive=true",
+        MARKER,
+        source,
+        getattr(thread, "name", "unknown"),
+        getattr(thread, "ident", None),
+    )
+    return True
+
+
+def repair_core_thread_once() -> tuple[bool, str]:
+    bot_main = _bot_main()
+    runtime = _runtime()
+    if bot_main is None or runtime is None:
+        return False, "runtime_unavailable"
+    if not bool(getattr(runtime, "acquired", False)) or bool(getattr(runtime, "lost", True)):
+        return False, "writer_not_acquired"
+
+    live = _live_core_thread(bot_main, runtime)
+    if live is not None:
+        return (_register_real_core(bot_main, runtime, live, "existing_live_thread"), "existing_live_thread")
+
+    os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+    if not bool(getattr(bot_main, "_startup_complete", False)):
+        return False, "startup_not_complete"
+    shutdown = getattr(bot_main, "_shutdown_event", None)
+    if shutdown is not None and callable(getattr(shutdown, "is_set", None)) and shutdown.is_set():
+        return False, "shutdown_requested"
+
+    strategy = _canonical_strategy()
+    if strategy is None:
+        return False, "canonical_strategy_unavailable"
+
+    if not _RESTART_LOCK.acquire(blocking=False):
+        return False, "restart_already_in_progress"
+    try:
+        # Re-check after acquiring the restart lock to prevent duplicate engines.
+        live = _live_core_thread(bot_main, runtime)
+        if live is not None:
+            return (_register_real_core(bot_main, runtime, live, "restart_race_existing"), "restart_race_existing")
+        engine = importlib.import_module("bot.nija_core_loop")
+        starter = getattr(engine, "start_trading_engine", None)
+        if not callable(starter):
+            return False, "start_trading_engine_unavailable"
+        thread = starter(strategy)
+        deadline = time.time() + 5.0
+        while not _thread_alive(thread) and time.time() < deadline:
+            time.sleep(0.05)
+        if not _thread_alive(thread):
+            os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+            return False, "restarted_core_not_alive"
+        if not _register_real_core(bot_main, runtime, thread, "canonical_strategy_restart"):
+            return False, "restarted_core_registration_failed"
+        LOGGER.critical(
+            "WRITER_V81_CORE_THREAD_RESTARTED marker=%s strategy=%s thread=%s ident=%s",
+            MARKER,
+            type(strategy).__name__,
+            getattr(thread, "name", "unknown"),
+            getattr(thread, "ident", None),
+        )
+        return True, "canonical_strategy_restart"
+    except Exception as exc:
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        LOGGER.error(
+            "WRITER_V81_CORE_THREAD_RESTART_FAILED marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False, f"restart_error:{type(exc).__name__}:{exc}"
+    finally:
+        _RESTART_LOCK.release()
+
+
+def _patch_runtime_authority_probe() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_authority_convergence_repair_patch")
+    except Exception:
+        return False
+    current = getattr(module, "_heartbeat_ready", None)
+    if not callable(current) or getattr(current, _PATCH_ATTR, False):
+        return bool(callable(current))
+
+    @wraps(current)
+    def heartbeat_ready_v81():
+        # Synchronize NIJA_CORE_THREAD_ALIVE from a real thread before the legacy
+        # convergence probe reads the env-only core-thread gate.
+        repair_core_thread_once()
+        return current()
+
+    setattr(heartbeat_ready_v81, _PATCH_ATTR, True)
+    setattr(heartbeat_ready_v81, "__wrapped__", current)
+    module._heartbeat_ready = heartbeat_ready_v81
+    LOGGER.critical("WRITER_V81_AUTHORITY_PROBE_PATCHED marker=%s", MARKER)
+    return True
+
+
+def reconcile_once() -> dict[str, Any]:
+    with _LOCK:
+        predicates = _patch_recovery_predicates()
+        authority_probe = _patch_runtime_authority_probe()
+        core_ok, core_reason = repair_core_thread_once()
+        return {
+            "predicates": predicates,
+            "authority_probe": authority_probe,
+            "core_ok": core_ok,
+            "core_reason": core_reason,
+        }
+
+
+def _watchdog() -> None:
+    try:
+        interval = max(2.0, _f(os.environ.get("NIJA_WRITER_V81_POLL_S"), 5.0))
+    except Exception:
+        interval = 5.0
+    last = ""
+    while not _STOP.wait(interval):
+        try:
+            state = reconcile_once()
+            signature = f"{state.get('core_ok')}:{state.get('core_reason')}"
+            if signature != last:
+                log = LOGGER.info if state.get("core_ok") else LOGGER.warning
+                log(
+                    "WRITER_V81_STATE marker=%s core_ok=%s core_reason=%s epoch_reason=%s",
+                    MARKER,
+                    str(bool(state.get("core_ok"))).lower(),
+                    state.get("core_reason"),
+                    os.environ.get("NIJA_WRITER_RECOVERY_EPOCH_REASON", ""),
+                )
+                last = signature
+        except Exception as exc:
+            LOGGER.warning("WRITER_V81_WATCHDOG_ERROR marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
+
+
+def install_import_hook() -> bool:
+    global _STARTED
+    with _LOCK:
+        _patch_recovery_predicates()
+        _patch_runtime_authority_probe()
+        if not _STARTED:
+            _STARTED = True
+            threading.Thread(target=_watchdog, name="WriterRecoveryEpochCoreV81", daemon=True).start()
+        os.environ["NIJA_WRITER_RECOVERY_EPOCH_CORE_V81_INSTALLED"] = "1"
+    LOGGER.critical(
+        "WRITER_RECOVERY_EPOCH_CORE_V81_INSTALLED marker=%s bounded_epoch=true real_core_only=true canonical_restart=true fail_closed=true",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "recoverable_reason",
+    "repair_core_thread_once",
+    "reconcile_once",
+    "_secondary_is_same_epoch",
+]

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -210,6 +210,7 @@ def _runtime_defaults() -> None:
         "NIJA_WRITER_LOCK_STALE_HEARTBEAT_THRESHOLD_S": "120",
         "NIJA_RAILWAY_STALE_LOCK_HEARTBEAT_THRESHOLD_S": "120",
         "NIJA_RUNTIME_CONVERGENCE_V80_POLL_S": "5",
+        "NIJA_WRITER_V81_POLL_S": "5",
     }
     for key, value in defaults.items():
         os.environ.setdefault(key, value)
@@ -264,6 +265,10 @@ def _install_kraken_ohlc_thread_guard() -> None:
 
 def _install_writer_kraken_runtime_convergence_v80() -> None:
     _install_patch_module(filename="writer_kraken_runtime_convergence_v80_patch.py", module_name="nija_writer_kraken_runtime_convergence_v80_patch", success_log="WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALL_REQUESTED", error_prefix="Writer/Kraken runtime convergence v80")
+
+
+def _install_writer_recovery_epoch_core_v81() -> None:
+    _install_patch_module(filename="writer_recovery_epoch_core_v81_patch.py", module_name="nija_writer_recovery_epoch_core_v81_patch", success_log="WRITER_RECOVERY_EPOCH_CORE_V81_INSTALL_REQUESTED", error_prefix="Writer recovery epoch/core v81")
 
 
 def _install_activation_snapshot_bridge() -> None:
@@ -380,6 +385,7 @@ _install_stale_exchange_kill_switch_recovery()
 _install_exchange_kill_switch_internal_reject_guard()
 _install_kraken_ohlc_thread_guard()
 _install_writer_kraken_runtime_convergence_v80()
+_install_writer_recovery_epoch_core_v81()
 _install_okx_min_notional_prefilter_repair()
 _install_okx_final_order_submission_bridge()
 _install_ecel_min_notional_rounding_repair()


### PR DESCRIPTION
## Production issue
Production on merge `4f758f3e` showed a recoverable writer-loss epoch being reclassified as terminal by the old heartbeat worker (`heartbeat_grace_expired:runtime_already_lost`) and LIVE activation remaining blocked because the canonical core-thread proof was stale/dead after re-election.

## Fix
- preserve the original approved recoverable writer-loss classification only for the same bounded recovery epoch
- keep unrelated/manual/core-thread loss reasons terminal
- synchronize authority from an actually alive registered core thread
- if the real core thread died after startup, restart only from the already-published canonical TradingStrategy
- verify the returned thread is alive before registering it with EntrypointWriterAuthority
- never fabricate `NIJA_CORE_THREAD_ALIVE`
- retain all Redis fencing, capital, broker, risk, emergency-stop and execution gates

## Regression coverage
Adds focused tests for bounded secondary-loss preservation, arbitrary loss rejection, live-thread rebinding, canonical-strategy restart, and no restart without writer authority.