### PR TITLE
Fix Kraken all-account connection supervision

### DIFF
--- a/authority_heartbeat_generation_scope_patch.py
+++ b/authority_heartbeat_generation_scope_patch.py
@@ -99,51 +99,8 @@ def _patch_module(module: ModuleType) -> bool:
             }
             client.set("nija:writer_heartbeat_active", json.dumps(heartbeat_data), ex=30)
 
-            lock_scope = os.environ.get("NIJA_WRITER_SCOPE", "platform")
-            lock_key = (
-                os.environ.get("NIJA_WRITER_LOCK_KEY", "").strip()
-                or f"nija:writer_lock:{lock_scope}"
-            )
-            lock_ttl_s = max(
-                60,
-                int(os.environ.get("NIJA_WRITER_LOCK_TTL_S", "30") or 30) * 3,
-            )
-            expected_token = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
-            if expected_token:
-                current_lock = client.get(lock_key)
-                if current_lock is not None:
-                    if isinstance(current_lock, bytes):
-                        current_lock = current_lock.decode("utf-8", errors="replace")
-                    current_prefix = str(current_lock or "").split(":", 1)[0]
-                    if current_prefix == expected_token:
-                        client.expire(lock_key, lock_ttl_s)
-                    else:
-                        logger.critical(
-                            "AUTHORITY_HEARTBEAT_LOCK_OWNER_MISMATCH marker=%s lock_key=%s expected=%s actual=%s",
-                            MARKER,
-                            lock_key,
-                            expected_token[:8],
-                            current_prefix[:8],
-                        )
-                else:
-                    owner_id = os.environ.get("NIJA_WRITER_OWNER_ID", "heartbeat_recovered")
-                    lock_value = f"{expected_token}:{owner_id}"
-                    reacquired = client.set(lock_key, lock_value, ex=lock_ttl_s, nx=True)
-                    if reacquired:
-                        logger.warning(
-                            "AUTHORITY_HEARTBEAT_LOCK_REACQUIRED marker=%s lock_key=%s token_prefix=%s",
-                            MARKER,
-                            lock_key,
-                            expected_token[:8],
-                        )
-                    else:
-                        logger.critical(
-                            "AUTHORITY_HEARTBEAT_LOCK_REACQUIRE_FAILED marker=%s lock_key=%s token_prefix=%s",
-                            MARKER,
-                            lock_key,
-                            expected_token[:8],
-                        )
-
+            # Telemetry only. The canonical EntrypointWriterAuthority heartbeat
+            # owns writer-lock renewal and updates lock metadata atomically.
             logger.info(
                 "AUTHORITY_HEARTBEAT_PLATFORM_GENERATION_PUBLISHED marker=%s generation=%s",
                 MARKER,

--- a/bot/authority_heartbeat.py
+++ b/bot/authority_heartbeat.py
@@ -1062,63 +1062,10 @@ class AuthorityHeartbeatMonitor:
                 ex=30,  # 30 second TTL
             )
 
-            # Refresh the writer lock key TTL so it does not expire between
-            # heartbeat cycles.  Use EXPIRE (not SET NX) so we only refresh an
-            # existing lock that this instance already holds — we never overwrite
-            # a lock that belongs to a different instance.
-            _lock_scope = os.environ.get("NIJA_WRITER_SCOPE", "platform")
-            _lock_key = (
-                os.environ.get("NIJA_WRITER_LOCK_KEY", "").strip()
-                or f"nija:writer_lock:{_lock_scope}"
-            )
-            _lock_ttl_s = max(
-                60,
-                int(os.environ.get("NIJA_WRITER_LOCK_TTL_S", "30") or 30) * 3,
-            )
-            try:
-                # Only refresh if the lock exists AND belongs to this instance.
-                # If the lock is MISSING (expired TTL gap), re-acquire it now
-                # rather than waiting for the next execute_entry path to do it,
-                # preventing repeated re-acquisition log noise.
-                _expected_token = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
-                if _expected_token:
-                    _current_lock = self._redis_client.get(_lock_key)
-                    if _current_lock is not None:
-                        if isinstance(_current_lock, bytes):
-                            _current_lock = _current_lock.decode("utf-8", errors="replace")
-                        _current_prefix = str(_current_lock or "").split(":", 1)[0]
-                        if _current_prefix == _expected_token:
-                            self._redis_client.expire(_lock_key, _lock_ttl_s)
-                            logger.debug(
-                                "AuthorityHeartbeat: refreshed writer lock TTL "
-                                "lock_key=%s ttl_s=%d token_prefix=%s",
-                                _lock_key, _lock_ttl_s, _expected_token[:8],
-                            )
-                        # else: lock is held by a different token — do not touch it
-                    else:
-                        # Lock is MISSING — re-acquire it proactively before the
-                        # authority check path encounters the gap and logs warnings.
-                        _owner_id = os.environ.get("NIJA_WRITER_OWNER_ID", "heartbeat_recovered")
-                        _lock_value = f"{_expected_token}:{_owner_id}"
-                        _reacquired = self._redis_client.set(_lock_key, _lock_value, ex=_lock_ttl_s, nx=True)
-                        if _reacquired:
-                            logger.warning(
-                                "AuthorityHeartbeat: writer lock key was MISSING — proactively "
-                                "re-acquired (lock_key=%s ttl_s=%d token_prefix=%s). "
-                                "This is expected after a TTL expiry gap between heartbeat cycles.",
-                                _lock_key, _lock_ttl_s, _expected_token[:8],
-                            )
-                        else:
-                            logger.warning(
-                                "AuthorityHeartbeat: writer lock key was missing but NX SET "
-                                "failed — another process may now hold the lock "
-                                "(lock_key=%s token_prefix=%s). "
-                                "Single-writer safety may be compromised.",
-                                _lock_key, _expected_token[:8],
-                            )
-            except Exception as _lock_refresh_exc:
-                logger.debug("AuthorityHeartbeat: writer lock TTL refresh failed: %s", _lock_refresh_exc)
-
+            # EntrypointWriterAuthority is the sole process-writer lease
+            # renewer. This monitor publishes telemetry only; it must never
+            # extend or recreate the writer lock without refreshing canonical
+            # metadata in the same atomic renewal.
             logger.debug("AuthorityHeartbeat: wrote heartbeat with generation=%s", local_gen)
         except Exception as e:
             logger.error("AuthorityHeartbeat: failed to write heartbeat: %s", e)

--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -216,6 +216,13 @@ class EntrypointWriterAuthority:
         # detach proof publication from the actual Redis renewal.
         self._nija_last_lease_renewal_monotonic: float = 0.0
         self._nija_last_lease_renewal_epoch: float = 0.0
+        # Readiness reconciliation may perform slow broker I/O. It must never
+        # run on the canonical Redis renewal thread or metadata/TTL refreshes
+        # can stall behind an exchange timeout. Keep at most one deduplicated
+        # reconciliation worker in flight; the heartbeat remains the sole
+        # writer-lease renewer.
+        self._runtime_reconcile_lock = threading.Lock()
+        self._runtime_reconcile_thread: Optional[threading.Thread] = None
         os.environ["NIJA_WRITER_STATE"] = self._writer_state.value
         os.environ["NIJA_WRITER_STATE_SINCE_TS"] = str(self._writer_state_since)
 
@@ -849,7 +856,7 @@ class EntrypointWriterAuthority:
         except Exception:
             pass
 
-    def _notify_runtime_reconciliation(self, trigger: str) -> None:
+    def _run_runtime_reconciliation(self, trigger: str) -> None:
         try:
             readiness = importlib.import_module("three_venue_execution_readiness")
             reconcile = getattr(readiness, "reconcile_execution_readiness", None)
