### PR TITLE
Bound writer-loss shutdown and demote stale Kraken state

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -39,12 +39,14 @@ _core_loop_thread: Optional[threading.Thread] = None
 _core_registration_restart_timer: Optional[threading.Timer] = None
 
 
-def _schedule_core_registration_restart(reason: str) -> None:
-    """Force a non-zero restart if graceful shutdown cannot leave startup.
+def _schedule_writer_authority_restart(reason: str) -> None:
+    """Force a non-zero restart if writer-loss shutdown cannot exit.
 
-    The writer lease has already been compare-deleted before this callback is
-    invoked.  A short grace period lets the canonical stack unwind normally;
-    ``os._exit(75)`` is the final bound for broker calls that never return.
+    The writer lease has already been lost or compare-deleted before this
+    callback is invoked.  A short grace period lets the canonical stack unwind
+    normally; ``os._exit(75)`` is the final bound for non-daemon broker and
+    reconciliation workers that would otherwise keep a fail-closed process
+    alive forever.
     """
 
     global _core_registration_restart_timer
@@ -53,14 +55,20 @@ def _schedule_core_registration_restart(reason: str) -> None:
     try:
         grace_s = max(
             1.0,
-            float(os.environ.get("NIJA_CORE_REGISTRATION_RESTART_GRACE_S", "15") or 15),
+            float(
+                os.environ.get(
+                    "NIJA_WRITER_AUTHORITY_RESTART_GRACE_S",
+                    os.environ.get("NIJA_CORE_REGISTRATION_RESTART_GRACE_S", "15"),
+                )
+                or 15
+            ),
         )
     except (TypeError, ValueError):
         grace_s = 15.0
 
     def _force_restart() -> None:
         logger.critical(
-            "CANONICAL_CORE_REGISTRATION_FORCED_RESTART reason=%s exit_code=75",
+            "WRITER_AUTHORITY_FORCED_RESTART reason=%s exit_code=75",
             reason,
         )
         for handler in logging.getLogger().handlers:
@@ -71,16 +79,22 @@ def _schedule_core_registration_restart(reason: str) -> None:
         os._exit(75)
 
     timer = threading.Timer(grace_s, _force_restart)
-    timer.name = "canonical-core-registration-forced-restart"
+    timer.name = "writer-authority-forced-restart"
     timer.daemon = True
     _core_registration_restart_timer = timer
     logger.critical(
-        "CANONICAL_CORE_REGISTRATION_RESTART_SCHEDULED reason=%s grace_s=%.1f "
-        "writer_released=true",
+        "WRITER_AUTHORITY_RESTART_SCHEDULED reason=%s grace_s=%.1f "
+        "writer_unavailable=true",
         reason,
         grace_s,
     )
     timer.start()
+
+
+def _schedule_core_registration_restart(reason: str) -> None:
+    """Backward-compatible wrapper for the original registration watchdog."""
+
+    _schedule_writer_authority_restart(reason)
 
 
 def _signal_handler(signum: int, frame) -> None:
@@ -141,8 +155,11 @@ def _acquire_writer_authority_before_nonce() -> bool:
                 except Exception:
                     pass
             _shutdown_event.set()
-            if "core_thread_registration_deadline_exceeded" in reason:
-                _schedule_core_registration_restart(reason)
+            # Every terminal writer-loss callback must have a process-lifetime
+            # bound.  Recoverable lock-missing events are intercepted by the
+            # v39/v55 re-election path before reaching this callback; all
+            # reasons that arrive here are terminal for the current process.
+            _schedule_writer_authority_restart(reason)
 
         if callable(getattr(runtime, "set_on_lost_callback", None)):
             runtime.set_on_lost_callback(_on_lease_lost)

--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -8241,6 +8241,40 @@ class KrakenBroker(BaseBroker):
         self.connected = False
         logger.critical("⛔ Kraken HARD STOP (%s): %s", self.account_identifier, reason)
 
+    def _demote_on_writer_authority_failure(self, error: BaseException) -> bool:
+        """Demote stale Kraken connectivity when private nonce authority is lost.
+
+        A broker that completed an earlier handshake is not operationally
+        connected once the canonical process writer can no longer issue its
+        nonces.  Keep the condition retryable (not a permanent hard-stop), but
+        make every registry/readiness consumer observe the real disconnected
+        state immediately.
+        """
+
+        message = str(error or "")
+        normalized = message.lower()
+        authority_failure = bool(
+            "canonical process writer authority unavailable" in normalized
+            or "nonce issuance blocked (pid lock not held)" in normalized
+            or "writer authority unavailable for kraken nonce lease" in normalized
+        )
+        if not authority_failure:
+            return False
+
+        self.connected = False
+        self._connection_already_complete = False
+        self._is_available = False
+        self.exit_only_mode = True
+        self.kraken_health = "ERROR"
+        self.last_connection_error = f"WRITER_AUTHORITY_UNAVAILABLE: {message}"
+        logger.critical(
+            "KRAKEN_PRIVATE_RUNTIME_DEMOTED account=%s "
+            "reason=writer_authority_unavailable connected=false "
+            "execution_eligible=false reconnect_required=true",
+            self.account_identifier,
+        )
+        return True
+
     def _initialize_nonce_manager(self) -> bool:
         """Initialize the DistributedNonceManager with heartbeat authority.
 
