### PR TITLE
Fix writer-loss restart and Kraken state convergence

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -186,7 +186,7 @@ def _acquire_writer_authority_before_nonce() -> bool:
         # Wire up the on-lost callback so _shutdown_event is set immediately
         # when the lease is lost (e.g. core thread dies), without waiting for
         # the _keep_process_alive_after_loop_return polling interval.
-        def _on_lease_lost(reason: str) -> None:
+        def _on_lease_lost(reason: str) -> bool:
             logger.critical(
                 "WRITER_AUTHORITY_LOST_SHUTDOWN_TRIGGERED marker=20260710u reason=%s",
                 reason,
@@ -205,6 +205,7 @@ def _acquire_writer_authority_before_nonce() -> bool:
             # v39/v55 re-election path before reaching this callback; all
             # reasons that arrive here are terminal for the current process.
             _schedule_writer_authority_restart(reason)
+            return True
 
         if callable(getattr(runtime, "set_on_lost_callback", None)):
             runtime.set_on_lost_callback(_on_lease_lost)

--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -1270,10 +1270,11 @@ _KRAKEN_CONNECT_PROBE_FALLBACK_MS: int = 300_000   # 5 min
 class KrakenStartupFSM:
     """Single source of truth for the Kraken platform startup sequence.
 
-    States (strictly linear — no backward transitions once CONNECTED):
+    States (startup is linear; runtime authority loss may demote CONNECTED):
 
         IDLE → CONNECTING → NONCE_READY → CAPITAL_READY → CONNECTED   (success path)
         IDLE → CONNECTING → FAILED                    (failure path)
+        CONNECTED → FAILED → CONNECTING               (runtime recovery path)
 
     Principle: **event = truth, state = derived.**
 
@@ -1352,12 +1353,19 @@ class KrakenStartupFSM:
             self._connected.set()
 
     def mark_failed(self) -> None:
-        """Atomically signal FAILED — wakes all waiting USER threads instantly."""
+        """Atomically signal FAILED and revoke any stale CONNECTED latch.
+
+        Startup CONNECTED is a stable success latch only while the live broker
+        retains private writer/nonce authority.  Runtime authority loss must
+        clear it so platform waiters and USER accounts cannot proceed from a
+        historical handshake after the platform broker has been demoted.
+        """
         with self._lock:
             self._connecting = False
+            self._connected.clear()
             self._nonce_ready.clear()
             self._capital_ready.clear()
-        self._failed.set()
+            self._failed.set()
 
     def reset(self) -> None:
         """Reset to IDLE so a retry can start fresh.
@@ -8267,10 +8275,13 @@ class KrakenBroker(BaseBroker):
         self.exit_only_mode = True
         self.kraken_health = "ERROR"
         self.last_connection_error = f"WRITER_AUTHORITY_UNAVAILABLE: {message}"
+        if getattr(self, "account_type", AccountType.PLATFORM) == AccountType.PLATFORM:
+            _KRAKEN_STARTUP_FSM.mark_failed()
         logger.critical(
             "KRAKEN_PRIVATE_RUNTIME_DEMOTED account=%s "
             "reason=writer_authority_unavailable connected=false "
-            "execution_eligible=false reconnect_required=true",
+            "execution_eligible=false reconnect_required=true "
+            "platform_fsm_connected=false",
             self.account_identifier,
         )
         return True

--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -1521,20 +1521,27 @@ class EntrypointWriterAuthority:
 
         The callback is called with a single positional argument: the reason
         string.  It is invoked inside ``_mark_lost()`` on the heartbeat thread,
-        so it must be lightweight (e.g. ``event.set()``).
+        so it must be lightweight (e.g. ``event.set()``).  Returning a truthy
+        value confirms that the callback installed its own bounded process
+        restart; false/``None`` leaves the runtime fallback responsible.
         """
         self._on_lost_callback = callback
 
-    def _schedule_unhandled_loss_restart(self, reason: str) -> None:
-        """Bound a live writer process when no external loss handler exists.
+    def _schedule_unhandled_loss_restart(
+        self,
+        reason: str,
+        *,
+        handler_confirmed: bool = False,
+    ) -> None:
+        """Bound a live writer process unless a callback confirmed handoff.
 
         The Redis lease is already released before this method is reached.
         Restarting cannot grant authority; it only prevents a callback-free
-        bootstrap process from continuing broker/readiness monitors forever
-        with generation zero.
+        or stale-callback bootstrap process from continuing broker/readiness
+        monitors forever with generation zero.
         """
 
-        if not _live_mode() or self._on_lost_callback is not None:
+        if not _live_mode() or handler_confirmed:
             return
         # Only a runtime that actually started the canonical renewal worker can
         # become the production zombie this guard targets.  This also keeps
@@ -1558,7 +1565,7 @@ class EntrypointWriterAuthority:
         def _force_restart() -> None:
             logger.critical(
                 "ENTRYPOINT_WRITER_AUTHORITY_FALLBACK_RESTART marker=%s "
-                "reason=%s exit_code=75 callback_installed=false",
+                "reason=%s exit_code=75 callback_handoff_confirmed=false",
                 _MARKER,
                 reason,
             )
@@ -1575,7 +1582,7 @@ class EntrypointWriterAuthority:
         self._unhandled_loss_restart_timer = timer
         logger.critical(
             "ENTRYPOINT_WRITER_AUTHORITY_FALLBACK_RESTART_SCHEDULED marker=%s "
-            "reason=%s grace_s=%.1f callback_installed=false",
+            "reason=%s grace_s=%.1f callback_handoff_confirmed=false",
             _MARKER,
             reason,
             grace_s,
@@ -1619,17 +1626,27 @@ class EntrypointWriterAuthority:
         )
         self._notify_runtime_reconciliation("writer_lost")
         callback = self._on_lost_callback
+        callback_handled = False
         if callback is not None:
             try:
-                callback(reason)
+                callback_handled = bool(callback(reason))
             except Exception as cb_exc:
                 logger.error(
                     "ENTRYPOINT_WRITER_AUTHORITY_LOST_CALLBACK_FAILED marker=%s err=%s",
                     _MARKER,
                     cb_exc,
                 )
-        else:
-            self._schedule_unhandled_loss_restart(reason)
+        logger.critical(
+            "ENTRYPOINT_WRITER_AUTHORITY_LOST_CALLBACK_HANDOFF marker=%s "
+            "callback_present=%s restart_confirmed=%s",
+            _MARKER,
+            callback is not None,
+            callback_handled,
+        )
+        self._schedule_unhandled_loss_restart(
+            reason,
+            handler_confirmed=callback_handled,
+        )
         try:
             from bot.single_execution_authority_kernel import get_seak
 

--- a/bot/multi_account_broker_manager.py
+++ b/bot/multi_account_broker_manager.py
@@ -4206,11 +4206,26 @@ class MultiAccountBrokerManager:
 
         # ── Kraken: single FSM wait — zero dual-representation drift ──────────
         if broker_type == BrokerType.KRAKEN:
-            # Fast path: already connected.
+            # Fast path: startup FSM and the live broker must agree.  The FSM
+            # is cleared by writer-authority demotion, but keep this defensive
+            # convergence here so a stale historical latch can never publish a
+            # false platform-ready result.
             if _KRAKEN_STARTUP_FSM.is_connected:
-                logger.info(f"✅ Platform {broker_name} ready (FSM fast-path)")
-                self._mark_platform_connected(broker_type)
-                return True
+                broker = self._platform_brokers.get(broker_type)
+                if broker is not None and bool(getattr(broker, "connected", False)):
+                    logger.info(
+                        f"✅ Platform {broker_name} ready "
+                        "(FSM + live broker fast-path)"
+                    )
+                    self._mark_platform_connected(broker_type)
+                    return True
+                _KRAKEN_STARTUP_FSM.mark_failed()
+                logger.error(
+                    "KRAKEN_PLATFORM_STALE_FSM_REVOKED "
+                    "fsm_connected=true broker_connected=false "
+                    "platform_ready=false user_connections_deferred=true"
+                )
+                return False
             # Fast path: already failed.
             if _KRAKEN_STARTUP_FSM.is_failed:
                 logger.error(f"❌ Platform {broker_name} connection failed (FSM)")
@@ -5666,6 +5681,26 @@ class MultiAccountBrokerManager:
                     if not _has_platform:
                         logger.warning("⚠️ Falling back to USER-ONLY mode")
                         allow_user_trading = True
+                    else:
+                        connection_key = (user.user_id, broker_type)
+                        self._failed_user_connections[connection_key] = (
+                            "platform_account_not_connected"
+                        )
+                        if user.user_id not in self._user_metadata:
+                            self._user_metadata[user.user_id] = {
+                                "name": user.name,
+                                "enabled": user.enabled,
+                                "brokers": {},
+                            }
+                        self._user_metadata[user.user_id]["brokers"][broker_type] = False
+                        logger.warning(
+                            "KRAKEN_USER_CONNECTION_DEFERRED user=%s broker=%s "
+                            "reason=platform_account_not_connected "
+                            "user_broker_io=false",
+                            user.user_id,
+                            broker_type.value,
+                        )
+                        continue
 
             # Add delay between sequential connections to the same broker type
             # This helps prevent nonce conflicts and API rate limiting, especially for Kraken

--- a/bot/runtime_guard_audit_patch.py
+++ b/bot/runtime_guard_audit_patch.py
@@ -8,7 +8,7 @@ import time
 from typing import Mapping
 
 logger = logging.getLogger("nija.runtime_guard_audit")
-_MARKER = "20260716-runtime-guard-audit-v3"
+_MARKER = "20260811-runtime-guard-audit-v4"
 _LOCK = threading.RLock()
 _STARTED = False
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -20,11 +20,53 @@ _REQUIRED = (
     "NIJA_OKX_FUNDING_WALLET_READINESS_INSTALLED",
     "NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED",
 )
+_DYNAMIC_WRITER_REQUIRED = (
+    "NIJA_WRITER_LEASE_ACQUIRED",
+    "NIJA_WRITER_HEARTBEAT_ACTIVE",
+)
+_DYNAMIC_WRITER_ARM_FLAGS = (
+    "NIJA_PREBOT_WRITER_AUTHORITY_READY",
+    "NIJA_CANONICAL_WRITER_FIRST_V59_READY",
+)
 
 
 def _ready(env: Mapping[str, str] | None = None) -> tuple[bool, list[str]]:
     source = os.environ if env is None else env
-    missing = [name for name in _REQUIRED if str(source.get(name, "") or "").strip().lower() not in _TRUE]
+    missing = [
+        name
+        for name in _REQUIRED
+        if str(source.get(name, "") or "").strip().lower() not in _TRUE
+    ]
+    # These flags are intentionally optional during early startup.  Once they
+    # exist, however, an explicit false value is terminal runtime truth and the
+    # audit must not keep claiming ready merely because static patch modules
+    # remain installed.
+    writer_truth = {
+        name: str(source.get(name, "") or "").strip().lower()
+        for name in _DYNAMIC_WRITER_REQUIRED
+    }
+    writer_armed = bool(
+        all(writer_truth[name] in _TRUE for name in _DYNAMIC_WRITER_REQUIRED)
+        or any(
+            str(source.get(name, "") or "").strip().lower() in _TRUE
+            for name in _DYNAMIC_WRITER_ARM_FLAGS
+        )
+    )
+    if writer_armed:
+        missing.extend(
+            name
+            for name in _DYNAMIC_WRITER_REQUIRED
+            if writer_truth[name] not in _TRUE
+        )
+    if (
+        str(source.get("NIJA_RUNTIME_TRADING_STATE", "") or "").strip().upper()
+        == "LIVE_ACTIVE"
+        and str(source.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "") or "")
+        .strip()
+        .lower()
+        not in _TRUE
+    ):
+        missing.append("NIJA_RUNTIME_EXECUTION_AUTHORITY")
     return not missing, missing
 
 
