### PR TITLE
Revoke stale writer readiness and report all Kraken users

### DIFF
--- a/.github/workflows/live-broker-profit-exit-v25.yml
+++ b/.github/workflows/live-broker-profit-exit-v25.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'main.py'
       - 'Dockerfile'
+      - 'scripts/install_sitecustomize_defer_guard.py'
       - 'scripts/runtime_entrypoint_attestation.py'
       - 'bot/live_broker_profit_exit_convergence_v25.py'
       - 'bot/live_engine_profit_exit_convergence_v25.py'
@@ -20,6 +21,7 @@ on:
     paths:
       - 'main.py'
       - 'Dockerfile'
+      - 'scripts/install_sitecustomize_defer_guard.py'
       - 'scripts/runtime_entrypoint_attestation.py'
       - 'bot/live_broker_profit_exit_convergence_v25.py'
       - 'bot/live_engine_profit_exit_convergence_v25.py'
@@ -48,11 +50,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install CI sitecustomize defer guard
+        run: python -S scripts/install_sitecustomize_defer_guard.py
       - name: Install focused dependencies
-        run: python -P -m pip install --disable-pip-version-check pytest redis requests
+        run: env -u PYTHONPATH python -P -m pip install --disable-pip-version-check pytest redis requests
       - name: Compile v25 runtime contract
         run: |
-          python -m py_compile \
+          python -S -m py_compile \
             main.py \
             scripts/runtime_entrypoint_attestation.py \
             bot/live_broker_profit_exit_convergence_v25.py \

--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -12201,6 +12201,7 @@ class KrakenBroker(BaseBroker):
             return positions
 
         except Exception as e:
+            self._demote_on_writer_authority_failure(e)
             logger.error(f"Error fetching Kraken positions: {e}")
             return []
 

--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -1535,6 +1535,17 @@ class EntrypointWriterAuthority:
         os.environ.pop("NIJA_WRITER_FENCING_TOKEN", None)
         os.environ.pop("NIJA_WRITER_GENERATION", None)
         os.environ.pop("NIJA_WRITER_LEASE_GENERATION", None)