@@ -8854,7 +8888,7 @@ class KrakenBroker(BaseBroker):
         _already_done = (
             _KRAKEN_STARTUP_FSM.is_connected and self.connected
             if self.account_type == AccountType.PLATFORM
-            else self._connection_already_complete
+            else self._connection_already_complete and self.connected
         )
         if _already_done:
             logger.debug(f"[KrakenBroker:{_label}] Connection already established — skipping reconnect routine")
@@ -10563,6 +10597,8 @@ class KrakenBroker(BaseBroker):
             return 0.0
 
         except Exception as e:
+            if self._demote_on_writer_authority_failure(e):
+                return 0.0
             _nonce_rebuild_cooldown_s = self._get_nonce_rebuild_retry_cooldown_seconds(e)
             if _nonce_rebuild_cooldown_s > 0.0:
                 _cached_balance = self._activate_nonce_rebuild_cooldown_recovery(
@@ -10813,6 +10849,14 @@ class KrakenBroker(BaseBroker):
             return {**default_balance, 'error_message': 'Unexpected API response format'}
 
         except Exception as e:
+            if self._demote_on_writer_authority_failure(e):
+                error_msg = str(e)
+                logger.error(
+                    "❌ Exception fetching Kraken detailed balance (%s): %s",
+                    self.account_identifier,
+                    error_msg,
+                )
+                return {**default_balance, 'error_message': error_msg}
             _nonce_rebuild_cooldown_s = self._get_nonce_rebuild_retry_cooldown_seconds(e)
             if _nonce_rebuild_cooldown_s > 0.0:
                 _cached_balance = self._activate_nonce_rebuild_cooldown_recovery(

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -231,15 +231,18 @@ def test_v54_blocks_core_start_without_exact_writer_proof(monkeypatch) -> None:
 def test_v54_requests_normal_shutdown_when_live_core_loses_writer(monkeypatch) -> None:
     v54 = _load("test_writer_runtime_v54_shutdown", V54)
     shutdown = threading.Event()
+    restart_reasons = []
     bot_main = ModuleType("bot.bot_main")
     bot_main._shutdown_event = shutdown
     bot_main._core_loop_thread = type("Thread", (), {"is_alive": lambda self: True})()
+    bot_main._schedule_writer_authority_restart = restart_reasons.append
     monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
     monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
 
     assert v54._request_canonical_shutdown("writer_lease_not_acquired") is True
     assert shutdown.is_set() is True
+    assert restart_reasons == ["v54_writer_proof_lost:writer_lease_not_acquired"]
     assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
     assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"
 

--- a/bot/tests/test_kraken_balance_cooldown.py
+++ b/bot/tests/test_kraken_balance_cooldown.py
@@ -10,6 +10,8 @@ class TestKrakenBalanceCooldown(unittest.TestCase):
         broker._gateway_url = ""
         broker.account_identifier = "PLATFORM"
         broker.last_connection_error = None
+        broker.connected = True
+        broker._connection_already_complete = True
         broker._last_known_balance = 321.0
         broker._balance_last_updated = None
         broker._kraken_balance_cache_ttl = 0
@@ -19,6 +21,40 @@ class TestKrakenBalanceCooldown(unittest.TestCase):
         broker.exit_only_mode = False
         broker.kraken_health = "UNKNOWN"
         return broker
+
+    def test_writer_authority_loss_demotes_stale_connection_immediately(self) -> None:
+        broker = self._build_broker()
+        broker._kraken_private_call = lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError(
+                "DistributedNonceManager.get_nonce: Redis nonce issuance failed "
+                "(Canonical process writer authority unavailable for Kraken nonce lease)"
+            )
+        )
+
+        balance = broker.get_account_balance(verbose=False)
+
+        self.assertEqual(balance, 0.0)
+        self.assertFalse(broker.connected)
+        self.assertFalse(broker._connection_already_complete)
+        self.assertFalse(broker.is_available())
+        self.assertTrue(broker.exit_only_mode)
+        self.assertEqual(broker.kraken_health, "ERROR")
+        self.assertIn("WRITER_AUTHORITY_UNAVAILABLE", broker.last_connection_error)
+
+    def test_detailed_writer_authority_loss_reports_error_and_demotes(self) -> None:
+        broker = self._build_broker()
+        broker._kraken_private_call = lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError(
+                "Canonical process writer authority unavailable for Kraken nonce lease"
+            )
+        )
+
+        detailed = broker.get_account_balance_detailed(verbose=False)
+
+        self.assertTrue(detailed["error"])
+        self.assertFalse(broker.connected)
+        self.assertFalse(broker._connection_already_complete)
+        self.assertFalse(broker.is_available())
 
     def test_balance_fetch_does_not_count_retry_suppressed_nonce_rebuilds(self) -> None:
         broker = self._build_broker()