@@ -36,7 +78,9 @@ def _emit() -> bool:
         "RUNTIME_GUARD_AUDIT marker=%s ready=%s commit=%s scan_hard_clamp=%s verified_cost_basis=%s "
         "daily_gain_harvest=%s kraken_min_notional=%s okx_dual_wallet=%s post_import_convergence=%s "
         "authority_policy=%s authority_min_brokers=%s okx_balance_observed=%s okx_funding_status=%s "
-        "okx_trading_spendable=%s okx_funding_spendable=%s missing=%s",
+        "okx_trading_spendable=%s okx_funding_spendable=%s "
+        "writer_lease=%s writer_heartbeat=%s execution_authority=%s runtime_state=%s "
+        "missing=%s",
         _MARKER,
         str(ready).lower(),
         commit,
@@ -52,9 +96,18 @@ def _emit() -> bool:
         os.environ.get("NIJA_OKX_FUNDING_STATUS", "unobserved"),
         os.environ.get("NIJA_OKX_TRADING_SPENDABLE_QUOTE", "unknown"),
         os.environ.get("NIJA_OKX_FUNDING_SPENDABLE_QUOTE", "unknown"),
+        os.environ.get("NIJA_WRITER_LEASE_ACQUIRED", "uninitialized"),
+        os.environ.get("NIJA_WRITER_HEARTBEAT_ACTIVE", "uninitialized"),
+        os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "uninitialized"),
+        os.environ.get("NIJA_RUNTIME_TRADING_STATE", "uninitialized"),
         ",".join(missing) or "none",
     )
