### PR TITLE
Fix canonical writer renewal proof freshness

### DIFF
--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -210,6 +210,12 @@ class EntrypointWriterAuthority:
         self._on_lost_callback: Optional[Any] = None
         self._writer_state: WriterState = WriterState.ACQUIRING
         self._writer_state_since: float = time.time()
+        # Canonical proof of the most recent successful Redis lease operation.
+        # The stale-renewal watchdog consumes this value.  Keep it on the
+        # authority itself so later runtime patch/canonicalization passes cannot
+        # detach proof publication from the actual Redis renewal.
+        self._nija_last_lease_renewal_monotonic: float = 0.0
+        self._nija_last_lease_renewal_epoch: float = 0.0
         os.environ["NIJA_WRITER_STATE"] = self._writer_state.value
         os.environ["NIJA_WRITER_STATE_SINCE_TS"] = str(self._writer_state_since)
 
@@ -756,6 +762,58 @@ class EntrypointWriterAuthority:
             )
         return None
 
+    def _record_successful_lease_renewal(self) -> None:
+        """Publish proof only after acquisition or exact Redis renewal succeeds."""
+        now_epoch = time.time()
+        self._nija_last_lease_renewal_monotonic = time.monotonic()
+        self._nija_last_lease_renewal_epoch = now_epoch
+        os.environ["NIJA_WRITER_LEASE_RENEWAL_ACTIVE"] = "1"
+        os.environ["NIJA_WRITER_LEASE_RENEWED_TS"] = f"{now_epoch:.6f}"
+
+    def _nija_lease_renewal_health(self) -> tuple[bool, str, float, float]:
+        """Return fail-closed freshness for the canonical renewal proof."""
+        if self._local_fallback:
+            return True, "local_fallback", 0.0, float("inf")
+        if not self.acquired:
+            return False, "writer_not_acquired", float("inf"), 0.0
+        if self.lost:
+            return False, "writer_lost", float("inf"), 0.0
+        if self._stop.is_set():
+            return False, "renewal_stop_requested", float("inf"), 0.0
+        thread = self._heartbeat_thread
+        if thread is None:
+            return False, "renewal_thread_missing", float("inf"), 0.0
+        try:
+            if not thread.is_alive():
+                return False, "renewal_thread_not_alive", float("inf"), 0.0
+        except Exception:
+            return False, "renewal_thread_state_unavailable", float("inf"), 0.0
+
+        try:
+            ttl_s = max(15.0, float(self._ttl_s or 60.0))
+        except (TypeError, ValueError):
+            ttl_s = 60.0
+        raw_interval = str(
+            os.environ.get("NIJA_WRITER_HEARTBEAT_INTERVAL_S", "") or ""
+        ).strip()
+        try:
+            interval_s = max(1.0, float(raw_interval)) if raw_interval else min(
+                5.0, max(1.0, ttl_s / 3.0)
+            )
+        except (TypeError, ValueError):
+            interval_s = min(5.0, max(1.0, ttl_s / 3.0))
+        max_age_s = min(
+            max(10.0, interval_s * 3.0),
+            max(interval_s * 2.0, ttl_s * 0.75),
+        )
+        last = float(self._nija_last_lease_renewal_monotonic or 0.0)
+        if last <= 0.0:
+            return False, "renewal_success_uninitialized", float("inf"), max_age_s
+        age_s = max(0.0, time.monotonic() - last)
+        if age_s > max_age_s:
+            return False, "renewal_success_stale", age_s, max_age_s
+        return True, "renewal_healthy", age_s, max_age_s
+
     def _publish_env(self, *, scope: str, generation_key: str, fallback: bool) -> None:
         now = str(time.time())
         os.environ["NIJA_WRITER_FENCING_TOKEN"] = self._token
@@ -774,6 +832,7 @@ class EntrypointWriterAuthority:
         os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "1"
         os.environ["NIJA_WRITER_HEARTBEAT_LAST_TS"] = now
         os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = now