--- a/bot/tests/test_runtime_startup_handoff_v87.py
+++ b/bot/tests/test_runtime_startup_handoff_v87.py
@@ -157,6 +157,35 @@ class RuntimeStartupHandoffV87Tests(unittest.TestCase):
         timer.start.assert_called_once_with()
         force_exit.assert_called_once_with(75)
 
+    def test_terminal_writer_loss_restart_uses_general_bound(self) -> None:
+        from bot import bot_main
+
+        timer = MagicMock()
+        bot_main._core_registration_restart_timer = None
+        self.addCleanup(
+            setattr,
+            bot_main,
+            "_core_registration_restart_timer",
+            None,
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"NIJA_WRITER_AUTHORITY_RESTART_GRACE_S": "4"},
+                clear=False,
+            ),
+            patch.object(bot_main.threading, "Timer", return_value=timer) as factory,
+        ):
+            bot_main._schedule_writer_authority_restart(
+                "lock_owned_by_different_writer"
+            )
+
+        factory.assert_called_once()
+        self.assertEqual(factory.call_args.args[0], 4.0)
+        self.assertEqual(timer.name, "writer-authority-forced-restart")
+        self.assertTrue(timer.daemon)
+        timer.start.assert_called_once_with()
+
     def test_account_status_uses_actual_platform_and_user_registries(self) -> None:
         manager = object.__new__(MultiAccountBrokerManager)
         manager._platform_brokers = {

--- a/bot/tests/test_writer_recovery_callback_guard_v55.py
+++ b/bot/tests/test_writer_recovery_callback_guard_v55.py
@@ -188,6 +188,18 @@ def test_core_thread_loss_is_never_recoverable(monkeypatch) -> None:
     assert started == []
 
 
+def test_fallback_shutdown_schedules_bounded_process_restart(monkeypatch) -> None:
+    v55 = _load("test_writer_recovery_v55_bounded_fallback")
+    bot_main = _install_fake_bot_main(monkeypatch)
+    restart_reasons: list[str] = []
+    bot_main._schedule_writer_authority_restart = restart_reasons.append
+
+    v55._fallback_shutdown("v39_reelection_exhausted:test")
+
+    assert bot_main._shutdown_event.is_set() is True
+    assert restart_reasons == ["v39_reelection_exhausted:test"]
+
+
 def test_canonical_fast_path_installs_v55() -> None:
     source = BOT_ENTRYPOINT.read_text(encoding="utf-8")
     fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(

--- a/bot/writer_recovery_callback_guard_v55_patch.py
+++ b/bot/writer_recovery_callback_guard_v55_patch.py
@@ -127,11 +127,33 @@ def _fallback_shutdown(reason: str) -> None:
     setter = getattr(shutdown, "set", None)
     if callable(setter):
         setter()
+    scheduler = (
+        getattr(bot_main, "_schedule_writer_authority_restart", None)
+        if bot_main is not None
+        else None
+    )
+    if not callable(scheduler) and bot_main is not None:
+        scheduler = getattr(bot_main, "_schedule_core_registration_restart", None)
+    restart_scheduled = False
+    if callable(scheduler):
+        try:
+            scheduler(str(reason or "v55_writer_recovery_failed"))
+            restart_scheduled = True
+        except Exception as exc:
+            LOGGER.error(
+                "WRITER_RECOVERY_V55_RESTART_SCHEDULE_FAILED marker=%s "
+                "reason=%s err=%s:%s",
+                MARKER,
+                str(reason or "unknown"),
+                type(exc).__name__,
+                exc,
+            )
     LOGGER.critical(
         "WRITER_RECOVERY_V55_SHUTDOWN marker=%s reason=%s "
-        "execution_fail_closed=true",
+        "execution_fail_closed=true restart_scheduled=%s",
         MARKER,
         str(reason or "unknown"),
+        restart_scheduled,
     )
 
 

--- a/bot/writer_runtime_lifecycle_supervisor_v54_patch.py
+++ b/bot/writer_runtime_lifecycle_supervisor_v54_patch.py
@@ -124,12 +124,30 @@ def _request_canonical_shutdown(reason: str) -> bool:
         )
         return False
     setter()
+    scheduler = getattr(module, "_schedule_writer_authority_restart", None)
+    if not callable(scheduler):
+        scheduler = getattr(module, "_schedule_core_registration_restart", None)
+    restart_scheduled = False
+    if callable(scheduler):
+        try:
+            scheduler(f"v54_writer_proof_lost:{reason}")
+            restart_scheduled = True
+        except Exception as exc:
+            LOGGER.error(
+                "WRITER_RUNTIME_V54_RESTART_SCHEDULE_FAILED marker=%s "
+                "reason=%s err=%s:%s",
+                MARKER,
+                reason,
+                type(exc).__name__,
+                exc,
+            )
     LOGGER.critical(
         "WRITER_RUNTIME_V54_SHUTDOWN_REQUESTED marker=%s reason=%s core_thread_alive=%s "
-        "execution_fail_closed=true normal_cleanup=true",
+        "execution_fail_closed=true normal_cleanup=true restart_scheduled=%s",
         MARKER,
         reason,
         _core_thread_alive(module),
+        restart_scheduled,
     )
     return True
 


### PR DESCRIPTION
## Summary

- apply the existing forced-restart bound to every terminal writer-authority loss
- force a bounded restart when runtime supervision or bounded writer recovery cannot restore authority
- mark Kraken platform and user brokers disconnected when canonical nonce authority is unavailable
- allow disconnected Kraken user brokers to run the authenticated reconnect path

## Root cause

Writer loss correctly revoked execution authority, but background workers could keep the process alive after normal shutdown was requested. Kraken then failed closed on nonce issuance while stale broker connection flags continued to report an earlier successful handshake.

## Impact

A terminal writer-loss state now exits nonzero after a short grace period so the deployment supervisor can start a fresh canonical writer. Kraken registry and readiness consumers see a disconnected broker immediately after nonce-authority loss instead of a false connected state.

## Validation

- 39 focused lifecycle and Kraken tests passed
- 15 canonical launcher tests passed
- 19 live broker/exit tests passed
- 8 entrypoint writer heartbeat tests passed independently
- Python compilation and git diff checks passed

## Review

This changes production writer-authority and broker-state behavior and requires human review before merge.