-    if not ready and str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).upper() == "LIVE_ACTIVE":
+    dynamic_writer_missing = any(name in missing for name in _DYNAMIC_WRITER_REQUIRED)
+    if not ready and (
+        dynamic_writer_missing
+        or str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).upper()
+        == "LIVE_ACTIVE"
+    ):
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
         logger.critical("RUNTIME_GUARD_AUDIT_FAIL_CLOSED marker=%s missing=%s", _MARKER, ",".join(missing))

--- a/bot/tests/test_entrypoint_writer_authority.py
+++ b/bot/tests/test_entrypoint_writer_authority.py
@@ -332,14 +332,31 @@ class EntrypointWriterAuthorityTests(unittest.TestCase):
         timer.start.assert_called_once_with()
         force_exit.assert_called_once_with(75)
 
-    def test_installed_loss_callback_owns_restart_scheduling(self):
+    def test_confirmed_loss_callback_owns_restart_scheduling(self):
         runtime = EntrypointWriterAuthority()
-        runtime.set_on_lost_callback(lambda _reason: None)
 
         with patch("bot.entrypoint_writer_authority.threading.Timer") as factory:
-            runtime._schedule_unhandled_loss_restart("writer_lost")
+            runtime._schedule_unhandled_loss_restart(
+                "writer_lost",
+                handler_confirmed=True,
+            )
 
         factory.assert_not_called()
