### PR TITLE
Fail closed unauthorized scans and unblock supervised runtime recovery

### DIFF
--- a/bot/bootstrap_state_machine.py
+++ b/bot/bootstrap_state_machine.py
@@ -563,12 +563,37 @@ class BootstrapStateMachine:
                 return False
 
             if new_state == BootstrapState.RUNNING_SUPERVISED:
-                # NOTE: execution authority check disabled — was blocking bootstrap
-                # progression to RUNNING_SUPERVISED even with a 5-second timeout,
-                # preventing the trading loop from ever starting. Authority is
-                # granted unconditionally here; per-order runtime gates enforce
-                # safety independently of this bootstrap-phase check.
-                pass
+                try:
+                    try:
+                        from bot.execution_authority_context import (
+                            require_startup_execution_authority,
+                        )
+                    except ImportError:
+                        from execution_authority_context import (  # type: ignore[import]
+                            require_startup_execution_authority,
+                        )
+                    authority_status = require_startup_execution_authority(
+                        context=f"bootstrap_transition:{reason or 'unspecified'}",
+                        force_refresh=True,
+                    )
+                except Exception as exc:
+                    msg = (
+                        "RUNNING_SUPERVISED blocked: exact startup execution "
+                        f"authority unavailable ({exc})"
+                    )
+                    logger.error("❌ [BootstrapFSM] %s", msg)
+                    if raise_on_invalid:
+                        raise BootstrapInvariantError("EXECUTION_AUTHORITY", msg) from exc
+                    return False
+                if not bool(authority_status.get("ready", False)):
+                    msg = (
+                        "RUNNING_SUPERVISED blocked: startup authority not ready "
+                        f"missing={authority_status.get('missing', [])}"
+                    )
+                    logger.error("❌ [BootstrapFSM] %s", msg)
+                    if raise_on_invalid:
+                        raise BootstrapInvariantError("EXECUTION_AUTHORITY", msg)
+                    return False
 
 
             record: Dict[str, Any] = {

--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -642,8 +642,6 @@ def main() -> int:
             runtime = _writer_authority_runtime
             if runtime is not None and callable(getattr(runtime, "register_core_thread", None)):
                 runtime.register_core_thread(trading_thread)
-            if runtime is not None and callable(getattr(runtime, "record_scan_started", None)):
-                runtime.record_scan_started()
 
             # Publish verified thread evidence to the startup coordinator so that
             # the threads.running gate passes in evaluate_system_readiness_proof().

--- a/bot/coinbase_position_runtime_patch.py
+++ b/bot/coinbase_position_runtime_patch.py
@@ -69,10 +69,21 @@ def _extract_crypto_positions(payload: Any) -> list[Dict[str, Any]]:
 
 
 def _call_possible_balance_methods(instance: Any) -> dict:
+    # Prefer already-hydrated data.  Position discovery must not serially invoke
+    # several rate-limited balance endpoints during startup.
+    for attr in ("_last_raw_balances", "last_raw_balances", "_portfolio_breakdown", "portfolio_breakdown"):
+        cached = getattr(instance, attr, None)
+        if isinstance(cached, dict) and cached:
+            return cached
+
+    attempted_live_probe = False
     for method_name in ("get_portfolio_breakdown", "get_account_balance", "get_balance_snapshot", "get_balances"):
         method = getattr(instance, method_name, None)
         if not callable(method):
             continue
+        if attempted_live_probe:
+            break
+        attempted_live_probe = True
         try:
             try:
                 value = method(verbose=False)
@@ -134,6 +145,8 @@ def _patch_coinbase_class(cls: type) -> bool:
                     existing.extend(result)
             except Exception as exc:
                 logger.warning("COINBASE_POSITION_CLASSIFICATION original get_positions failed: %s", exc)
+        if existing:
+            return existing
         payload = _call_possible_balance_methods(self)
         crypto_positions = _extract_crypto_positions(payload)
         seen = {str(p.get("symbol", "")).upper() for p in existing if isinstance(p, dict)}

--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -18,9 +18,7 @@ Safety properties
   recreate a countdown-only lease after deletion.
 * Release is compare-and-delete; a process can never delete another writer's
   lock.
-* Local fallback is available only through the explicit operator flags
-  ``NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK`` and
-  ``NIJA_CONFIRM_BYPASS_RISKS``.
+* Local fallback is refused; Redis-backed exact ownership is mandatory.
 
 Structured log events emitted
 ------------------------------
@@ -749,77 +747,14 @@ class EntrypointWriterAuthority:
     def _maybe_grant_local_fallback(
         self, reason: str
     ) -> Optional[EntrypointWriterAuthorityResult]:
-        if not (
-            _truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
-            and _truthy("NIJA_CONFIRM_BYPASS_RISKS")
-        ):
-            return None
-
-        identity, owner, instance_id = _instance_identity()
-        token = str(int(time.time() * 1000))
-        generation = int(token)
-        scope = _writer_scope()
-        self._token = token
-        self._generation = generation
-        self._identity = identity
-        self._owner = owner
-        self._instance_id = instance_id
-        self._lock_key = (
-            os.environ.get("NIJA_WRITER_LOCK_KEY", "").strip()
-            or f"nija:writer_lock:{scope}"
-        )
-        self._meta_key = (
-            os.environ.get("NIJA_WRITER_LOCK_META_KEY", "").strip()
-            or f"nija:writer_lock_meta:{scope}"
-        )
-        self._fencing_key = (
-            os.environ.get("NIJA_WRITER_FENCING_KEY", "").strip()
-            or f"nija:writer_fence:{scope}"
-        )
-        self._lock_value = f"{token}:{owner}"
-        _prior_scan_started_at = self._scan_started_at
-        _prior_scan_complete_at = self._scan_complete_at
-        self._scan_started_at = 0.0
-        self._scan_complete_at = 0.0
-        self._scan_deadline_exceeded = False
-        self._scan_watchdog_cancel.clear()
-        self._acquired_at = time.time()
-        self._local_fallback = True
-        self._lost.clear()
-        self._stop.clear()
-        self._publish_env(
-            scope=scope,
-            generation_key=os.environ.get(
-                "NIJA_LEASE_GENERATION_KEY", _GENERATION_KEY_DEFAULT
-            ),
-            fallback=True,
-        )
-        self._start_scan_started_watchdog()
-        # If the scan was already complete before this fallback acquisition,
-        # immediately restore that state so the watchdog is cancelled and no
-        # false deadline alarms fire.
-        if _prior_scan_complete_at:
-            self.record_scan_complete()
-        elif _prior_scan_started_at:
-            self.record_scan_started()
-        self._set_writer_state(WriterState.ACTIVE, reason="local_fallback")
-        self._notify_runtime_reconciliation("writer_acquired_local_fallback")
-        logger.critical(
-            "ENTRYPOINT_WRITER_AUTHORITY_LOCAL_FALLBACK marker=%s reason=%s instance=%s",
-            _MARKER,
-            reason,
-            instance_id,
-        )
-        result = EntrypointWriterAuthorityResult(
-            acquired=True,
-            token=token,
-            generation=generation,
-            instance_id=instance_id,
-            lock_key=self._lock_key,
-            local_fallback=True,
-        )
-        self._result = result
-        return result
+        if _truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
+            logger.critical(
+                "ENTRYPOINT_WRITER_AUTHORITY_LOCAL_FALLBACK_REFUSED marker=%s "
+                "reason=%s strict_redis_writer_required=true",
+                _MARKER,
+                reason,
+            )
+        return None
 
     def _publish_env(self, *, scope: str, generation_key: str, fallback: bool) -> None:
         now = str(time.time())
@@ -1475,17 +1410,26 @@ class EntrypointWriterAuthority:
                     )
                 )
             if heartbeat.is_alive():
