### PR TITLE
fix: complete post-merge production activation convergence

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -21,8 +21,6 @@ from typing import Iterable
 logger = logging.getLogger("nija.bot_entrypoint")
 _FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v57-v34"
 
-# Each tuple is (module, success log label). Names remain explicit so startup
-# attestation and source audits can prove which guards are eligible.
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
@@ -44,9 +42,10 @@ _FAST_PATH_INSTALLERS = (
     ("bot.okx_order_instid_payload_repair_patch", "OKX_ORDER_INSTID_PAYLOAD_REPAIR"),
     ("bot.okx_final_order_submission_bridge_patch", "OKX_FINAL_ORDER_SUBMISSION_BRIDGE"),
     ("bot.stalled_writer_release_guard_v22", "STALLED_WRITER_RELEASE_GUARD_V22"),
-    # v58 must install after the legacy guard modules so it can narrow their
-    # canonical-production ownership without bypassing any safety gate.
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
+    # v59 must install last: it corrects post-merge ownership/monitor wiring
+    # observed in production after v58 without weakening any safety proof.
+    ("bot.final_production_activation_repair_v59_patch", "FINAL_PRODUCTION_ACTIVATION_V59"),
 )
 
 _FAST_PATH_COMPAT_OPTIONAL_GUARDS = frozenset(
@@ -72,12 +71,7 @@ _LEGACY_INSTALLERS = (
 
 def _truthy(name: str) -> bool:
     return str(os.environ.get(name, "")).strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-        "enabled",
-        "y",
+        "1", "true", "yes", "on", "enabled", "y",
     }
 
 
@@ -101,44 +95,29 @@ def _install_guards(
     for module_name, label in specs:
         try:
             module = importlib.import_module(module_name)
-            installer = getattr(module, "install_import_hook", None) or getattr(
-                module, "install", None
-            )
+            installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
             if not callable(installer):
                 raise RuntimeError("installer_missing")
             result = installer()
             if result is False:
                 raise RuntimeError("installer_returned_false")
             installed.append(label)
-            logger.warning(
-                "%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s",
-                label,
-                mode,
-            )
+            logger.warning("%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s", label, mode)
         except Exception as exc:
             if label in optional_labels:
                 logger.warning(
                     "%s_INSTALL_SKIPPED_OPTIONAL source=bot_entrypoint mode=%s err=%s",
-                    label,
-                    mode,
-                    exc,
+                    label, mode, exc,
                 )
                 continue
             ready = False
             logger.critical(
                 "%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s",
-                label,
-                mode,
-                exc,
-                exc_info=True,
+                label, mode, exc, exc_info=True,
             )
     logger.critical(
-        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s "
-        "installed=%s",
-        _FAST_PATH_MARKER,
-        mode,
-        ready,
-        ",".join(installed) or "none",
+        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s installed=%s",
+        _FAST_PATH_MARKER, mode, ready, ",".join(installed) or "none",
     )
     return ready
 
@@ -151,18 +130,14 @@ if _canonical_fast_path_enabled():
     ):
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
-        raise RuntimeError(
-            "canonical fast-path safety guards failed; trading remains fail closed"
-        )
+        raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
     logger.critical(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s "
-        "package_hook_fanout=deferred handoff=bot.bot_main",
+        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s package_hook_fanout=deferred handoff=bot.bot_main",
         _FAST_PATH_MARKER,
     )
 else:
     logger.warning(
-        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s "
-        "canonical_fast_path=false",
+        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false",
         _FAST_PATH_MARKER,
     )
     _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")

--- a/bot/final_production_activation_repair_v59_patch.py
+++ b/bot/final_production_activation_repair_v59_patch.py
@@ -1,0 +1,233 @@
+"""Post-merge production activation repair v59.
+
+Addresses regressions observed after PR #2494:
+- canonical stalled-writer monitor must never own BootstrapFSM/runtime authority;
+- writer core registration must not synchronously wait on broker readiness I/O;
+- v16 proof monitor must actually run on the canonical fast path;
+- accepted fresh CapitalAuthority snapshot must reach TradingStateMachine's
+  first-snapshot latch through the existing fail-closed activation bridge.
+
+No trading/risk/nonce/SEAK/venue thresholds are weakened.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+logger = logging.getLogger("nija.final_production_activation_repair_v59")
+MARKER = "20260812-final-production-activation-v59"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _canonical_fast_path() -> bool:
+    return _truthy("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH") and _truthy("NIJA_DEFER_RUNTIME_SITE_HOOKS")
+
+
+def _patch_stalled_writer_diagnostic_only() -> bool:
+    guard = importlib.import_module("bot.stalled_writer_release_guard_v22")
+
+    original_bootstrap = getattr(guard, "_attempt_bootstrap_progression", None)
+    original_authority = getattr(guard, "_attempt_authority_convergence_retry", None)
+
+    if callable(original_bootstrap) and not getattr(original_bootstrap, "_nija_v59_diagnostic_only", False):
+        @wraps(original_bootstrap)
+        def bootstrap_only(source: str) -> bool:
+            if _canonical_fast_path():
+                logger.warning(
+                    "STALLED_WRITER_BOOTSTRAP_MUTATION_SUPPRESSED marker=%s source=%s "
+                    "reason=canonical_bot_main_single_owner diagnostic_only=true",
+                    MARKER,
+                    source,
+                )
+                return False
+            return bool(original_bootstrap(source))
+        bootstrap_only._nija_v59_diagnostic_only = True  # type: ignore[attr-defined]
+        guard._attempt_bootstrap_progression = bootstrap_only
+
+    if callable(original_authority) and not getattr(original_authority, "_nija_v59_diagnostic_only", False):
+        @wraps(original_authority)
+        def authority_only(source: str) -> bool:
+            if _canonical_fast_path():
+                logger.warning(
+                    "STALLED_WRITER_AUTHORITY_MUTATION_SUPPRESSED marker=%s source=%s "
+                    "reason=canonical_bot_main_single_owner diagnostic_only=true",
+                    MARKER,
+                    source,
+                )
+                return False
+            return bool(original_authority(source))
+        authority_only._nija_v59_diagnostic_only = True  # type: ignore[attr-defined]
+        guard._attempt_authority_convergence_retry = authority_only
+
+    os.environ["NIJA_STALLED_WRITER_CANONICAL_DIAGNOSTIC_ONLY"] = "1"
+    logger.critical(
+        "FINAL_ACTIVATION_V59_STALLED_WRITER_DIAGNOSTIC_ONLY marker=%s "
+        "bootstrap_mutation=false authority_mutation=false writer_release=false",
+        MARKER,
+    )
+    return True
+
+
+def _patch_writer_reconciliation_async() -> bool:
+    module = importlib.import_module("bot.entrypoint_writer_authority")
+    cls = getattr(module, "EntrypointWriterAuthority", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "_notify_runtime_reconciliation", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_v59_all_async", False):
+        return True
+
+    def notify_async(self: Any, trigger: str) -> None:
+        """Never block lease/core registration on exchange/readiness I/O."""
+        lock = getattr(self, "_runtime_reconcile_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._runtime_reconcile_lock = lock
+
+        with lock:
+            worker = getattr(self, "_runtime_reconcile_thread", None)
+            if worker is not None and worker.is_alive():
+                logger.info(
+                    "WRITER_READINESS_RECONCILE_DEDUPED marker=%s trigger=%s existing_worker=true",
+                    MARKER,
+                    trigger,
+                )
+                return
+
+            def _worker() -> None:
+                try:
+                    runner = getattr(self, "_run_runtime_reconciliation", None)
+                    if callable(runner):
+                        runner(trigger)
+                except Exception:
+                    logger.exception(
+                        "WRITER_READINESS_RECONCILE_ASYNC_FAILED marker=%s trigger=%s",
+                        MARKER,
+                        trigger,
+                    )
+                finally:
+                    with lock:
+                        if getattr(self, "_runtime_reconcile_thread", None) is threading.current_thread():
+                            self._runtime_reconcile_thread = None
+
+            worker = threading.Thread(
+                target=_worker,
+                name=f"writer-readiness-reconciliation-{trigger}"[:80],
+                daemon=True,
+            )
+            self._runtime_reconcile_thread = worker
+            worker.start()
+            logger.critical(
+                "WRITER_READINESS_RECONCILE_ASYNC_DISPATCHED marker=%s trigger=%s "
+                "core_registration_blocked=false",
+                MARKER,
+                trigger,
+            )
+
+    notify_async._nija_v59_all_async = True  # type: ignore[attr-defined]
+    notify_async.__wrapped__ = current  # type: ignore[attr-defined]
+    cls._notify_runtime_reconciliation = notify_async
+    logger.critical(
+        "FINAL_ACTIVATION_V59_WRITER_RECONCILE_PATCHED marker=%s all_triggers_async=true",
+        MARKER,
+    )
+    return True
+
+
+def _install_proof_convergence() -> bool:
+    """Start the already-existing proof stack; never fabricate a proof."""
+    identity = importlib.import_module("runtime_module_identity_convergence_patch")
+    identity_install = getattr(identity, "install", None) or getattr(identity, "install_import_hook", None)
+    if callable(identity_install):
+        identity_install()
+
+    v15 = importlib.import_module("runtime_convergence_v15_patch")
+    v15_install = getattr(v15, "install", None)
+    if callable(v15_install):
+        v15_install()
+
+    v16 = importlib.import_module("preactivation_readiness_convergence_v16_patch")
+    # v58 must already have replaced this function with incremental publication.
+    mark = getattr(v16, "_mark_proven_readiness", None)
+    if not callable(mark):
+        return False
+    v16_install = getattr(v16, "install", None) or getattr(v16, "install_import_hook", None)
+    if not callable(v16_install):
+        return False
+    result = v16_install()
+    logger.critical(
+        "FINAL_ACTIVATION_V59_PROOF_MONITORS_STARTED marker=%s "
+        "module_identity=true runtime_v15=true preactivation_v16=true",
+        MARKER,
+    )
+    return result is not False
+
+
+def _install_first_snapshot_bridge() -> bool:
+    bridge = importlib.import_module("bot.activation_snapshot_bridge_patch")
+    installer = getattr(bridge, "install_import_hook", None)
+    if not callable(installer):
+        return False
+    installer()
+    logger.critical(
+        "FINAL_ACTIVATION_V59_FIRST_SNAPSHOT_BRIDGE_STARTED marker=%s "
+        "source=accepted_capital_authority fail_closed=true",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return True
+        failures: list[str] = []
+        for name, step in (
+            ("stalled_writer_diagnostic_only", _patch_stalled_writer_diagnostic_only),
+            ("writer_reconciliation_async", _patch_writer_reconciliation_async),
+            ("proof_convergence", _install_proof_convergence),
+            ("first_snapshot_bridge", _install_first_snapshot_bridge),
+        ):
+            try:
+                if step() is False:
+                    failures.append(name)
+            except Exception as exc:
+                failures.append(f"{name}:{type(exc).__name__}:{exc}")
+                logger.critical(
+                    "FINAL_ACTIVATION_V59_STEP_FAILED marker=%s step=%s err=%s",
+                    MARKER,
+                    name,
+                    exc,
+                    exc_info=True,
+                )
+        _INSTALLED = not failures
+        os.environ["NIJA_FINAL_PRODUCTION_ACTIVATION_V59_INSTALLED"] = "1" if _INSTALLED else "0"
+        logger.critical(
+            "FINAL_PRODUCTION_ACTIVATION_V59_INSTALLED marker=%s ready=%s failures=%s "
+            "thresholds_unchanged=true force_activation=false",
+            MARKER,
+            _INSTALLED,
+            failures or "none",
+        )
+        return _INSTALLED
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/tests/test_final_production_activation_repair_v59.py
+++ b/bot/tests/test_final_production_activation_repair_v59.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import types
+
+from bot import final_production_activation_repair_v59_patch as repair
+
+
+def test_stalled_writer_is_diagnostic_only_on_canonical_path(monkeypatch):
+    monkeypatch.setenv("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH", "1")
+    monkeypatch.setenv("NIJA_DEFER_RUNTIME_SITE_HOOKS", "1")
+    import bot.stalled_writer_release_guard_v22 as guard
+
+    original_bootstrap = guard._attempt_bootstrap_progression
+    original_authority = guard._attempt_authority_convergence_retry
+    try:
+        assert repair._patch_stalled_writer_diagnostic_only() is True
+        assert guard._attempt_bootstrap_progression("test") is False
+        assert guard._attempt_authority_convergence_retry("test") is False
+    finally:
+        guard._attempt_bootstrap_progression = original_bootstrap
+        guard._attempt_authority_convergence_retry = original_authority
+
+
+def test_writer_registration_reconciliation_dispatches_async(monkeypatch):
+    import bot.entrypoint_writer_authority as module
+
+    original = module.EntrypointWriterAuthority._notify_runtime_reconciliation
+    try:
+        assert repair._patch_writer_reconciliation_async() is True
+        runtime = module.EntrypointWriterAuthority()
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_reconcile(trigger):
+            started.set()
+            release.wait(timeout=2.0)
+
+        runtime._run_runtime_reconciliation = slow_reconcile
+        t0 = time.monotonic()
+        runtime._notify_runtime_reconciliation("core_thread_registered")
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.25
+        assert started.wait(timeout=1.0)
+        release.set()
+    finally:
+        module.EntrypointWriterAuthority._notify_runtime_reconciliation = original
+
+
+def test_proof_convergence_starts_existing_monitors(monkeypatch):
+    calls = []
+
+    identity = types.ModuleType("runtime_module_identity_convergence_patch")
+    identity.install = lambda: calls.append("identity")
+    v15 = types.ModuleType("runtime_convergence_v15_patch")
+    v15.install = lambda: calls.append("v15") or True
+    v16 = types.ModuleType("preactivation_readiness_convergence_v16_patch")
+    v16._mark_proven_readiness = lambda proofs: (False, [])
+    v16.install = lambda: calls.append("v16") or True
+
+    monkeypatch.setitem(sys.modules, identity.__name__, identity)
+    monkeypatch.setitem(sys.modules, v15.__name__, v15)
+    monkeypatch.setitem(sys.modules, v16.__name__, v16)
+
+    assert repair._install_proof_convergence() is True
+    assert calls == ["identity", "v15", "v16"]
+
+
+def test_first_snapshot_uses_existing_fail_closed_bridge(monkeypatch):
+    bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    calls = []
+    bridge.install_import_hook = lambda: calls.append("bridge")
+    monkeypatch.setitem(sys.modules, bridge.__name__, bridge)
+
+    assert repair._install_first_snapshot_bridge() is True
+    assert calls == ["bridge"]
+
+
+def test_v59_declared_after_v58_in_canonical_entrypoint():
+    path = os.path.join(os.path.dirname(__file__), "..", "bot.py")
+    source = open(path, encoding="utf-8").read()
+    assert source.index("FINAL_PRODUCTION_ACTIVATION_V58") < source.index("FINAL_PRODUCTION_ACTIVATION_V59")
+
+
+def test_v59_does_not_force_trade_or_lower_thresholds():
+    path = os.path.join(os.path.dirname(__file__), "..", "final_production_activation_repair_v59_patch.py")
+    source = open(path, encoding="utf-8").read()
+    for forbidden in (
+        "MIN_ENTRY_SCORE =",
+        "MIN_TRADE_USD =",
+        "FORCE_TRADE =",
+        "NIJA_FORCE_ACTIVATION =",
+        "_first_snap_accepted = True",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## What changed

Policy-compliant replacement for #2495. Code/head content is identical to the validated v59 repair; only the branch prefix changed from disallowed `agent/*` to `fix/*`.

- Makes `stalled_writer_release_guard_v22` fully diagnostic-only on the canonical fast path: it can no longer advance BootstrapFSM or retry runtime-authority convergence there.
- Makes every writer-triggered readiness reconciliation asynchronous/deduplicated so `register_core_thread()` cannot block bot_main behind broker/private balance I/O.
- Explicitly starts the existing runtime module-identity, v15 structural convergence, and v16 readiness-proof monitors on the bounded canonical path.
- Starts the existing fail-closed activation snapshot bridge so a genuinely accepted, hydrated, fresh CapitalAuthority snapshot can synchronize TradingStateMachine's first-snapshot latch.
- Adds deterministic tests for all four post-merge regressions.

## Latest production evidence

The latest #2494 deployment still shows healthy writer generations 3704/3705 and healthy capital, but the readiness table remains stale and activation remains closed. The 17:15 restart also proves the old stalled-writer helper is being suppressed pre-core rather than taking ownership, while bot_main has not yet registered the core. These logs predate v59 because #2495 was not merged.

## Safety

No strategy thresholds, risk thresholds, minimum order sizes, nonce rules, SEAK controls, kill switches, venue eligibility, or force-trade/force-activation flags are changed. v59 only wires existing proof-based components and removes overlapping lifecycle ownership. Trading remains fail-closed unless canonical proofs pass.

## Expected production sequence

`CORE_THREAD_REGISTRATION_SUCCEEDED` should return promptly, followed by bot_main-owned `RUNNING_SUPERVISED`; v16 should publish independently proven readiness keys; the accepted CapitalAuthority snapshot should reach the first-snapshot latch through the existing activation bridge; then normal activation may reach `LIVE_ACTIVE`, coordinator `EXECUTING/LIVE`, `TRADING_ENGINE_READY_SET`, and `SCAN_STARTED` if all structural/risk proofs pass.