+
+    def test_unconfirmed_loss_callback_falls_back_to_runtime_restart(self):
+        runtime = EntrypointWriterAuthority()
+        runtime._heartbeat_thread = MagicMock(is_alive=MagicMock(return_value=True))
+        runtime.set_on_lost_callback(lambda _reason: None)
+        timer = MagicMock()
+
+        with patch(
+            "bot.entrypoint_writer_authority.threading.Timer",
+            return_value=timer,
+        ) as factory:
+            runtime._mark_lost("core_thread_registration_deadline_exceeded")
+
+        factory.assert_called_once()
+        timer.start.assert_called_once_with()
 
     def test_local_fallback_is_always_refused(self):
         os.environ["NIJA_FORCE_LOCAL_WRITER_LOCK_FALLBACK"] = "true"
@@ -508,6 +525,17 @@ class BotMainAuthorityOrderingTests(unittest.TestCase):
         self.assertEqual(order, ["bind", "heartbeat"])
         assert_writer.assert_called_once_with()
         runtime.set_on_lost_callback.assert_called_once()
+        callback = runtime.set_on_lost_callback.call_args.args[0]
+        self.addCleanup(self.bot_main._shutdown_event.clear)
+        with patch.object(
+            self.bot_main,
+            "_schedule_writer_authority_restart",
+        ) as schedule_restart:
+            handled = callback("core_thread_registration_deadline_exceeded")
+        self.assertTrue(handled)
+        schedule_restart.assert_called_once_with(
+            "core_thread_registration_deadline_exceeded"
+        )
 
     def test_post_acquisition_exception_releases_writer_and_revokes_readiness(self):
         import bot.entrypoint_writer_authority as authority