+        try:
+            from bot.readiness_table import revoke_ready
+
+            for component in ("authority_ready", "nonce_ready", "execution_ready"):
+                revoke_ready(component, reason=f"writer_authority_lost:{reason}")
+        except Exception:
+            logger.debug(
+                "ENTRYPOINT_WRITER_AUTHORITY_READINESS_REVOKE_FAILED marker=%s",
+                _MARKER,
+                exc_info=True,
+            )
         logger.critical(
             "ENTRYPOINT_WRITER_AUTHORITY_LOST marker=%s reason=%s",
             _MARKER,
@@ -1567,6 +1578,17 @@ class EntrypointWriterAuthority:
 
         self._stop.set()
         self._set_writer_state(WriterState.LOST, reason="release_called")
+        try:
+            from bot.readiness_table import revoke_ready
+
+            for component in ("authority_ready", "nonce_ready", "execution_ready"):
+                revoke_ready(component, reason="writer_authority_release_called")
+        except Exception:
+            logger.debug(
+                "ENTRYPOINT_WRITER_AUTHORITY_READINESS_REVOKE_FAILED marker=%s",
+                _MARKER,
+                exc_info=True,
+            )
         heartbeat = self._heartbeat_thread
         if heartbeat is not None and heartbeat is not threading.current_thread():
             if heartbeat.is_alive():

--- a/bot/heartbeat_authority_single_source_patch.py
+++ b/bot/heartbeat_authority_single_source_patch.py
@@ -437,6 +437,14 @@ def _patch_three_venue_execution_readiness(module: ModuleType) -> None:
                 bool(str(os.getenv("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()),
             )
         )
+        strict_ready = bool(
+            status.ready
+            and state_allows_execution
+            and lease_effective
+            and fencing_token
+            and heartbeat_effective
+            and core_loop_alive
+        )
         return {
             "lease_acquired": lease_effective,
             "lease_acquired_raw": _truthy("NIJA_WRITER_LEASE_ACQUIRED"),
@@ -456,7 +464,7 @@ def _patch_three_venue_execution_readiness(module: ModuleType) -> None:
             "missing": list(status.missing),
             "source": status.source,
             "reason": status.reason,
-            "ready": bool(status.ready),
+            "ready": strict_ready,
         }
 
     module.writer_authority_snapshot = writer_authority_snapshot

--- a/bot/live_broker_profit_exit_convergence_v25.py
+++ b/bot/live_broker_profit_exit_convergence_v25.py
@@ -385,7 +385,13 @@ def _platform_connectivity(manager: Any) -> dict[str, bool]:
 
 
 def _kraken_user_connectivity(manager: Any) -> dict[str, int | bool]:
-    """Return deduplicated registered/connected Kraken user counts."""
+    """Return deduplicated registered/connected Kraken user counts.
+
+    A configured user remains part of the denominator when broker creation
+    fails or credentials are missing.  Otherwise the status snapshot can
+    incorrectly claim every user is connected by silently dropping the users
+    for which no broker object could be constructed.
+    """
     records: dict[str, Any] = {}
     all_users = getattr(manager, "_all_user_brokers", {}) if manager is not None else {}
     try:
@@ -414,6 +420,38 @@ def _kraken_user_connectivity(manager: Any) -> dict[str, int | bool]:
             label = str(getattr(broker_type, "value", broker_type) or "").strip().lower()
             if label == "kraken" and broker is not None:
                 records[str(user_id)] = broker
+
+    metadata = getattr(manager, "_user_metadata", {}) if manager is not None else {}
+    try:
+        metadata_items = list(metadata.items())
+    except Exception:
+        metadata_items = []
+    for user_id, user_metadata in metadata_items:
+        broker_map = user_metadata.get("brokers", {}) if isinstance(user_metadata, dict) else {}
+        try:
+            broker_types = list(broker_map)
+        except Exception:
+            broker_types = []
+        for broker_type in broker_types:
+            label = str(getattr(broker_type, "value", broker_type) or "").strip().lower()
+            if label == "kraken":
+                records.setdefault(str(user_id), None)
+
+    # Failed connection attempts and missing credentials are registrations,
+    # even though neither path necessarily creates a broker object.
+    for registry_name in ("_failed_user_connections", "_users_without_credentials"):
+        registry = getattr(manager, registry_name, {}) if manager is not None else {}
+        try:
+            registry_keys = list(registry)
+        except Exception:
+            registry_keys = []
+        for key in registry_keys:
+            if not isinstance(key, tuple) or len(key) != 2:
+                continue
+            user_id, broker_type = key
+            label = str(getattr(broker_type, "value", broker_type) or "").strip().lower()
+            if label == "kraken":
+                records.setdefault(str(user_id), None)
 
     registered = len(records)
     connected = sum(1 for broker in records.values() if bool(getattr(broker, "connected", False)))

--- a/bot/readiness_table.py
+++ b/bot/readiness_table.py
@@ -71,8 +71,18 @@ _VERSION = 0
 # Write API
 # ---------------------------------------------------------------------------
 
-def set_ready(component: str, value: bool) -> None:
-    """Set *component* readiness while preventing normal true-to-false regressions."""
+def set_ready(
+    component: str,
+    value: bool,
+    *,
+    allow_regression: bool = False,
+) -> None:
+    """Set readiness while preventing ordinary true-to-false regressions.
+
+    Runtime authority loss is intentionally different from an ordinary startup
+    update: a previously valid writer/nonce proof must be revocable.  Callers
+    should use :func:`revoke_ready` for that explicit terminal transition.
+    """
     global _VERSION
     _snapshot = None
     _changed = False
@@ -82,7 +92,7 @@ def set_ready(component: str, value: bool) -> None:
             _TABLE[component] = False
             _changed = True
         current = _TABLE.get(component)
-        if current is True and value is False:
+        if current is True and value is False and not allow_regression:
             logger.warning("Prevented readiness regression | %s", component)
             return
         if current != bool(value):
@@ -117,6 +127,18 @@ def mark_ready(component: str) -> None:
     logger.critical(
         "✅ READINESS_TABLE mark_ready=%s table=%s",
         component,
+        _TABLE,
+    )
+
+
+def revoke_ready(component: str, *, reason: str) -> None:
+    """Revoke a dynamic readiness proof after terminal runtime invalidation."""
+
+    set_ready(component, False, allow_regression=True)
+    logger.critical(
+        "READINESS_TABLE_REVOKED component=%s reason=%s table=%s",
+        component,
+        reason,
         _TABLE,
     )
 

--- a/bot/test_readiness_broker_gate.py
+++ b/bot/test_readiness_broker_gate.py
@@ -54,6 +54,16 @@ class TestReadinessBrokerGate(unittest.TestCase):
         readiness_table.set_ready("broker_connected", False)
         self.assertTrue(readiness_table.snapshot()["broker_connected"])
 
+    def test_runtime_readiness_can_be_explicitly_revoked(self):
+        readiness_table.mark_ready("authority_ready")
+
+        readiness_table.revoke_ready(
+            "authority_ready",
+            reason="writer_authority_lost:test",
+        )
+
+        self.assertFalse(readiness_table.snapshot()["authority_ready"])
+
     def test_is_ready_requires_all_keys(self):
         self._mark_all_except_broker()
         self.assertFalse(readiness_table.is_ready())

--- a/bot/tests/test_kraken_balance_cooldown.py
+++ b/bot/tests/test_kraken_balance_cooldown.py
@@ -56,6 +56,22 @@ class TestKrakenBalanceCooldown(unittest.TestCase):
         self.assertFalse(broker._connection_already_complete)
         self.assertFalse(broker.is_available())
 
+    def test_position_writer_authority_loss_demotes_stale_connection(self) -> None:
+        broker = self._build_broker()
+        broker._kraken_private_call = lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError(
+                "Canonical process writer authority unavailable for Kraken nonce lease"
+            )
+        )
+
+        positions = broker.get_positions()
+
+        self.assertEqual(positions, [])
+        self.assertFalse(broker.connected)
+        self.assertFalse(broker._connection_already_complete)
+        self.assertFalse(broker.is_available())
+        self.assertTrue(broker.exit_only_mode)
+
     def test_balance_fetch_does_not_count_retry_suppressed_nonce_rebuilds(self) -> None:
         broker = self._build_broker()
         broker._kraken_private_call = lambda *args, **kwargs: (_ for _ in ()).throw(

--- a/bot/tests/test_runtime_startup_handoff_v87.py
+++ b/bot/tests/test_runtime_startup_handoff_v87.py
@@ -338,6 +338,49 @@ class RuntimeStartupHandoffV87Tests(unittest.TestCase):
             },
         )
 