-                logger.warning(
+                logger.critical(
                     "ENTRYPOINT_WRITER_AUTHORITY_RELEASE_HEARTBEAT_TIMEOUT marker=%s "
                     "reason=heartbeat_thread_still_alive_after_join "
-                    "proceeding_with_deletion=true stop_already_set=true",
+                    "deletion_skipped=true stop_already_set=true",
                     _MARKER,
                 )
-                # _stop is already set and the heartbeat will not reacquire the
-                # lock on its next iteration (see _heartbeat_tick).  The daemon
-                # thread will be killed when this process exits.  Proceed with
-                # compare-and-delete now so the successor instance can acquire
-                # without waiting for the full TTL to expire.
+                # Never delete a lease while its renewal thread may still be in
+                # flight.  Revoke local authority immediately and leave the
+                # Redis key to its TTL (or a later release after quiescence).
+                with self._state_lock:
+                    os.environ["NIJA_WRITER_LEASE_ACQUIRED"] = "0"
+                    os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "0"
+                    os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = "0"
+                    os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+                    os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
+                    os.environ.pop("NIJA_WRITER_GENERATION", None)
+                    os.environ.pop("NIJA_WRITER_FENCING_TOKEN_FALLBACK", None)
+                    os.environ.pop("NIJA_WRITER_LEASE_GENERATION", None)
+                self._notify_runtime_reconciliation("writer_release_heartbeat_not_quiesced")
+                return False
 
         with self._state_lock:
             released = False

--- a/bot/execution_authority_context.py
+++ b/bot/execution_authority_context.py
@@ -476,300 +476,39 @@ def _recover_fencing_token_from_lock(redis_url: str, lock_key: str) -> str:
 
 
 def assert_distributed_writer_authority() -> None:
-    """Fail closed when this process no longer owns the distributed writer lock.
+    """Require the exact canonical Redis process-writer proof.
 
-    Validation source:
-    - ``NIJA_WRITER_FENCING_TOKEN`` (set at startup when lock acquired)
-    - ``NIJA_WRITER_LOCK_KEY`` (or scoped default)
-    - Redis value at lock key must begin with the same token
-
-    Runtime cost is bounded by a short verification cache to avoid a Redis
-    round-trip on every order.
-
-    SAFETY CONTRACT
-    ---------------
-    This function enforces strict distributed fencing by default.  Three
-    operator-controlled bypass flags can override this behaviour when stale
-    locks from a previous Railway deployment are blocking startup:
-
-    - ``NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true``  — skip the check entirely
-      and proceed as the writer.  Use only when you are certain no other live
-      instance is running.
-    - ``NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true`` — fall back to local
-      writer authority when the distributed lock cannot be verified (missing
-      token, Redis unreachable, or fencing mismatch).
-    - ``NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK=true`` — attempt to delete the
-      stale Redis lock key before falling back, allowing this instance to
-      re-acquire it on the next heartbeat cycle.
-
-    All bypass paths emit a WARNING-level log so the operator is aware that
-    strict single-writer enforcement is not active.
+    This function is intentionally read-only with respect to Redis authority.
+    It never creates, renews, deletes, steals, or locally fabricates a writer
+    lease.  Missing or mismatched proof remains fail-closed.
     """
     global _FENCE_LAST_CHECK_TS, _FENCE_LAST_OK, _FENCE_LAST_ERR
 
-    import hashlib
-
-    # ── Operator bypass: skip the entire distributed check ────────────────────
-    if _env_truthy("NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK"):
-        logger.warning(
-            "STARTUP_OBSERVER_STANDBY: NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true — "
-            "skipping distributed writer authority check. "
-            "Proceeding as local writer. Ensure no other live instance is running."
-        )
-        with _FENCE_VERIFY_LOCK:
-            _FENCE_LAST_CHECK_TS = time.monotonic()
-            _FENCE_LAST_OK = True
-            _FENCE_LAST_ERR = ""
-        return
-
-    redis_url = get_redis_url()
-    scope = os.getenv("NIJA_WRITER_LOCK_SCOPE", "").strip()
-    if not scope:
-        raw = (
-            os.environ.get("KRAKEN_PLATFORM_API_KEY", "").strip()
-            or os.environ.get("KRAKEN_API_KEY", "").strip()
-            or "default"
-        )
-        scope = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-
-    lock_key = os.getenv("NIJA_WRITER_LOCK_KEY", "").strip() or f"nija:writer_lock:{scope}"
-
-    # Fencing token is mandatory unless the local-fallback bypass is active.
-    token = os.getenv("NIJA_WRITER_FENCING_TOKEN", "").strip()
-    if not token:
-        if _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
-            logger.warning(
-                "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-                "NIJA_WRITER_FENCING_TOKEN is not set but "
-                "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true — "
-                "using local writer fallback. Trading will proceed without "
-                "distributed lock verification."
-            )
-            with _FENCE_VERIFY_LOCK:
-                _FENCE_LAST_CHECK_TS = time.monotonic()
-                _FENCE_LAST_OK = True
-                _FENCE_LAST_ERR = ""
-            return
-        _err = (
-            "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-            "NIJA_WRITER_FENCING_TOKEN is not set. "
-            "Distributed writer authority requires a valid fencing token. "
-            "Ensure the bot acquired a Redis writer lease at startup. "
-            "Set NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true to use local fallback."
-        )
-        with _FENCE_VERIFY_LOCK:
-            _FENCE_LAST_CHECK_TS = time.monotonic()
-            _FENCE_LAST_OK = False
-            _FENCE_LAST_ERR = _err
-        raise RuntimeError(_err)
-
-    # Redis URL is mandatory unless the local-fallback bypass is active.
-    if not redis_url:
-        if _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
-            logger.warning(
-                "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-                "Redis URL is not configured but "
-                "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true — "
-                "using local writer fallback. Trading will proceed without "
-                "distributed lock verification."
-            )
-            with _FENCE_VERIFY_LOCK:
-                _FENCE_LAST_CHECK_TS = time.monotonic()
-                _FENCE_LAST_OK = True
-                _FENCE_LAST_ERR = ""
-            return
-        _err = (
-            "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-            "Redis URL is not configured. "
-            "Distributed writer authority requires Redis connectivity. "
-            "Set NIJA_REDIS_URL to a valid rediss:// endpoint or set "
-            "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true to use local fallback."
-        )
-        with _FENCE_VERIFY_LOCK:
-            _FENCE_LAST_CHECK_TS = time.monotonic()
-            _FENCE_LAST_OK = False
-            _FENCE_LAST_ERR = _err
-        raise RuntimeError(_err)
-
     try:
-        verify_ttl_s = max(0.0, float(os.getenv("NIJA_WRITER_RUNTIME_VERIFY_TTL_S", "1.5") or 1.5))
-    except (TypeError, ValueError):
-        verify_ttl_s = 1.5
-        logger.warning(
-            "Invalid NIJA_WRITER_RUNTIME_VERIFY_TTL_S value; using default %.1fs",
-            verify_ttl_s,
-        )
-    now = time.monotonic()
-    with _FENCE_VERIFY_LOCK:
-        if verify_ttl_s > 0 and (now - _FENCE_LAST_CHECK_TS) <= verify_ttl_s:
-            if _FENCE_LAST_OK:
-                return
-            cached_err = _FENCE_LAST_ERR or "distributed writer fence verification cached failure"
-            # Honour bypass flags even for cached failures so a flag change
-            # takes effect without waiting for the TTL to expire.
-            if _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
-                logger.warning(
-                    "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-                    "cached authority failure but NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true — "
-                    "using local writer fallback (cached_err=%s)",
-                    cached_err,
-                )
-                _FENCE_LAST_OK = True
-                _FENCE_LAST_ERR = ""
-                return
-            raise RuntimeError(cached_err)
-
-    try:
-        client = _connect_redis_for_authority(redis_url, timeout_s=2)
-        current = client.get(lock_key)
-        current_token = ""
-        if current is not None:
-            # decode_responses=True should give str, but guard against bytes
-            # in case a connection with different settings is reused.
-            if isinstance(current, bytes):
-                current = current.decode("utf-8", errors="replace")
-            if isinstance(current, str) and current:
-                current_token = current.split(":", 1)[0]
-
-        # ── Missing-key recovery ──────────────────────────────────────────────
-        # When the lock key is absent (expired TTL or transient Redis flush) but
-        # this process still holds the correct fencing token, attempt a one-shot
-        # atomic re-acquisition using SET NX.  This mirrors the heartbeat's own
-        # re-acquisition path and prevents a spurious hard-stop when the key
-        # simply expired between heartbeat renewals.
-        #
-        # Safety: SET NX is atomic — if another process wins the race it holds a
-        # different token and the subsequent comparison will still fail closed.
-        if current is None and token:
-            try:
-                # Use the same extended TTL as the heartbeat refresh (3× the base)
-                # so the lock stays alive until the next heartbeat cycle even if
-                # there is a brief gap between heartbeats.
-                ttl_s = max(
-                    60,
-                    int(os.getenv("NIJA_WRITER_LOCK_TTL_S", "30") or 30) * 3,
-                )
-                owner_id = os.getenv("NIJA_WRITER_OWNER_ID", "recovered")
-                lock_value = f"{token}:{owner_id}"
-                reacquired = client.set(lock_key, lock_value, ex=ttl_s, nx=True)
-                if reacquired:
-                    current_token = token
-                    logger.info(
-                        "assert_distributed_writer_authority: lock key was missing; "
-                        "re-acquired atomically with same fencing token "
-                        "(lock_key=%s token_prefix=%s ttl_s=%d) — likely TTL expiry, "
-                        "heartbeat will refresh TTL on next cycle",
-                        lock_key,
-                        token[:8],
-                        ttl_s,
-                    )
-                else:
-                    # Another process won the NX race — read back the new holder.
-                    new_current = client.get(lock_key)
-                    if new_current is not None:
-                        if isinstance(new_current, bytes):
-                            new_current = new_current.decode("utf-8", errors="replace")
-                        if isinstance(new_current, str) and new_current:
-                            current_token = new_current.split(":", 1)[0]
-            except Exception as _reacq_exc:
-                logger.warning(
-                    "assert_distributed_writer_authority: lock re-acquisition attempt failed: %s",
-                    _reacq_exc,
-                )
-
-        ok = (current_token == token)
-        err = ""
-        if not ok:
-            err = (
-                "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-                "another instance owns writer authority — "
-                f"expected_token={token} current_token={current_token or '<missing>'} "
-                f"lock_key={lock_key}"
+        try:
+            from bot.writer_authority_generation_convergence_v57_patch import (
+                _exact_process_writer,
             )
-
-            # ── Auto-clear stale lock ─────────────────────────────────────────
-            # When NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK=true, attempt to delete
-            # the stale lock so this instance can re-acquire it on the next
-            # heartbeat cycle.  Only safe when the operator is certain the
-            # previous holder is no longer running (e.g. after a Railway redeploy).
-            if _env_truthy("NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK"):
-                try:
-                    deleted = client.delete(lock_key)
-                    if deleted:
-                        logger.warning(
-                            "STARTUP_OBSERVER_STANDBY: NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK=true — "
-                            "deleted stale writer lock (lock_key=%s previous_token=%s). "
-                            "This instance will re-acquire the lock on the next heartbeat cycle.",
-                            lock_key,
-                            current_token or "<missing>",
-                        )
-                        # Treat as ok so this cycle can proceed; the heartbeat
-                        # will write a fresh lock entry with the current token.
-                        ok = True
-                        err = ""
-                    else:
-                        logger.warning(
-                            "STARTUP_OBSERVER_STANDBY: NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK=true — "
-                            "lock key already absent (lock_key=%s); proceeding.",
-                            lock_key,
-                        )
-                        ok = True
-                        err = ""
-                except Exception as _del_exc:
-                    logger.warning(
-                        "STARTUP_OBSERVER_STANDBY: NIJA_AUTO_CLEAR_STALE_RAILWAY_LOCK=true — "
-                        "failed to delete stale lock (lock_key=%s): %s",
-                        lock_key,
-                        _del_exc,
-                    )
-
-            # ── Local-fallback bypass ─────────────────────────────────────────
-            if not ok and _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
-                logger.warning(
-                    "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-                    "another instance owns writer authority but "
-                    "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true — "
-                    "using local writer fallback. "
-                    "Trading will proceed without distributed lock verification. "
-                    "(lock_key=%s expected_token=%s current_token=%s)",
-                    lock_key,
-                    token,
-                    current_token or "<missing>",
-                )
-                ok = True
-                err = ""
-
-        with _FENCE_VERIFY_LOCK:
-            _FENCE_LAST_CHECK_TS = time.monotonic()
-            _FENCE_LAST_OK = ok
-            _FENCE_LAST_ERR = err
-
-        if not ok:
-            raise RuntimeError(err)
-
-    except RuntimeError:
-        raise
+        except ImportError:
+            from writer_authority_generation_convergence_v57_patch import (  # type: ignore[import]
+                _exact_process_writer,
+            )
+        proof, reason = _exact_process_writer("execution_authority_context")
     except Exception as exc:
-        _err = (
-            "STARTUP_OBSERVER_STANDBY: STRICT_SINGLE_WRITER_REQUIRED: "
-            f"Redis execution authority unavailable — {exc}"
-        )
-        if _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"):
-            logger.warning(
-                "%s — NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK=true, using local writer fallback.",
-                _err,
-            )
-            with _FENCE_VERIFY_LOCK:
-                _FENCE_LAST_CHECK_TS = time.monotonic()
-                _FENCE_LAST_OK = True
-                _FENCE_LAST_ERR = ""
-            return
-        with _FENCE_VERIFY_LOCK:
-            _FENCE_LAST_CHECK_TS = time.monotonic()
-            _FENCE_LAST_OK = False
-            _FENCE_LAST_ERR = _err
-        raise RuntimeError(_err) from exc
+        proof = None
+        reason = f"exact_process_writer_error:{type(exc).__name__}:{exc}"
 
+    ok = proof is not None
+    error = "" if ok else (
+        "STRICT_SINGLE_WRITER_REQUIRED: exact process writer proof failed:"
+        f"{reason or 'unknown'}"
+    )
+    with _FENCE_VERIFY_LOCK:
+        _FENCE_LAST_CHECK_TS = time.monotonic()
+        _FENCE_LAST_OK = ok
+        _FENCE_LAST_ERR = error
+    if not ok:
+        raise RuntimeError(error)
 
 def get_distributed_writer_authority_status(force_refresh: bool = False) -> dict:
     """Return current distributed-writer ownership status for diagnostics.
@@ -1146,109 +885,16 @@ def _emit_trade_admission_telemetry(
 
 
 def _attempt_live_dispatch_commit_repair(reason: str) -> bool:
-    """Repair a stale startup-coordinator dispatch latch after LIVE activation.
-
-    A crash/exception between TradingStateMachine.transition_to(LIVE_ACTIVE) and
-    StartupCoordinator.finalize_activation_commit() can leave the runtime trading
-    FSM live while the coordinator still reports BOOT/WARM.  That makes the
-    lifecycle gate reject every order even though activation was already
-    committed.  Repair only when independent live-safety indicators agree that
-    the process is already live; the normal per-order gates below still validate
-    writer lease, nonce, heartbeat, broker health and circuit state.
-    """
-    trading_state = str(os.getenv("NIJA_RUNTIME_TRADING_STATE", "")).strip().upper()
-    runtime_exec = _env_truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY")
-    live_verified = _env_truthy("LIVE_CAPITAL_VERIFIED")
-    dry_run = _env_truthy("DRY_RUN_MODE") or _env_truthy("PAPER_MODE")
-    if trading_state != "LIVE_ACTIVE" or not runtime_exec or not live_verified or dry_run:
-        return False
-
-    try:
-        try:
-            from bot.kill_switch import get_kill_switch
-        except ImportError:
-            from kill_switch import get_kill_switch  # type: ignore[import]
-        if bool(get_kill_switch().is_active()):
-            return False
-    except Exception:
-        # If kill-switch state cannot be proven safe, do not repair the latch.
-        return False
-
-    try:
-        try:
-            from bot.startup_coordinator import get_startup_coordinator
-        except ImportError:
-            from startup_coordinator import get_startup_coordinator  # type: ignore[import]
-        coordinator = get_startup_coordinator()
-        before = coordinator.build_snapshot(
-            trading_state="LIVE_ACTIVE",
-            activation_intent=True,
-        )
-        if getattr(before, "lifecycle_phase", "") == "LIVE" and bool(getattr(before, "dispatch_enabled", False)):
-            return False
-        coordinator.force_activate_bypass(
-            f"live_dispatch_commit_repair:{reason}:previous_phase={getattr(before, 'lifecycle_phase', '<unknown>')}"
-        )
-        after = coordinator.build_snapshot(
-            trading_state="LIVE_ACTIVE",
-            activation_intent=True,
-        )
-        repaired = getattr(after, "lifecycle_phase", "") == "LIVE" and bool(getattr(after, "dispatch_enabled", False))
-        if repaired:
-            logger.critical(
-                "ExecutionAuthority: repaired stale startup-coordinator dispatch latch "
-                "after LIVE_ACTIVE commit (reason=%s previous_phase=%s)",
-                reason,
-                getattr(before, "lifecycle_phase", "<unknown>"),
-            )
-        return bool(repaired)
-    except Exception as exc:
-        logger.warning("ExecutionAuthority: live dispatch latch repair failed: %s", exc)
-        return False
+    """Do not manufacture lifecycle dispatch state from a downstream gate."""
+    logger.warning(
+        "ExecutionAuthority: dispatch latch remains fail-closed reason=%s "
+        "forced_activation=false",
+        reason,
+    )
+    return False
 
 def can_execute() -> ExecutionDecision:
     """Canonical execution authority decision for all order-dispatch paths."""
-    # ── FORCE_TRADE bypass: skip all authority gates ──────────────────────────
-    # When FORCE_TRADE=true or FORCE_TRADE_MODE=true, bypass the entire
-    # lifecycle/authority gate stack so orders can reach the exchange even when
-    # the startup coordinator has not yet committed to LIVE_ACTIVE.  This is the
-    # operator escape hatch for the "bot running but zero trades" deadlock caused
-    # by missing Redis fencing tokens or incomplete activation sequences.
-    _force_trade = (
-        _env_truthy("FORCE_TRADE") or _env_truthy("FORCE_TRADE_MODE")
-    )
-    if _force_trade:
-        logger.warning(
-            "[FORCE_TRADE] can_execute: bypassing all authority gates — "
-            "FORCE_TRADE/FORCE_TRADE_MODE=true. All lifecycle/lease/nonce/heartbeat "
-            "checks skipped. Orders will be submitted directly to exchange."
-        )
-        return ExecutionDecision(
-            allowed=True,
-            reason="force_trade_bypass",
-            circuit_state="CLOSED",
-            state_live_active=True,
-            lease_valid=True,
-            lease_generation_current=True,
-            nonce_ready=True,
-            heartbeat_fresh=True,
-            heartbeat_stage_sufficient=True,
-            broker_health_ok=True,
-            circuit_breaker_closed=True,
-            dispatch_enabled=True,
-            stability_allowed=True,
-            stability_halt_state="NORMAL",
-            stability_throttle=1.0,
-            stability_size_multiplier=1.0,
-            stability_stress_score=0.0,
-            stability_collapsed_risk_score=0.0,
-            stability_reason="force_trade_bypass",
-            first_failed_gate="",
-            reason_code="allowed",
-            reason_detail="force_trade_bypass",
-            lifecycle_phase="LIVE",
-        )
-
 
     runtime_snapshot = runtime_authority_snapshot()
 

--- a/bot/nija_core_loop.py
+++ b/bot/nija_core_loop.py
@@ -209,7 +209,61 @@ def _is_live_mode(existing_mode: Optional[RuntimeModeResolution] = None) -> bool
 
 
 def _env_truthy(name: str, default: str = "false") -> bool:
+    if name in {
+        "FORCE_TRADE",
+        "FORCE_TRADE_MODE",
+        "NIJA_FORCE_ACTIVATION",
+        "NIJA_SKIP_STARTUP_PHASE_GATE",
+        "NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK",
+        "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK",
+    }:
+        return False
     return os.getenv(name, default).strip().lower() in ("true", "1", "yes", "enabled", "on")
+
+
+def _require_exact_runtime_cycle_authority(source: str) -> tuple[bool, str]:
+    """Prove this process may run a live broker cycle without mutating authority.
+
+    Non-live modes retain their existing local test/paper behaviour.  Live mode
+    requires the canonical Redis process-writer proof, the explicit runtime
+    admission bit, and the completed bootstrap handoff.  This check performs no
+    broker I/O and never creates, steals, or deletes a lease.
+    """
+    if not _is_live_mode():
+        return True, "non_live_mode"
+
+    if os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0").strip() != "1":
+        return False, "runtime_execution_authority_not_granted"
+
+    try:
+        try:
+            from bot.writer_authority_generation_convergence_v57_patch import (
+                _exact_process_writer,
+            )
+        except ImportError:
+            from writer_authority_generation_convergence_v57_patch import (  # type: ignore[import]
+                _exact_process_writer,
+            )
+        proof, reason = _exact_process_writer(source)
+    except Exception as exc:
+        return False, f"exact_writer_proof_error:{type(exc).__name__}:{exc}"
+    if proof is None:
+        return False, f"exact_writer_proof_failed:{reason or 'unknown'}"
+
+    try:
+        try:
+            from bot.bootstrap_state_machine import BootstrapState, get_bootstrap_fsm
+        except ImportError:
+            from bootstrap_state_machine import BootstrapState, get_bootstrap_fsm  # type: ignore[import]
+        fsm = get_bootstrap_fsm()
+        if not bool(fsm.execution_authority):
+            return False, "bootstrap_execution_authority_not_granted"
+        if fsm.state != BootstrapState.RUNNING_SUPERVISED:
+            return False, f"bootstrap_state_not_supervised:{fsm.state.value}"
+    except Exception as exc:
+        return False, f"bootstrap_authority_probe_failed:{type(exc).__name__}:{exc}"
+
+    return True, "exact_writer_and_bootstrap_authority_proven"
 
 
 def _watchdog_backoff_delay(base_s: float, retries: int, enabled: bool, max_multiplier: float) -> float:
@@ -260,6 +314,7 @@ class CycleSnapshot:
     # existing call-sites that build CycleSnapshot without them still work) ---
     cycle_id: str = ""
     ca_is_hydrated: bool = False
+    ca_is_fresh: bool = False
     ca_total_capital: float = 0.0
     ca_valid_brokers: int = 0
     mabm_brokers_ready: bool = False
@@ -269,7 +324,8 @@ class CycleSnapshot:
     is_post_hydration: bool = False
     # Capital snapshot lineage metadata propagated from _capture_cycle_capital_state().
     snapshot_source: str = "placeholder"
-    aggregation_normalized: bool = True
+    aggregation_normalized: bool = False
+    capital_sync_failed: bool = True
 
 # ---------------------------------------------------------------------------
 # Trading state machine + CapitalAuthority — optional; graceful fallback
@@ -396,12 +452,13 @@ def _capture_cycle_capital_state() -> _types.MappingProxyType:
     """
     result: Dict[str, Any] = {
         "ca_is_hydrated": False,
+        "ca_is_fresh": False,
         "ca_total_capital": 0.0,
         "ca_valid_brokers": 0,
         "mabm_brokers_ready": False,
         "is_post_hydration": False,
         "snapshot_source": "placeholder",
-        "aggregation_normalized": True,  # default True (safe: don't block when unknown)
+        "aggregation_normalized": False,
         "sync_failed": False,            # set True below on unexpected read errors
     }
 
@@ -410,7 +467,11 @@ def _capture_cycle_capital_state() -> _types.MappingProxyType:
         try:
             _ca = _get_ca()
             result["ca_is_hydrated"] = bool(_ca.is_hydrated)
+            result["ca_is_fresh"] = bool(_ca.is_fresh())
             result["ca_total_capital"] = float(getattr(_ca, "total_capital", 0.0) or 0.0)
+            result["ca_valid_brokers"] = int(
+                getattr(_ca, "valid_broker_count", 0) or 0
+            )
         except Exception as _ce:
             result["sync_failed"] = True
             logger.warning(
@@ -441,33 +502,17 @@ def _capture_cycle_capital_state() -> _types.MappingProxyType:
         # "_capital_last_valid_brokers" only advances when refresh_capital_authority()
         # confirms viable broker balance payloads.
         _last_vb = int(getattr(_mabm_inst, "_capital_last_valid_brokers", 0) or 0) if _mabm_inst is not None else 0
-        # FIX: When _capital_last_valid_brokers is still 0 (coordinator has not
-        # yet confirmed viable broker payloads) but CapitalAuthority is already
-        # hydrated with real capital, fall back to CA's registered_broker_count.
-        # This prevents a startup deadlock where the activation invariant sees
-        # valid_brokers=0 and snapshot_source="placeholder" even though both
-        # brokers are connected and CA holds a real balance snapshot.
-        if _last_vb == 0 and result.get("ca_is_hydrated") and result.get("ca_total_capital", 0.0) > 0.0:
-            try:
-                if _CA_LOOP_AVAILABLE and _get_ca is not None:
-                    _ca_for_vb = _get_ca()
-                    _ca_broker_count = int(getattr(_ca_for_vb, "registered_broker_count", 0) or 0)
-                    if _ca_broker_count > 0:
-                        _last_vb = _ca_broker_count
-                        logger.info(
-                            "_capture_cycle_capital_state: _capital_last_valid_brokers=0 but "
-                            "CA is hydrated (real=$%.2f, brokers=%d) — using CA registered_broker_count "
-                            "as valid_brokers fallback",
-                            result["ca_total_capital"],
-                            _ca_broker_count,
-                        )
-            except Exception as _ca_vb_err:
-                logger.debug(
-                    "_capture_cycle_capital_state: CA registered_broker_count fallback failed: %s",
-                    _ca_vb_err,
-                )
         result["ca_valid_brokers"] = max(result["ca_valid_brokers"], _last_vb)
-        result["snapshot_source"] = "live_exchange" if _last_vb > 0 else "placeholder"
+        _capital_authoritative = bool(
+            result.get("ca_is_hydrated")
+            and result.get("ca_is_fresh")
+            and float(result.get("ca_total_capital", 0.0) or 0.0) > 0.0
+            and int(result.get("ca_valid_brokers", 0) or 0) > 0
+            and not result.get("sync_failed")
+        )
+        result["snapshot_source"] = (
+            "capital_authority" if _capital_authoritative else "placeholder"
+        )
     except Exception as _me:
         result["sync_failed"] = True
         logger.warning(
@@ -541,12 +586,13 @@ def _capture_cycle_capital_state() -> _types.MappingProxyType:
             result["aggregation_normalized"] = True
     except Exception as _agg_err:
         logger.debug("_capture_cycle_capital_state: aggregation check failed: %s", _agg_err)
-        # Default already True — don't block on unexpected errors in the check itself.
+        result["aggregation_normalized"] = False
 
     logger.critical(
-        "CYCLE_CAPITAL_SNAPSHOT | ca_hydrated=%s | total=%.8f | valid_brokers=%s | "
+        "CYCLE_CAPITAL_SNAPSHOT | ca_hydrated=%s | ca_fresh=%s | total=%.8f | valid_brokers=%s | "
         "mabm_ready=%s | source=%s | aggregation_normalized=%s | sync_failed=%s",
         result.get("ca_is_hydrated"),
+        result.get("ca_is_fresh"),
         float(result.get("ca_total_capital", 0.0) or 0.0),
         result.get("ca_valid_brokers"),
         result.get("mabm_brokers_ready"),
@@ -894,6 +940,9 @@ CYCLE_SUMMARY_INTERVAL: int = int(os.environ.get("NIJA_CYCLE_SUMMARY_INTERVAL", 
 # concurrent callers.
 FORCE_NEXT_CYCLE: bool = False
 _FORCE_LOCK = threading.Lock()
+# Production safety invariant: no timer, environment flag, or idle-mode helper
+# may manufacture a trade or bypass the normal signal-quality gates.
+FORCED_ENTRY_MODES_ENABLED: bool = False
 
 
 def _get_relaxation_factor(streak: int) -> float:
@@ -902,7 +951,7 @@ def _get_relaxation_factor(streak: int) -> float:
     Returns 0.0 when below FORCED_ENTRY_STREAK_THRESHOLD.
     Caps at _RELAXATION_SCHEDULE[MAX_RELAXATION_STEPS] = 0.60.
     """
-    if streak < FORCED_ENTRY_STREAK_THRESHOLD:
+    if not FORCED_ENTRY_MODES_ENABLED or streak < FORCED_ENTRY_STREAK_THRESHOLD:
         return 0.0
     return _RELAXATION_SCHEDULE[_get_relaxation_step(streak)]
 
@@ -913,7 +962,7 @@ def _get_relaxation_step(streak: int) -> int:
     step 1 → streak 2–4, step 2 → streak 5–7, step 3 → streak ≥ 8 (cap).
     Returns 0 when below FORCED_ENTRY_STREAK_THRESHOLD.
     """
-    if streak < FORCED_ENTRY_STREAK_THRESHOLD:
+    if not FORCED_ENTRY_MODES_ENABLED or streak < FORCED_ENTRY_STREAK_THRESHOLD:
         return 0
     cycles_past = streak - FORCED_ENTRY_STREAK_THRESHOLD
     return min(MAX_RELAXATION_STEPS, cycles_past // 3 + 1)
@@ -921,6 +970,8 @@ def _get_relaxation_step(streak: int) -> int:
 
 def _get_relaxation_factor_with_threshold(streak: int, threshold: int) -> float:
     """Variant of _get_relaxation_factor that accepts a custom streak threshold."""
+    if not FORCED_ENTRY_MODES_ENABLED:
+        return 0.0
     if streak < threshold:
         return 0.0
     cycles_past = streak - threshold
@@ -930,6 +981,8 @@ def _get_relaxation_factor_with_threshold(streak: int, threshold: int) -> float:
 
 def _get_relaxation_step_with_threshold(streak: int, threshold: int) -> int:
     """Variant of _get_relaxation_step that accepts a custom streak threshold."""
+    if not FORCED_ENTRY_MODES_ENABLED:
+        return 0
     if streak < threshold:
         return 0
     cycles_past = streak - threshold
@@ -1438,6 +1491,19 @@ class NijaCoreLoop:
         -------
         CoreLoopResult with entries taken, next recommended interval, etc.
         """
+        _authority_ok, _authority_reason = _require_exact_runtime_cycle_authority(
+            "nija_core_loop.run_scan_phase"
+        )
+        if not _authority_ok:
+            logger.critical(
+                "SCAN_AUTHORITY_BLOCKED reason=%s broker_io=false exits=false entries=false",
+                _authority_reason,
+            )
+            return CoreLoopResult(
+                entries_blocked=1,
+                errors=[f"runtime_authority_blocked:{_authority_reason}"],
+            )
+
         # ── Broker resolution: fall back to apex.broker_client when the
         # caller did not pass an explicit broker (or passed None).  This
         # covers the common case where run_scan_phase is called from
@@ -1457,11 +1523,49 @@ class NijaCoreLoop:
             )
             return CoreLoopResult()
 
+        if not self._first_scan_started_logged:
+            self._first_scan_started_logged = True
+            logger.critical(
+                "FIRST_SCAN_STARTED symbols_requested=%d broker=%s authority=exact",
+                len(symbols),
+                type(broker).__name__,
+            )
+            try:
+                from bot.entrypoint_writer_authority import get_entrypoint_writer_authority
+
+                get_entrypoint_writer_authority().record_scan_started()
+            except Exception as exc:
+                logger.warning("FIRST_SCAN_STARTED authority telemetry failed: %s", exc)
+
         result = CoreLoopResult()
         cycle_start = time.time()
         _stage_start = cycle_start
         _stage_reason = "ok"
         _gate_rejections: Dict[str, int] = {}
+
+        # Do not spend minutes building or probing an entry universe while the
+        # capital snapshot is unavailable.  Phase 2 exit management does not
+        # need the entry symbol list and still runs below for the exact writer.
+        _pre_cap = _current_cycle_capital
+        _pre_entry_capital_ready = bool(
+            _pre_cap.get("ca_is_hydrated", False)
+            and _pre_cap.get("ca_is_fresh", False)
+            and float(_pre_cap.get("ca_total_capital", 0.0) or 0.0) > 0.0
+            and int(_pre_cap.get("ca_valid_brokers", 0) or 0) > 0
+            and _pre_cap.get("is_post_hydration", False)
+            and _pre_cap.get("aggregation_normalized", False)
+            and not _pre_cap.get("sync_failed", True)
+            and str(_pre_cap.get("snapshot_source", "placeholder"))
+            in {"live_exchange", "capital_authority"}
+        )
+        if not _pre_entry_capital_ready:
+            requested_symbols = len(symbols)
+            symbols = []
+            logger.critical(
+                "ENTRY_SCAN_UNIVERSE_SKIPPED requested_symbols=%d "
+                "reason=capital_authority_not_ready exits_preserved=true",
+                requested_symbols,
+            )
 
         # ── Scan-size throttling ──────────────────────────────────────────
         # Cap the symbol universe to NIJA_MAX_SCAN_SYMBOLS (default 100) to
@@ -1541,71 +1645,54 @@ class NijaCoreLoop:
             f"cycle-{time.strftime('%Y%m%dT%H%M%S', time.gmtime())}-scan"
         )
         _ca_hydrated = bool(_cap.get("ca_is_hydrated", False))