--- a/bot/tests/test_kraken_connection_lifecycle.py
+++ b/bot/tests/test_kraken_connection_lifecycle.py
@@ -80,9 +80,10 @@ def _make_fsm():
         def mark_failed(self) -> None:
             with self._lock:
                 self._connecting = False
+                self._connected.clear()
                 self._nonce_ready.clear()
                 self._capital_ready.clear()
-            self._failed.set()
+                self._failed.set()
 
         def reset(self) -> None:
             with self._lock:
@@ -239,6 +240,17 @@ class TestKrakenStartupFSM:
         self.fsm.begin_platform_boot()
         self.fsm.mark_connected()
         assert not self.fsm.is_failed
+
+    def test_runtime_failure_revokes_connected_latch(self):
+        self.fsm.begin_platform_boot()
+        self.fsm.mark_connected()
+
+        self.fsm.mark_failed()
+
+        assert not self.fsm.is_connected
+        assert self.fsm.is_failed
+        assert not self.fsm.is_nonce_ready
+        assert not self.fsm.is_capital_ready
 
     def test_successful_reconnect_clears_prior_failure_latch(self):
         self.fsm.begin_platform_boot()

--- a/bot/tests/test_kraken_writer_authority_gate_v91.py
+++ b/bot/tests/test_kraken_writer_authority_gate_v91.py
@@ -6,15 +6,23 @@ from types import ModuleType, SimpleNamespace
 import unittest
 from unittest.mock import MagicMock, patch
 
-from bot.broker_manager import KrakenBroker
+from bot.broker_manager import AccountType, KrakenBroker, KrakenStartupFSM
+from bot.multi_account_broker_manager import (
+    BrokerType,
+    MultiAccountBrokerManager,
+)
 
 
 class KrakenWriterAuthorityGateV91Tests(unittest.TestCase):
     def _broker(self) -> KrakenBroker:
         broker = object.__new__(KrakenBroker)
         broker.account_identifier = "PLATFORM"
+        broker.account_type = AccountType.PLATFORM
         broker.connected = True
         broker._connection_already_complete = True
+        broker._is_available = True
+        broker.exit_only_mode = False
+        broker.kraken_health = "HEALTHY"
         broker.last_connection_error = ""
         return broker
 
@@ -80,6 +88,96 @@ class KrakenWriterAuthorityGateV91Tests(unittest.TestCase):
         source = __import__("inspect").getsource(KrakenBroker.connect)
         self.assertIn("if not self._initialize_nonce_manager():", source)
         self.assertIn("return False", source)
