### PR TITLE
Fence superseded Kraken nonce lease holders

### DIFF
--- a/bot/distributed_nonce_manager.py
+++ b/bot/distributed_nonce_manager.py
@@ -232,6 +232,24 @@ _REDIS_NONCE_RESET_BUFFER_MS = max(
 )
 
 
+def _assert_canonical_writer_for_nonce_lease(key_id: str) -> None:
+    """Require exact process-writer authority before touching a nonce lease.
+
+    The per-key Kraken lease is subordinate to the canonical process writer.
+    A superseded container must therefore stop renewing its nonce lease as
+    soon as it loses the process writer, even if its broker thread remains
+    alive during a rolling deployment.
+    """
+
+    try:
+        assert_startup_write_authority()
+    except Exception as exc:
+        raise RuntimeError(
+            "Canonical process writer authority unavailable for Kraken nonce "
+            f"lease (key_id={key_id})"
+        ) from exc
+
+
 def _startup_nonce_resync_future_ms() -> int:
     """Return how far ahead startup nonce recovery should advance Redis counters.
 
@@ -487,7 +505,13 @@ class _PerKeyRedisBackend:
     _LEASE_VERSION_PREFIX = "nija:kraken:writer:lease_version:"
     _LEASE_VERSION_COUNTER_PREFIX = "nija:kraken:writer:version_counter:"
     _LEASE_FINGERPRINT_PREFIX = "nija:kraken:writer:fingerprint:"
-    _LEASE_GENERATION_KEY = "nija:lease:generation"
+    # Kraken nonce fencing has a separate lineage from the canonical process
+    # writer.  Sharing the process generation key here would let a per-account
+    # handoff invalidate the process writer that authorized it.
+    _LEASE_GENERATION_KEY = os.environ.get(
+        "NIJA_KRAKEN_NONCE_LEASE_GENERATION_KEY",
+        "nija:kraken:writer:generation",
+    ).strip() or "nija:kraken:writer:generation"
 
     # Lua scripts execute atomically on Redis; internal read/write sequences do not interleave.
     # Renewal logic is duplicated across lease scripts to keep each Lua script self-contained.
@@ -774,8 +798,20 @@ class _PerKeyRedisBackend:
         stop_event: threading.Event,
         interval_s: float,
     ) -> None:
-        """Heartbeat loop that renews the Redis writer lease periodically."""
+        """Renew only while this process remains the canonical writer."""
         while not stop_event.wait(interval_s):
+            try:
+                _assert_canonical_writer_for_nonce_lease(key_id)
+            except RuntimeError as exc:
+                released = self.release_writer_lease(key_id)
+                _logger.critical(
+                    "KRAKEN_NONCE_LEASE_RELEASED_ON_CANONICAL_AUTHORITY_LOSS "
+                    "key=%s released=%s reason=%s",
+                    key_id,
+                    released,
+                    exc,
+                )
+                return
             try:
                 self._ensure_writer_lease(key_id)
             except Exception as exc:
@@ -996,6 +1032,8 @@ class _PerKeyRedisBackend:
         Fail closed when lease ownership changes or when fencing token rotates
         within the same process lifetime.
         """
+        _assert_canonical_writer_for_nonce_lease(key_id)
+
         owner_key = self._LEASE_OWNER_PREFIX + key_id
         version_key = self._LEASE_VERSION_PREFIX + key_id
         counter_key = self._LEASE_VERSION_COUNTER_PREFIX + key_id
@@ -1027,6 +1065,25 @@ class _PerKeyRedisBackend:
             return _granted, _lease_version, _prev_owner
 
         granted, lease_version, current_owner = _run_lease_script()
+        if not granted and prev is None and current_owner:
+            # The exact canonical process writer is the parent authority for
+            # every Kraken nonce writer.  If another process still renews this
+            # per-key lease after canonical re-election, fence it immediately
+            # instead of deadlocking a rolling deployment until the old
+            # container becomes healthy or exits.
+            _assert_canonical_writer_for_nonce_lease(key_id)
+            previous_owner = current_owner
+            granted, lease_version, _force_previous_owner = _force_takeover()
+            if granted:
+                current_owner = self._owner_id
+                _logger.critical(
+                    "KRAKEN_NONCE_LEASE_CANONICAL_HANDOFF key=%s lease_version=%d "
+                    "previous_owner=%s canonical_writer_verified=true "
+                    "action=fence_superseded_holder",
+                    key_id,
+                    lease_version,
+                    previous_owner,
+                )
         if not granted:
             # Startup safety: if this process has not held the lease yet, wait
             # through the observed holder TTL for the current holder to

--- a/bot/tests/test_distributed_nonce_manager_authority.py
+++ b/bot/tests/test_distributed_nonce_manager_authority.py
@@ -13,6 +13,7 @@ from bot.distributed_nonce_manager import (
     DistributedNonceManager,
     _PerKeyRedisBackend,
     _REDIS_NONCE_RESET_BUFFER_MS,
+    _assert_canonical_writer_for_nonce_lease,
     _emit_nonce_debug_hook,
 )
 from bot import global_kraken_nonce as gkn
