### PR TITLE
Fix CI regressions after authority hardening

### DIFF
--- a/apply_bot_package_defer_fix.py
+++ b/apply_bot_package_defer_fix.py
@@ -45,14 +45,13 @@ _BOUNDED_STARTUP_COMMENT_MARKER = "side-effect bounded"
 _BOUNDED_STARTUP_LOG_MARKER = "BOT_PACKAGE_STARTUP_BOUNDED"
 
 
-def _is_already_patched(text: str) -> bool:
-    has_defer_assignment = f"{DEFER_NAME} =" in text
-    has_deferred_log_marker = MARKER in text
-    has_bounded_startup_comment = _BOUNDED_STARTUP_COMMENT_MARKER in text
-    has_bounded_startup_log_marker = _BOUNDED_STARTUP_LOG_MARKER in text
-
-    return (has_defer_assignment and has_deferred_log_marker) or (
-        has_bounded_startup_comment and has_bounded_startup_log_marker
+def _has_bounded_startup_contract(text: str) -> bool:
+    """Return whether the post-PR-2474 initializer needs no legacy patch."""
+    return bool(
+        _BOUNDED_STARTUP_COMMENT_MARKER in text
+        and _BOUNDED_STARTUP_LOG_MARKER in text
+        and "sitecustomize" not in text
+        and "_PATCH_HOOKS" not in text
     )
 
 
@@ -68,25 +67,25 @@ def _validate(text: str) -> None:
 
 
 def _is_already_patched(text: str) -> bool:
-    """Detect if the patch has already been applied to the file.
-    
-    Idempotency detection: recognize markers that indicate the file has
-    already been patched in a previous run:
-    
-    1. _NIJA_BOT_PACKAGE_RUNTIME_HOOKS_DEFERRED = assignment
-    2. Log marker for deferred startup
-    3. Bounded startup comment (added in PR #2474)
-    4. Runtime startup bounded marker
-    """
-    return bool(
-        f"{DEFER_NAME} =" in text
-        or "side-effect bounded" in text
-        or "BOT_PACKAGE_STARTUP_BOUNDED" in text
+    """Recognize only a complete legacy patch or the bounded initializer."""
+    if _has_bounded_startup_contract(text):
+        return True
+
+    legacy_markers = (
+        f"{DEFER_NAME} =" in text,
+        MARKER_LOG_LITERAL in text,
+        _HOOKS_REPLACEMENT in text,
     )
+    if not any(legacy_markers):
+        return False
+
+    # A partially patched legacy initializer is unsafe to accept as a no-op.
+    # Validation raises a specific error instead of silently shipping it.
+    _validate(text)
+    return True
 
 
 def patch_text(text: str) -> str:
-    # Idempotency: if already patched, return unchanged
     if _is_already_patched(text):
         return text
 
@@ -107,15 +106,13 @@ def patch_text(text: str) -> str:
 def main() -> None:
     original = BOT_INIT_PATH.read_text(encoding="utf-8")
     patched = patch_text(original)
-    if patched == original:
-        print("NIJA_BOT_PACKAGE_DEFER_PATCH_ALREADY_APPLIED idempotent=true no_changes=true")
-    else:
-        BOT_INIT_PATH.write_text(patched, encoding="utf-8")
-        print("NIJA_BOT_PACKAGE_DEFER_PATCH_APPLIED idempotent=true")
     changed = patched != original
     if changed:
         BOT_INIT_PATH.write_text(patched, encoding="utf-8")
-    print(f"NIJA_BOT_PACKAGE_DEFER_PATCH_APPLIED idempotent=true changed={str(changed).lower()}")
+        event = "NIJA_BOT_PACKAGE_DEFER_PATCH_APPLIED"
+    else:
+        event = "NIJA_BOT_PACKAGE_DEFER_PATCH_ALREADY_APPLIED"
+    print(f"{event} idempotent=true changed={str(changed).lower()}")
 
 
 if __name__ == "__main__":

--- a/bot/tests/test_activation_convergence_v17.py
+++ b/bot/tests/test_activation_convergence_v17.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
+import builtins
+import json
 import os
 import time
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from bot.activation_convergence_v17_patch import (
-    _patch_entrypoint_writer_authority,
-    _patch_preactivation,
-    _patch_startup_coordinator,
-    _patch_writer_reentry_guard,
+    install,
+    install_import_hook,
 )
 from bot.entrypoint_writer_authority import (
     EntrypointWriterAuthority,
@@ -42,16 +43,6 @@ def _clean_runtime(monkeypatch: pytest.MonkeyPatch):
 
 def test_startup_coordinator_treats_capital_ready_as_running_equivalent() -> None:
     """CapitalBootstrapFSM READY must not strand LIVE activation at commit_version=0."""
-    import bot.startup_coordinator as startup_coordinator
-
-    cls = startup_coordinator.StartupCoordinator
-    patch_attr = "_NIJA_ACTIVATION_CONVERGENCE_V17_COORDINATOR_PATCHED"
-    if hasattr(cls, patch_attr):
-        # The production fast path may have installed the patch before this test.
-        pass
-    else:
-        _patch_startup_coordinator(startup_coordinator)
-
     coordinator = get_startup_coordinator()
     coordinator.record_bootstrap_state("RUNNING_SUPERVISED")
     coordinator.record_capital_state(
@@ -79,9 +70,6 @@ def test_startup_coordinator_treats_capital_ready_as_running_equivalent() -> Non
 
 
 def _seed_acquired_runtime(*, thread_alive: bool, renewal_age_s: float) -> EntrypointWriterAuthority:
-    import bot.entrypoint_writer_authority as entrypoint
-
-    _patch_entrypoint_writer_authority(entrypoint)
     runtime = EntrypointWriterAuthority()
     runtime._result = EntrypointWriterAuthorityResult(
         acquired=True,
@@ -115,55 +103,52 @@ def test_lease_renewal_health_rejects_stale_success() -> None:
     assert age_s > max_age_s
 
 
-def test_preactivation_reader_uses_canonical_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
-    import bot.activation_convergence_v17_patch as convergence
+def test_retired_shim_is_side_effect_free() -> None:
+    original_import = builtins.__import__
 
-    fake = ModuleType("preactivation_readiness_convergence_v16_patch")
-    fake._heartbeat_ready = lambda: (False, "legacy_wall_clock")
-    monkeypatch.setattr(
-        convergence,
-        "_canonical_heartbeat_ready",
-        lambda source: (True, f"canonical:{source}", {"authoritative": True}),
+    assert install_import_hook() is True
+    assert install() is True
+    assert builtins.__import__ is original_import
+
+
+def test_reentry_proof_uses_exact_redis_metadata_not_legacy_alive_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import bot.writer_authority_recursion_guard_patch as guard
+
+    now = time.time()
+    client = MagicMock()
+    client.get.return_value = json.dumps(
+        {
+            "token": "token-123",
+            "generation": 3323,
+            "heartbeat_at": now,
+        }
     )
-
-    _patch_preactivation(fake)
-    ok, detail = fake._heartbeat_ready()
-
-    assert ok is True
-    assert detail.startswith("canonical:preactivation_readiness_convergence_v16")
-
-
-def test_reentry_proof_ignores_legacy_alive_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
-    import bot.activation_convergence_v17_patch as convergence
-
-    fake = ModuleType("writer_authority_recursion_guard_patch")
-    fake._writer_reentry_proof = lambda: {"ok": False}
+    runtime = SimpleNamespace(client=client, _client=client, _meta_key="writer:meta", _ttl_s=60)
+    monkeypatch.setattr(
+        guard,
+        "_exact_process_writer_proof",
+        lambda: (
+            {
+                "runtime": runtime,
+                "client": client,
+                "token": "token-123",
+                "generation": 3323,
+            },
+            "",
+        ),
+    )
     monkeypatch.setenv("NIJA_WRITER_LEASE_ACQUIRED", "1")
     monkeypatch.setenv("NIJA_WRITER_FENCING_TOKEN", "token-123")
     monkeypatch.setenv("NIJA_WRITER_LEASE_GENERATION", "3323")
     monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ACTIVE", "1")
     monkeypatch.setenv("NIJA_WRITER_HEARTBEAT_ALIVE_TS", "1")
     monkeypatch.setenv("REDIS_URL", "redis://example.invalid:6379/0")
-    monkeypatch.setattr(
-        convergence,
-        "_canonical_heartbeat_ready",
-        lambda source: (
-            True,
-            "canonical_fresh",
-            {
-                "active": True,
-                "authoritative": True,
-                "heartbeat_age_s": 2.0,
-                "heartbeat_max_age_s": 120.0,
-            },
-        ),
-    )
-    monkeypatch.setattr(convergence, "_redis_configured", lambda: True)
 
-    _patch_writer_reentry_guard(fake)
-    proof = fake._writer_reentry_proof()
+    proof = guard._writer_reentry_proof()
 
     assert proof["ok"] is True
-    assert proof["heartbeat_authoritative"] is True
-    assert proof["heartbeat_age_s"] == 2.0
+    assert proof["reason"] == "exact_redis_writer_metadata"
+    assert proof["heartbeat_age_s"] < 1.0
     assert os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] == "1"

--- a/bot/tests/test_bot_package_defer_fix.py
+++ b/bot/tests/test_bot_package_defer_fix.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[2]
 PATCHER = ROOT / "apply_bot_package_defer_fix.py"
@@ -57,6 +59,55 @@ def test_bot_package_patch_detects_bounded_startup_marker() -> None:
         'logger.info("BOT_PACKAGE_STARTUP_BOUNDED runtime_import_hooks=false")\n'
     )
     assert module.patch_text(source) == source
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "# Importing the package must remain side-effect bounded.\n",
+        'logger.info("BOT_PACKAGE_STARTUP_BOUNDED runtime_import_hooks=false")\n',
+        (
+            "# Importing the package must remain side-effect bounded.\n"
+            'logger.info("BOT_PACKAGE_STARTUP_BOUNDED runtime_import_hooks=false")\n'
+            "_PATCH_HOOKS = (\n)\n"
+        ),
+    ],
+)
+def test_bot_package_patch_rejects_partial_bounded_markers(source: str) -> None:
+    module = _load_patcher()
+
+    with pytest.raises(RuntimeError, match="sitecustomize anchor not found"):
+        module.patch_text(source)
+
+
+def test_bot_package_patch_rejects_partial_legacy_patch() -> None:
+    module = _load_patcher()
+    partially_patched = module.patch_text(_sample()).replace(
+        "_PATCH_HOOKS = () if _NIJA_BOT_PACKAGE_RUNTIME_HOOKS_DEFERRED else (",
+        "_PATCH_HOOKS = (",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="bot package patch-hook defer guard count invalid",
+    ):
+        module.patch_text(partially_patched)
+
+
+def test_main_writes_changed_file_once(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_patcher()
+    target = tmp_path / "__init__.py"
+    target.write_text(_sample(), encoding="utf-8")
+    monkeypatch.setattr(module, "BOT_INIT_PATH", target)
+
+    module.main()
+
+    output = capsys.readouterr().out
+    assert output.count("NIJA_BOT_PACKAGE_DEFER_PATCH_APPLIED") == 1
+    assert "changed=true" in output
+    assert module.patch_text(target.read_text(encoding="utf-8")) == target.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_repository_bot_init_is_already_patch_safe() -> None:

--- a/bot/tests/test_cycle_integrity_tightening.py
+++ b/bot/tests/test_cycle_integrity_tightening.py
@@ -303,6 +303,13 @@ class TestRunFallbackCycleIdWarning(unittest.TestCase):
         pipeline._emit_execution_rejection_telemetry = lambda **kwargs: None
         return pipeline
 
+    @staticmethod
+    def _allowing_capital_manager():
+        return SimpleNamespace(
+            can_open_trade=lambda _requested_risk: True,
+            update_account_risk=lambda _account_id, _requested_risk: None,
+        )
+
     def test_warning_logged_when_signal_missing_cycle_id(self):
         """A WARNING should fire when signal dict lacks cycle_id."""
         import bot.execution_pipeline as ep_mod
@@ -330,7 +337,11 @@ class TestRunFallbackCycleIdWarning(unittest.TestCase):
         log.setLevel(logging.DEBUG)
         try:
             with patch.object(ep_mod, "get_execution_integrity_layer", None), \
-                 patch.object(ep_mod, "get_global_capital_manager", None), \
+                 patch.object(
+                     ep_mod,
+                     "get_global_capital_manager",
+                     return_value=self._allowing_capital_manager(),
+                 ), \
                  patch.object(ep_mod, "get_master_strategy_router", None), \
                  patch.object(ep_mod, "get_signal_broadcaster", None), \
                  patch.object(ep_mod, "get_account_performance_dashboard", None), \
@@ -377,7 +388,11 @@ class TestRunFallbackCycleIdWarning(unittest.TestCase):
         log.setLevel(logging.DEBUG)
         try:
             with patch.object(ep_mod, "get_execution_integrity_layer", None), \
-                 patch.object(ep_mod, "get_global_capital_manager", None), \
+                 patch.object(
+                     ep_mod,
+                     "get_global_capital_manager",
+                     return_value=self._allowing_capital_manager(),
+                 ), \
                  patch.object(ep_mod, "get_master_strategy_router", None), \
                  patch.object(ep_mod, "get_signal_broadcaster", None), \
                  patch.object(ep_mod, "get_account_performance_dashboard", None), \

--- a/bot/tests/test_execution_authority_convergence_fsm.py
+++ b/bot/tests/test_execution_authority_convergence_fsm.py
@@ -248,7 +248,7 @@ class TestMaybeAutoActivateDelegation(unittest.TestCase):
                 self.assertIn("runtime_lifecycle_phase", snap)
                 self.assertIn("execution_permitted", snap)
 
-    def test_force_live_active_resyncs_env_and_coordinator_when_already_live(self) -> None:
+    def test_force_live_active_requires_canonical_proof_even_when_already_live(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             state_path = os.path.join(tmp, "state.json")
             with patch.dict(
@@ -265,6 +265,22 @@ class TestMaybeAutoActivateDelegation(unittest.TestCase):
                 "bot.trading_state_machine._startup_ownership_gate",
                 return_value=(True, ""),
             ):
+                coordinator = get_startup_coordinator()
+                coordinator.record_bootstrap_state("RUNNING_SUPERVISED")
+                coordinator.record_capital_state(
+                    state="READY",
+                    hydrated=True,
+                    balance=395.30,
+                    stale=False,
+                )
+                coordinator.record_threads_supervised(
+                    2,
+                    bootstrap_state="RUNNING_SUPERVISED",
+                )
+                coordinator.record_authority(ready=True, status={"ok": True})
+                coordinator.record_nonce_status(ready=True, detail="nonce_ready")
+                coordinator.record_dispatch_health(ready=True, detail="dispatch_ready")
+
                 sm = TradingStateMachine(state_file=state_path)
                 self.assertTrue(sm._force_live_active_transition("first"))
                 self.assertEqual(sm.get_current_state(), TradingState.LIVE_ACTIVE)
@@ -273,13 +289,11 @@ class TestMaybeAutoActivateDelegation(unittest.TestCase):
                 os.environ.pop("NIJA_RUNTIME_EXECUTION_AUTHORITY", None)
                 get_startup_coordinator().reset_for_testing()
 
-                self.assertTrue(sm._force_live_active_transition("resync"))
+                self.assertFalse(sm._force_live_active_transition("resync"))
+                self.assertEqual(sm.get_current_state(), TradingState.LIVE_ACTIVE)
+                self.assertIsNone(os.environ.get("NIJA_RUNTIME_TRADING_STATE"))
+                self.assertIsNone(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY"))
                 self.assertEqual(
-                    os.environ.get("NIJA_RUNTIME_TRADING_STATE"),
-                    TradingState.LIVE_ACTIVE.value,
-                )
-                self.assertEqual(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY"), "1")
-                self.assertGreater(
                     get_startup_coordinator()._runtime.last_committed_snapshot_version,
                     0,
                 )

--- a/bot/tests/test_pr2009_review_comments.py
+++ b/bot/tests/test_pr2009_review_comments.py
@@ -39,7 +39,7 @@ def _request() -> PipelineRequest:
 
 
 class TestPr2009ReviewComments(unittest.TestCase):
-    def test_force_trade_bypasses_monitor_safety_denial(self) -> None:
+    def test_force_trade_does_not_bypass_monitor_safety_denial(self) -> None:
         safety = _FakeSafetyController(_TradingMode.MONITOR, allowed=False, reason="monitor mode")
         fake_mod = types.SimpleNamespace(
             get_safety_controller=lambda: safety,
@@ -51,7 +51,9 @@ class TestPr2009ReviewComments(unittest.TestCase):
             with patch.dict(os.environ, {"FORCE_TRADE": "true", "FORCE_TRADE_MODE": ""}, clear=False):
                 result = ExecutionPipeline._enforce_execution_gate(fake_self, _request(), time.monotonic())
 
-        self.assertIsNone(result)
+        self.assertIsInstance(result, PipelineResult)
+        self.assertFalse(result.success)
+        self.assertIn("monitor mode", result.error)
 
     def test_without_force_trade_monitor_mode_remains_blocked(self) -> None:
         safety = _FakeSafetyController(_TradingMode.MONITOR, allowed=False, reason="monitor mode")

--- a/bot/tests/test_three_venue_execution_readiness.py
+++ b/bot/tests/test_three_venue_execution_readiness.py
@@ -64,6 +64,16 @@ def _set_canonical_writer_ready(monkeypatch, module) -> None:
     known-good canonical state.
     """
     _set_writer_ready_env(monkeypatch)
+    authority_context = importlib.import_module("bot.execution_authority_context")
+    monkeypatch.setattr(
+        authority_context,
+        "get_distributed_writer_authority_status",
+        lambda force_refresh=False: {
+            "effective_strict_required": True,
+            "ok": True,
+            "redis_reachable": True,
+        },
+    )
     monkeypatch.setattr(
         module,
         "writer_authority_snapshot",

--- a/bot/tests/test_writer_generation_tracker.py
+++ b/bot/tests/test_writer_generation_tracker.py
@@ -327,6 +327,7 @@ class TestHeartbeatGenerationIntegration(unittest.TestCase):
             "NIJA_WRITER_FENCING_TOKEN_FALLBACK": "0",
         }, clear=False), \
              patch("bot.redis_env.get_redis_url", return_value="redis://localhost:6379"), \
+             patch("bot.entrypoint_writer_authority.get_entrypoint_writer_authority", return_value=None), \
              patch("bot.execution_authority_context.assert_distributed_writer_authority", return_value=None), \
              patch("bot.writer_generation_tracker.validate_generation_for_heartbeat",
                    return_value=(False, "generation_mismatch:local=3 redis=7")):
@@ -343,6 +344,7 @@ class TestHeartbeatGenerationIntegration(unittest.TestCase):
             "NIJA_WRITER_FENCING_TOKEN_FALLBACK": "0",
         }, clear=False), \
              patch("bot.redis_env.get_redis_url", return_value="redis://localhost:6379"), \
+             patch("bot.entrypoint_writer_authority.get_entrypoint_writer_authority", return_value=None), \
              patch("bot.execution_authority_context.assert_distributed_writer_authority", return_value=None), \
              patch("bot.writer_generation_tracker.validate_generation_for_heartbeat",
                    return_value=(True, "")):
@@ -351,11 +353,11 @@ class TestHeartbeatGenerationIntegration(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(err, "")
 
-    def test_heartbeat_skips_generation_check_in_fallback_mode(self) -> None:
-        """Generation check must be skipped when is_fallback=True."""
+    def test_heartbeat_rejects_process_local_fallback_mode(self) -> None:
+        """Process-local fallback cannot satisfy distributed live authority."""
         with patch.dict(os.environ, {
             "NIJA_WRITER_FENCING_TOKEN": "test-token",
-            "NIJA_WRITER_LEASE_ACQUIRED": "0",
+            "NIJA_WRITER_LEASE_ACQUIRED": "1",
             "NIJA_WRITER_FENCING_TOKEN_FALLBACK": "1",
         }, clear=False), \
              patch("bot.redis_env.get_redis_url", return_value="redis://localhost:6379"):
@@ -367,9 +369,10 @@ class TestHeartbeatGenerationIntegration(unittest.TestCase):
                        return_value=(False, "generation_mismatch:local=0 redis=5")) as mock_gen_check:
                 from bot.authority_heartbeat import _check_authority_once
                 ok, err = _check_authority_once(timeout_s=2.0)
-            # Generation check should NOT have been called in fallback mode.
+            # The fallback is rejected before generation validation.
             mock_gen_check.assert_not_called()
-        self.assertTrue(ok)
+        self.assertFalse(ok)
+        self.assertIn("process-local writer fallback", err)
 
     def test_heartbeat_generation_exception_is_non_fatal(self) -> None:
         """A generation validation exception must not crash the heartbeat check."""
@@ -379,6 +382,7 @@ class TestHeartbeatGenerationIntegration(unittest.TestCase):
             "NIJA_WRITER_FENCING_TOKEN_FALLBACK": "0",
         }, clear=False), \
              patch("bot.redis_env.get_redis_url", return_value="redis://localhost:6379"), \
+             patch("bot.entrypoint_writer_authority.get_entrypoint_writer_authority", return_value=None), \
              patch("bot.execution_authority_context.assert_distributed_writer_authority", return_value=None), \
              patch("bot.writer_generation_tracker.validate_generation_for_heartbeat",
                    side_effect=RuntimeError("unexpected tracker error")):

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -2186,7 +2186,9 @@ class TradingStateMachine:
         # LPC state is safe: it does NOT execute trades.
         with self._lock:
             _early_arm_state = self._current_state
-        if _early_arm_state == TradingState.OFF and (_live_activation_intent or _force):
+        if _early_arm_state == TradingState.OFF and (
+            _live_activation_intent or _compat_activation_request
+        ):
             try:
                 self.transition_to(
                     TradingState.LIVE_PENDING_CONFIRMATION,
@@ -2322,7 +2324,7 @@ class TradingStateMachine:
                 self._activation_committed,
                 _lcv_quick,
                 _dry_run_quick,
-                _force,
+                _compat_activation_request,
                 _heartbeat_required_first,
                 _heartbeat_ok,
                 _heartbeat_err or "",
@@ -2335,7 +2337,7 @@ class TradingStateMachine:
             self._activation_committed,
             _lcv_quick,
             _dry_run_quick,
-            _force,
+            _compat_activation_request,
             _heartbeat_required_first,
             _heartbeat_ok,
             _heartbeat_err or "",
@@ -2369,12 +2371,12 @@ class TradingStateMachine:
 
         # Ensure explicit activation intent is reflected in FSM state even when
         # downstream commit gates are still converging.
-        # _force covers FORCE_TRADE / FORCE_TRADE_MODE / FORCE_LIVE_TRANSITION:
-        # when any of these operator override flags is set, treat it the same as
-        # live activation intent so the FSM arms to LIVE_PENDING_CONFIRMATION and
-        # the 5-minute auto-transition timeout can fire even without
-        # LIVE_CAPITAL_VERIFIED being explicitly set.
-        if current == TradingState.OFF and (_live_activation_intent or _force):
+        # A legacy force flag is only a compatibility activation request. It may
+        # arm LIVE_PENDING_CONFIRMATION, but it never bypasses canonical safety
+        # or ownership gates.
+        if current == TradingState.OFF and (
+            _live_activation_intent or _compat_activation_request
+        ):
             try:
                 self.transition_to(
                     TradingState.LIVE_PENDING_CONFIRMATION,
@@ -2394,7 +2396,7 @@ class TradingStateMachine:
         if (
             not authority_ready
             and current == TradingState.OFF
-            and (_live_activation_intent or _force)
+            and (_live_activation_intent or _compat_activation_request)
         ):
             try:
                 self.transition_to(
@@ -2563,7 +2565,9 @@ class TradingStateMachine:
             kill_state,
         )
 
-        _activation_requested = bool(_lcv_quick or _force or _live_activation_intent)
+        _activation_requested = bool(
+            _lcv_quick or _compat_activation_request or _live_activation_intent
+        )
 
         # Final consolidated gate diagnostic — single source of truth for activation state.
         _live_verified_bool = bool(_live_activation_intent)


### PR DESCRIPTION
## Purpose

Follow up PR #2476, which merged at its prior head while these fixes were being validated. This PR contains the completed fixes for the CI regressions and the unresolved defer-patcher review comment.

## Changes

- Require the complete legacy defer contract before treating the helper as already patched; handle the bounded post-PR-2474 initializer separately.
- Remove duplicate patch-helper writes and duplicate status output.
- Replace stale `_force` references that caused activation `NameError` failures with the fail-closed compatibility-request variable.
- Update stale tests and fixtures to match strict distributed writer authority, monitor-mode blocking, and retired runtime monkeypatch contracts.
- Add regressions for partial patch markers and one-write patch application.

## Safety

- No force flag bypass was restored.
- Process-local writer fallback remains rejected for live authority.
- Monitor mode remains fail closed.
- No account-level or deployment changes.

## Validation

- Local CI baseline after rebase: `CI_BASELINE_RATCHET_PASSED tests=1923 known=70 resolved=13 unexpected=0`
- Focused affected suite: 104 passed
- Final safety/defer suite: 39 passed
- `py_compile` clean on all changed Python files
- `git diff --check` clean
- Secret scan: no new secret findings (one pre-existing test fixture keyword outside changed lines)
- GitHub Actions: all 12 PR workflows passed, including `CI` and `NIJA Deployment Safety`