@@ -862,6 +869,33 @@ class EntrypointWriterAuthority:
                 trigger,
                 exc_info=True,
             )
+
+    def _notify_runtime_reconciliation(self, trigger: str) -> None:
+        """Notify readiness without allowing broker I/O to stall lease renewal."""
+        if trigger != "heartbeat_renewed":
+            self._run_runtime_reconciliation(trigger)
+            return
+
+        with self._runtime_reconcile_lock:
+            worker = self._runtime_reconcile_thread
+            if worker is not None and worker.is_alive():
+                return
+
+            def _worker() -> None:
+                try:
+                    self._run_runtime_reconciliation(trigger)
+                finally:
+                    with self._runtime_reconcile_lock:
+                        if self._runtime_reconcile_thread is threading.current_thread():
+                            self._runtime_reconcile_thread = None
+
+            worker = threading.Thread(
+                target=_worker,
+                name="writer-readiness-reconciliation",
+                daemon=True,
+            )
+            self._runtime_reconcile_thread = worker
+            worker.start()
 
     def _metadata_payload(self) -> str:
         core_alive = False

--- a/bot/independent_broker_trader.py
+++ b/bot/independent_broker_trader.py
@@ -916,6 +916,18 @@ class IndependentBrokerTrader:
         logger.info("✅ %s: nonce resync reconnect succeeded", broker_name)
         return True
 
+    @staticmethod
+    def _require_exact_cycle_authority(source: str) -> tuple[bool, str]:
+        try:
+            try:
+                from bot import nija_core_loop as core_loop
+            except ImportError:
+                import nija_core_loop as core_loop  # type: ignore[import]
+            ok, reason = core_loop._require_exact_runtime_cycle_authority(source)
+            return bool(ok), str(reason or "")
+        except Exception as exc:
+            return False, f"authority_guard_unavailable:{type(exc).__name__}:{exc}"
+
     def _execute_trading_cycle(
         self,
         broker_type,
@@ -923,7 +935,7 @@ class IndependentBrokerTrader:
         broker_name: str,
         cycle_count: int,
         balance: float,
-    ) -> None:
+    ) -> bool:
         """
         Execute a single platform trading cycle for the given broker.
 
@@ -938,6 +950,18 @@ class IndependentBrokerTrader:
             cycle_count: Current cycle number (for logging)
             balance: Account balance fetched before this cycle (USD)
         """
+        authority_ok, authority_reason = self._require_exact_cycle_authority(
+            "independent_broker_trader.platform_execute"
+        )
+        if not authority_ok:
+            logger.critical(
+                "PLATFORM_CYCLE_AUTHORITY_BLOCKED broker=%s cycle=%d reason=%s broker_io=false",
+                broker_name,
+                cycle_count,
+                authority_reason,
+            )
+            return False
+
         logger.info(f"   {'═' * 55}")
         logger.info(f"   🎯 {broker_name.upper()} PLATFORM TRADING CYCLE #{cycle_count}")
         logger.info(f"   {'═' * 55}")
@@ -990,9 +1014,22 @@ class IndependentBrokerTrader:
 
         logger.info(f"   ✅ {broker_name.upper()} cycle completed successfully")
         logger.info("")
+        return True
 
     def _run_platform_cycle(self, broker_type, broker, broker_name: str, cycle_count: int) -> float:
         """Run exactly one platform broker scan cycle and return the next sleep interval."""