@@ -147,6 +148,94 @@ class TestPerKeyRedisBackendReset(unittest.TestCase):
         self.assertEqual(before, 9_000_000)
         self.assertEqual(after, 9_000_000)
         backend._client.set.assert_called_once_with("nija:kraken:nonce:kid", "9000000")
+
+
+class TestCanonicalWriterNonceLeaseHandoff(unittest.TestCase):
+    def _make_backend(self) -> "_PerKeyRedisBackend":
+        backend = _PerKeyRedisBackend.__new__(_PerKeyRedisBackend)
+        backend._client = Mock()
+        backend._owner_id = "new-owner"
+        backend._owner_fingerprint = "new-instance"
+        backend._owner_instance_id = "new-instance"
+        backend._lease_ttl_ms = 60_000
+        backend._strict_lease = True
+        backend._lease_by_key = {}
+        backend._startup_backoff_done = {"kid"}
+        backend._lease_heartbeat_threads = {}
+        backend._lease_heartbeat_stop = {}
+        backend._lease_status_last_log = {}
+        backend._wait_log_next_at = {}
+        backend._wait_log_lock = Mock()
+        backend._ensure_lease_heartbeat = Mock()
+        backend._log_lease_status = Mock()
+        backend._publish_lock_acquired_state = Mock()
+        backend._clear_wait_log_gate = Mock()
+        return backend
+
+    def test_nonce_generation_domain_is_separate_from_process_writer(self) -> None:
+        self.assertEqual(
+            _PerKeyRedisBackend._LEASE_GENERATION_KEY,
+            "nija:kraken:writer:generation",
+        )
+
+    def test_canonical_writer_fences_superseded_nonce_holder(self) -> None:
+        backend = self._make_backend()
+        backend._lease_script = Mock(return_value=[0, 119, "old-owner"])
+        backend._lease_force_script = Mock(return_value=[1, 120, "old-owner"])
+
+        with patch(
+            "bot.distributed_nonce_manager.assert_startup_write_authority",
+            return_value=None,
+        ) as authority:
+            version = backend._ensure_writer_lease("kid")
+
+        self.assertEqual(version, 120)
+        self.assertGreaterEqual(authority.call_count, 2)
+        backend._lease_force_script.assert_called_once()
+        self.assertEqual(backend._lease_force_script.call_args.kwargs["args"][-1], 1)
+        self.assertEqual(backend._lease_by_key["kid"].owner_id, "new-owner")
+        backend._ensure_lease_heartbeat.assert_called_once_with("kid")
+
+    def test_nonce_lease_touch_fails_before_redis_without_canonical_writer(self) -> None:
+        backend = self._make_backend()
+        backend._lease_script = Mock()
+        backend._lease_force_script = Mock()
+
+        with patch(
+            "bot.distributed_nonce_manager.assert_startup_write_authority",
+            side_effect=RuntimeError("not canonical"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Canonical process writer"):
+                backend._ensure_writer_lease("kid")
+
+        backend._lease_script.assert_not_called()
+        backend._lease_force_script.assert_not_called()
+
+    def test_heartbeat_releases_lease_after_canonical_authority_loss(self) -> None:
+        backend = self._make_backend()
+        backend.release_writer_lease = Mock(return_value=True)
+        backend._ensure_writer_lease = Mock()
+        stop_event = Mock()
+        stop_event.wait.return_value = False
+
+        with patch(
+            "bot.distributed_nonce_manager.assert_startup_write_authority",
+            side_effect=RuntimeError("superseded"),
+        ):
+            backend._lease_heartbeat_loop("kid", stop_event, 20.0)
+
+        backend.release_writer_lease.assert_called_once_with("kid")
+        backend._ensure_writer_lease.assert_not_called()
+
+    def test_authority_helper_redacts_underlying_proof_details(self) -> None:
+        with patch(
+            "bot.distributed_nonce_manager.assert_startup_write_authority",
+            side_effect=RuntimeError("redis lock payload"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "key_id=kid") as ctx:
+                _assert_canonical_writer_for_nonce_lease("kid")
+
+        self.assertNotIn("redis lock payload", str(ctx.exception))
 
 
 class TestDistributedNonceProbeServerSync(unittest.TestCase):


### PR DESCRIPTION
## Summary

- bind Kraken per-key nonce leases to exact canonical process-writer authority
- release an owned nonce lease when canonical authority is lost
- atomically fence a lease retained by a superseded process during canonical handoff
- separate Kraken nonce generation lineage from process-writer generation lineage
- add focused regression coverage

This remains fail-closed and does not weaken Redis ownership or execution authority.

## Validation

- 32 focused tests passed
- 5 new handoff regression tests passed
- Python syntax compilation passed
- diff and unsafe-bypass scans passed
- no strategy, risk, sizing, or order-routing behavior changed