+    def test_kraken_connectivity_counts_users_without_broker_objects(self) -> None:
+        kraken = _BrokerType("kraken")
+        connected_user = SimpleNamespace(connected=True)
+        manager = SimpleNamespace(
+            _all_user_brokers={
+                ("connected_customer", kraken): connected_user,
+            },
+            user_brokers={
+                "connected_customer": {kraken: connected_user},
+            },
+            _user_metadata={
+                "connected_customer": {"brokers": {kraken: True}},
+                "failed_customer": {"brokers": {kraken: False}},
+                "missing_credentials_customer": {"brokers": {kraken: False}},
+            },
+            _failed_user_connections={
+                ("failed_customer", kraken): "connection_failed",
+            },
+            _users_without_credentials={
+                ("missing_credentials_customer", kraken): True,
+            },
+        )
+
+        users = connectivity._kraken_user_connectivity(manager)
+
+        self.assertEqual(
+            users,
+            {
+                "registered": 3,
+                "connected": 1,
+                "disconnected": 2,
+                "all_connected": False,
+            },
+        )
+
+    def test_activation_diagnostics_do_not_recommend_authority_bypass(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "trading_state_machine.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("to bypass all gates immediately", source)
+        self.assertNotIn("TIP: Set FORCE_TRADE=1", source)
+
     def test_kraken_supervision_uses_canonical_manager_singleton(self) -> None:
         target = "bot.multi_account_broker_manager"
         previous = sys.modules.get(target)

--- a/bot/tests/test_runtime_startup_handoff_v87.py
+++ b/bot/tests/test_runtime_startup_handoff_v87.py
@@ -127,6 +127,22 @@ class RuntimeStartupHandoffV87Tests(unittest.TestCase):
         runtime._release_owned_lock_for_reelection.assert_called_once_with(reason)
         runtime._client.eval.assert_not_called()
 
+    def test_writer_loss_revokes_dynamic_readiness_truth(self) -> None:
+        from bot import readiness_table
+
+        runtime = EntrypointWriterAuthority()
+        runtime._notify_runtime_reconciliation = MagicMock()
+        for component in ("authority_ready", "nonce_ready", "execution_ready"):
+            readiness_table.mark_ready(component)
+        self.addCleanup(readiness_table.reset)
+
+        runtime._mark_lost("core_thread_registration_deadline_exceeded")
+
+        table = readiness_table.snapshot()
+        self.assertFalse(table["authority_ready"])
+        self.assertFalse(table["nonce_ready"])
+        self.assertFalse(table["execution_ready"])
+
     def test_core_registration_restart_is_bounded_and_nonzero(self) -> None:
         from bot import bot_main
 

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -386,6 +386,41 @@ def test_writer_not_ready_keeps_execution_fail_closed(monkeypatch) -> None:
     assert result["execution_ready"] is False
 
 
+def test_writer_status_cannot_override_dead_core_or_unhealthy_heartbeat(
+    monkeypatch,
+) -> None:
+    module = _module()
+    status = SimpleNamespace(
+        state="ACTIVE",
+        checks={
+            "heartbeat_active": True,
+            "lease_acquired": True,
+            "fencing_token_active": True,
+            "authority_verified": True,
+            "redis_reachable": True,
+        },
+        missing=(),
+        source="test",
+        reason="cached_ready",
+        ready=True,
+    )
+    monkeypatch.setattr(
+        "bot.writer_authority.WriterAuthority.get_status",
+        lambda **_kwargs: status,
+    )
+    monkeypatch.setattr(module, "_writer_core_loop_alive", lambda: False)
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
+    monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ALIVE_TS", "1")
+
+    snapshot = module.writer_authority_snapshot(now=1000.0)
+
+    assert snapshot["lease_acquired"] is True
+    assert snapshot["fencing_token"] is True
+    assert snapshot["heartbeat_healthy"] is False
+    assert snapshot["core_loop_alive"] is False
+    assert snapshot["ready"] is False
+
+
 def test_unfunded_capital_keeps_execution_fail_closed(monkeypatch) -> None:
     module = _module()
     _set_credentials(monkeypatch)

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -1736,7 +1736,8 @@ class TradingStateMachine:
             if not _live_ok:
                 logger.critical(
                     "[FORCE_ACTIVATE BLOCKED] reason=SAFE_START detail=%s requested_reason=%s | "
-                    "TIP: Set FORCE_TRADE=1 or NIJA_FORCE_ACTIVATION=1 to bypass distributed authority gates.",
+                    "ACTION: restore canonical writer authority and wait for a healthy heartbeat; "
+                    "activation remains fail closed.",
                     _live_err,
                     reason,
                 )
@@ -2322,7 +2323,8 @@ class TradingStateMachine:
                     "[ACTIVATION MONITOR] state=LIVE_PENDING_CONFIRMATION elapsed=%.1fs — "
                     "bot is waiting for activation gates to pass. "
                     "LIVE_CAPITAL_VERIFIED=%s DRY_RUN_MODE=%s "
-                    "Set NIJA_FORCE_ACTIVATION=1 to bypass all gates immediately.",
+                    "Restore canonical writer authority and wait for a healthy heartbeat; "
+                    "activation remains fail closed.",
                     _elapsed_pending,
                     _lcv_quick,
                     _dry_run_quick,
@@ -2505,7 +2507,8 @@ class TradingStateMachine:
                 f"NIJA_WRITER_FENCING_TOKEN={'set' if os.environ.get('NIJA_WRITER_FENCING_TOKEN') else 'unset'} "
                 f"NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK={os.environ.get('NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK', 'unset')} "
                 f"NIJA_WRITER_HEARTBEAT_ACTIVE={os.environ.get('NIJA_WRITER_HEARTBEAT_ACTIVE', 'unset')} "
-                f"— FIX: set NIJA_FORCE_ACTIVATION=1 to bypass all gates immediately",
+                f"— ACTION: restore the canonical writer lease and heartbeat; "
+                f"production activation remains fail closed",
                 flush=True,
             )
             _log_activation_diag_once(
@@ -2514,7 +2517,8 @@ class TradingStateMachine:
                 "[AUTO_ACTIVATE BLOCKED] reason=SAFE_START detail=%s "
                 "state=%s LIVE_CAPITAL_VERIFIED=%s FORCE_TRADE=%s NIJA_FORCE_ACTIVATION=%s "
                 "fencing_token=%s local_fallback=%s heartbeat_active=%s "
-                "— FIX: set NIJA_FORCE_ACTIVATION=1 to bypass all gates immediately",
+                "— ACTION: restore the canonical writer lease and heartbeat; "
+                "production activation remains fail closed",
                 _live_err,
                 _diag_state,
                 os.environ.get("LIVE_CAPITAL_VERIFIED", "unset"),

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -193,6 +193,15 @@ def writer_authority_snapshot(*, now: float | None = None) -> dict[str, Any]:
             bool(str(os.getenv("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()),
         )
     )
+    heartbeat_effective = bool(heartbeat_healthy or writer_state == "REFRESHING")
+    strict_ready = bool(
+        status.ready
+        and state_allows_execution
+        and lease_effective
+        and fencing_token
+        and heartbeat_effective
+        and core_loop_alive
+    )
     return {
         "lease_acquired": lease_effective,
         "lease_acquired_raw": _truthy("NIJA_WRITER_LEASE_ACQUIRED"),
@@ -204,7 +213,7 @@ def writer_authority_snapshot(*, now: float | None = None) -> dict[str, Any]:
         "heartbeat_age_s": heartbeat_age_s,
         "heartbeat_max_age_s": heartbeat_max_age_s,
         "heartbeat_healthy": heartbeat_healthy,
-        "heartbeat_effective": heartbeat_healthy or writer_state == "REFRESHING",
+        "heartbeat_effective": heartbeat_effective,
         "core_loop_alive": core_loop_alive,
         "authority_verified": bool(checks.get("authority_verified", False)),
         "redis_reachable": bool(checks.get("redis_reachable", False)),
@@ -212,7 +221,7 @@ def writer_authority_snapshot(*, now: float | None = None) -> dict[str, Any]:
         "missing": list(status.missing),
         "source": status.source,
         "reason": status.reason,
-        "ready": bool(status.ready),
+        "ready": strict_ready,
     }
 
 


### PR DESCRIPTION
## Summary

- count configured, failed, and missing-credential Kraken users in connectivity reporting even when no broker object was created
- revoke `authority_ready`, `nonce_ready`, and `execution_ready` when canonical writer authority is lost or released
- require a live core loop and healthy/effective heartbeat in three-venue writer readiness, even if cached status says ready
- demote Kraken platform/user connectivity immediately when balance, detailed-balance, or position reads lose canonical writer/nonce authority
- replace unsafe authority-bypass guidance with fail-closed recovery instructions
- keep the v25 CI compile check isolated from repository `sitecustomize` and install the standard defer guard before dependency/test Python processes

## Context

PR #2469 merged the bounded writer-loss restart and initial Kraken stale-connectivity demotion. Production logs from merged commit `0891af6` exposed remaining reporting paths: missing Kraken registrations were omitted from the denominator, readiness stayed true after writer loss, and a failed private position read could leave a user broker temporarily reported connected.

The v25 CI job also timed out because plain `python -m py_compile` auto-imported repository `sitecustomize`; with no CI `REDIS_URL`, that startup path entered the writer-authority standby loop until the 15-minute job timeout.

## Production impact

Connectivity and account counts now reflect actual registries. Dynamic execution readiness is revoked immediately on writer loss and cannot be resurrected by cached writer status. Any observed Kraken private-read authority failure now demotes the broker and requires a genuine authenticated reconnect. Execution remains fail closed.

Deployed Kraken credentials and host clock synchronization remain external control-plane requirements. This change does not fabricate credentials, suppress nonce errors, or bypass authority gates.

## Validation

- 50 modified-path readiness, writer-loss, registry, and venue tests passed
- 76 activation and fail-closed authority tests passed
- 7 focused Kraken broker-demotion tests passed
- full v25 compile contract passed with `python -S -m py_compile`
- defer-guard installer behavior passed in a temporary site-packages directory
- Python compilation passed for all modified modules
- `git diff --check` passed

## Post-deploy verification

Confirm the deployed commit matches this PR head and observe:

- positive writer generation
- healthy authoritative heartbeat
- registered and alive canonical core loop
- readiness revoked after writer loss
- Kraken platform and every configured user counted separately
- Kraken connectivity demoted on every private-read authority failure
- no execution until all strict proofs are valid