+        authority_ok, authority_reason = self._require_exact_cycle_authority(
+            "independent_broker_trader.platform_scan"
+        )
+        if not authority_ok:
+            logger.critical(
+                "SCAN_CYCLE_AUTHORITY_BLOCKED broker=%s cycle=%d reason=%s broker_io=false",
+                broker_name,
+                cycle_count,
+                authority_reason,
+            )
+            return 5.0
+
         with self._scan_guard(broker_name, cycle_count):
             logger.critical(
                 "SCAN_CYCLE_START %d broker=%s thread=%d",
@@ -1076,7 +1113,11 @@ class IndependentBrokerTrader:
             with self._phase_marker(broker_name, cycle_count, "PHASE3"):
                 try:
                     start_time = time.time()
-                    self._execute_trading_cycle(broker_type, broker, broker_name, cycle_count, balance)
+                    executed = self._execute_trading_cycle(
+                        broker_type, broker, broker_name, cycle_count, balance
+                    )
+                    if not executed:
+                        return 5.0
                     elapsed = time.time() - start_time
                     logger.info(f"✅ {broker_name.upper()} cycle completed in {elapsed:.2f}s")
                     if self.failure_manager:
@@ -1272,6 +1313,21 @@ class IndependentBrokerTrader:
                     try:
                         cycle_count += 1
                         logger.info(f"🔄 {broker_name} (USER) - Cycle #{cycle_count}")
+
+                        authority_ok, authority_reason = self._require_exact_cycle_authority(
+                            "independent_broker_trader.user_scan"
+                        )
+                        if not authority_ok:
+                            logger.critical(
+                                "USER_SCAN_AUTHORITY_BLOCKED user=%s broker=%s cycle=%d "
+                                "reason=%s broker_io=false",
+                                user_id,
+                                broker_type.value,
+                                cycle_count,
+                                authority_reason,
+                            )
+                            stop_flag.wait(5)
+                            continue
 
                         # Guard: ensure the platform broker is still CONNECTED before user trades,
                         # but allow trading if the user broker itself is directly connected
@@ -1475,6 +1531,21 @@ class IndependentBrokerTrader:
                             # configured with "independent_trading": true.
                             # When independent_trading is disabled the account runs in position-management
                             # mode only (user_mode=True) and relies on copy-trade signals from the platform.
+                            authority_ok, authority_reason = self._require_exact_cycle_authority(
+                                "independent_broker_trader.user_execute"
+                            )
+                            if not authority_ok:
+                                logger.critical(
+                                    "USER_CYCLE_AUTHORITY_BLOCKED user=%s broker=%s cycle=%d "
+                                    "reason=%s broker_io=false",
+                                    user_id,
+                                    broker_type.value,
+                                    cycle_count,
+                                    authority_reason,
+                                )
+                                stop_flag.wait(5)
+                                continue
+
                             if is_independent:
                                 logger.info(f"   {broker_name} (USER): Running INDEPENDENT strategy (APEX signal generation)...")
                                 self.trading_strategy.run_cycle(broker=broker, user_mode=False)

--- a/bot/kraken_all_account_supervision_v86.py
+++ b/bot/kraken_all_account_supervision_v86.py
@@ -1,0 +1,251 @@
+"""Writer-scoped Kraken connection supervision for platform and user accounts.
+
+The existing v44 reconciler owns the platform recovery path.  This module adds
+the missing per-user half: every Kraken broker already registered by the
+MultiAccountBrokerManager is observed, and a disconnected broker is reconnected
+through its own authenticated ``connect()`` implementation.
+
+No connection flag, credential, nonce, balance, writer lease, or execution
+authority is fabricated.  Broker I/O is scheduled only after the canonical
+writer runtime has fresh exact Redis metadata, and Kraken reconnects are
+serialized to preserve per-key nonce/rate-limit ordering.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+from bot import kraken_connection_convergence_v44_patch as v44
+
+
+LOGGER = logging.getLogger("nija.kraken_all_account_supervision_v86")
+MARKER = "20260810-kraken-all-account-supervision-v86"
+_LOCK = threading.RLock()
+_CONNECT_SERIAL_LOCK = threading.Lock()
+_INFLIGHT: set[str] = set()
+_FAILURES: dict[str, int] = {}
+_NEXT_RETRY: dict[str, float] = {}
+
+
+def _label(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").strip().lower()
+
+
+def _writer_proof() -> tuple[bool, str]:
+    runtime = v44._writer_runtime()
+    if runtime is None:
+        return False, "writer_runtime_missing"
+    health = getattr(runtime, "_nija_lease_renewal_health", None)
+    max_age_s = 15.0
+    if callable(health):
+        try:
+            _ok, _reason, _age_s, observed_max_age_s = health()
+            max_age_s = max(5.0, float(observed_max_age_s or max_age_s))
+        except Exception:
+            pass
+    proof = v44._exact_writer_renewal_proof(runtime, max_age_s)
+    if not proof.get("ok"):
+        return False, str(proof.get("reason") or "exact_writer_proof_failed")
+    return True, "exact_writer_renewal_proof"
+
+
+def _user_records(manager: Any) -> list[tuple[str, str, Any, Any]]:
+    """Return unique registered Kraken users, including disconnected brokers."""
+    records: dict[str, tuple[str, str, Any, Any]] = {}
+    all_users = getattr(manager, "_all_user_brokers", {})
+    try:
+        all_items = list(all_users.items())
+    except Exception:
+        all_items = []
+    for key, broker in all_items:
+        if not isinstance(key, tuple) or len(key) != 2:
+            continue
+        user_id, broker_type = key
+        if _label(broker_type) != "kraken" or broker is None:
+            continue
+        account_id = f"user:{user_id}:kraken"
+        records[account_id] = (account_id, str(user_id), broker_type, broker)
+
+    connected_users = getattr(manager, "user_brokers", {})
+    try:
+        connected_items = list(connected_users.items())
+    except Exception:
+        connected_items = []
+    for user_id, mapping in connected_items:
+        try:
+            broker_items = list(mapping.items())
+        except Exception:
+            continue
+        for broker_type, broker in broker_items:
+            if _label(broker_type) != "kraken" or broker is None:
+                continue
+            account_id = f"user:{user_id}:kraken"
+            records[account_id] = (account_id, str(user_id), broker_type, broker)
+    return [records[key] for key in sorted(records)]
+
+
+def _retry_delay(failures: int) -> float:
+    try:
+        base = max(5.0, float(os.environ.get("NIJA_KRAKEN_USER_RECONNECT_BASE_S", "10") or 10))
+    except (TypeError, ValueError):
+        base = 10.0
+    try:
+        ceiling = max(base, float(os.environ.get("NIJA_KRAKEN_USER_RECONNECT_MAX_S", "300") or 300))
+    except (TypeError, ValueError):
+        ceiling = 300.0
+    return min(ceiling, base * (2 ** max(0, min(failures - 1, 8))))
+
+
+def _mark_connected(manager: Any, user_id: str, broker_type: Any, broker: Any) -> None:
+    if not bool(getattr(broker, "connected", False)):
+        return
+    user_map = getattr(manager, "user_brokers", None)
+    if isinstance(user_map, dict):
+        user_map.setdefault(user_id, {})[broker_type] = broker
+    failed = getattr(manager, "_failed_user_connections", None)
+    if isinstance(failed, dict):
+        failed.pop((user_id, broker_type), None)
+
+
+def _connect_account(
+    manager: Any,
+    account_id: str,
+    user_id: str,
+    broker_type: Any,
+    broker: Any,
+) -> None:
+    try:
+        with _CONNECT_SERIAL_LOCK:
+            if bool(getattr(broker, "connected", False)):
+                _mark_connected(manager, user_id, broker_type, broker)
+                with _LOCK:
+                    _FAILURES.pop(account_id, None)
+                    _NEXT_RETRY.pop(account_id, None)
+                return
+
+            proof_ok, proof_reason = _writer_proof()
+            if not proof_ok:
+                with _LOCK:
+                    _NEXT_RETRY[account_id] = time.monotonic() + 5.0
+                LOGGER.warning(
+                    "KRAKEN_USER_RECONNECT_BLOCKED marker=%s account=%s reason=%s "
+                    "broker_io=false fail_closed=true",
+                    MARKER,
+                    account_id,
+                    proof_reason,
+                )
+                return
+
+            user_config = getattr(manager, "user_configs", {}).get(user_id)
+            resync = getattr(manager, "_resync_single_user_kraken_nonce", None)
+            if user_config is not None and callable(resync):
+                try:
+                    resync(user_config)
+                except Exception as exc:
+                    LOGGER.warning(
+                        "KRAKEN_USER_NONCE_RESYNC_FAILED marker=%s account=%s error=%s:%s",
+                        MARKER,
+                        account_id,
+                        type(exc).__name__,
+                        exc,
+                    )
+
+            connect = getattr(broker, "connect", None)
+            if not callable(connect):
+                raise RuntimeError("broker_connect_unavailable")
+            connect()
+            if not bool(getattr(broker, "connected", False)):
+                raise RuntimeError("authenticated_connect_did_not_confirm_connected")
+
+            _mark_connected(manager, user_id, broker_type, broker)
+            with _LOCK:
+                _FAILURES.pop(account_id, None)
+                _NEXT_RETRY.pop(account_id, None)
+            LOGGER.critical(
+                "KRAKEN_USER_RECONNECTED marker=%s account=%s "
+                "authenticated=true fabricated_connected=false",
+                MARKER,
+                account_id,
+            )
+    except Exception as exc:
+        with _LOCK:
+            failures = _FAILURES.get(account_id, 0) + 1
+            _FAILURES[account_id] = failures
+            delay = _retry_delay(failures)
+            _NEXT_RETRY[account_id] = time.monotonic() + delay
+        LOGGER.warning(
+            "KRAKEN_USER_RECONNECT_FAILED marker=%s account=%s failures=%d "
+            "retry_s=%.1f error=%s:%s isolated=true",
+            MARKER,
+            account_id,
+            failures,
+            delay,
+            type(exc).__name__,
+            exc,
+        )
+    finally:
+        with _LOCK:
+            _INFLIGHT.discard(account_id)
+
+
+def _schedule(manager: Any, record: tuple[str, str, Any, Any]) -> str:
+    account_id, user_id, broker_type, broker = record
+    if bool(getattr(broker, "connected", False)):
+        _mark_connected(manager, user_id, broker_type, broker)
+        with _LOCK:
+            _FAILURES.pop(account_id, None)
+            _NEXT_RETRY.pop(account_id, None)
+        return "connected"
+    if getattr(broker, "credentials_configured", None) is False:
+        return "credentials_not_configured"
+
+    now = time.monotonic()
+    with _LOCK:
+        if account_id in _INFLIGHT:
+            return "reconnect_inflight"
+        if now < _NEXT_RETRY.get(account_id, 0.0):
+            return "backoff"
+        _INFLIGHT.add(account_id)
+    threading.Thread(
+        target=_connect_account,
+        args=(manager, account_id, user_id, broker_type, broker),
+        name=f"KrakenUserReconnect-{user_id}",
+        daemon=True,
+    ).start()
+    return "reconnect_scheduled"
+
+
+def reconcile_once(manager: Any = None) -> dict[str, Any]:
+    if manager is None:
+        try:
+            from bot.multi_account_broker_manager import get_multi_account_broker_manager
+            manager = get_multi_account_broker_manager()
+        except Exception as exc:
+            return {"ok": False, "reason": f"manager_unavailable:{type(exc).__name__}:{exc}"}
+    records = _user_records(manager)
+    states = {account_id: _schedule(manager, record) for record in records for account_id in [record[0]]}
+    disconnected = sum(1 for state in states.values() if state != "connected")
+    return {
+        "ok": disconnected == 0,
+        "reason": "all_registered_kraken_users_connected" if disconnected == 0 else "recovery_active",
+        "registered": len(records),
+        "connected": len(records) - disconnected,
+        "disconnected": disconnected,
+        "states": states,
+    }
+
+
+def install() -> bool:
+    os.environ["NIJA_KRAKEN_ALL_ACCOUNT_SUPERVISION_V86_INSTALLED"] = "1"
+    LOGGER.critical(
+        "KRAKEN_ALL_ACCOUNT_SUPERVISION_V86_INSTALLED marker=%s "
+        "platform=v44 users=authenticated_per_account writer_scoped=true",
+        MARKER,
+    )
+    return True
+
+
+__all__ = ["MARKER", "install", "reconcile_once", "_user_records", "_writer_proof"]

--- a/bot/tests/test_authority_heartbeat_generation_scope_patch.py
+++ b/bot/tests/test_authority_heartbeat_generation_scope_patch.py
@@ -71,7 +71,7 @@ def test_heartbeat_writer_uses_platform_generation_not_global_counter(monkeypatc
     payload = json.loads(heartbeat_call[1])
     assert payload["generation"] == "439"
     assert payload["generation_scope"] == "platform_kraken_key"
-    assert client.expire_calls == [("nija:writer_lock:platform", 90)]
+    assert client.expire_calls == []
 
 
 def test_heartbeat_writer_fails_closed_when_platform_generation_missing(monkeypatch):

--- a/bot/tests/test_entrypoint_writer_heartbeat.py
+++ b/bot/tests/test_entrypoint_writer_heartbeat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import types
 import unittest
 from unittest.mock import MagicMock, patch
@@ -83,13 +84,18 @@ class EntrypointWriterHeartbeatTests(unittest.TestCase):
         self.runtime._client.eval.return_value = 1
         self.runtime._set_writer_state(WriterState.ACTIVE, reason="test_setup")
         calls = []
+        completed = threading.Event()
         readiness = types.ModuleType("three_venue_execution_readiness")
-        readiness.reconcile_execution_readiness = lambda **kwargs: calls.append(
-            (kwargs, os.environ.get("NIJA_WRITER_STATE"))
-        )
+
+        def reconcile(**kwargs):
+            calls.append((kwargs, os.environ.get("NIJA_WRITER_STATE")))
+            completed.set()
+
+        readiness.reconcile_execution_readiness = reconcile
 
         with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
             ok, reason = self.runtime._heartbeat_tick()
+            self.assertTrue(completed.wait(1.0))
 
         self.assertTrue(ok)
         self.assertEqual(reason, "")

--- a/bot/tests/test_kraken_all_account_supervision_v86.py
+++ b/bot/tests/test_kraken_all_account_supervision_v86.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from bot import kraken_all_account_supervision_v86 as v86
+
+
+class _BrokerType:
+    value = "kraken"
+
+
+class _Broker:
+    def __init__(self, *, connected: bool = False, configured: bool = True) -> None:
+        self.connected = connected
+        self.credentials_configured = configured
+        self.connect_calls = 0
+
+    def connect(self) -> bool:
+        self.connect_calls += 1
+        self.connected = True
+        return True
+
+
+def _clear_state() -> None:
+    with v86._LOCK:
+        v86._INFLIGHT.clear()
+        v86._FAILURES.clear()
+        v86._NEXT_RETRY.clear()
+
+
+def test_records_include_disconnected_registered_users_without_duplicates() -> None:
+    broker = _Broker()
+    manager = SimpleNamespace(
+        _all_user_brokers={("alice", _BrokerType): broker},
+        user_brokers={"alice": {_BrokerType: broker}},
+    )
+
+    records = v86._user_records(manager)
+
+    assert records == [("user:alice:kraken", "alice", _BrokerType, broker)]
+
+
+def test_reconnect_uses_exact_writer_proof_and_canonical_connect(monkeypatch) -> None:
+    _clear_state()
+    broker = _Broker()
+    user = SimpleNamespace(user_id="alice", broker_type="KRAKEN")
+    resync_calls: list[object] = []
+    manager = SimpleNamespace(
+        user_brokers={},
+        user_configs={"alice": user},
+        _failed_user_connections={("alice", _BrokerType): "timeout"},
+        _resync_single_user_kraken_nonce=lambda config: resync_calls.append(config),
+    )
+    monkeypatch.setattr(v86, "_writer_proof", lambda: (True, "exact"))
+
+    v86._connect_account(manager, "user:alice:kraken", "alice", _BrokerType, broker)
+
+    assert broker.connect_calls == 1
+    assert broker.connected is True
+    assert manager.user_brokers["alice"][_BrokerType] is broker
+    assert manager._failed_user_connections == {}
+    assert resync_calls == [user]
+
+
+def test_reconnect_fails_closed_without_writer_proof(monkeypatch) -> None:
+    _clear_state()
+    broker = _Broker()
+    manager = SimpleNamespace(
+        user_brokers={}, user_configs={}, _failed_user_connections={}
+    )
+    monkeypatch.setattr(v86, "_writer_proof", lambda: (False, "metadata_stale"))
+
+    v86._connect_account(manager, "user:alice:kraken", "alice", _BrokerType, broker)
+
+    assert broker.connect_calls == 0
+    assert broker.connected is False
+    assert v86._NEXT_RETRY["user:alice:kraken"] > time.monotonic()
+
+
+def test_missing_credentials_never_schedule_broker_io() -> None:
+    _clear_state()
+    broker = _Broker(configured=False)
+    manager = SimpleNamespace(user_brokers={}, _failed_user_connections={})
+
+    state = v86._schedule(
+        manager,
+        ("user:alice:kraken", "alice", _BrokerType, broker),
+    )
+
+    assert state == "credentials_not_configured"
+    assert broker.connect_calls == 0
+    assert v86._INFLIGHT == set()

--- a/bot/tests/test_kraken_all_account_supervision_v86.py
+++ b/bot/tests/test_kraken_all_account_supervision_v86.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import time
 from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
 
 from bot import kraken_all_account_supervision_v86 as v86
 
@@ -29,65 +31,83 @@ def _clear_state() -> None:
         v86._NEXT_RETRY.clear()
 
 
-def test_records_include_disconnected_registered_users_without_duplicates() -> None:
-    broker = _Broker()
-    manager = SimpleNamespace(
-        _all_user_brokers={("alice", _BrokerType): broker},
-        user_brokers={"alice": {_BrokerType: broker}},
-    )
+class KrakenAllAccountSupervisionV86Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        _clear_state()
 
-    records = v86._user_records(manager)
+    def tearDown(self) -> None:
+        _clear_state()
 
-    assert records == [("user:alice:kraken", "alice", _BrokerType, broker)]
+    def test_records_include_disconnected_registered_users_without_duplicates(self) -> None:
+        broker = _Broker()
+        manager = SimpleNamespace(
+            _all_user_brokers={("alice", _BrokerType): broker},
+            user_brokers={"alice": {_BrokerType: broker}},
+        )
 
+        records = v86._user_records(manager)
 
-def test_reconnect_uses_exact_writer_proof_and_canonical_connect(monkeypatch) -> None:
-    _clear_state()
-    broker = _Broker()
-    user = SimpleNamespace(user_id="alice", broker_type="KRAKEN")
-    resync_calls: list[object] = []
-    manager = SimpleNamespace(
-        user_brokers={},
-        user_configs={"alice": user},
-        _failed_user_connections={("alice", _BrokerType): "timeout"},
-        _resync_single_user_kraken_nonce=lambda config: resync_calls.append(config),
-    )
-    monkeypatch.setattr(v86, "_writer_proof", lambda: (True, "exact"))
+        self.assertEqual(
+            records,
+            [("user:alice:kraken", "alice", _BrokerType, broker)],
+        )
 
-    v86._connect_account(manager, "user:alice:kraken", "alice", _BrokerType, broker)
+    def test_reconnect_uses_exact_writer_proof_and_canonical_connect(self) -> None:
+        broker = _Broker()
+        user = SimpleNamespace(user_id="alice", broker_type="KRAKEN")
+        resync_calls: list[object] = []
+        manager = SimpleNamespace(
+            user_brokers={},
+            user_configs={"alice": user},
+            _failed_user_connections={("alice", _BrokerType): "timeout"},
+            _resync_single_user_kraken_nonce=lambda config: resync_calls.append(config),
+        )
+        with patch.object(v86, "_writer_proof", return_value=(True, "exact")):
+            v86._connect_account(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+                broker,
+            )
 
-    assert broker.connect_calls == 1
-    assert broker.connected is True
-    assert manager.user_brokers["alice"][_BrokerType] is broker
-    assert manager._failed_user_connections == {}
-    assert resync_calls == [user]
+        self.assertEqual(broker.connect_calls, 1)
+        self.assertTrue(broker.connected)
+        self.assertIs(manager.user_brokers["alice"][_BrokerType], broker)
+        self.assertEqual(manager._failed_user_connections, {})
+        self.assertEqual(resync_calls, [user])
 
+    def test_reconnect_fails_closed_without_writer_proof(self) -> None:
+        broker = _Broker()
+        manager = SimpleNamespace(
+            user_brokers={}, user_configs={}, _failed_user_connections={}
+        )
+        with patch.object(
+            v86,
+            "_writer_proof",
+            return_value=(False, "metadata_stale"),
+        ):
+            v86._connect_account(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+                broker,
+            )
 
-def test_reconnect_fails_closed_without_writer_proof(monkeypatch) -> None:
-    _clear_state()
-    broker = _Broker()
-    manager = SimpleNamespace(
-        user_brokers={}, user_configs={}, _failed_user_connections={}
-    )
-    monkeypatch.setattr(v86, "_writer_proof", lambda: (False, "metadata_stale"))
+        self.assertEqual(broker.connect_calls, 0)
+        self.assertFalse(broker.connected)
+        self.assertGreater(v86._NEXT_RETRY["user:alice:kraken"], time.monotonic())
 
-    v86._connect_account(manager, "user:alice:kraken", "alice", _BrokerType, broker)
+    def test_missing_credentials_never_schedule_broker_io(self) -> None:
+        broker = _Broker(configured=False)
+        manager = SimpleNamespace(user_brokers={}, _failed_user_connections={})
 
-    assert broker.connect_calls == 0
-    assert broker.connected is False
-    assert v86._NEXT_RETRY["user:alice:kraken"] > time.monotonic()
+        state = v86._schedule(
+            manager,
+            ("user:alice:kraken", "alice", _BrokerType, broker),
+        )
 
-
-def test_missing_credentials_never_schedule_broker_io() -> None:
-    _clear_state()
-    broker = _Broker(configured=False)
-    manager = SimpleNamespace(user_brokers={}, _failed_user_connections={})
-
-    state = v86._schedule(
-        manager,
-        ("user:alice:kraken", "alice", _BrokerType, broker),
-    )
-
-    assert state == "credentials_not_configured"
-    assert broker.connect_calls == 0
-    assert v86._INFLIGHT == set()
+        self.assertEqual(state, "credentials_not_configured")
+        self.assertEqual(broker.connect_calls, 0)
+        self.assertEqual(v86._INFLIGHT, set())

--- a/bot/tests/test_writer_authority_recursion_guard_patch.py
+++ b/bot/tests/test_writer_authority_recursion_guard_patch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import time
 from types import ModuleType
@@ -26,13 +27,29 @@ def test_status_reentry_guard_returns_cached_result(monkeypatch):
     assert "cache" in result
 
 
-def test_status_reentry_guard_accepts_fresh_writer_proof(monkeypatch):
+def test_status_reentry_guard_accepts_fresh_exact_writer_proof(monkeypatch):
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("NIJA_REDIS_URL", "redis://example")
     monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "tok-123")
     monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "42")
     monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
-    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ALIVE_TS", str(time.time()))
+
+    class Client:
+        def get(self, key):
+            assert key == "meta"
+            return json.dumps(
+                {"token": "tok-123", "generation": 42, "heartbeat_at": time.time()}
+            )
+
+    runtime = type("Runtime", (), {"_client": Client(), "_meta_key": "meta", "_ttl_s": 60})()
+    exact = {
+        "runtime": runtime,
+        "client": runtime._client,
+        "token": "tok-123",
+        "generation": 42,
+        "pttl_ms": 55000,
+    }
+    monkeypatch.setattr(patch, "_exact_process_writer_proof", lambda: (exact, ""))
 
     module = ModuleType("bot.execution_authority_context")
     module._FENCE_LAST_OK = False
@@ -44,18 +61,20 @@ def test_status_reentry_guard_accepts_fresh_writer_proof(monkeypatch):
 
     module.get_distributed_writer_authority_status = recursive_status
     assert patch._patch_execution_authority_context(module) is True
-
     result = module.get_distributed_writer_authority_status()
 
     assert result["ok"] is True
     assert result["redis_reachable"] is True
     assert result["authority_verified"] is True
-    assert result["token_present"] is True
     assert result["lease_generation"] == "42"
     assert result["cache"]["reentry_proof_ok"] is True
 
-
 def test_status_reentry_guard_fails_closed_without_fresh_writer_proof(monkeypatch):
+    monkeypatch.setattr(
+        patch,
+        "_exact_process_writer_proof",
+        lambda: (None, "metadata_heartbeat_stale"),
+    )
     monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "true")
     monkeypatch.setenv("NIJA_REDIS_URL", "redis://example")
     monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "tok-123")

--- a/bot/tests/test_writer_generation_handoff_v45.py
+++ b/bot/tests/test_writer_generation_handoff_v45.py
@@ -149,6 +149,22 @@ def test_heartbeat_never_recreates_missing_lock(monkeypatch):
     assert redis.expires == []
 
 
+def test_heartbeat_telemetry_never_extends_owned_process_lock(monkeypatch):
+    _, redis = install_runtime(monkeypatch)
+    module = types.ModuleType("bot.authority_heartbeat")
+
+    class Monitor:
+        pass
+
+    Monitor._write_heartbeat_to_redis = lambda self: None
+    module.AuthorityHeartbeatMonitor = Monitor
+    assert v45._patch_heartbeat_module(module) is True
+    Monitor()._write_heartbeat_to_redis()
+    assert len(redis.sets) == 1
+    assert redis.sets[0][0][0] == "nija:writer_heartbeat_active"
+    assert redis.expires == []
+
+
 def test_v42_expected_generation_prefers_proven_runtime(monkeypatch):
     install_runtime(monkeypatch)
     monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "10")

--- a/bot/tests/test_writer_reconciliation_async_v86.py
+++ b/bot/tests/test_writer_reconciliation_async_v86.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import threading
 import types
+import unittest
 from unittest.mock import MagicMock, patch
 
 from bot.entrypoint_writer_authority import EntrypointWriterAuthority
@@ -28,42 +29,52 @@ def _runtime() -> EntrypointWriterAuthority:
     return runtime
 
 
-def test_slow_readiness_reconciliation_never_blocks_redis_renewal() -> None:
-    runtime = _runtime()
-    started = threading.Event()
-    release = threading.Event()
-    calls: list[dict[str, object]] = []
-    readiness = types.ModuleType("three_venue_execution_readiness")
+class WriterReconciliationAsyncV86Tests(unittest.TestCase):
+    def test_slow_readiness_reconciliation_never_blocks_redis_renewal(self) -> None:
+        runtime = _runtime()
+        started = threading.Event()
+        release = threading.Event()
+        calls: list[dict[str, object]] = []
+        readiness = types.ModuleType("three_venue_execution_readiness")
 
-    def reconcile(**kwargs: object) -> None:
-        calls.append(kwargs)
-        started.set()
-        release.wait(2.0)
+        def reconcile(**kwargs: object) -> None:
+            calls.append(kwargs)
+            started.set()
+            release.wait(2.0)
 
-    readiness.reconcile_execution_readiness = reconcile
-    with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
-        ok, reason = runtime._heartbeat_tick()
-        assert ok is True
-        assert reason == ""
-        assert started.wait(1.0)
+        readiness.reconcile_execution_readiness = reconcile
+        with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
+            ok, reason = runtime._heartbeat_tick()
+            self.assertTrue(ok)
+            self.assertEqual(reason, "")
+            self.assertTrue(started.wait(1.0))
 
-        # A second renewal succeeds while the first readiness pass is blocked,
-        # and it does not create another broker-I/O worker.
-        ok, reason = runtime._heartbeat_tick()
-        assert ok is True
-        assert reason == ""
-        assert calls == [{"trigger": "heartbeat_renewed", "force": True}]
-        assert runtime._client.eval.call_count == 2
-        release.set()
+            # A second renewal succeeds while the first readiness pass is
+            # blocked, and it does not create another broker-I/O worker.
+            ok, reason = runtime._heartbeat_tick()
+            self.assertTrue(ok)
+            self.assertEqual(reason, "")
+            self.assertEqual(
+                calls,
+                [{"trigger": "heartbeat_renewed", "force": True}],
+            )
+            self.assertEqual(runtime._client.eval.call_count, 2)
+            release.set()
+            worker = runtime._runtime_reconcile_thread
+            if worker is not None:
+                worker.join(1.0)
+            self.assertIsNone(runtime._runtime_reconcile_thread)
 
+    def test_non_heartbeat_reconciliation_remains_synchronous(self) -> None:
+        runtime = _runtime()
+        calls: list[dict[str, object]] = []
+        readiness = types.ModuleType("three_venue_execution_readiness")
+        readiness.reconcile_execution_readiness = lambda **kwargs: calls.append(kwargs)
 
-def test_non_heartbeat_reconciliation_remains_synchronous() -> None:
-    runtime = _runtime()
-    calls: list[dict[str, object]] = []
-    readiness = types.ModuleType("three_venue_execution_readiness")
-    readiness.reconcile_execution_readiness = lambda **kwargs: calls.append(kwargs)
+        with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
+            runtime._notify_runtime_reconciliation("core_thread_registered")
 
-    with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
-        runtime._notify_runtime_reconciliation("core_thread_registered")
-
-    assert calls == [{"trigger": "core_thread_registered", "force": True}]
+        self.assertEqual(
+            calls,
+            [{"trigger": "core_thread_registered", "force": True}],
+        )

--- a/bot/tests/test_writer_reconciliation_async_v86.py
+++ b/bot/tests/test_writer_reconciliation_async_v86.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import MagicMock, patch
+
+from bot.entrypoint_writer_authority import EntrypointWriterAuthority
+
+
+def _runtime() -> EntrypointWriterAuthority:
+    runtime = EntrypointWriterAuthority()
+    runtime._client = MagicMock()
+    runtime._client.eval.return_value = 1
+    runtime._lock_key = "lock"
+    runtime._meta_key = "meta"
+    runtime._fencing_key = "fence"
+    runtime._lock_value = "11:owner"
+    runtime._token = "11"
+    runtime._generation = 7
+    runtime._instance_id = "test"
+    runtime._identity = {"instance_id": "test"}
+    runtime._owner = "owner"
+    runtime._ttl_s = 60
+    runtime._acquired_at = 1.0
+    runtime._core_thread = MagicMock()
+    runtime._core_thread.is_alive.return_value = True
+    return runtime
+
+
+def test_slow_readiness_reconciliation_never_blocks_redis_renewal() -> None:
+    runtime = _runtime()
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[dict[str, object]] = []
+    readiness = types.ModuleType("three_venue_execution_readiness")
+
+    def reconcile(**kwargs: object) -> None:
+        calls.append(kwargs)
+        started.set()
+        release.wait(2.0)
+
+    readiness.reconcile_execution_readiness = reconcile
+    with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
+        ok, reason = runtime._heartbeat_tick()
+        assert ok is True
+        assert reason == ""
+        assert started.wait(1.0)
+
+        # A second renewal succeeds while the first readiness pass is blocked,
+        # and it does not create another broker-I/O worker.
+        ok, reason = runtime._heartbeat_tick()
+        assert ok is True
+        assert reason == ""
+        assert calls == [{"trigger": "heartbeat_renewed", "force": True}]
+        assert runtime._client.eval.call_count == 2
+        release.set()
+
+
+def test_non_heartbeat_reconciliation_remains_synchronous() -> None:
+    runtime = _runtime()
+    calls: list[dict[str, object]] = []
+    readiness = types.ModuleType("three_venue_execution_readiness")
+    readiness.reconcile_execution_readiness = lambda **kwargs: calls.append(kwargs)
+
+    with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
+        runtime._notify_runtime_reconciliation("core_thread_registered")
+
+    assert calls == [{"trigger": "core_thread_registered", "force": True}]

--- a/bot/tests/test_writer_reconciliation_async_v86.py
+++ b/bot/tests/test_writer_reconciliation_async_v86.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import threading
 import types
@@ -43,26 +44,37 @@ class WriterReconciliationAsyncV86Tests(unittest.TestCase):
             release.wait(2.0)
 
         readiness.reconcile_execution_readiness = reconcile
-        with patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}):
-            ok, reason = runtime._heartbeat_tick()
-            self.assertTrue(ok)
-            self.assertEqual(reason, "")
-            self.assertTrue(started.wait(1.0))
+        writer_env = {
+            "NIJA_WRITER_LEASE_ACQUIRED": "1",
+            "NIJA_WRITER_FENCING_TOKEN": "11",
+            "NIJA_WRITER_LEASE_GENERATION": "7",
+        }
+        with (
+            patch.dict(os.environ, writer_env, clear=False),
+            patch("bot.entrypoint_writer_authority._get_heartbeat_state"),
+            patch.dict(sys.modules, {"three_venue_execution_readiness": readiness}),
+        ):
+            try:
+                ok, reason = runtime._heartbeat_tick()
+                self.assertTrue(ok, reason)
+                self.assertEqual(reason, "")
+                self.assertTrue(started.wait(1.0))
 
-            # A second renewal succeeds while the first readiness pass is
-            # blocked, and it does not create another broker-I/O worker.
-            ok, reason = runtime._heartbeat_tick()
-            self.assertTrue(ok)
-            self.assertEqual(reason, "")
-            self.assertEqual(
-                calls,
-                [{"trigger": "heartbeat_renewed", "force": True}],
-            )
-            self.assertEqual(runtime._client.eval.call_count, 2)
-            release.set()
-            worker = runtime._runtime_reconcile_thread
-            if worker is not None:
-                worker.join(1.0)
+                # A second renewal succeeds while the first readiness pass is
+                # blocked, and it does not create another broker-I/O worker.
+                ok, reason = runtime._heartbeat_tick()
+                self.assertTrue(ok, reason)
+                self.assertEqual(reason, "")
+                self.assertEqual(
+                    calls,
+                    [{"trigger": "heartbeat_renewed", "force": True}],
+                )
+                self.assertEqual(runtime._client.eval.call_count, 2)
+            finally:
+                release.set()
+                worker = runtime._runtime_reconcile_thread
+                if worker is not None:
+                    worker.join(1.0)
             self.assertIsNone(runtime._runtime_reconcile_thread)
 
     def test_non_heartbeat_reconciliation_remains_synchronous(self) -> None:

--- a/bot/writer_authority_recursion_guard_patch.py
+++ b/bot/writer_authority_recursion_guard_patch.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import builtins
+import importlib
+import json
 import logging
 import os
 import sys
@@ -27,41 +29,119 @@ def _float_env(name: str, default: float = 0.0) -> float:
         return default
 
 
-def _writer_reentry_proof() -> dict[str, Any]:
-    """Return local proof for recursive status calls without probing Redis again.
+def _exact_process_writer_proof() -> tuple[Any, str]:
+    module = (
+        sys.modules.get("bot.writer_authority_generation_convergence_v57_patch")
+        or sys.modules.get("writer_authority_generation_convergence_v57_patch")
+    )
+    if not isinstance(module, ModuleType):
+        try:
+            module = importlib.import_module(
+                "bot.writer_authority_generation_convergence_v57_patch"
+            )
+        except Exception as exc:
+            return None, f"exact_process_writer_import_error:{type(exc).__name__}:{exc}"
+    prove = getattr(module, "_exact_process_writer", None)
+    if not callable(prove):
+        return None, "exact_process_writer_unavailable"
+    try:
+        proof, reason = prove("writer_authority_status_reentry")
+        return proof, str(reason or "")
+    except Exception as exc:
+        return None, f"exact_process_writer_error:{type(exc).__name__}:{exc}"
 
-    This is not a bypass. It is used only while the authority-status function is
-    already active and a second nested status request would recurse. The proof is
-    accepted only when live writer artifacts from the previously verified path
-    are present: Redis is configured, a fencing token exists, a lease generation
-    exists, and the writer heartbeat is fresh.
-    """
-    token = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
-    generation = os.environ.get("NIJA_WRITER_LEASE_GENERATION", "").strip()
+
+def _writer_reentry_proof() -> dict[str, Any]:
+    """Return exact Redis/metadata proof for a recursive authority status call."""
+    token_env = os.environ.get("NIJA_WRITER_FENCING_TOKEN", "").strip()
+    generation_env = os.environ.get("NIJA_WRITER_LEASE_GENERATION", "").strip()
     heartbeat_active = _truthy("NIJA_WRITER_HEARTBEAT_ACTIVE")
     alive_ts = _float_env("NIJA_WRITER_HEARTBEAT_ALIVE_TS", 0.0)
-    max_age_s = max(5.0, _float_env("NIJA_WRITER_REENTRY_HEARTBEAT_MAX_AGE_S", 75.0))
     now_wall = time.time()
-    heartbeat_age_s = max(0.0, now_wall - alive_ts) if alive_ts > 0 else 999999.0
+    local_age_s = max(0.0, now_wall - alive_ts) if alive_ts > 0 else 999999.0
     redis_configured = bool(os.environ.get("NIJA_REDIS_URL") or os.environ.get("REDIS_URL"))
-    proof_ok = bool(
-        redis_configured
-        and token
-        and generation
-        and heartbeat_active
-        and heartbeat_age_s <= max_age_s
-    )
-    return {
-        "ok": proof_ok,
+    result = {
+        "ok": False,
+        "reason": "uninitialized",
         "redis_configured": redis_configured,
-        "redis_reachable": proof_ok,
-        "token_present": bool(token),
-        "token_prefix": token[:8],
-        "lease_generation": generation,
+        "redis_reachable": False,
+        "token_present": bool(token_env),
+        "token_prefix": token_env[:8],
+        "lease_generation": generation_env,
         "heartbeat_active": heartbeat_active,
-        "heartbeat_age_s": heartbeat_age_s,
-        "heartbeat_max_age_s": max_age_s,
+        "heartbeat_age_s": local_age_s,
+        "heartbeat_max_age_s": 15.0,
     }
+
+    proof, reason = _exact_process_writer_proof()
+    if not isinstance(proof, dict):
+        result["reason"] = reason or "exact_process_writer_failed"
+        return result
+    result["redis_reachable"] = True
+    runtime = proof.get("runtime")
+    client = proof.get("client") or getattr(runtime, "_client", None)
+    meta_key = str(getattr(runtime, "_meta_key", "") or "").strip()
+    token = str(proof.get("token", "") or "").strip()
+    try:
+        generation = int(proof.get("generation", 0) or 0)
+    except (TypeError, ValueError):
+        generation = 0
+    result.update(
+        token_present=bool(token),
+        token_prefix=token[:8],
+        lease_generation=str(generation or ""),
+    )
+    if client is None or not meta_key or not token or generation <= 0:
+        result["reason"] = "exact_metadata_inputs_missing"
+        return result
+
+    try:
+        raw = client.get(meta_key)
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
+        metadata = json.loads(str(raw or ""))
+    except Exception as exc:
+        result["reason"] = f"metadata_read_error:{type(exc).__name__}:{exc}"
+        return result
+    try:
+        metadata_generation = int(metadata.get("generation", 0) or 0)
+        heartbeat_at = float(metadata.get("heartbeat_at", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        result["reason"] = "metadata_values_invalid"
+        return result
+    metadata_token = str(metadata.get("token", "") or "").strip()
+    try:
+        ttl_s = max(15.0, float(getattr(runtime, "_ttl_s", 60.0) or 60.0))
+    except (TypeError, ValueError):
+        ttl_s = 60.0
+    try:
+        interval_s = max(
+            1.0,
+            float(
+                os.environ.get("NIJA_WRITER_HEARTBEAT_INTERVAL_S", "")
+                or min(5.0, max(1.0, ttl_s / 3.0))
+            ),
+        )
+    except (TypeError, ValueError):
+        interval_s = min(5.0, max(1.0, ttl_s / 3.0))
+    max_age_s = min(
+        max(10.0, interval_s * 3.0),
+        max(interval_s * 2.0, ttl_s * 0.75),
+    )
+    metadata_age_s = max(0.0, now_wall - heartbeat_at) if heartbeat_at > 0 else 999999.0
+    result["heartbeat_age_s"] = metadata_age_s
+    result["heartbeat_max_age_s"] = max_age_s
+    if metadata_token != token:
+        result["reason"] = "metadata_token_mismatch"
+        return result
+    if metadata_generation != generation:
+        result["reason"] = "metadata_generation_mismatch"
+        return result
+    if metadata_age_s > max_age_s:
+        result["reason"] = f"metadata_heartbeat_stale:{metadata_age_s:.1f}>{max_age_s:.1f}"
+        return result
+    result.update(ok=True, reason="exact_redis_writer_metadata")
+    return result
 
 
 def _patch_execution_authority_context(module: ModuleType) -> bool:
@@ -81,7 +161,7 @@ def _patch_execution_authority_context(module: ModuleType) -> bool:
             ok = bool(cached_ok or proof["ok"])
             if proof["ok"] and not cached_ok:
                 logger.warning(
-                    "WRITER_AUTHORITY_STATUS_REENTRY_PROOF_ACCEPTED marker=%s cached_age_s=%.3f heartbeat_age_s=%.3f generation=%s token_prefix=%s",
+                    "WRITER_AUTHORITY_STATUS_REENTRY_EXACT_PROOF_ACCEPTED marker=%s cached_age_s=%.3f heartbeat_age_s=%.3f generation=%s token_prefix=%s",
                     _MARKER,
                     age_s,
                     float(proof.get("heartbeat_age_s", 999999.0)),

--- a/bot/writer_generation_handoff_v45_patch.py
+++ b/bot/writer_generation_handoff_v45_patch.py
@@ -349,7 +349,6 @@ def _safe_heartbeat_writer(self: Any) -> None:
     lock_key = str(proof["lock_key"])
     lock_value = str(proof["lock_value"])
     generation = int(proof["generation"])
-    runtime = proof["runtime"]
     try:
         current_lock = _text(client.get(lock_key))
         if current_lock != lock_value:
@@ -359,7 +358,6 @@ def _safe_heartbeat_writer(self: Any) -> None:
                 lock_key,
             )
             return
-        ttl_s = max(15, _integer(getattr(runtime, "_ttl_s", 60), 60))
         heartbeat_data = {
             "timestamp": time.time(),
             "generation": str(generation),
@@ -367,9 +365,9 @@ def _safe_heartbeat_writer(self: Any) -> None:
             "instance_id": os.environ.get("NIJA_WRITER_INSTANCE_ID", "unknown"),
         }
         client.set("nija:writer_heartbeat_active", json.dumps(heartbeat_data), ex=30)
-        client.expire(lock_key, ttl_s)
         LOGGER.info(
-            "WRITER_GENERATION_V45_HEARTBEAT_PUBLISHED marker=%s generation=%s token_prefix=%s",
+            "WRITER_GENERATION_V45_HEARTBEAT_PUBLISHED marker=%s generation=%s "
+            "token_prefix=%s lock_mutation=false",
             MARKER,
             generation,
             str(proof["token"])[:8],

--- a/bot/writer_kraken_runtime_convergence_v80_patch.py
+++ b/bot/writer_kraken_runtime_convergence_v80_patch.py
@@ -23,6 +23,7 @@ import threading
 from typing import Any
 
 from bot import kraken_connection_convergence_v44_patch as v44
+from bot import kraken_all_account_supervision_v86 as v86
 from bot import writer_authority_reconstitution_v77_patch as v77
 
 LOGGER = logging.getLogger("nija.writer_kraken_runtime_convergence_v80")
@@ -119,7 +120,8 @@ def reconcile_once() -> dict[str, Any]:
         if not writer.get("ok"):
             return {"writer": writer, "kraken": {"ok": False, "reason": "writer_not_ready"}}
         kraken = dict(v44.reconcile_once() or {})
-        return {"writer": writer, "kraken": kraken}
+        kraken_users = dict(v86.reconcile_once() or {})
+        return {"writer": writer, "kraken": kraken, "kraken_users": kraken_users}
 
 
 def _watchdog() -> None:
@@ -133,17 +135,26 @@ def _watchdog() -> None:
             state = reconcile_once()
             writer = state.get("writer", {})
             kraken = state.get("kraken", {})
-            signature = f"{writer.get('ok')}:{writer.get('reason')}:{kraken.get('connected')}:{kraken.get('reason')}"
+            users = state.get("kraken_users", {})
+            signature = (
+                f"{writer.get('ok')}:{writer.get('reason')}:"
+                f"{kraken.get('connected')}:{kraken.get('reason')}:"
+                f"{users.get('connected')}:{users.get('disconnected')}:{users.get('reason')}"
+            )
             if signature != last:
                 log = LOGGER.info if writer.get("ok") and kraken.get("connected") else LOGGER.warning
                 log(
-                    "RUNTIME_V80_STATE marker=%s writer_ok=%s writer_reason=%s kraken_connected=%s kraken_action=%s kraken_reason=%s",
+                    "RUNTIME_V80_STATE marker=%s writer_ok=%s writer_reason=%s "
+                    "kraken_connected=%s kraken_action=%s kraken_reason=%s "
+                    "kraken_users_connected=%s kraken_users_disconnected=%s",
                     MARKER,
                     str(bool(writer.get("ok"))).lower(),
                     writer.get("reason"),
                     str(bool(kraken.get("connected"))).lower(),
                     kraken.get("action"),
                     kraken.get("reason"),
+                    users.get("connected", 0),
+                    users.get("disconnected", 0),
                 )
                 last = signature
         except Exception as exc:
@@ -155,6 +166,7 @@ def install_import_hook() -> bool:
     with _LOCK:
         v77.install_import_hook()
         v44.install_import_hook()
+        v86.install()
         if not _STARTED:
             _STARTED = True
             threading.Thread(target=_watchdog, name="WriterKrakenRuntimeConvergenceV80", daemon=True).start()
@@ -165,7 +177,9 @@ def install_import_hook() -> bool:
     except Exception as exc:
         LOGGER.warning("RUNTIME_V80_INITIAL_RECONCILE_FAILED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
     LOGGER.critical(
-        "WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALLED marker=%s writer_exact_or_reacquire=true kraken_authenticated_recovery=true fail_closed=true",
+        "WRITER_KRAKEN_RUNTIME_CONVERGENCE_V80_INSTALLED marker=%s "
+        "writer_exact_or_reacquire=true kraken_platform_authenticated_recovery=true "
+        "kraken_users_authenticated_recovery=true fail_closed=true",
         MARKER,
     )
     return True


### PR DESCRIPTION
## Summary

- keep canonical Redis writer renewal independent of potentially 180-second readiness/broker refresh calls
- make EntrypointWriterAuthority the sole writer-lock TTL renewer; legacy authority heartbeats now publish telemetry only
- require exact process-writer plus fresh Redis metadata for recursive authority checks
- fail closed before independent platform or user broker I/O when runtime execution authority is unavailable
- supervise every registered Kraken user broker, including disconnected registrations, through its own authenticated `connect()` path
- serialize Kraken reconnects and apply per-account exponential backoff; preserve platform recovery through the existing v44 reconciler

## Production safety

- no credentials, nonces, balances, connection flags, orders, fills, or writer ownership are fabricated
- no risk, min-notional, emergency-stop, capital-readiness, or strategy gates are weakened
- reconnect workers re-check fresh exact writer metadata immediately before broker I/O
- missing user credentials do not schedule reconnect I/O
- all user failures remain isolated to the affected account

## Validation

Passed on head `599e864ad8d07d5727e796537eebb5cfa8eef797`:

- CI — imports smoke test
- CI — preflight check & lint
- Branch policy
- gh Auth Verify
- NIJA Deployment Safety
- Build image (with GH_TOKEN)
- CodeQL Security Scanning
- Continuous Threat Modeling
- Security Scanning
- Artifact Scanning
- Zero-Trust CI Isolation
- all six new `unittest discover` regression cases for Kraken all-account supervision and non-blocking writer reconciliation

The broad `CI` test job still reports the repository's known baseline of `43 failures, 42 errors`. Its failure/error set is identical to the prior head: zero failures or errors were added by this PR.

Local `python -m py_compile` passed for the new supervisor, canonical writer changes, and focused tests. The available scratch checkout is partial, so full dependency validation was performed by GitHub Actions.

## Runtime evidence addressed

- `metadata_heartbeat_stale:...>15.0` log storm while another heartbeat layer continued extending the lock
- recursive authority accepting a 53-second process-local heartbeat under a looser 75-second window
- independent broker scans reaching order-attempt context after runtime authority was denied
- Kraken supervision covering the platform broker but not all registered user brokers
- production writer renewal frozen for 900+ seconds while venue connectivity snapshots remained nominal

Human review required for writer-heartbeat, startup/runtime authority, and broker reconnect behavior.