+
+    def test_runtime_authority_demotion_revokes_platform_fsm(self) -> None:
+        broker = self._broker()
+        fsm = KrakenStartupFSM()
+        fsm.begin_platform_boot()
+        fsm.mark_connected()
+
+        with patch("bot.broker_manager._KRAKEN_STARTUP_FSM", fsm):
+            demoted = broker._demote_on_writer_authority_failure(
+                RuntimeError(
+                    "Canonical process writer authority unavailable for Kraken nonce lease"
+                )
+            )
+
+        self.assertTrue(demoted)
+        self.assertFalse(broker.connected)
+        self.assertFalse(fsm.is_connected)
+        self.assertTrue(fsm.is_failed)
+
+    def test_platform_wait_rejects_stale_connected_fsm(self) -> None:
+        fsm = KrakenStartupFSM()
+        fsm.begin_platform_boot()
+        fsm.mark_connected()
+        manager = object.__new__(MultiAccountBrokerManager)
+        manager._platform_brokers = {
+            BrokerType.KRAKEN: SimpleNamespace(connected=False)
+        }
+        manager._mark_platform_connected = MagicMock()
+
+        with patch("bot.multi_account_broker_manager._KRAKEN_STARTUP_FSM", fsm):
+            ready = manager.wait_for_platform_ready(BrokerType.KRAKEN, timeout=1)
+
+        self.assertFalse(ready)
+        self.assertFalse(fsm.is_connected)
+        self.assertTrue(fsm.is_failed)
+        manager._mark_platform_connected.assert_not_called()
+
+    def test_configured_platform_disconnect_defers_user_broker_io(self) -> None:
+        manager = object.__new__(MultiAccountBrokerManager)
+        manager._platform_brokers = {
+            BrokerType.KRAKEN: SimpleNamespace(connected=False)
+        }
+        manager._platform_failed_types = set()
+        manager._all_user_brokers = {}
+        manager.user_brokers = {}
+        manager.user_configs = {}
+        manager.kraken_copy_trading_active = False
+        manager._failed_user_connections = {}
+        manager._users_without_credentials = {}
+        manager._capital_blocked_users = {}
+        manager._user_metadata = {}
+        manager._should_skip_user_connections = MagicMock(return_value=False)
+        manager.is_platform_connected = MagicMock(return_value=False)
+        manager.wait_for_platform_ready = MagicMock(return_value=False)
+        manager.add_user_broker = MagicMock()
+        manager._format_platform_broker_status = MagicMock(
+            return_value="DISCONNECTED"
+        )
+        user = SimpleNamespace(
+            user_id="user-1",
+            name="User One",
+            broker_type="KRAKEN",
+            enabled=True,
+        )
+        loader = SimpleNamespace(get_all_enabled_users=lambda: [user])
+        platform_layer = SimpleNamespace(
+            has_platform_account=lambda _venue: True
+        )
+
+        with (
+            patch(
+                "config.user_loader.get_user_config_loader",
+                return_value=loader,
+            ),
+            patch(
+                "bot.multi_account_broker_manager.get_platform_account_layer",
+                return_value=platform_layer,
+            ),
+        ):
+            connected = manager.connect_users_from_config()
+
+        self.assertEqual(connected, {})
+        manager.add_user_broker.assert_not_called()
+        self.assertEqual(
+            manager._failed_user_connections[("user-1", BrokerType.KRAKEN)],
+            "platform_account_not_connected",
+        )
+        self.assertFalse(
+            manager._user_metadata["user-1"]["brokers"][BrokerType.KRAKEN]
+        )
 
 
 if __name__ == "__main__":

--- a/bot/tests/test_runtime_guard_audit_patch.py
+++ b/bot/tests/test_runtime_guard_audit_patch.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
+
 import bot.runtime_guard_audit_patch as audit
 
 
@@ -16,3 +19,73 @@ def test_missing_guard_is_reported():
     ready, missing = audit._ready(env)
     assert ready is False
     assert missing == [audit._REQUIRED[1]]
+
+
+def test_explicit_writer_loss_makes_runtime_audit_not_ready():
+    env = {name: "1" for name in audit._REQUIRED}
+    env.update(
+        {
+            "NIJA_WRITER_LEASE_ACQUIRED": "0",
+            "NIJA_WRITER_HEARTBEAT_ACTIVE": "0",
+            "NIJA_CANONICAL_WRITER_FIRST_V59_READY": "1",
+        }
+    )
+
+    ready, missing = audit._ready(env)
+
+    assert ready is False
+    assert missing == list(audit._DYNAMIC_WRITER_REQUIRED)
+
+
+def test_live_active_requires_execution_authority():
+    env = {name: "1" for name in audit._REQUIRED}
+    env.update(
+        {
+            "NIJA_WRITER_LEASE_ACQUIRED": "1",
+            "NIJA_WRITER_HEARTBEAT_ACTIVE": "1",
+            "NIJA_RUNTIME_TRADING_STATE": "LIVE_ACTIVE",
+            "NIJA_RUNTIME_EXECUTION_AUTHORITY": "0",
+        }
+    )
+
+    ready, missing = audit._ready(env)
+
+    assert ready is False
+    assert missing == ["NIJA_RUNTIME_EXECUTION_AUTHORITY"]
+
+
+def test_pre_acquisition_zero_writer_flags_do_not_break_guard_install():
+    env = {name: "1" for name in audit._REQUIRED}
+    env.update(
+        {
+            "NIJA_WRITER_LEASE_ACQUIRED": "0",
+            "NIJA_WRITER_HEARTBEAT_ACTIVE": "0",
+            "NIJA_PREBOT_WRITER_AUTHORITY_READY": "0",
+            "NIJA_CANONICAL_WRITER_FIRST_V59_READY": "0",
+        }
+    )
+
+    ready, missing = audit._ready(env)
+
+    assert ready is True
+    assert missing == []
+
+
+def test_emit_fails_closed_after_explicit_writer_loss():
+    env = {name: "1" for name in audit._REQUIRED}
+    env.update(
+        {
+            "NIJA_WRITER_LEASE_ACQUIRED": "0",
+            "NIJA_WRITER_HEARTBEAT_ACTIVE": "0",
+            "NIJA_CANONICAL_WRITER_FIRST_V59_READY": "1",
+            "NIJA_RUNTIME_TRADING_STATE": "LIVE_ACTIVE",
+            "NIJA_RUNTIME_EXECUTION_AUTHORITY": "1",
+        }
+    )
+
+    with patch.dict(os.environ, env, clear=True):
+        ready = audit._emit()
+
+        assert ready is False
+        assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+        assert os.environ["NIJA_RUNTIME_TRADING_STATE"] == "OFF"

