### PR TITLE
Fix runtime handoff, capital freshness, and Kraken recovery v83

### DIFF
--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -1306,8 +1306,13 @@ class KrakenStartupFSM:
         """
         with self._lock:
             self._connecting = False
+            # A successful authenticated reconnect supersedes a prior FAILED
+            # attempt.  Clear the failure latch atomically with the nonce-ready
+            # transition so capital_ready and USER waiters observe one coherent
+            # CONNECTED state.
+            self._failed.clear()
             self._nonce_ready.set()
-        self._connected.set()
+            self._connected.set()
 
     def mark_failed(self) -> None:
         """Atomically signal FAILED — wakes all waiting USER threads instantly."""

--- a/bot/capital_authority.py
+++ b/bot/capital_authority.py
@@ -2205,7 +2205,49 @@ class CapitalAuthority:
             else datetime.now(timezone.utc)
         )
 
-        with self._lock:
+        # Reject an expired snapshot before it can mutate capital or readiness.
+        # A coordinator may finish its broker fetches and then wait behind another
+        # capital writer.  Applying that now-stale result first and only labelling
+        # it stale afterwards creates a contradictory state: positive capital and
+        # CAPITAL_SYSTEM_READY alongside a rejected first-snapshot gate.
+        _preflight_expiry = computed_at + timedelta(seconds=_DEFAULT_FRESHNESS_TTL_S)
+        if datetime.now(timezone.utc) >= _preflight_expiry:
+            with self._timed_lock(timeout=5.0):
+                self._last_snapshot_publication = SnapshotPublicationStatus(
+                    accepted=False,
+                    stale=True,
+                    reason="snapshot expired before publish",
+                    timestamp=computed_at,
+                    expiry=_preflight_expiry,
+                )
+            logger.warning(
+                "[CapitalAuthority] publish_snapshot REJECTED before mutation — "
+                "snapshot expired (computed_at=%s expiry=%s)",
+                computed_at.isoformat(),
+                _preflight_expiry.isoformat(),
+            )
+            return False
+
+        # Bound lock acquisition so a live snapshot cannot wait indefinitely and
+        # age beyond its freshness TTL.  The RLock is re-entrant, so downstream
+        # accessors used inside this block remain safe.
+        with self._timed_lock(timeout=5.0):
+            if datetime.now(timezone.utc) >= _preflight_expiry:
+                self._last_snapshot_publication = SnapshotPublicationStatus(
+                    accepted=False,
+                    stale=True,
+                    reason="snapshot expired while waiting to publish",
+                    timestamp=computed_at,
+                    expiry=_preflight_expiry,
+                )
+                logger.warning(
+                    "[CapitalAuthority] publish_snapshot REJECTED before mutation — "
+                    "snapshot expired while waiting for authority lock "
+                    "(computed_at=%s expiry=%s)",
+                    computed_at.isoformat(),
+                    _preflight_expiry.isoformat(),
+                )
+                return False
             # Monotonic-timestamp guard: reject snapshots whose computed_at is
             # not strictly newer than the current authority state.  This prevents
             # an in-flight coordinator run that started *before* a faster one from

--- a/bot/capital_flow_state_machine.py
+++ b/bot/capital_flow_state_machine.py
@@ -1377,9 +1377,36 @@ class CapitalRefreshCoordinator:
         # Single atomic write to CapitalAuthority.  Rejected if writer_id
         # does not match the authorised constant.
         # =================================================================
-        accepted = authority.publish_snapshot(snapshot, writer_id=self.WRITER_ID)
+        try:
+            accepted = authority.publish_snapshot(snapshot, writer_id=self.WRITER_ID)
+        except RuntimeError as exc:
+            if "lock acquisition timed out" not in str(exc):
+                raise
+            logger.warning(
+                "[Coordinator] capital authority publish lock timed out — "
+                "queuing a fresh non-recursive refresh: %s",
+                exc,
+            )
+            self._bus.request_refresh("capital_authority_publish_lock_timeout")
+            self._bus.emit(CapitalEvent(
+                event_type=CapitalEventType.SNAPSHOT_REJECTED,
+                trigger=trigger,
+                snapshot=snapshot,
+                metadata={"error": str(exc), "retry_queued": True},
+            ))
+            return None
 
         if not accepted:
+            # A snapshot that aged out while waiting for the authority lock must
+            # be retried with fresh broker observations.  Queue the refresh on the
+            # event bus rather than recursing into the coordinator while this run
+            # still owns its in-flight guard.
+            try:
+                _rejected_status = authority.get_snapshot_publication_status()
+            except Exception:
+                _rejected_status = None
+            if _rejected_status is not None and bool(getattr(_rejected_status, "stale", False)):
+                self._bus.request_refresh("stale_snapshot_rejected_before_publish")
             self._bus.emit(CapitalEvent(
                 event_type=CapitalEventType.SNAPSHOT_REJECTED,
                 trigger=trigger,

--- a/bot/stale_renewal_recovery_v40_patch.py
+++ b/bot/stale_renewal_recovery_v40_patch.py
@@ -44,6 +44,7 @@ _IMPORTLIB_FLAG = "_NIJA_STALE_RENEWAL_RECOVERY_V40_IMPORTLIB_HOOK"
 _PATCH_ATTR = "_nija_stale_renewal_recovery_v40"
 _WATCHDOG_ATTR = "_nija_stale_renewal_watchdog_v40"
 _WATCHDOG_STOP_ATTR = "_nija_stale_renewal_watchdog_stop_v40"
+_WATCHDOG_GENERATION_ATTR = "_nija_stale_renewal_watchdog_generation_v40"
 _PATCH_LOCK = threading.RLock()
 
 
@@ -123,6 +124,7 @@ def _watchdog_loop(runtime: Any, stop_event: threading.Event) -> None:
     stale_confirmations = max(1, int(_cfg_float("NIJA_STALE_RENEWAL_CONFIRMATIONS", 2.0, 1.0)))
     stale_seen = 0
     last_log = 0.0
+    watched_generation = int(getattr(runtime, "_generation", 0) or 0)
 
     LOGGER.critical(
         "STALE_RENEWAL_V40_WATCHDOG_STARTED marker=%s generation=%s poll_s=%.2f confirmations=%d",
@@ -133,6 +135,15 @@ def _watchdog_loop(runtime: Any, stop_event: threading.Event) -> None:
     )
 
     while not stop_event.is_set():
+        current_generation = int(getattr(runtime, "_generation", 0) or 0)
+        if current_generation != watched_generation:
+            LOGGER.info(
+                "STALE_RENEWAL_V40_STALE_EPOCH_EXIT marker=%s watched_generation=%s current_generation=%s",
+                MARKER,
+                watched_generation,
+                current_generation,
+            )
+            return
         if bool(getattr(runtime, "lost", False)):
             return
         if not bool(getattr(runtime, "acquired", False)):
@@ -141,6 +152,14 @@ def _watchdog_loop(runtime: Any, stop_event: threading.Event) -> None:
             continue
 
         ok, reason, age_s, max_age_s = _runtime_health(runtime)
+        if int(getattr(runtime, "_generation", 0) or 0) != watched_generation:
+            LOGGER.info(
+                "STALE_RENEWAL_V40_STALE_EPOCH_EXIT marker=%s watched_generation=%s current_generation=%s",
+                MARKER,
+                watched_generation,
+                getattr(runtime, "_generation", 0),
+            )
+            return
         if ok:
             stale_seen = 0
             stop_event.wait(poll_s)
@@ -190,16 +209,36 @@ def _watchdog_loop(runtime: Any, stop_event: threading.Event) -> None:
 
 
 def _start_watchdog(runtime: Any) -> bool:
+    generation = int(getattr(runtime, "_generation", 0) or 0)
     existing = getattr(runtime, _WATCHDOG_ATTR, None)
     if existing is not None and callable(getattr(existing, "is_alive", None)) and existing.is_alive():
-        return True
+        existing_generation = int(getattr(existing, _WATCHDOG_GENERATION_ATTR, 0) or 0)
+        if existing_generation == generation:
+            return True
+        old_stop = getattr(runtime, _WATCHDOG_STOP_ATTR, None)
+        if old_stop is not None and callable(getattr(old_stop, "set", None)):
+            old_stop.set()
+        if existing is not threading.current_thread():
+            existing.join(timeout=3.0)
+        if existing.is_alive():
+            LOGGER.error(
+                "STALE_RENEWAL_V40_OLD_EPOCH_STILL_ALIVE marker=%s "
+                "old_generation=%s new_generation=%s action=fail_closed",
+                MARKER,
+                existing_generation,
+                generation,
+            )
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            return False
     stop_event = threading.Event()
     thread = threading.Thread(
         target=_watchdog_loop,
         args=(runtime, stop_event),
-        name="writer-stale-renewal-watchdog-v40",
+        name=f"writer-stale-renewal-watchdog-v40-g{generation}",
         daemon=True,
     )
+    setattr(thread, _WATCHDOG_GENERATION_ATTR, generation)
     setattr(runtime, _WATCHDOG_STOP_ATTR, stop_event)
     setattr(runtime, _WATCHDOG_ATTR, thread)
     thread.start()

--- a/bot/tests/test_capital_snapshot_publication_status.py
+++ b/bot/tests/test_capital_snapshot_publication_status.py
@@ -208,6 +208,48 @@ class CapitalSnapshotPublicationStatusTests(unittest.TestCase):
         self.assertNotIn(CapitalEventType.SNAPSHOT_PUBLISHED, bus_events)
         self.assertEqual(authority.publish_calls, 1)
 
+    def test_publish_lock_timeout_queues_fresh_refresh(self) -> None:
+        status = SnapshotPublicationStatus(
+            accepted=False,
+            stale=True,
+            reason="capital authority lock timeout",
+            timestamp=None,
+            expiry=None,
+        )
+        authority = _AuthorityForCoordinator(status)
+
+        def _timeout(_snapshot, writer_id: str) -> bool:
+            _ = writer_id
+            raise RuntimeError(
+                "CapitalAuthority lock acquisition timed out after 5.0s — possible deadlock"
+            )
+
+        authority.publish_snapshot = _timeout
+        bootstrap = get_capital_bootstrap_fsm()
+        bootstrap.claim_bootstrap_ownership()
+        bootstrap.force_transition(CapitalBootstrapState.BOOT_IDLE, "test reset")
+        bus_events = []
+        bus = CapitalEventBus()
+        coordinator = CapitalRefreshCoordinator(
+            event_bus=bus,
+            runtime_fsm=CapitalRuntimeStateMachine(),
+            bootstrap_fsm=bootstrap,
+        )
+        bus.subscribe(lambda event: bus_events.append(event.event_type))
+        with patch(
+            "bot.capital_authority.get_capital_authority",
+            return_value=authority,
+        ):
+            snapshot = coordinator.execute_refresh(
+                broker_map={"kraken": _PositiveBroker(100.0)},
+                trigger="watchdog",
+                open_exposure_usd=0.0,
+            )
+        bus.dispatch_pending()
+        self.assertIsNone(snapshot)
+        self.assertIn(CapitalEventType.REFRESH_REQUESTED, bus_events)
+        self.assertIn(CapitalEventType.SNAPSHOT_REJECTED, bus_events)
+
     def test_cache_timestamps_updated_on_publish(self) -> None:
         ca = _make_bare_ca()
         t1 = datetime.now(timezone.utc) - timedelta(seconds=10)
@@ -222,10 +264,14 @@ class CapitalSnapshotPublicationStatusTests(unittest.TestCase):
         ca = _make_bare_ca()
         stale_computed_at = datetime.now(timezone.utc) - timedelta(seconds=300)
         stale_snapshot = _FakeSnapshot({"kraken": 50.0}, stale_computed_at)
-        self.assertTrue(ca.publish_snapshot(stale_snapshot, writer_id="mabm_capital_refresh_coordinator"))
+        self.assertFalse(ca.publish_snapshot(stale_snapshot, writer_id="mabm_capital_refresh_coordinator"))
         status = ca.get_snapshot_publication_status()
         self.assertFalse(status.accepted)
         self.assertTrue(status.stale)
+        self.assertEqual(status.reason, "snapshot expired before publish")
+        self.assertEqual(ca._broker_balances, {})
+        self.assertIsNone(ca._last_typed_snapshot)
+        self.assertFalse(ca._hydrated)
         self.assertFalse(status.accepted and status.stale)
 
 

--- a/bot/tests/test_kraken_connection_lifecycle.py
+++ b/bot/tests/test_kraken_connection_lifecycle.py
@@ -17,6 +17,7 @@ import os
 import sys
 import threading
 import types
+import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -288,6 +289,22 @@ class TestKrakenStartupFSM:
     def test_mark_connecting_is_alias_for_begin_platform_boot(self):
         self.fsm.mark_connecting()
         assert self.fsm.is_connecting
+
+
+class TestKrakenReconnectFailureLatch(unittest.TestCase):
+    def test_successful_reconnect_clears_failure_and_allows_capital_ready(self) -> None:
+        fsm = _make_fsm()()
+        fsm.begin_platform_boot()
+        fsm.mark_failed()
+        self.assertTrue(fsm.is_failed)
+
+        fsm.mark_connected()
+        fsm.mark_capital_ready()
+
+        self.assertTrue(fsm.is_connected)
+        self.assertFalse(fsm.is_failed)
+        self.assertTrue(fsm.is_nonce_ready)
+        self.assertTrue(fsm.is_capital_ready)
 
 
 # ---------------------------------------------------------------------------

--- a/bot/tests/test_kraken_connection_lifecycle.py
+++ b/bot/tests/test_kraken_connection_lifecycle.py
@@ -72,8 +72,9 @@ def _make_fsm():
         def mark_connected(self) -> None:
             with self._lock:
                 self._connecting = False
+                self._failed.clear()
                 self._nonce_ready.set()
-            self._connected.set()
+                self._connected.set()
 
         def mark_failed(self) -> None:
             with self._lock:
@@ -237,6 +238,17 @@ class TestKrakenStartupFSM:
         self.fsm.begin_platform_boot()
         self.fsm.mark_connected()
         assert not self.fsm.is_failed
+
+    def test_successful_reconnect_clears_prior_failure_latch(self):
+        self.fsm.begin_platform_boot()
+        self.fsm.mark_failed()
+        assert self.fsm.is_failed
+        self.fsm.mark_connected()
+        self.fsm.mark_capital_ready()
+        assert self.fsm.is_connected
+        assert not self.fsm.is_failed
+        assert self.fsm.is_nonce_ready
+        assert self.fsm.is_capital_ready
 
     def test_begin_platform_boot_noop_after_connected(self):
         """begin_platform_boot() must not reset a CONNECTED FSM."""

--- a/bot/tests/test_stale_renewal_epoch_v83.py
+++ b/bot/tests/test_stale_renewal_epoch_v83.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import threading
+import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 
 BOT_DIR = Path(__file__).resolve().parents[1]
@@ -20,59 +23,69 @@ def _load_patch():
     return module
 
 
-def test_watchdog_rotates_when_writer_generation_changes() -> None:
-    patch = _load_patch()
-    runtime = SimpleNamespace(
-        _generation=41,
-        acquired=False,
-        lost=False,
-    )
+class StaleRenewalEpochV83Tests(unittest.TestCase):
+    def test_watchdog_rotates_when_writer_generation_changes(self) -> None:
+        patch = _load_patch()
+        runtime = SimpleNamespace(
+            _generation=41,
+            acquired=False,
+            lost=False,
+        )
 
-    assert patch._start_watchdog(runtime)
-    old_thread = getattr(runtime, patch._WATCHDOG_ATTR)
-    assert getattr(old_thread, patch._WATCHDOG_GENERATION_ATTR) == 41
+        self.assertTrue(patch._start_watchdog(runtime))
+        old_thread = getattr(runtime, patch._WATCHDOG_ATTR)
+        self.assertEqual(getattr(old_thread, patch._WATCHDOG_GENERATION_ATTR), 41)
 
-    runtime._generation = 42
-    assert patch._start_watchdog(runtime)
-    new_thread = getattr(runtime, patch._WATCHDOG_ATTR)
-    assert new_thread is not old_thread
-    assert getattr(new_thread, patch._WATCHDOG_GENERATION_ATTR) == 42
+        runtime._generation = 42
+        self.assertTrue(patch._start_watchdog(runtime))
+        new_thread = getattr(runtime, patch._WATCHDOG_ATTR)
+        self.assertIsNot(new_thread, old_thread)
+        self.assertEqual(getattr(new_thread, patch._WATCHDOG_GENERATION_ATTR), 42)
 
-    getattr(runtime, patch._WATCHDOG_STOP_ATTR).set()
-    new_thread.join(timeout=3.0)
-    old_thread.join(timeout=3.0)
-    assert not old_thread.is_alive()
-    assert not new_thread.is_alive()
+        getattr(runtime, patch._WATCHDOG_STOP_ATTR).set()
+        new_thread.join(timeout=3.0)
+        old_thread.join(timeout=3.0)
+        self.assertFalse(old_thread.is_alive())
+        self.assertFalse(new_thread.is_alive())
+
+    def test_stale_epoch_exits_before_fail_closed_mutation(self) -> None:
+        patch = _load_patch()
+        health_entered = threading.Event()
+        health_release = threading.Event()
+
+        def blocked_health(_runtime):
+            health_entered.set()
+            health_release.wait(timeout=2.0)
+            return False, "renewal_success_stale", 30.0, 15.0
+
+        runtime = SimpleNamespace(
+            _generation=7,
+            acquired=True,
+            lost=False,
+        )
+        env = {
+            "NIJA_RUNTIME_EXECUTION_AUTHORITY": "1",
+            "NIJA_EXECUTION_ACTIVE": "true",
+        }
+        with mock.patch.object(patch, "_runtime_health", blocked_health), mock.patch.object(
+            patch, "_cfg_float", lambda *_args: 0.25
+        ), mock.patch.dict(os.environ, env, clear=False):
+            stop = threading.Event()
+            thread = threading.Thread(
+                target=patch._watchdog_loop,
+                args=(runtime, stop),
+                daemon=True,
+            )
+            thread.start()
+            self.assertTrue(health_entered.wait(timeout=1.0))
+            runtime._generation = 8
+            health_release.set()
+            thread.join(timeout=2.0)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"], "1")
+            self.assertEqual(os.environ["NIJA_EXECUTION_ACTIVE"], "true")
 
 
-def test_stale_epoch_exits_before_fail_closed_mutation(monkeypatch) -> None:
-    patch = _load_patch()
-    health_entered = threading.Event()
-    health_release = threading.Event()
-
-    def blocked_health(_runtime):
-        health_entered.set()
-        health_release.wait(timeout=2.0)
-        return False, "renewal_success_stale", 30.0, 15.0
-
-    runtime = SimpleNamespace(
-        _generation=7,
-        acquired=True,
-        lost=False,
-    )
-    monkeypatch.setattr(patch, "_runtime_health", blocked_health)
-    monkeypatch.setattr(patch, "_cfg_float", lambda *_args: 0.25)
-    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
-    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
-
-    stop = threading.Event()
-    thread = threading.Thread(target=patch._watchdog_loop, args=(runtime, stop), daemon=True)
-    thread.start()
-    assert health_entered.wait(timeout=1.0)
-    runtime._generation = 8
-    health_release.set()
-    thread.join(timeout=2.0)
-
-    assert not thread.is_alive()
-    assert patch.os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "1"
-    assert patch.os.environ["NIJA_EXECUTION_ACTIVE"] == "true"
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_stale_renewal_epoch_v83.py
+++ b/bot/tests/test_stale_renewal_epoch_v83.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+
+BOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_patch():
+    spec = importlib.util.spec_from_file_location(
+        "stale_renewal_recovery_v40_patch_under_test",
+        BOT_DIR / "stale_renewal_recovery_v40_patch.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_watchdog_rotates_when_writer_generation_changes() -> None:
+    patch = _load_patch()
+    runtime = SimpleNamespace(
+        _generation=41,
+        acquired=False,
+        lost=False,
+    )
+
+    assert patch._start_watchdog(runtime)
+    old_thread = getattr(runtime, patch._WATCHDOG_ATTR)
+    assert getattr(old_thread, patch._WATCHDOG_GENERATION_ATTR) == 41
+
+    runtime._generation = 42
+    assert patch._start_watchdog(runtime)
+    new_thread = getattr(runtime, patch._WATCHDOG_ATTR)
+    assert new_thread is not old_thread
+    assert getattr(new_thread, patch._WATCHDOG_GENERATION_ATTR) == 42
+
+    getattr(runtime, patch._WATCHDOG_STOP_ATTR).set()
+    new_thread.join(timeout=3.0)
+    old_thread.join(timeout=3.0)
+    assert not old_thread.is_alive()
+    assert not new_thread.is_alive()
+
+
+def test_stale_epoch_exits_before_fail_closed_mutation(monkeypatch) -> None:
+    patch = _load_patch()
+    health_entered = threading.Event()
+    health_release = threading.Event()
+
+    def blocked_health(_runtime):
+        health_entered.set()
+        health_release.wait(timeout=2.0)
+        return False, "renewal_success_stale", 30.0, 15.0
+
+    runtime = SimpleNamespace(
+        _generation=7,
+        acquired=True,
+        lost=False,
+    )
+    monkeypatch.setattr(patch, "_runtime_health", blocked_health)
+    monkeypatch.setattr(patch, "_cfg_float", lambda *_args: 0.25)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    stop = threading.Event()
+    thread = threading.Thread(target=patch._watchdog_loop, args=(runtime, stop), daemon=True)
+    thread.start()
+    assert health_entered.wait(timeout=1.0)
+    runtime._generation = 8
+    health_release.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert patch.os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "1"
+    assert patch.os.environ["NIJA_EXECUTION_ACTIVE"] == "true"


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug
- Backup owner:

## Purpose

Fix the post-#2457 runtime convergence failures visible in production logs:

- stale renewal watchdogs continued observing a prior writer generation after a fresh Redis lease epoch;
- a capital snapshot waited behind an unbounded authority lock until it expired, then mutated capital/readiness before reporting itself stale;
- successful Kraken reconnects could retain the prior FAILED latch, leaving nonce/capital readiness and USER waiters inconsistent.

The change remains fail-closed. It does not grant execution authority, mutate Redis ownership from the watchdog, bypass nonce checks, or alter strategy/risk/order logic.

## Risk Assessment

- Risk level: high
- Impacted areas:
  - writer renewal watchdog lifecycle
  - capital snapshot publication and retry scheduling
  - Kraken startup/reconnect FSM
- Key failure modes:
  - stale watchdog fails to quiesce during an epoch transition;
  - capital publication retries repeatedly under sustained lock contention;
  - Kraken reconnect state is observed before all FSM latches converge.

## Rollback Plan

- Revert strategy:
  - Revert the seven commits in this PR (or the squash commit if merged) and redeploy the prior main SHA `525fcb79fe46e251080b42616cf7efb2dcd14556`.
- Data/state considerations:
  - No migrations or persistent schema changes.
  - A process restart recreates in-memory watchdog, readiness, and Kraken FSM state.
  - Redis writer lock/fencing keys are not changed by this patch.

## Validation

- [x] Local checks passed
- [ ] CI checks passed
- [x] Monitoring/observability impact reviewed

Local checks:

- `python -m py_compile` clean for all seven changed Python files.
- 6/6 capital snapshot publication tests passed with `unittest`.
- Writer epoch handoff checks passed: old watchdog exits and does not clear newer execution state.
- Kraken FAILED → CONNECTED → capital-ready recovery invariant passed.
- Changed-line secret/unsafe-bypass pattern scan clean.
- Local image did not provide `pytest`, CodeQL, or the repository secret-scanning command; CI must run the full configured checks.

### NIJA Safety Checks

- [x] `python -m py_compile` clean on all changed `.py` files
- [x] No bypass flags committed (FORCE_TRADE, NIJA_FORCE_ACTIVATION, NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK, NIJA_DISABLE_WRITER_LOCK, NIJA_SKIP_STARTUP_PHASE_GATE)
- [x] Authority-gate denials are NOT recorded as exchange order rejections (kill-switch feedback loop invariant preserved)
- [x] Trading logic unchanged; backtest not applicable

## Expected production signals

- watchdog thread names include their writer generation and old epochs log `STALE_RENEWAL_V40_STALE_EPOCH_EXIT`;
- stale capital publishes are rejected before mutation and queue a fresh non-recursive refresh;
- Kraken reconnect clears FAILED, restores nonce-ready, and permits capital-ready to advance;
- Coinbase and OKX remain independently available while Kraken recovers.