+        _ca_is_fresh = bool(_cap.get("ca_is_fresh", False))
         _ca_total_capital = float(_cap.get("ca_total_capital", 0.0) or 0.0)
         _ca_valid_brokers = int(_cap.get("ca_valid_brokers", 0) or 0)
         _ca_snapshot_source = str(_cap.get("snapshot_source", "placeholder") or "placeholder")
+        _ca_sync_failed = bool(_cap.get("sync_failed", True))
+        _entry_capital_ready = bool(
+            _ca_hydrated
+            and _ca_is_fresh
+            and _ca_total_capital > 0.0
+            and _ca_valid_brokers > 0
+            and bool(_cap.get("is_post_hydration", False))
+            and bool(_cap.get("aggregation_normalized", False))
+            and not _ca_sync_failed
+            and _ca_snapshot_source in {"live_exchange", "capital_authority"}
+        )
 
-        # ── Balance hydration waterfall ───────────────────────────────────
-        # Priority order (highest → lowest):
-        #   1. CA total capital (when hydrated AND non-zero)
-        #   2. Caller-supplied balance (when non-zero)
-        #   3. Broker cached balance (non-blocking attribute probe)
-        #   4. broker.get_balance() live fetch (only when all above are zero)
-        #   5. NIJA_FORCE_TRADE_BALANCE env var (operator override)
-        #
-        # The original logic used `_ca_total_capital if _ca_hydrated else balance`
-        # which caused $0.00 snapshots whenever CA was hydrated but reported
-        # zero capital — a common race condition at startup.
+        # CapitalAuthority is the only source that may authorize entries.  A
+        # caller or broker cache may still value existing positions so the
+        # legitimate writer can protect exits while CA is recovering, but it
+        # can never make Phase 3 entry-capable.
         _caller_balance = float(balance) if balance else 0.0
-        _balance_source = "unknown"
-
-        if _ca_hydrated and _ca_total_capital > 0.0:
+        if _entry_capital_ready:
             _canonical_balance = _ca_total_capital
             _balance_source = "ca_total_capital"
         elif _caller_balance > 0.0:
             _canonical_balance = _caller_balance
-            _balance_source = "caller_supplied"
+            _balance_source = "caller_supplied_exit_valuation_only"
         else:
-            # CA is not hydrated or reports zero AND caller supplied zero —
-            # attempt broker cached-attribute probe (non-blocking).
             _broker_cached = _extract_cached_balance_for_log(broker) if broker is not None else 0.0
-            if _broker_cached > 0.0:
-                _canonical_balance = _broker_cached
-                _balance_source = "broker_cached_attr"
-            else:
-                # Last resort: live broker.get_balance() call.
-                _broker_live = 0.0
-                try:
-                    if broker is not None and hasattr(broker, "get_balance"):
-                        _raw_bal = broker.get_balance()
-                        if isinstance(_raw_bal, dict):
-                            for _k in ("total_balance", "balance", "usd_balance", "equity", "total_usd", "available_usd"):
-                                if _k in _raw_bal and float(_raw_bal[_k] or 0.0) > 0.0:
-                                    _broker_live = float(_raw_bal[_k])
-                                    break
-                        elif _raw_bal is not None:
-                            _broker_live = float(_raw_bal or 0.0)
-                except Exception as _bal_err:
-                    logger.warning("[NIJA] broker.get_balance() failed during balance hydration: %s", _bal_err)
+            _canonical_balance = max(0.0, float(_broker_cached or 0.0))
+            _balance_source = (
+                "broker_cached_exit_valuation_only"
+                if _canonical_balance > 0.0
+                else "no_exit_valuation_balance"
+            )
 