--- a/bot/tests/test_runtime_startup_handoff_v87.py
+++ b/bot/tests/test_runtime_startup_handoff_v87.py
@@ -143,6 +143,23 @@ class RuntimeStartupHandoffV87Tests(unittest.TestCase):
         self.assertFalse(table["nonce_ready"])
         self.assertFalse(table["execution_ready"])
 
+    def test_writer_loss_callback_must_confirm_bounded_restart_handoff(self) -> None:
+        runtime = EntrypointWriterAuthority()
+        runtime._heartbeat_thread = MagicMock(is_alive=MagicMock(return_value=True))
+        runtime._notify_runtime_reconciliation = MagicMock()
+        runtime.set_on_lost_callback(MagicMock(return_value=None))
+
+        with patch.object(
+            runtime,
+            "_schedule_unhandled_loss_restart",
+        ) as fallback:
+            runtime._mark_lost("core_thread_registration_deadline_exceeded")
+
+        fallback.assert_called_once_with(
+            "core_thread_registration_deadline_exceeded",
+            handler_confirmed=False,
+        )
+
     def test_writer_bootstrap_failure_revokes_dynamic_readiness_truth(self) -> None:
         from bot import bot_main, readiness_table
 


### PR DESCRIPTION
## Summary

This follow-up fixes the production failure mode observed after the merged v92 writer watchdog released the lease but the process did not restart, leaving runtime readiness and Kraken connection state inconsistent.

## Root cause

- Writer-loss handling treated the presence of a callback as proof that a bounded restart had been installed, even when that callback returned without confirming a handoff.
- Kraken's startup FSM could retain a stale connected latch after writer-authority loss.
- Runtime guard auditing verified installed patches but did not fail closed after an already-acquired writer lease or heartbeat was lost.
- Kraken user connection attempts could continue while the configured platform broker was disconnected.

## Changes

- Require a truthy writer-loss callback handoff; otherwise install the runtime's bounded exit-75 restart fallback.
- Clear Kraken FSM connection and readiness state on authority-loss demotion.
- Reject stale Kraken platform fast paths and defer user broker I/O until the platform reconnects.
- Audit armed live writer lease, heartbeat, execution authority, and runtime state while permitting the expected pre-acquisition startup state.
- Keep broker/user connectivity reporting tied to actual registry state.

## Safety impact

The changes fail closed: no Kraken nonce or broker I/O proceeds without live platform and writer authority. Trading strategy, signals, position sizing, and risk thresholds are unchanged.

## Validation

- 65 surrounding writer/Kraken lifecycle unit tests passed.
- 18 direct Kraken FSM transition tests passed.
- 6 direct runtime-guard tests passed.
- Python compilation and `git diff --check` passed.
- Added-line secret/bypass scan found no findings.

GitHub Actions is the authoritative full CI run.