+        self._record_successful_lease_renewal()
         if fallback:
             os.environ["NIJA_WRITER_FENCING_TOKEN_FALLBACK"] = "1"
             os.environ["NIJA_LOCK_BYPASS_MODE"] = (
@@ -1198,6 +1257,7 @@ class EntrypointWriterAuthority:
                 os.environ["NIJA_WRITER_HEARTBEAT_LAST_TS"] = now
                 os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = now
                 os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "1"
+                self._record_successful_lease_renewal()
                 try:
                     _get_heartbeat_state().record_heartbeat(generation=self._generation)
                 except Exception:

--- a/bot/tests/test_writer_renewal_proof_v85.py
+++ b/bot/tests/test_writer_renewal_proof_v85.py
@@ -60,7 +60,9 @@ class WriterRenewalProofV85Tests(unittest.TestCase):
         runtime._nija_last_lease_renewal_monotonic = 11.5
         runtime._heartbeat_thread = MagicMock()
         runtime._heartbeat_thread.is_alive.return_value = True
-        with patch.object(runtime, "_notify_runtime_reconciliation"), patch(
+        with patch.object(
+            runtime, "_check_authority_invariant", return_value=(True, "")
+        ), patch.object(runtime, "_notify_runtime_reconciliation"), patch(
             "bot.entrypoint_writer_authority.time.monotonic", return_value=42.0
         ), patch("bot.entrypoint_writer_authority.time.time", return_value=202.5):
             ok, reason = runtime._heartbeat_tick()
@@ -81,7 +83,9 @@ class WriterRenewalProofV85Tests(unittest.TestCase):
         runtime._nija_last_lease_renewal_monotonic = 11.5
         runtime._nija_last_lease_renewal_epoch = 101.25
 
-        with patch("bot.entrypoint_writer_authority.time.monotonic", return_value=42.0), patch(
+        with patch.object(
+            runtime, "_check_authority_invariant", return_value=(True, "")
+        ), patch("bot.entrypoint_writer_authority.time.monotonic", return_value=42.0), patch(
             "bot.entrypoint_writer_authority.time.time", return_value=202.5
         ):
             ok, reason = runtime._heartbeat_tick()

--- a/bot/tests/test_writer_renewal_proof_v85.py
+++ b/bot/tests/test_writer_renewal_proof_v85.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from bot.entrypoint_writer_authority import (
+    EntrypointWriterAuthority,
+    EntrypointWriterAuthorityResult,
+)
+
+
+class WriterRenewalProofV85Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = {
+            key: os.environ.get(key)
+            for key in (
+                "NIJA_WRITER_LEASE_RENEWAL_ACTIVE",
+                "NIJA_WRITER_LEASE_RENEWED_TS",
+            )
+        }
+        for key in self.saved:
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        for key, value in self.saved.items():
+            os.environ.pop(key, None)
+            if value is not None:
+                os.environ[key] = value
+
+    @staticmethod
+    def _acquired_runtime(redis_code: int) -> EntrypointWriterAuthority:
+        runtime = EntrypointWriterAuthority()
+        runtime._client = MagicMock()
+        runtime._client.eval.return_value = redis_code
+        runtime._result = EntrypointWriterAuthorityResult(acquired=True)
+        runtime._lock_key = "nija:writer_lock:test"
+        runtime._meta_key = "nija:writer_lock_meta:test"
+        runtime._fencing_key = "nija:writer_fence:test"
+        runtime._lock_value = "17:owner"
+        runtime._token = "17"
+        runtime._generation = 23
+        runtime._instance_id = "instance-1"
+        return runtime
+
+    def test_publish_env_records_initial_renewal_proof(self) -> None:
+        runtime = self._acquired_runtime(1)
+        with patch("bot.entrypoint_writer_authority.time.monotonic", return_value=11.5), patch(
+            "bot.entrypoint_writer_authority.time.time", return_value=101.25
+        ):
+            runtime._publish_env(scope="test", generation_key="generation", fallback=False)
+
+        self.assertEqual(runtime._nija_last_lease_renewal_monotonic, 11.5)
+        self.assertEqual(runtime._nija_last_lease_renewal_epoch, 101.25)
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_RENEWAL_ACTIVE"], "1")
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_RENEWED_TS"], "101.250000")
+
+    def test_successful_canonical_heartbeat_refreshes_renewal_proof(self) -> None:
+        runtime = self._acquired_runtime(1)
+        runtime._nija_last_lease_renewal_monotonic = 11.5
+        runtime._heartbeat_thread = MagicMock()
+        runtime._heartbeat_thread.is_alive.return_value = True
+        with patch.object(runtime, "_notify_runtime_reconciliation"), patch(
+            "bot.entrypoint_writer_authority.time.monotonic", return_value=42.0
+        ), patch("bot.entrypoint_writer_authority.time.time", return_value=202.5):
+            ok, reason = runtime._heartbeat_tick()
+            healthy, health_reason, age_s, max_age_s = runtime._nija_lease_renewal_health()
+
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+        self.assertEqual(runtime._nija_last_lease_renewal_monotonic, 42.0)
+        self.assertEqual(runtime._nija_last_lease_renewal_epoch, 202.5)
+        self.assertEqual(os.environ["NIJA_WRITER_LEASE_RENEWED_TS"], "202.500000")
+        self.assertTrue(healthy)
+        self.assertEqual(health_reason, "renewal_healthy")
+        self.assertEqual(age_s, 0.0)
+        self.assertGreaterEqual(max_age_s, 10.0)
+
+    def test_failed_heartbeat_does_not_refresh_renewal_proof(self) -> None:
+        runtime = self._acquired_runtime(0)
+        runtime._nija_last_lease_renewal_monotonic = 11.5
+        runtime._nija_last_lease_renewal_epoch = 101.25
+
+        with patch("bot.entrypoint_writer_authority.time.monotonic", return_value=42.0), patch(
+            "bot.entrypoint_writer_authority.time.time", return_value=202.5
+        ):
+            ok, reason = runtime._heartbeat_tick()
+
+        self.assertFalse(ok)
+        self.assertEqual(reason, "lock_owned_by_different_writer")
+        self.assertEqual(runtime._nija_last_lease_renewal_monotonic, 11.5)
+        self.assertEqual(runtime._nija_last_lease_renewal_epoch, 101.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- publish lease-renewal proof from the canonical writer authority on acquisition and only after an exact Redis heartbeat renewal succeeds
- provide canonical fail-closed renewal-health evaluation so the stale-renewal watchdog does not depend on a detachable runtime wrapper
- add regressions proving successful renewals refresh watchdog proof while rejected renewals do not

## Runtime evidence
The deployed merge commit `55a186b` repeatedly reported `STALE_RENEWAL_V40_PROBE reason=renewal_success_stale` while Redis still reported `lock_owned_exact`. The renewal age increased from roughly 47s to 103s. The canonical heartbeat refreshed Redis and heartbeat environment fields but did not refresh `_nija_last_lease_renewal_monotonic`, which v40 measures.

## Safety
- no lock, fencing, capital, nonce, dispatch, or strategy gate is weakened
- missing/dead/stopped heartbeat proof remains fail-closed
- rejected or errored Redis renewals do not refresh proof
- genuine stale renewals still trip the existing v40 fail-closed path

## Validation
- `python -m py_compile bot/entrypoint_writer_authority.py bot/tests/test_writer_renewal_proof_v85.py`
- `python -m unittest -v bot.tests.test_writer_renewal_proof_v85 bot.tests.test_stale_renewal_epoch_v83` (5 tests passed locally)

Draft for required human review of writer-heartbeat changes.