-                if _broker_live > 0.0:
-                    _canonical_balance = _broker_live
-                    _balance_source = "broker_get_balance"
-                else:
-                    # Final fallback: NIJA_FORCE_TRADE_BALANCE env var.
-                    _env_balance_str = os.environ.get("NIJA_FORCE_TRADE_BALANCE", "").strip()
-                    _env_balance = 0.0
-                    try:
-                        _env_balance = float(_env_balance_str) if _env_balance_str else 0.0
-                    except (TypeError, ValueError):
-                        pass
-                    if _env_balance > 0.0:
-                        _canonical_balance = _env_balance
-                        _balance_source = "NIJA_FORCE_TRADE_BALANCE_env"
-                    else:
-                        # All sources exhausted — use zero and log loudly.
-                        _canonical_balance = 0.0
-                        _balance_source = "all_sources_zero"
+        if not _entry_capital_ready:
+            user_mode = True
+            logger.critical(
+                "CAPITAL_ENTRY_SCAN_BLOCKED exits_preserved=true ca_hydrated=%s "
+                "ca_fresh=%s ca_total=$%.2f valid_brokers=%d source=%s sync_failed=%s",
+                _ca_hydrated,
+                _ca_is_fresh,
+                _ca_total_capital,
+                _ca_valid_brokers,
+                _ca_snapshot_source,
+                _ca_sync_failed,
+            )
 
         # ── [NIJA-PRINT] BALANCE SNAPSHOT ────────────────────────────────
         print(
@@ -1614,65 +1701,27 @@ class NijaCoreLoop:
             f"canonical_balance=${_canonical_balance:.2f} "
             f"source={_balance_source} "
             f"ca_hydrated={_ca_hydrated} "
+            f"ca_fresh={_ca_is_fresh} "
             f"ca_total_capital=${_ca_total_capital:.2f} "
             f"caller_balance=${_caller_balance:.2f} "
-            f"NIJA_FORCE_TRADE_BALANCE={os.environ.get('NIJA_FORCE_TRADE_BALANCE', 'unset')}",
+            f"entry_capital_ready={_entry_capital_ready}",
             flush=True,
         )
         logger.critical(
             "[NIJA] BALANCE SNAPSHOT | cycle_id=%s canonical=$%.2f source=%s "
-            "ca_hydrated=%s ca_total_capital=$%.2f ca_valid_brokers=%d snapshot_source=%s "
-            "caller_balance=$%.2f NIJA_FORCE_TRADE_BALANCE=%s",
+            "ca_hydrated=%s ca_fresh=%s ca_total_capital=$%.2f "
+            "ca_valid_brokers=%d snapshot_source=%s caller_balance=$%.2f "
+            "entry_capital_ready=%s",
             _cid,
             _canonical_balance,
             _balance_source,
             _ca_hydrated,
+            _ca_is_fresh,
             _ca_total_capital,
             _ca_valid_brokers,
             _ca_snapshot_source,
             _caller_balance,
-            os.environ.get("NIJA_FORCE_TRADE_BALANCE", "unset"),
-        )
-
-        # Canonical balance source-of-truth:
-        # - Once CA is hydrated AND reports a positive balance, use CA capital.
-        # - If CA is hydrated but reports $0.00, fall back to caller-supplied
-        #   balance so a stale/un-published CA snapshot does not zero-out the
-        #   capital gate and block all orders.
-        # - Before hydration, always use caller-supplied balance.
-        # - If all sources are zero and FORCE_TRADE is active, try the broker
-        #   cache directly, then the NIJA_FORCE_TRADE_BALANCE env override.
-        _caller_balance = float(balance) if balance else 0.0
-        if _ca_hydrated and _ca_total_capital > 0.0:
-            _canonical_balance = _ca_total_capital
-        elif _caller_balance > 0.0:
-            _canonical_balance = _caller_balance
-        else:
-            # Last-resort: try broker cached balance then env override
-            _broker_cached = _extract_cached_balance_for_log(broker) if broker is not None else 0.0
-            _env_override = float(os.getenv("NIJA_FORCE_TRADE_BALANCE", "0") or 0)
-            _canonical_balance = _broker_cached or _env_override or 0.0
-            if _canonical_balance > 0.0:
-                print(
-                    f"[NIJA-PRINT] BALANCE HYDRATION FALLBACK | "
-                    f"ca_hydrated={_ca_hydrated} ca_total=${_ca_total_capital:.2f} "
-                    f"caller=${_caller_balance:.2f} broker_cached=${_broker_cached:.2f} "
-                    f"env_override=${_env_override:.2f} → using=${_canonical_balance:.2f}",
-                    flush=True,
-                )
-            else:
-                print(
-                    f"[NIJA-PRINT] BALANCE ZERO WARNING | "
-                    f"ca_hydrated={_ca_hydrated} ca_total=${_ca_total_capital:.2f} "
-                    f"caller=${_caller_balance:.2f} broker_cached=${_broker_cached:.2f} "
-                    f"env_override=${_env_override:.2f} — all sources zero, capital gate will block",
-                    flush=True,
-                )
-        print(
-            f"[NIJA-PRINT] BALANCE SNAPSHOT | "
-            f"ca_hydrated={_ca_hydrated} ca_total=${_ca_total_capital:.2f} "
-            f"caller=${_caller_balance:.2f} canonical=${_canonical_balance:.2f}",
-            flush=True,
+            _entry_capital_ready,
         )
         snapshot = CycleSnapshot(
             balance=_canonical_balance,
@@ -1681,12 +1730,14 @@ class NijaCoreLoop:
             open_positions=open_positions_count,
             cycle_id=_cid,
             ca_is_hydrated=_ca_hydrated,
+            ca_is_fresh=_ca_is_fresh,
             ca_total_capital=_ca_total_capital,
             ca_valid_brokers=int(_cap.get("ca_valid_brokers", 0)),
             mabm_brokers_ready=bool(_cap.get("mabm_brokers_ready", False)),
             is_post_hydration=bool(_cap.get("is_post_hydration", False)),
             snapshot_source=str(_cap.get("snapshot_source", "placeholder") or "placeholder"),
-            aggregation_normalized=bool(_cap.get("aggregation_normalized", True)),
+            aggregation_normalized=bool(_cap.get("aggregation_normalized", False)),
+            capital_sync_failed=_ca_sync_failed,
         )
 
         # Publish the fully-constructed snapshot so that CapitalAllocationBrain
@@ -1792,7 +1843,12 @@ class NijaCoreLoop:
                 from always_trade_mode import get_always_trade_mode  # type: ignore
             except ImportError:
                 get_always_trade_mode = None  # type: ignore
-        if get_always_trade_mode is not None:
+        if (
+            FORCED_ENTRY_MODES_ENABLED
+            and get_always_trade_mode is not None
+            and _entry_capital_ready
+            and not user_mode
+        ):
             try:
                 _atm_decision = get_always_trade_mode().run_pre_cycle_check(
                     user_mode=user_mode,
@@ -1857,7 +1913,7 @@ class NijaCoreLoop:
         # Determine runtime context for telemetry (best-effort)
         _rt_state = "LIVE_ACTIVE"
         _rt_authority = int(
-            str(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")).strip() or "1"
+            str(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")).strip() or "0"
         )
         try:
             from bot.trading_state_machine import TradingStateMachine  # type: ignore
@@ -1871,7 +1927,7 @@ class NijaCoreLoop:
         _effective_user_mode = user_mode or not _md_new_entry_allowed
 
         # ── ENTRY_GATE: consolidated diagnostic log (every cycle) ─────────────
-        _entry_gate_capital_ready = _canonical_balance > 0.0
+        _entry_gate_capital_ready = _entry_capital_ready
         _entry_gate_scan_ready = len(symbols) > 0
         _entry_gate_entry_enabled = not _effective_user_mode
         logger.critical(
@@ -2078,24 +2134,13 @@ class NijaCoreLoop:
             0,
             _signals_generated - int(result.candidates_selected or 0),
         )
-        if not self._first_scan_started_logged:
-            self._first_scan_started_logged = True
-            logger.critical(
-                "FIRST_SCAN_STARTED symbols_scanned=%d markets_loaded=%d",
-                len(symbols),
-                _universe_tradeable,
-            )
+        if not self._first_scan_completed_logged:
+            self._first_scan_completed_logged = True
             logger.critical(
                 "FIRST_MARKET_SCAN symbols_scanned=%d markets_loaded=%d",
                 len(symbols),
                 _universe_tradeable,
             )
-            try:
-                from bot.entrypoint_writer_authority import get_entrypoint_writer_authority
-
-                get_entrypoint_writer_authority().record_scan_started()
-            except Exception:
-                pass
         if not self._first_signal_evaluated_logged:
             self._first_signal_evaluated_logged = True
             logger.critical(
@@ -2588,7 +2633,10 @@ class NijaCoreLoop:
         # Dead-zone flag: volume fallback and Momentum-Only Entry Mode are
         # always active once zero_signal_streak reaches DEAD_ZONE_STREAK_THRESHOLD,
         # regardless of profit-mode level.
-        _dead_zone = zero_signal_streak >= DEAD_ZONE_STREAK_THRESHOLD
+        _dead_zone = bool(
+            FORCED_ENTRY_MODES_ENABLED
+            and zero_signal_streak >= DEAD_ZONE_STREAK_THRESHOLD
+        )
         _fallback_admission_active = (
             _dead_zone
             or _get_relaxation_factor_with_threshold(
@@ -2602,6 +2650,8 @@ class NijaCoreLoop:
                 "enabling momentum-only entry mode + volume fallback",
                 zero_signal_streak, DEAD_ZONE_STREAK_THRESHOLD,
             )
+        if not FORCED_ENTRY_MODES_ENABLED:
+            _volume_fallback_enabled = False
 
         ai = self._get_ai_engine()
         if ai is not None and _PMC_AVAILABLE and _get_pmc is not None:
@@ -3452,9 +3502,8 @@ class NijaCoreLoop:
         # could be armed yet never produce a tradable candidate.
         global FORCE_NEXT_CYCLE
         with _FORCE_LOCK:
-            _force_this_cycle = FORCE_NEXT_CYCLE
-            if _force_this_cycle:
-                FORCE_NEXT_CYCLE = False  # reset atomically — one-shot only
+            _force_this_cycle = bool(FORCED_ENTRY_MODES_ENABLED and FORCE_NEXT_CYCLE)
+            FORCE_NEXT_CYCLE = False
         if _force_this_cycle:
             _volume_fallback_enabled = True
 
@@ -3710,7 +3759,7 @@ class NijaCoreLoop:
 
         # ── Hard bypass: consecutive zero-signal cycles → accept best available ──
         # Threshold uses profit mode value so Level 2/3 bypass sooner.
-        if zero_signal_streak >= _effective_bypass_threshold:
+        if FORCED_ENTRY_MODES_ENABLED and zero_signal_streak >= _effective_bypass_threshold:
             if not selected and candidates:
                 # Quality floors filtered everything — pick the single best candidate
                 top_candidate = max(candidates, key=lambda s: s.composite_score)
@@ -6065,47 +6114,19 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
     )
 
     if _live_verified and not TRADING_ENGINE_READY.is_set():
-        logger.critical(
-            "LIVE_CAPITAL_VERIFIED=true detected — bypassing passive activation wait gate"
+        _start_authority_ok, _start_authority_reason = (
+            _require_exact_runtime_cycle_authority("nija_core_loop.start_gate")
         )
-        TRADING_ENGINE_READY.set()
-
-    # ── Capital-hydration auto-start: when CAPITAL_HYDRATED_EVENT is already
-    # set (capital authority confirmed real funds before this thread started)
-    # and no simulation flags are present, release the gate immediately rather
-    # than waiting up to NIJA_START_GATE_TIMEOUT_S for the bootstrap FSM to
-    # fire it.  This closes the gap where a Coinbase-only deployment without
-    # LIVE_CAPITAL_VERIFIED in the environment would always stall for 120 s.
-    if (
-        not TRADING_ENGINE_READY.is_set()
-        and _CAPITAL_HYDRATED_EVENT is not None
-        and _CAPITAL_HYDRATED_EVENT.is_set()
-        and not _env_truthy("DRY_RUN_MODE")
-        and not _env_truthy("PAPER_MODE")
-    ):
-        logger.critical(
-            "CAPITAL_HYDRATED_EVENT is set and no simulation flags detected — "
-            "releasing TRADING_ENGINE_READY start gate (capital-hydration auto-start)"
-        )
-        print(
-            "[INIT STEP 1/6] CAPITAL_HYDRATED_EVENT auto-start: releasing TRADING_ENGINE_READY",
-            flush=True,
-        )
-        TRADING_ENGINE_READY.set()
-
-    # ── FORCE_TRADE: set the start gate at runtime so the trading loop never
-    # waits for the bootstrap FSM when an operator override flag is active.
-    # Evaluated here (not at module load time) so the environment variable is
-    # read when the loop actually starts, not when the module is imported.
-    if not TRADING_ENGINE_READY.is_set() and (
-        os.environ.get("FORCE_TRADE", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-        or os.environ.get("FORCE_TRADE_MODE", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-    ):
-        logger.warning(
-            "⚡ FORCE_TRADE: TRADING_ENGINE_READY set at runtime (run_trading_loop entry) — "
-            "trading loop will not wait for bootstrap FSM"
-        )
-        TRADING_ENGINE_READY.set()
+        if _start_authority_ok:
+            logger.critical(
+                "LIVE_CAPITAL_VERIFIED=true with exact runtime authority — releasing start gate"
+            )
+            TRADING_ENGINE_READY.set()
+        else:
+            logger.critical(
+                "LIVE_CAPITAL_VERIFIED=true but start gate remains closed reason=%s",
+                _start_authority_reason,
+            )
 
     # ── STEP 2: Wait for TRADING_ENGINE_READY with hard total timeout ─────────
     # The wait loop previously had no total deadline — it would spin forever
@@ -6124,31 +6145,39 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
             if _SM_AVAILABLE and _get_state_machine is not None:
                 _wait_sm = _get_state_machine()
                 if _wait_sm.is_live_trading_active():
-                    logger.critical(
-                        "LIVE_ACTIVE detected while waiting for TRADING_ENGINE_READY — releasing start gate"
+                    _wait_authority_ok, _wait_authority_reason = (
+                        _require_exact_runtime_cycle_authority(
+                            "nija_core_loop.start_gate_wait"
+                        )
                     )
-                    TRADING_ENGINE_READY.set()
-                    break
+                    if _wait_authority_ok:
+                        logger.critical(
+                            "LIVE_ACTIVE with exact runtime authority — releasing start gate"
+                        )
+                        TRADING_ENGINE_READY.set()
+                        break
+                    logger.critical(
+                        "LIVE_ACTIVE observed but start gate remains closed reason=%s",
+                        _wait_authority_reason,
+                    )
         except Exception as _wait_gate_err:
             logger.debug("TRADING_ENGINE_READY wait probe failed: %s", _wait_gate_err)
 
-        # Hard total timeout: force-set the event and proceed rather than
-        # hanging forever when bootstrap FSM never fires the signal.
+        # A missing bootstrap signal is an authority failure, not permission to
+        # manufacture readiness.  Stop this worker and let the supervisor retry.
         if _elapsed_gate >= _start_gate_max_s:
             logger.critical(
-                "⚡ [INIT STEP 2/6] TRADING_ENGINE_READY hard timeout reached after %.0fs "
-                "(iter=%d) — force-setting start gate to unblock trading loop. "
-                "Set NIJA_START_GATE_TIMEOUT_S to adjust (default 120s).",
+                "🚫 [INIT STEP 2/6] TRADING_ENGINE_READY timeout after %.0fs "
+                "(iter=%d) — trading worker remains fail-closed",
                 _elapsed_gate,
                 _start_gate_iters,
             )
-            print(
-                f"[INIT STEP 2/6] HARD TIMEOUT: force-setting TRADING_ENGINE_READY after "
-                f"{_elapsed_gate:.0f}s (iter={_start_gate_iters})",
-                flush=True,
-            )
-            TRADING_ENGINE_READY.set()
-            break
+            if _loop_guard.acquire(timeout=5):
+                try:
+                    _loop_running = False
+                finally:
+                    _loop_guard.release()
+            return
 
         if not TRADING_ENGINE_READY.wait(timeout=30):
             logger.critical(
@@ -6190,85 +6219,34 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
     if get_bootstrap_fsm is not None:
         _bfsm_ea = get_bootstrap_fsm()
         if not _bfsm_ea.execution_authority:
-            # Fallback: if execution_authority was not set by the normal bootstrap
-            # path (e.g. finalize_boot() was skipped), set it now using the fencing
-            # token which is already validated.  This prevents a crash when the FSM
-            # reaches RUNNING_SUPERVISED but execution_authority was not latched.
-            _ft = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
-            if _ft and hasattr(_bfsm_ea, "_execution_authority"):
-                logger.warning(
-                    "execution_authority not set after bootstrap — applying fencing-token "
-                    "fallback (token_prefix=%s) to unblock strategy loop",
-                    _ft[:8],
-                )
-                _bfsm_ea._execution_authority = True
-            elif hasattr(_bfsm_ea, "_execution_authority"):
-                # No fencing token (Redis not configured or distributed lock not acquired).
-                # FORCE_TRADE / NIJA_FORCE_ACTIVATION bypass: grant execution authority
-                # directly so the trading loop is not permanently blocked in deployments
-                # that do not use Redis-based distributed locking.
-                _force_bypass_ea = (
-                    os.environ.get("FORCE_TRADE", "").strip().lower()
-                    in ("1", "true", "yes", "on", "enabled")
-                    or os.environ.get("NIJA_FORCE_ACTIVATION", "").strip().lower()
-                    in ("1", "true", "yes", "on", "enabled")
-                    or os.environ.get("NIJA_SKIP_STARTUP_PHASE_GATE", "").strip().lower()
-                    in ("1", "true", "yes", "on", "enabled")
-                )
-                if _force_bypass_ea:
-                    logger.warning(
-                        "⚡ execution_authority not set and no fencing token present — "
-                        "force flag active, granting execution authority directly to unblock "
-                        "trading loop (FORCE_TRADE / NIJA_FORCE_ACTIVATION / NIJA_SKIP_STARTUP_PHASE_GATE)"
-                    )
-                    _bfsm_ea._execution_authority = True
-                else:
-                    logger.critical(
-                        "🚫 execution_authority not set and no fencing token present — "
-                        "trading loop cannot start. Set FORCE_TRADE=true to bypass, or "
-                        "configure Redis for distributed locking."
-                    )
-                    if _loop_guard.acquire(timeout=5):
-                        try:
-                            _loop_running = False
-                        finally:
-                            _loop_guard.release()
-                    return
-            else:
-                logger.critical(
-                    "🚫 execution_authority not set and BootstrapFSM has no _execution_authority "
-                    "attribute — trading loop cannot start safely."
-                )
-                if _loop_guard.acquire(timeout=5):
-                    try:
-                        _loop_running = False
-                    finally:
-                        _loop_guard.release()
-                return
+            logger.critical(
+                "🚫 execution_authority not granted by BootstrapFSM — trading loop blocked"
+            )
+            if _loop_guard.acquire(timeout=5):
+                try:
+                    _loop_running = False
+                finally:
+                    _loop_guard.release()
+            return
+
+    _cycle_authority_ok, _cycle_authority_reason = _require_exact_runtime_cycle_authority(
+        "nija_core_loop.start"
+    )
+    if not _cycle_authority_ok:
+        logger.critical(
+            "🚫 exact runtime cycle authority missing — trading loop blocked reason=%s",
+            _cycle_authority_reason,
+        )
+        if _loop_guard.acquire(timeout=5):
+            try:
+                _loop_running = False
+            finally:
+                _loop_guard.release()
+        return
 
 
     logger.critical("[INIT STEP 3/6] ✅ Bootstrap FSM execution authority check complete")
     print("[INIT STEP 3/6] ✅ Bootstrap FSM execution authority check complete", flush=True)
-
-    # ── Fix: record scan-started immediately after the FSM authority check ───
-    # The writer-authority watchdog fires SCAN_STARTED_DEADLINE_EXCEEDED when
-    # the scan loop does not call record_scan_started() within
-    # NIJA_SCAN_STARTED_DEADLINE_S (default 300 s) of lock acquisition.
-    # Capital hydration and CSM barriers (steps 4–5) can each consume tens of
-    # seconds, so signalling here — once it is known the loop is alive and the
-    # FSM has granted authority — prevents a false-positive watchdog alarm.
-    try:
-        from bot.entrypoint_writer_authority import get_entrypoint_writer_authority
-        get_entrypoint_writer_authority().record_scan_started()
-        logger.critical(
-            "[INIT STEP 3/6] SCAN_STARTED_RECORDED — watchdog deadline satisfied early "
-            "(loop alive, FSM authority confirmed; first cycle will follow after barriers)"
-        )
-    except Exception as _early_scan_started_err:
-        logger.debug(
-            "[INIT STEP 3/6] Early record_scan_started() failed (non-fatal): %s",
-            _early_scan_started_err,
-        )
 
     # Supervisor-mode hard gate: only block execution when supervisor mode is
     # enabled AND live trading is not active.
@@ -6426,44 +6404,21 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                 "is_hydrated=True, broker snapshot received. Proceeding to trading loop."
             )
         except _CapIntegrityErr as _hb_err:
-            # ── FORCE FLAG BYPASS ─────────────────────────────────────────────
-            # When NIJA_SKIP_STARTUP_PHASE_GATE=true, NIJA_FORCE_ACTIVATION=true,
-            # or FORCE_TRADE=true, proceed past the hydration barrier even if the
-            # capital pipeline has not yet delivered a snapshot.
-            _hb_force_bypass = (
-                os.environ.get("NIJA_SKIP_STARTUP_PHASE_GATE", "").strip().lower()
-                in ("1", "true", "yes", "on", "enabled")
-                or os.environ.get("NIJA_FORCE_ACTIVATION", "").strip().lower()
-                in ("1", "true", "yes", "on", "enabled")
-                or os.environ.get("FORCE_TRADE", "").strip().lower()
-                in ("1", "true", "yes", "on", "enabled")
+            # Keep the supervised loop alive so an exact writer can continue
+            # managing exits, but never convert a missing capital snapshot into
+            # entry authority.  run_scan_phase() independently requires a fresh,
+            # positive Capital Authority snapshot before building an entry
+            # universe or submitting an entry.
+            logger.critical(
+                "[HYDRATION_BARRIER] CAPITAL INTEGRITY ERROR: %s — "
+                "entry admission remains blocked; exit-only supervision continues",
+                _hb_err,
             )
-            if _hb_force_bypass:
-                logger.warning(
-                    "⚡ [HYDRATION_BARRIER] CAPITAL INTEGRITY ERROR bypassed — force flag active. "
-                    "error=%s (NIJA_SKIP_STARTUP_PHASE_GATE / NIJA_FORCE_ACTIVATION / FORCE_TRADE)",
-                    _hb_err,
-                )
-            else:
-                # ── HARD-TIMEOUT BYPASS ───────────────────────────────────────
-                # Previously this path aborted the trading loop entirely, which
-                # caused a silent hang (the thread exited with no further logs).
-                # Now we log a critical warning and proceed anyway — a hydration
-                # timeout means the capital pipeline is slow, not that the bot
-                # should stop trading.  The downstream strategy cycle will handle
-                # a $0 balance gracefully (skip entries, wait for next cycle).
-                logger.critical(
-                    "⚠️ [HYDRATION_BARRIER] CAPITAL INTEGRITY ERROR: %s — "
-                    "proceeding past hydration barrier after timeout to prevent "
-                    "trading loop abort. Set NIJA_SKIP_STARTUP_PHASE_GATE=true or "
-                    "FORCE_TRADE=true to suppress this warning.",
-                    _hb_err,
-                )
-                print(
-                    f"[INIT STEP 4/6] WARNING: hydration barrier timed out ({_hb_err}) — "
-                    "proceeding anyway to prevent loop abort",
-                    flush=True,
-                )
+            print(
+                f"[INIT STEP 4/6] hydration unavailable ({_hb_err}) — "
+                "entry admission blocked; exit-only supervision continues",
+                flush=True,
+            )
         except (ImportError, Exception) as _hb_exc:
             logger.warning(
                 "⚠️ [HYDRATION_BARRIER] Could not enforce hydration barrier (%s) — "
@@ -6543,50 +6498,16 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                         _csm.blocked_reason,
                     )
                 elif _csm_state_now == _CsmState.BLOCKED:
-                    # ── FORCE FLAG BYPASS ─────────────────────────────────────
-                    # When NIJA_SKIP_STARTUP_PHASE_GATE=true, NIJA_FORCE_ACTIVATION=true,
-                    # or FORCE_TRADE=true the operator has explicitly acknowledged that
-                    # the CSM gate may not be satisfied (e.g. capital pipeline has not
-                    # yet delivered a snapshot) and wants the trading loop to start
-                    # immediately.  Treat BLOCKED as DEGRADED in this case so the loop
-                    # proceeds rather than aborting.
-                    _csm_force_bypass = (
-                        os.environ.get("NIJA_SKIP_STARTUP_PHASE_GATE", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_FORCE_ACTIVATION", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("FORCE_TRADE", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
+                    logger.critical(
+                        "[CSM-BARRIER] CSM BLOCKED — entry admission remains blocked; "
+                        "exit-only supervision continues. reason=%s",
+                        _csm.blocked_reason,
                     )
-                    if _csm_force_bypass:
-                        logger.warning(
-                            "⚡ CSM BLOCKED but force flag active — bypassing CSM gate and proceeding. "
-                            "reason=%s (NIJA_SKIP_STARTUP_PHASE_GATE / NIJA_FORCE_ACTIVATION / FORCE_TRADE)",
-                            _csm.blocked_reason,
-                        )
-                    else:
-                        # ── HARD-TIMEOUT BYPASS ───────────────────────────────
-                        # Previously this path raised _CsmIntegrityErr which was
-                        # caught below and caused the trading loop to abort (return),
-                        # producing a silent hang with no further log output.
-                        # Now we log a critical warning and proceed — a BLOCKED CSM
-                        # state (e.g. LIVE_CAPITAL_VERIFIED not set, or capital
-                        # pipeline not yet delivered a snapshot) should not
-                        # permanently prevent the loop from running.  The downstream
-                        # strategy cycle and execution engine enforce their own gates.
-                        logger.critical(
-                            "⚠️ [CSM-BARRIER] CSM BLOCKED — proceeding past barrier to prevent "
-                            "trading loop abort. reason=%s  "
-                            "Set NIJA_SKIP_STARTUP_PHASE_GATE=true or FORCE_TRADE=true to "
-                            "suppress this warning. Trades will be blocked by execution engine "
-                            "until CSM reaches READY state.",
-                            _csm.blocked_reason,
-                        )
-                        print(
-                            f"[INIT STEP 5/6] WARNING: CSM BLOCKED ({_csm.blocked_reason}) — "
-                            "proceeding anyway to prevent loop abort",
-                            flush=True,
-                        )
+                    print(
+                        f"[INIT STEP 5/6] CSM BLOCKED ({_csm.blocked_reason}) — "
+                        "entry admission blocked; exit-only supervision continues",
+                        flush=True,
+                    )
                 else:
                     # INITIALIZING after timeout — try a verified repair before giving up.
                     # Proceeding with INITIALIZING means no capital snapshot has been
@@ -6832,91 +6753,30 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
         if get_bootstrap_fsm is not None:
             _bfsm_sched = get_bootstrap_fsm()
             if not _bfsm_sched.execution_authority:
-                # Fallback: same fencing-token recovery as the strategy loop gate above.
-                _ft_sched = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
-                if _ft_sched and hasattr(_bfsm_sched, "_execution_authority"):
-                    logger.warning(
-                        "execution_authority not set before scheduler — applying fencing-token "
-                        "fallback (token_prefix=%s) to unblock cycle scheduler",
-                        _ft_sched[:8],
-                    )
-                    _bfsm_sched._execution_authority = True
-                elif hasattr(_bfsm_sched, "_execution_authority"):
-                    # No fencing token (Redis not configured or distributed lock not acquired).
-                    # FORCE_TRADE / NIJA_FORCE_ACTIVATION bypass: grant execution authority
-                    # directly so the cycle scheduler is not permanently blocked in deployments
-                    # that do not use Redis-based distributed locking.
-                    _force_bypass_sched = (
-                        os.environ.get("FORCE_TRADE", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_FORCE_ACTIVATION", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_SKIP_STARTUP_PHASE_GATE", "").strip().lower()
-                        in ("1", "true", "yes", "on", "enabled")
-                    )
-                    if _force_bypass_sched:
-                        logger.warning(
-                            "⚡ execution_authority not set and no fencing token present — "
-                            "force flag active, granting execution authority directly to unblock "
-                            "cycle scheduler (FORCE_TRADE / NIJA_FORCE_ACTIVATION / NIJA_SKIP_STARTUP_PHASE_GATE)"
-                        )
-                        _bfsm_sched._execution_authority = True
-                    else:
-                        logger.critical(
-                            "🚫 execution_authority not set and no fencing token present — "
-                            "cycle scheduler cannot start. Set FORCE_TRADE=true to bypass, or "
-                            "configure Redis for distributed locking."
-                        )
-                        if _loop_guard.acquire(timeout=5):
-                            try:
-                                _loop_running = False
-                            finally:
-                                _loop_guard.release()
-                        return
-                else:
-                    # Graceful fallback: same force-flag recovery as the strategy loop
-                    # gate above.  A hard assert here crashes the trading thread
-                    # silently; instead, check for FORCE_TRADE / NIJA_FORCE_ACTIVATION /
-                    # NIJA_SKIP_STARTUP_PHASE_GATE and grant authority when set.
-                    # NOTE: hasattr(_bfsm_sched, "_execution_authority") is False in this
-                    # else-branch (the outer elif already confirmed the positive case), so
-                    # checking hasattr here would be dead code.  Only the force-flag check
-                    # matters.
-                    _force_flags_sched = (
-                        os.environ.get("FORCE_TRADE", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_FORCE_ACTIVATION", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_SKIP_STARTUP_PHASE_GATE", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-                        or os.environ.get("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK", "").strip().lower() in ("1", "true", "yes", "on", "enabled")
-                    )
-                    if _force_flags_sched:
-                        logger.warning(
-                            "⚡ execution_authority not set and BootstrapFSM has no "
-                            "_execution_authority attribute — force flag active, "
-                            "proceeding to cycle scheduler without bootstrap authority "
-                            "(FORCE_TRADE / NIJA_FORCE_ACTIVATION / NIJA_SKIP_STARTUP_PHASE_GATE "
-                            "/ NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK)"
-                        )
-                        print(
-                            "[NIJA] FORCE flag: proceeding to cycle scheduler despite missing "
-                            "_execution_authority attribute",
-                            flush=True,
-                        )
-                    else:
-                        logger.critical(
-                            "execution_authority not set, no fencing token, and no FORCE flag — "
-                            "cycle scheduler cannot start; set FORCE_TRADE=true to override"
-                        )
-                        print("[NIJA] ERROR: execution_authority missing — cycle scheduler blocked")
-                        logger.critical(
-                            "🚫 execution_authority not set and BootstrapFSM has no _execution_authority "
-                            "attribute — cycle scheduler cannot start safely."
-                        )
-                        if _loop_guard.acquire(timeout=5):
-                            try:
-                                _loop_running = False
-                            finally:
-                                _loop_guard.release()
-                        return
+                logger.critical(
+                    "🚫 execution_authority not granted before scheduler — cycle scheduler blocked"
+                )
+                if _loop_guard.acquire(timeout=5):
+                    try:
+                        _loop_running = False
+                    finally:
+                        _loop_guard.release()
+                return
+
+        _scheduler_authority_ok, _scheduler_authority_reason = (
+            _require_exact_runtime_cycle_authority("nija_core_loop.scheduler")
+        )
+        if not _scheduler_authority_ok:
+            logger.critical(
+                "🚫 exact runtime authority missing before scheduler reason=%s",
+                _scheduler_authority_reason,
+            )
+            if _loop_guard.acquire(timeout=5):
+                try:
+                    _loop_running = False
+                finally:
+                    _loop_guard.release()
+            return
         logger.critical("LIFECYCLE: entering cycle scheduler")
         while _trading_active:
             try:
@@ -7114,19 +6974,6 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     logger.critical("✅ FIRST STRATEGY TICK")
                     logger.critical("SCAN_LOOP_STARTED cycle=%d", cycle)
                     logger.critical("MARKET_SCAN_STARTED cycle=%d", cycle)
-                    # Notify the writer authority watchdog that the scan loop is
-                    # active.  This must be done at the *start* of cycle 1 (not
-                    # after the first scan completes) so that slow first-scan
-                    # startups — e.g. due to Kraken symbol resolution — do not
-                    # keep the watchdog logging SCAN_STARTED_DEADLINE_EXCEEDED
-                    # for the entire duration of the first market scan.
-                    try:
-                        from bot.entrypoint_writer_authority import (
-                            get_entrypoint_writer_authority,
-                        )
-                        get_entrypoint_writer_authority().record_scan_started()
-                    except Exception:
-                        pass
                     # Emit a clear operator diagnostic if LIVE_CAPITAL_VERIFIED is not set.
                     _runtime_mode_cycle = resolve_runtime_mode_safe(logger)
                     _lcv_val = (
@@ -7535,22 +7382,10 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                         time.sleep(cycle_secs)
                         continue
 
-                    # FORCE_TRADE / NIJA_FORCE_ACTIVATION bypass: when an operator override
-                    # flag is active, allow the strategy cycle to run even before the FSM
-                    # has fully converged to LIVE_ACTIVE.  The downstream broker adapter
-                    # still enforces can_execute() (which requires LIVE_ACTIVE), so no
-                    # orders are placed until activation completes — but market scanning
-                    # and signal generation proceed immediately.  This unblocks the pipeline
-                    # in deployments where Redis or capital-authority hydration is delayed.
-                    # NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK is also included here because
-                    # it signals that Redis is not available and the FSM should not be
-                    # blocked waiting for distributed lock infrastructure.
-                    _force_cycle_bypass = (
-                        _env_truthy("FORCE_TRADE")
-                        or _env_truthy("NIJA_FORCE_ACTIVATION")
-                        or _env_truthy("FORCE_TRADE_MODE")
-                        or _env_truthy("NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK")
-                    )
+                    # No operator flag can bypass the lifecycle commit.  A cycle
+                    # without committed dispatch authority performs no strategy or
+                    # broker work and waits for the public FSM proof to converge.
+                    _force_cycle_bypass = False
 
                     if (not _committed_gate) or (not _dispatch_gate) or (not _live_gate):
                         _skip_signature = (

--- a/bot/nija_core_loop.py
+++ b/bot/nija_core_loop.py
@@ -467,10 +467,16 @@ def _capture_cycle_capital_state() -> _types.MappingProxyType:
         try:
             _ca = _get_ca()
             result["ca_is_hydrated"] = bool(_ca.is_hydrated)
-            result["ca_is_fresh"] = bool(_ca.is_fresh())
             result["ca_total_capital"] = float(getattr(_ca, "total_capital", 0.0) or 0.0)
             result["ca_valid_brokers"] = int(
                 getattr(_ca, "valid_broker_count", 0) or 0
+            )
+            # Freshness is an entry-admission gate, but older/read-only CA
+            # facades may not expose it. Preserve their diagnostic capital
+            # fields while treating freshness as false.
+            _freshness_probe = getattr(_ca, "is_fresh", None)
+            result["ca_is_fresh"] = bool(
+                _freshness_probe() if callable(_freshness_probe) else False
             )
         except Exception as _ce:
             result["sync_failed"] = True

--- a/bot/startup_runtime_safety.py
+++ b/bot/startup_runtime_safety.py
@@ -18,6 +18,8 @@ REDIS_URL_FLAGS = (
     "REDIS_PUBLIC_URL",
 )
 LIVE_BYPASS_FLAGS = (
+    "FORCE_TRADE",
+    "FORCE_TRADE_MODE",
     "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK",
     "NIJA_DISABLE_WRITER_LOCK",
     "NIJA_FORCE_ACTIVATION",
@@ -110,30 +112,14 @@ def _redis_lock_emergency_enabled(env: MutableMapping[str, str]) -> bool:
 
 
 def _apply_redis_lock_emergency_fallback(env: MutableMapping[str, str], notes: list[str]) -> None:
-    """Handle legacy emergency fallback flags without creating a live Redis race."""
+    """Refuse legacy emergency fallback flags in every live deployment."""
 
     if not _redis_lock_emergency_enabled(env):
         return
 
-    if redis_configured(env):
-        notes.append("blocked:REDIS_LOCK_EMERGENCY_FALLBACK_LIVE_REDIS")
-        _enforce_strict_live_redis_authority(env, notes)
-        return
-    # Non-Redis live recovery remains explicit/operator-confirmed.  This path is
-    # kept only for deployments that truly have no Redis endpoint configured.
-    env["NIJA_CONFIRM_BYPASS_RISKS"] = "true"
-    env["NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK"] = "true"
-    env["NIJA_DISABLE_WRITER_LOCK"] = "true"
-    env["NIJA_STRICT_REDIS_LEASE"] = "0"
-    env["NIJA_REQUIRE_DISTRIBUTED_LOCK"] = "false"
-    env["NIJA_STRICT_WRITER_LOCK"] = "false"
-    env["NIJA_FAIL_CLOSED_EXIT_ON_UNREACHABLE_REDIS"] = "false"
-    env["NIJA_FAIL_CLOSED_RETRY_ON_LOCK_FAILURE"] = "false"
-    env["NIJA_FAIL_CLOSED_MAX_RETRY_ATTEMPTS"] = "0"
-    env["NIJA_RUNTIME_DEGRADED_MODE"] = "true"
-    env["NIJA_ALLOW_DEGRADED_WRITER_AUTHORITY"] = "true"
-    env["NIJA_ALLOW_LOCAL_WRITER_LOCK_FALLBACK"] = "true"
-    notes.append("enabled:REDIS_LOCK_EMERGENCY_FALLBACK")
+    notes.append("blocked:REDIS_LOCK_EMERGENCY_FALLBACK")
+    _enforce_strict_live_redis_authority(env, notes)
+    env["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
 
 
 def _resolve_class(module_names: tuple[str, ...], class_name: str):
@@ -310,6 +296,42 @@ def _patch_core_loop_class(cls) -> bool:
         return True
 
     def _run_scan_phase_broker_scoped(self, *args, **kwargs):
+        owner_module = sys.modules.get(cls.__module__)
+        authority_guard = getattr(
+            owner_module,
+            "_require_exact_runtime_cycle_authority",
+            None,
+        )
+        if callable(authority_guard):
+            try:
+                authority_ok, authority_reason = authority_guard(
+                    "startup_runtime_safety.run_scan_phase"
+                )
+            except Exception as exc:
+                authority_ok = False
+                authority_reason = f"authority_guard_error:{type(exc).__name__}:{exc}"
+        else:
+            authority_ok = not live_mode_enabled(os.environ)
+            authority_reason = "authority_guard_unavailable"
+        if not authority_ok:
+            logger.critical(
+                "BROKER_SLOT_SCOPE_AUTHORITY_BLOCKED reason=%s broker_io=false",
+                authority_reason,
+            )
+            try:
+                from types import SimpleNamespace
+
+                return SimpleNamespace(
+                    symbols_scored=0,
+                    entries_taken=0,
+                    entries_blocked=1,
+                    exits_taken=0,
+                    next_interval=15,
+                    errors=[f"runtime_authority_blocked:{authority_reason}"],
+                )
+            except Exception:
+                return None
+
         broker = kwargs.get("broker") if "broker" in kwargs else (args[0] if args else None)
         broker_name = _broker_name_for_log(broker)
         broker_count = _broker_tracker_position_count(broker)
@@ -734,13 +756,14 @@ def normalize_runtime_startup_env(env: MutableMapping[str, str]) -> list[str]:
     if not live_mode_enabled(env):
         return notes
 
-    if redis_configured(env):
-        _enforce_strict_live_redis_authority(env, notes)
-    else:
+    _enforce_strict_live_redis_authority(env, notes)
+    if env.get("NIJA_FORCE_TRADE_BALANCE") != "0":
+        env["NIJA_FORCE_TRADE_BALANCE"] = "0"
+        notes.append("set:NIJA_FORCE_TRADE_BALANCE=0")
+    if not redis_configured(env):
         _apply_redis_lock_emergency_fallback(env, notes)
-        bypass_confirmed = env_truthy(env.get("NIJA_CONFIRM_BYPASS_RISKS"))
-        if not bypass_confirmed:
-            _clear_truthy_flags(env, LIVE_BYPASS_FLAGS, notes)
+        env["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        notes.append("blocked:LIVE_RUNTIME_WITHOUT_REDIS")
 
     hf_flip_mode = env_truthy(env.get("HF_FLIP_MODE"))
     hf_scalp_mode = env_truthy(env.get("HF_SCALP_MODE"))

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -180,14 +180,8 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
         self.assertIsNone(runtime._heartbeat_thread)
         self.assertEqual(os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"], "0")
 
-    def test_release_proceeds_with_deletion_when_heartbeat_cannot_quiesce(self):
-        """release() must delete the lock even when the heartbeat thread survives the join.
-
-        The heartbeat sets _stop before the join; the daemon thread therefore
-        cannot reacquire the lock.  Skipping deletion would leave a live lock in
-        Redis and force the successor instance to wait a full TTL before it can
-        become the active writer.
-        """
+    def test_release_skips_deletion_when_heartbeat_cannot_quiesce(self):
+        """An in-flight renewal must never race compare-and-delete."""
         client = MagicMock()
         client.eval.return_value = 1  # compare-and-delete succeeds
 
@@ -205,8 +199,10 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
         runtime._lock_value = "17:local-owner"
         runtime._heartbeat_thread = StuckHeartbeat()
 
-        self.assertTrue(runtime.release())
-        client.eval.assert_called_once()
+        self.assertFalse(runtime.release())
+        client.eval.assert_not_called()
+        self.assertIsNotNone(runtime._heartbeat_thread)
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_ACQUIRED"], "0")
 
     def test_redis_unavailable_remains_fail_closed_without_explicit_fallback(self):
         runtime = EntrypointWriterAuthority()
@@ -259,7 +255,7 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
 
         self.assertFalse(runtime._scan_deadline_exceeded)
 
-    def test_local_fallback_requires_risk_confirmation(self):
+    def test_local_fallback_is_always_refused(self):
         os.environ["NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"] = "true"
         runtime = EntrypointWriterAuthority()
         with patch(
@@ -283,9 +279,9 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
         ):
             granted = runtime.acquire_once()
 
-        self.assertTrue(granted.acquired)
-        self.assertTrue(granted.local_fallback)
-        self.assertEqual(os.environ["NIJA_WRITER_FENCING_TOKEN_FALLBACK"], "1")
+        self.assertFalse(granted.acquired)
+        self.assertFalse(granted.local_fallback)
+        self.assertNotIn("NIJA_WRITER_FENCING_TOKEN_FALLBACK", os.environ)
 
     def test_release_uses_compare_and_delete_script(self):
         client = MagicMock()
@@ -586,7 +582,7 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
             ],
         )
 
-    def test_main_registers_core_thread_before_waiting_for_scan_started(self):
+    def test_main_registers_core_thread_without_fabricating_scan_started(self):
         core_loop = types.ModuleType("bot.nija_core_loop")
         manager = types.SimpleNamespace(
             _fsm_initialized=True,
@@ -651,9 +647,9 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         runtime.register_core_thread.assert_called_once()
-        runtime.record_scan_started.assert_called_once()
+        runtime.record_scan_started.assert_not_called()
 
-    def test_main_records_scan_started_immediately_after_core_thread_registration(self):
+    def test_main_does_not_record_scan_started_before_real_scan(self):
         core_loop = types.ModuleType("bot.nija_core_loop")
         manager = types.SimpleNamespace(
             _fsm_initialized=True,
@@ -718,7 +714,7 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         runtime.register_core_thread.assert_called_once()
-        runtime.record_scan_started.assert_called_once()
+        runtime.record_scan_started.assert_not_called()
 
     def test_thread_start_failure_still_releases_writer_authority(self):
         core_loop = types.ModuleType("bot.nija_core_loop")

--- a/bot/tests/test_force_activation_lifecycle.py
+++ b/bot/tests/test_force_activation_lifecycle.py
@@ -204,8 +204,8 @@ class TestForceActivationEndToEnd(unittest.TestCase):
         self.assertEqual(snap.runtime_authority_state, RuntimeAuthorityState.EXECUTING.value)
         self.assertEqual(snap.runtime_authority_reason, "committed_live_dispatch")
 
-    def test_can_execute_repairs_stale_live_dispatch_commit(self) -> None:
-        """Gate 0 repairs the coordinator latch when TSM is already LIVE_ACTIVE."""
+    def test_can_execute_fails_closed_on_stale_live_dispatch_commit(self) -> None:
+        """Gate 0 must not manufacture a coordinator commit from downstream state."""
         from bot.execution_authority_context import RuntimeAuthoritySnapshot, can_execute, execution_authority_scope
 
         class _KillSwitch:
@@ -293,8 +293,10 @@ class TestForceActivationEndToEnd(unittest.TestCase):
         ):
             decision = can_execute()
 
-        self.assertNotEqual(decision.reason, "lifecycle_phase:WARM")
-        self.assertEqual(decision.lifecycle_phase, LifecyclePhase.LIVE.value)
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.reason, "lifecycle_phase:WARM")
+        self.assertEqual(decision.lifecycle_phase, LifecyclePhase.WARM.value)
+        self.assertEqual(snapshots["calls"], 1)
 
 
 if __name__ == "__main__":

--- a/bot/tests/test_runtime_authority_convergence_repair_patch.py
+++ b/bot/tests/test_runtime_authority_convergence_repair_patch.py
@@ -92,7 +92,7 @@ def test_capital_authority_ready_for_logged_579_case(monkeypatch):
     assert detail["valid_brokers"] == 3
 
 
-def test_capital_authority_rejects_stale_handoff_without_usable_capital(monkeypatch):
+def test_capital_authority_accepts_handoff_ready_snapshot_without_usable_field(monkeypatch):
     _live_env(monkeypatch)
     monkeypatch.delenv("LIVE_CAPITAL_VERIFIED", raising=False)
     monkeypatch.setenv("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY", "1")
@@ -101,12 +101,12 @@ def test_capital_authority_rejects_stale_handoff_without_usable_capital(monkeypa
 
     ready, reason, detail = patch._capital_authority_ready()
 
-    assert ready is False
-    assert "capital_not_ready" in reason
+    assert ready is True
+    assert "handoff=True" in reason
     assert detail["real"] == 466.62
-    assert detail["usable"] == 0.0
-    assert detail["valid_brokers"] == 0
-    assert detail["fresh"] is False
+    assert detail["usable"] == 466.62
+    assert detail["valid_brokers"] == 3
+    assert detail["fresh"] is True
 
 
 def test_capital_freshness_uses_one_consistent_ttl(monkeypatch):
@@ -148,16 +148,6 @@ def test_heartbeat_accepts_writer_generation_alias(monkeypatch):
     _live_env(monkeypatch)
     monkeypatch.delenv("NIJA_WRITER_LEASE_GENERATION", raising=False)
     monkeypatch.setenv("NIJA_WRITER_GENERATION", "2257")
-
-    ready, reason = patch._heartbeat_ready()
-
-    assert ready is True
-    assert "heartbeat_ready" in reason
-
-
-def test_kraken_nonce_outage_does_not_block_global_writer_heartbeat(monkeypatch):
-    _live_env(monkeypatch)
-    monkeypatch.setenv("KRAKEN_NONCE_LEASE_REQUIRED", "1")
 
     ready, reason = patch._heartbeat_ready()
 
@@ -378,8 +368,6 @@ def test_converge_marks_authority_ready_in_readiness_table(monkeypatch):
         def __init__(self):
             self.state = tsm.TradingState.LIVE_PENDING_CONFIRMATION
             self.commit_calls = 0
-            self.committed = False
-            self.dispatch = False
 
         def get_current_state(self):
             return self.state
@@ -388,15 +376,7 @@ def test_converge_marks_authority_ready_in_readiness_table(monkeypatch):
             self.commit_calls += 1
             # commit returns True to simulate success
             self.state = tsm.TradingState.LIVE_ACTIVE
-            self.committed = True
-            self.dispatch = True
             return True
-
-        def get_activation_committed(self):
-            return self.committed
-
-        def can_dispatch_trades(self):
-            return self.dispatch
 
     sm = FakeSM()
 
@@ -445,16 +425,7 @@ def test_converge_sets_env_auth_to_1_after_successful_commit(monkeypatch):
 
         def commit_activation(self, cycle_capital=None):
             self.state = tsm.TradingState.LIVE_ACTIVE
-            self._activation_committed = True
-            self._execution_authority = True
-            self._can_dispatch_trades = True
             return True
-
-        def get_activation_committed(self):
-            return self._activation_committed
-
-        def can_dispatch_trades(self):
-            return self._can_dispatch_trades
 
     sm = FakeSM()
 

--- a/bot/tests/test_runtime_authority_convergence_repair_patch.py
+++ b/bot/tests/test_runtime_authority_convergence_repair_patch.py
@@ -92,7 +92,7 @@ def test_capital_authority_ready_for_logged_579_case(monkeypatch):
     assert detail["valid_brokers"] == 3
 
 
-def test_capital_authority_accepts_handoff_ready_snapshot_without_usable_field(monkeypatch):
+def test_capital_authority_rejects_stale_handoff_without_usable_capital(monkeypatch):
     _live_env(monkeypatch)
     monkeypatch.delenv("LIVE_CAPITAL_VERIFIED", raising=False)
     monkeypatch.setenv("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY", "1")
@@ -101,12 +101,12 @@ def test_capital_authority_accepts_handoff_ready_snapshot_without_usable_field(m
 
     ready, reason, detail = patch._capital_authority_ready()
 
-    assert ready is True
-    assert "handoff=True" in reason
+    assert ready is False
+    assert "capital_not_ready" in reason
     assert detail["real"] == 466.62
-    assert detail["usable"] == 466.62
-    assert detail["valid_brokers"] == 3
-    assert detail["fresh"] is True
+    assert detail["usable"] == 0.0
+    assert detail["valid_brokers"] == 0
+    assert detail["fresh"] is False
 
 
 def test_capital_freshness_uses_one_consistent_ttl(monkeypatch):
@@ -148,6 +148,16 @@ def test_heartbeat_accepts_writer_generation_alias(monkeypatch):
     _live_env(monkeypatch)
     monkeypatch.delenv("NIJA_WRITER_LEASE_GENERATION", raising=False)
     monkeypatch.setenv("NIJA_WRITER_GENERATION", "2257")
+
+    ready, reason = patch._heartbeat_ready()
+
+    assert ready is True
+    assert "heartbeat_ready" in reason
+
+
+def test_kraken_nonce_outage_does_not_block_global_writer_heartbeat(monkeypatch):
+    _live_env(monkeypatch)
+    monkeypatch.setenv("KRAKEN_NONCE_LEASE_REQUIRED", "1")
 
     ready, reason = patch._heartbeat_ready()
 
@@ -368,6 +378,8 @@ def test_converge_marks_authority_ready_in_readiness_table(monkeypatch):
         def __init__(self):
             self.state = tsm.TradingState.LIVE_PENDING_CONFIRMATION
             self.commit_calls = 0
+            self.committed = False
+            self.dispatch = False
 
         def get_current_state(self):
             return self.state
@@ -376,7 +388,15 @@ def test_converge_marks_authority_ready_in_readiness_table(monkeypatch):
             self.commit_calls += 1
             # commit returns True to simulate success
             self.state = tsm.TradingState.LIVE_ACTIVE
+            self.committed = True
+            self.dispatch = True
             return True
+
+        def get_activation_committed(self):
+            return self.committed
+
+        def can_dispatch_trades(self):
+            return self.dispatch
 
     sm = FakeSM()
 
@@ -425,7 +445,16 @@ def test_converge_sets_env_auth_to_1_after_successful_commit(monkeypatch):
 
         def commit_activation(self, cycle_capital=None):
             self.state = tsm.TradingState.LIVE_ACTIVE
+            self._activation_committed = True
+            self._execution_authority = True
+            self._can_dispatch_trades = True
             return True
+
+        def get_activation_committed(self):
+            return self._activation_committed
+
+        def can_dispatch_trades(self):
+            return self._can_dispatch_trades
 
     sm = FakeSM()
 

--- a/bot/tests/test_runtime_fail_closed_v84.py
+++ b/bot/tests/test_runtime_fail_closed_v84.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import inspect
+import os
+import threading
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class RuntimeFailClosedV84Tests(unittest.TestCase):
+    def test_core_scan_blocks_before_broker_io_without_exact_authority(self):
+        from bot import nija_core_loop as core
+
+        loop = object.__new__(core.NijaCoreLoop)
+        broker = MagicMock()
+        broker.connected = True
+        with patch.object(
+            core,
+            "_require_exact_runtime_cycle_authority",
+            return_value=(False, "test_missing_writer"),
+        ):
+            result = loop.run_scan_phase(
+                broker=broker,
+                balance=100.0,
+                symbols=["BTC-USD"],
+            )
+
+        self.assertEqual(result.entries_taken, 0)
+        self.assertEqual(result.exits_taken, 0)
+        self.assertEqual(result.entries_blocked, 1)
+        self.assertIn("runtime_authority_blocked", result.errors[0])
+        self.assertEqual(broker.mock_calls, [])
+
+    def test_runtime_authority_bit_defaults_fail_closed(self):
+        from bot import nija_core_loop as core
+
+        with (
+            patch.object(core, "_is_live_mode", return_value=True),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("NIJA_RUNTIME_EXECUTION_AUTHORITY", None)
+            allowed, reason = core._require_exact_runtime_cycle_authority("test")
+
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "runtime_execution_authority_not_granted")
+
+    def test_forced_balance_cannot_authorize_scan_entries(self):
+        from bot import nija_core_loop as core
+
+        source = inspect.getsource(core.NijaCoreLoop.run_scan_phase)
+        self.assertNotIn("NIJA_FORCE_TRADE_BALANCE", source)
+        self.assertIn("_entry_capital_ready", source)
+        self.assertIn("CAPITAL_ENTRY_SCAN_BLOCKED", source)
+
+    def test_forced_entry_modes_are_disabled(self):
+        from bot import nija_core_loop as core
+
+        self.assertFalse(core.FORCED_ENTRY_MODES_ENABLED)
+        self.assertEqual(core._get_relaxation_factor(10_000), 0.0)
+        self.assertFalse(core._env_truthy("FORCE_TRADE", "true"))
+        self.assertFalse(core._env_truthy("NIJA_FORCE_ACTIVATION", "true"))
+
+    def test_loop_does_not_report_scan_before_authorized_scan_phase(self):
+        from bot import nija_core_loop as core
+
+        loop_source = inspect.getsource(core.run_trading_loop)
+        scan_source = inspect.getsource(core.NijaCoreLoop.run_scan_phase)
+        self.assertNotIn("record_scan_started", loop_source)
+        self.assertEqual(scan_source.count("record_scan_started"), 1)
+        self.assertIn("_require_exact_runtime_cycle_authority", scan_source)
+
+    def test_execution_authority_requires_exact_writer_without_force_repair(self):
+        from bot import execution_authority_context as authority
+
+        writer_source = inspect.getsource(authority.assert_distributed_writer_authority)
+        execute_source = inspect.getsource(authority.can_execute)
+        repair_source = inspect.getsource(authority._attempt_live_dispatch_commit_repair)
+        self.assertIn("_exact_process_writer", writer_source)
+        self.assertNotIn("FORCE_TRADE", execute_source)
+        self.assertNotIn("force_activate_bypass", repair_source)
+        self.assertIn("return False", repair_source)
+
+    def test_raw_running_transition_requires_startup_authority(self):
+        from bot.bootstrap_state_machine import BootstrapState, BootstrapStateMachine
+
+        fsm = BootstrapStateMachine()
+        fsm._state = BootstrapState.THREADS_STARTING
+        fsm._owner_thread_id = threading.get_ident()
+        authority = types.SimpleNamespace(
+            require_startup_execution_authority=lambda **_: {
+                "ready": False,
+                "missing": ["writer.lock.exact"],
+            }
+        )
+        with patch.dict(
+            "sys.modules",
+            {"bot.execution_authority_context": authority},
+        ):
+            transitioned = fsm.transition(
+                BootstrapState.RUNNING_SUPERVISED,
+                "test must fail closed",
+            )
+
+        self.assertFalse(transitioned)
+        self.assertEqual(fsm.state, BootstrapState.THREADS_STARTING)
+        self.assertFalse(fsm.execution_authority)
+
+    def test_scan_wrapper_blocks_before_base_scan(self):
+        import scan_wrapper_convergence_repair_patch as wrapper
+
+        calls: list[str] = []
+
+        class Core:
+            def run_scan_phase(self, *args, **kwargs):
+                calls.append("base")
+                return types.SimpleNamespace(
+                    symbols_scored=1,
+                    entries_taken=0,
+                    entries_blocked=0,
+                    exits_taken=0,
+                    next_interval=15,
+                )
+
+        module = types.ModuleType("test_core_module")
+        module.NijaCoreLoop = Core
+        module._require_exact_runtime_cycle_authority = lambda _source: (
+            False,
+            "test_missing_writer",
+        )
+        self.assertTrue(wrapper._patch_core_loop(module))
+
+        result = module.NijaCoreLoop().run_scan_phase()
+        self.assertEqual(calls, [])
+        self.assertEqual(result.entries_blocked, 1)
+        self.assertIn("runtime_authority_blocked", result.errors[0])
+
+    def test_coinbase_existing_positions_do_not_trigger_balance_probe(self):
+        from bot import coinbase_position_runtime_patch as coinbase_patch
+
+        class CoinbaseBroker:
+            def __init__(self):
+                self.balance_calls = 0
+
+            def get_positions(self):
+                return [{"symbol": "BTC-USD", "quantity": 0.1}]
+
+            def get_portfolio_breakdown(self):
+                self.balance_calls += 1
+                return {"crypto": {"ETH": 1.0}}
+
+        self.assertTrue(coinbase_patch._patch_coinbase_class(CoinbaseBroker))
+        broker = CoinbaseBroker()
+        positions = broker.get_positions()
+
+        self.assertEqual([p["symbol"] for p in positions], ["BTC-USD"])
+        self.assertEqual(broker.balance_calls, 0)
+
+    def test_coinbase_uses_cache_before_live_balance_probe(self):
+        from bot import coinbase_position_runtime_patch as coinbase_patch
+
+        broker = types.SimpleNamespace(
+            _last_raw_balances={"crypto": {"ETH": 1.0}},
+            get_portfolio_breakdown=MagicMock(),
+        )
+        payload = coinbase_patch._call_possible_balance_methods(broker)
+
+        self.assertEqual(payload, {"crypto": {"ETH": 1.0}})
+        broker.get_portfolio_breakdown.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_runtime_fail_closed_v84.py
+++ b/bot/tests/test_runtime_fail_closed_v84.py
@@ -81,6 +81,19 @@ class RuntimeFailClosedV84Tests(unittest.TestCase):
         self.assertNotIn("force_activate_bypass", repair_source)
         self.assertIn("return False", repair_source)
 
+    def test_kraken_nonce_is_not_a_global_execution_gate(self):
+        from bot import execution_authority_context as authority
+
+        ready, reason = authority._runtime_nonce_authority_status()
+        self.assertTrue(ready)
+        self.assertEqual(reason, "venue_scoped_to_order_adapter")
+        execute_source = inspect.getsource(authority.can_execute)
+        self.assertIn("nonce_ready = bool(runtime_nonce_ready)", execute_source)
+        self.assertNotIn(
+            "nonce_ready = bool(startup_nonce_ready and runtime_nonce_ready)",
+            execute_source,
+        )
+
     def test_raw_running_transition_requires_startup_authority(self):
         from bot.bootstrap_state_machine import BootstrapState, BootstrapStateMachine
 

--- a/bot/tests/test_runtime_fail_closed_v84.py
+++ b/bot/tests/test_runtime_fail_closed_v84.py
@@ -81,19 +81,6 @@ class RuntimeFailClosedV84Tests(unittest.TestCase):
         self.assertNotIn("force_activate_bypass", repair_source)
         self.assertIn("return False", repair_source)
 
-    def test_kraken_nonce_is_not_a_global_execution_gate(self):
-        from bot import execution_authority_context as authority
-
-        ready, reason = authority._runtime_nonce_authority_status()
-        self.assertTrue(ready)
-        self.assertEqual(reason, "venue_scoped_to_order_adapter")
-        execute_source = inspect.getsource(authority.can_execute)
-        self.assertIn("nonce_ready = bool(runtime_nonce_ready)", execute_source)
-        self.assertNotIn(
-            "nonce_ready = bool(startup_nonce_ready and runtime_nonce_ready)",
-            execute_source,
-        )
-
     def test_raw_running_transition_requires_startup_authority(self):
         from bot.bootstrap_state_machine import BootstrapState, BootstrapStateMachine
 

--- a/bot/tests/test_runtime_fail_closed_v84.py
+++ b/bot/tests/test_runtime_fail_closed_v84.py
@@ -82,29 +82,42 @@ class RuntimeFailClosedV84Tests(unittest.TestCase):
         self.assertIn("return False", repair_source)
 
     def test_raw_running_transition_requires_startup_authority(self):
-        from bot.bootstrap_state_machine import BootstrapState, BootstrapStateMachine
+        from bot.bootstrap_state_machine import BootstrapState, get_bootstrap_fsm
 
-        fsm = BootstrapStateMachine()
-        fsm._state = BootstrapState.THREADS_STARTING
-        fsm._owner_thread_id = threading.get_ident()
+        fsm = get_bootstrap_fsm()
+        with fsm._lock:
+            saved_state = fsm._state
+            saved_owner = fsm._owner_thread_id
+            saved_authority = fsm._execution_authority
+            saved_history = list(fsm._history)
+            fsm._state = BootstrapState.THREADS_STARTING
+            fsm._owner_thread_id = threading.get_ident()
+            fsm._execution_authority = False
         authority = types.SimpleNamespace(
             require_startup_execution_authority=lambda **_: {
                 "ready": False,
                 "missing": ["writer.lock.exact"],
             }
         )
-        with patch.dict(
-            "sys.modules",
-            {"bot.execution_authority_context": authority},
-        ):
-            transitioned = fsm.transition(
-                BootstrapState.RUNNING_SUPERVISED,
-                "test must fail closed",
-            )
+        try:
+            with patch.dict(
+                "sys.modules",
+                {"bot.execution_authority_context": authority},
+            ):
+                transitioned = fsm.transition(
+                    BootstrapState.RUNNING_SUPERVISED,
+                    "test must fail closed",
+                )
 
-        self.assertFalse(transitioned)
-        self.assertEqual(fsm.state, BootstrapState.THREADS_STARTING)
-        self.assertFalse(fsm.execution_authority)
+            self.assertFalse(transitioned)
+            self.assertEqual(fsm.state, BootstrapState.THREADS_STARTING)
+            self.assertFalse(fsm.execution_authority)
+        finally:
+            with fsm._lock:
+                fsm._state = saved_state
+                fsm._owner_thread_id = saved_owner
+                fsm._execution_authority = saved_authority
+                fsm._history[:] = saved_history
 
     def test_scan_wrapper_blocks_before_base_scan(self):
         import scan_wrapper_convergence_repair_patch as wrapper

--- a/bot/tests/test_runtime_fail_closed_v84.py
+++ b/bot/tests/test_runtime_fail_closed_v84.py
@@ -82,42 +82,34 @@ class RuntimeFailClosedV84Tests(unittest.TestCase):
         self.assertIn("return False", repair_source)
 
     def test_raw_running_transition_requires_startup_authority(self):
-        from bot.bootstrap_state_machine import BootstrapState, get_bootstrap_fsm
+        from bot.bootstrap_state_machine import BootstrapState, BootstrapStateMachine
 
-        fsm = get_bootstrap_fsm()
-        with fsm._lock:
-            saved_state = fsm._state
-            saved_owner = fsm._owner_thread_id
-            saved_authority = fsm._execution_authority
-            saved_history = list(fsm._history)
-            fsm._state = BootstrapState.THREADS_STARTING
-            fsm._owner_thread_id = threading.get_ident()
-            fsm._execution_authority = False
+        # Build an isolated unit under test without touching the process-wide
+        # singleton guard or shared bootstrap state used by other test modules.
+        fsm = object.__new__(BootstrapStateMachine)
+        fsm._lock = threading.Lock()
+        fsm._history = []
+        fsm._state = BootstrapState.THREADS_STARTING
+        fsm._owner_thread_id = threading.get_ident()
+        fsm._execution_authority = False
         authority = types.SimpleNamespace(
             require_startup_execution_authority=lambda **_: {
                 "ready": False,
                 "missing": ["writer.lock.exact"],
             }
         )
-        try:
-            with patch.dict(
-                "sys.modules",
-                {"bot.execution_authority_context": authority},
-            ):
-                transitioned = fsm.transition(
-                    BootstrapState.RUNNING_SUPERVISED,
-                    "test must fail closed",
-                )
+        with patch.dict(
+            "sys.modules",
+            {"bot.execution_authority_context": authority},
+        ):
+            transitioned = fsm.transition(
+                BootstrapState.RUNNING_SUPERVISED,
+                "test must fail closed",
+            )
 
-            self.assertFalse(transitioned)
-            self.assertEqual(fsm.state, BootstrapState.THREADS_STARTING)
-            self.assertFalse(fsm.execution_authority)
-        finally:
-            with fsm._lock:
-                fsm._state = saved_state
-                fsm._owner_thread_id = saved_owner
-                fsm._execution_authority = saved_authority
-                fsm._history[:] = saved_history
+        self.assertFalse(transitioned)
+        self.assertEqual(fsm.state, BootstrapState.THREADS_STARTING)
+        self.assertFalse(fsm.execution_authority)
 
     def test_scan_wrapper_blocks_before_base_scan(self):
         import scan_wrapper_convergence_repair_patch as wrapper

--- a/bot/tests/test_startup_runtime_safety.py
+++ b/bot/tests/test_startup_runtime_safety.py
@@ -22,17 +22,17 @@ class StartupRuntimeSafetyTests(unittest.TestCase):
 
         self.assertEqual(env["NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK"], "0")
         self.assertEqual(env["NIJA_DISABLE_WRITER_LOCK"], "0")
-        self.assertEqual(env["FORCE_TRADE"], "true")
-        self.assertEqual(env["FORCE_TRADE_MODE"], "true")
+        self.assertEqual(env["FORCE_TRADE"], "false")
+        self.assertEqual(env["FORCE_TRADE_MODE"], "false")
         self.assertEqual(env["NIJA_FORCE_ACTIVATION"], "false")
         self.assertEqual(env["NIJA_SKIP_STARTUP_PHASE_GATE"], "false")
         self.assertEqual(env["HF_SCALP_MODE"], "1")
         self.assertEqual(env["HF_SCALPING_MODE"], "1")
         self.assertIn("cleared:NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK", notes)
         self.assertIn("enabled:HF_SCALP_MODE", notes)
-        self.assertNotIn("cleared:FORCE_TRADE", notes)
+        self.assertIn("cleared:FORCE_TRADE", notes)
 
-    def test_confirmed_live_bypass_is_preserved_without_redis_endpoint(self) -> None:
+    def test_confirmed_live_bypass_is_refused_without_redis_endpoint(self) -> None:
         env = {
             "DRY_RUN_MODE": "false",
             "PAPER_MODE": "false",
@@ -45,8 +45,9 @@ class StartupRuntimeSafetyTests(unittest.TestCase):
 
         normalize_runtime_startup_env(env)
 
-        self.assertEqual(env["NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK"], "true")
-        self.assertEqual(env["FORCE_TRADE"], "true")
+        self.assertEqual(env["NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK"], "0")
+        self.assertEqual(env["FORCE_TRADE"], "false")
+        self.assertEqual(env["NIJA_RUNTIME_EXECUTION_AUTHORITY"], "0")
         self.assertEqual(env["HF_SCALP_MODE"], "0")
         self.assertEqual(env["HF_SCALPING_MODE"], "0")
 
@@ -86,7 +87,7 @@ class StartupRuntimeSafetyTests(unittest.TestCase):
         self.assertEqual(env["NIJA_STRICT_WRITER_LOCK"], "true")
         self.assertEqual(env["NIJA_RUNTIME_DEGRADED_MODE"], "false")
         self.assertEqual(env["NIJA_FAIL_CLOSED_MAX_RETRY_ATTEMPTS"], "12")
-        self.assertEqual(env["FORCE_TRADE"], "true")
+        self.assertEqual(env["FORCE_TRADE"], "false")
         self.assertIn("cleared:NIJA_CONFIRM_BYPASS_RISKS", notes)
         self.assertIn("set:NIJA_STRICT_REDIS_LEASE=1", notes)
 

--- a/bot/tests/test_writer_recovery_epoch_core_v81.py
+++ b/bot/tests/test_writer_recovery_epoch_core_v81.py
@@ -44,12 +44,13 @@ class WriterRecoveryEpochCoreV81Tests(unittest.TestCase):
 
             def __init__(self) -> None:
                 self.registered = None
+                self.scan_started_calls = 0
 
             def register_core_thread(self, thread):
                 self.registered = thread
 
             def record_scan_started(self):
-                return None
+                self.scan_started_calls += 1
 
         stop = threading.Event()
         thread = threading.Thread(target=lambda: stop.wait(2.0), name="real-core", daemon=True)
@@ -70,6 +71,7 @@ class WriterRecoveryEpochCoreV81Tests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(reason, "existing_live_thread")
         self.assertIs(runtime.registered, thread)
+        self.assertEqual(runtime.scan_started_calls, 0)
         strategy.assert_not_called()
 
     def test_dead_core_restarts_only_from_canonical_strategy(self) -> None:
@@ -80,12 +82,13 @@ class WriterRecoveryEpochCoreV81Tests(unittest.TestCase):
 
             def __init__(self) -> None:
                 self.registered = None
+                self.scan_started_calls = 0
 
             def register_core_thread(self, thread):
                 self.registered = thread
 
             def record_scan_started(self):
-                return None
+                self.scan_started_calls += 1
 
         class Strategy:
             def run_cycle(self):
@@ -128,6 +131,7 @@ class WriterRecoveryEpochCoreV81Tests(unittest.TestCase):
         self.assertEqual(reason, "canonical_strategy_restart")
         self.assertIs(runtime.registered, created[0])
         self.assertIs(bot_main._core_loop_thread, created[0])
+        self.assertEqual(runtime.scan_started_calls, 0)
 
     def test_no_restart_without_writer_authority(self) -> None:
         runtime = types.SimpleNamespace(acquired=False, lost=True, _core_thread=None)

--- a/bot/trading_strategy.py
+++ b/bot/trading_strategy.py
@@ -1999,19 +1999,76 @@ class TradingStrategy:
                 # broker and every user cycle silently scans/executes the wrong
                 # account.
                 _broker = broker if broker is not None else self._get_active_broker()
+
+                # The exact writer proof is the first live broker-cycle boundary.
+                # Block before symbol discovery, balance probes, position reads,
+                # pending-order reconciliation, or any other exchange I/O.
+                try:
+                    try:
+                        from bot import nija_core_loop as _core_loop_module
+                    except ImportError:
+                        import nija_core_loop as _core_loop_module  # type: ignore[import]
+                    _authority_ok, _authority_reason = (
+                        _core_loop_module._require_exact_runtime_cycle_authority(
+                            "trading_strategy.run_cycle"
+                        )
+                    )
+                except Exception as _authority_exc:
+                    _authority_ok = False
+                    _authority_reason = (
+                        f"authority_guard_unavailable:{type(_authority_exc).__name__}:"
+                        f"{_authority_exc}"
+                    )
+                if not _authority_ok:
+                    logger.critical(
+                        "RUN_CYCLE_AUTHORITY_BLOCKED reason=%s broker_io=false",
+                        _authority_reason,
+                    )
+                    return next_interval_s
+
+                _cycle_capital = getattr(_core_loop_module, "_current_cycle_capital", {})
+                _entry_scan_capital_ready = bool(
+                    _cycle_capital.get("ca_is_hydrated", False)
+                    and _cycle_capital.get("ca_is_fresh", False)
+                    and float(_cycle_capital.get("ca_total_capital", 0.0) or 0.0) > 0.0
+                    and int(_cycle_capital.get("ca_valid_brokers", 0) or 0) > 0
+                    and _cycle_capital.get("is_post_hydration", False)
+                    and _cycle_capital.get("aggregation_normalized", False)
+                    and not _cycle_capital.get("sync_failed", True)
+                    and str(_cycle_capital.get("snapshot_source", "placeholder"))
+                    in {"live_exchange", "capital_authority"}
+                )
+                if self.nija_core_loop is None and _core_loop_module._is_live_mode():
+                    logger.critical(
+                        "RUN_CYCLE_BLOCKED reason=canonical_core_loop_unavailable "
+                        "legacy_execution_refused=true"
+                    )
+                    return next_interval_s
+
                 if _broker is not None and self.broker != _broker:
                     self.broker = _broker
                     if hasattr(self.apex, "update_broker_client"):
                         self.apex.update_broker_client(_broker)
 
-                self._maybe_refresh_symbols()
-                _symbols_to_scan = self._symbols_for_broker(
-                    _broker,
-                    max_symbols=20 if self.nija_core_loop is None else None,
-                )
+                if _entry_scan_capital_ready:
+                    self._maybe_refresh_symbols()
+                    _symbols_to_scan = self._symbols_for_broker(
+                        _broker,
+                        max_symbols=20 if self.nija_core_loop is None else None,
+                    )
+                else:
+                    _symbols_to_scan = []
+                    logger.critical(
+                        "RUN_CYCLE_ENTRY_UNIVERSE_SKIPPED "
+                        "reason=capital_authority_not_ready exits_preserved=true"
+                    )
 
                 _account_balance = float(getattr(self.apex, "_last_account_balance", 0.0) or 0.0)
-                if _account_balance <= 0.0 and _broker is not None:
+                if (
+                    _entry_scan_capital_ready
+                    and _account_balance <= 0.0
+                    and _broker is not None
+                ):
                     _balance_method = getattr(_broker, "get_account_balance", None)
                     if callable(_balance_method):
                         try:
@@ -2096,7 +2153,7 @@ class TradingStrategy:
                             )
                     # ── End reconcile stale pending orders ───────────────────
 
-                    if not _symbols_to_scan:
+                    if not _symbols_to_scan and _entry_scan_capital_ready:
                         self._maybe_refresh_symbols(force=True)
                         _symbols_to_scan = self._symbols_for_broker(_broker)
                     # Last-resort fallback: if broker discovery and the
@@ -2105,7 +2162,7 @@ class TradingStrategy:
                     # with at least the core liquid pairs.  This prevents a
                     # silent scan skip when the broker's get_available_markets()
                     # call fails transiently on the first cycle.
-                    if not _symbols_to_scan:
+                    if not _symbols_to_scan and _entry_scan_capital_ready:
                         _symbols_to_scan = list(_HEARTBEAT_SYMBOL_CANDIDATES)
                         logger.warning(
                             "⚠️ [RUN_CYCLE_FALLBACK] broker symbol discovery returned empty — "
@@ -2117,7 +2174,7 @@ class TradingStrategy:
                             f"[NIJA-PRINT] RUN_CYCLE_SYMBOL_FALLBACK candidates={_symbols_to_scan}",
                             flush=True,
                         )
-                    if not _symbols_to_scan:
+                    if not _symbols_to_scan and _entry_scan_capital_ready:
                         logger.warning(
                             "⚠️ [RUN_CYCLE_EXIT] symbol universe empty — "
                             "skipping scan. RUN_CYCLE_PHASE3_START will not be reached."

--- a/bot/writer_recovery_epoch_core_v81_impl.py
+++ b/bot/writer_recovery_epoch_core_v81_impl.py
@@ -220,12 +220,6 @@ def _register_real_core(bot_main: ModuleType, runtime: Any, thread: Any, source:
         os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
         return False
     os.environ["NIJA_CORE_THREAD_ALIVE"] = "1"
-    record = getattr(runtime, "record_scan_started", None)
-    if callable(record):
-        try:
-            record()
-        except Exception:
-            pass
     LOGGER.critical(
         "WRITER_V81_CORE_THREAD_BOUND marker=%s source=%s thread=%s ident=%s alive=true",
         MARKER,

--- a/scan_wrapper_convergence_repair_patch.py
+++ b/scan_wrapper_convergence_repair_patch.py
@@ -259,6 +259,34 @@ def _patch_core_loop(module: ModuleType) -> bool:
         )
 
     def run_scan_phase(self: Any, *args: Any, **kwargs: Any) -> Any:
+        authority_guard = getattr(module, "_require_exact_runtime_cycle_authority", None)
+        if callable(authority_guard):
+            try:
+                authority_ok, authority_reason = authority_guard(
+                    "scan_wrapper_convergence.run_scan_phase"
+                )
+            except Exception as exc:
+                authority_ok = False
+                authority_reason = f"authority_guard_error:{type(exc).__name__}:{exc}"
+        else:
+            live_mode = (
+                str(os.environ.get("LIVE_CAPITAL_VERIFIED", "")).strip().lower()
+                in {"1", "true", "yes", "on", "enabled"}
+                and str(os.environ.get("DRY_RUN_MODE", "")).strip().lower()
+                not in {"1", "true", "yes", "on", "enabled"}
+                and str(os.environ.get("PAPER_MODE", "")).strip().lower()
+                not in {"1", "true", "yes", "on", "enabled"}
+            )
+            authority_ok = not live_mode
+            authority_reason = "authority_guard_unavailable"
+        if not authority_ok:
+            logger.critical(
+                "SCAN_GUARD_AUTHORITY_BLOCKED marker=%s reason=%s broker_io=false",
+                _MARKER,
+                authority_reason,
+            )
+            return _duplicate_result(f"runtime_authority_blocked:{authority_reason}")
+
         broker = (
             kwargs.get("broker")
             or getattr(self, "broker", None)


### PR DESCRIPTION
## Production symptom

Runtime `9dda412` continued into Phase 3 after bootstrap authority finalization failed. Capital Authority was unhydrated/zero, but a caller balance plus `NIJA_FORCE_TRADE_BALANCE` still authorized a 100-symbol scan. The scan took ~214 seconds and produced no orders; only a downstream capital gate prevented an unsafe submit.

## Fix

- require the exact Redis process-writer proof before any scan/broker work
- require public bootstrap/FSM execution-authority proof; remove private/forced activation repair
- accept entry capital only from a fresh, hydrated, positive Capital Authority snapshot with a valid broker
- preserve exact-writer exit supervision while skipping the expensive entry universe when capital is unavailable
- disable force-trade, force-activation, local-writer, and startup-gate bypasses in live mode
- refuse local writer fallback and avoid compare-delete when the heartbeat thread cannot quiesce
- record scan-start only at the first real, authorized scan
- use Coinbase cached/existing position data before any live balance probe
- refuse the legacy live execution path when the canonical core loop is unavailable

## Safety invariants

- no local/degraded writer authority
- no broker I/O from a non-owner
- no entry authorization from caller/forced balances
- exits remain available to the legitimate exact writer
- no activation or dispatch by mutating private FSM fields

## Verification

- `python -m compileall -q fix_v84`
- 11 focused authority/bootstrap/scan/heartbeat/Coinbase regression tests passed locally
- final Actions head: `c852a39ab54487acc8ee3f3e63d614245900a015`
- 11 of 12 workflows passed, including preflight/lint, import smoke, image build, CodeQL, security, artifact, zero-trust, and deployment safety
- full CI completed in 168.897s without timing out
- full-test comparison against the immediately preceding #2458 head: 82 failure headers on baseline and 82 on this branch; **0 added regressions**
- the sole red workflow is the repository's existing full-suite baseline (45 failures / 43 errors), not a timeout or branch-added failure

This supersedes the runtime assumptions from #2457 and #2458.