### PR TITLE
Fix activation/capital convergence under slow venue refresh

### DIFF
--- a/bot/activation_capital_convergence_v62_patch.py
+++ b/bot/activation_capital_convergence_v62_patch.py
@@ -11,8 +11,8 @@ This repair closes two fail-closed startup races without manufacturing authority
 
 2. ``three_venue_execution_readiness`` historically allowed environment handoff
    flags to override CapitalAuthority staleness. Replace that observer with a
-   canonical check: hydrated authority, positive real capital, and a current
-   non-stale publication are all required.
+   canonical check: hydrated authority, positive real capital, and a currently
+   accepted, non-stale publication are all required.
 
 No writer, nonce, kill-switch, dispatch-health, risk, or freshness gate is
 bypassed. The coordinator's existing readiness proof remains the final authority.
@@ -47,7 +47,7 @@ def _state_value(module_name: str, getter_name: str) -> str:
 
 
 def _authority_snapshot() -> tuple[bool, float | None, bool]:
-    """Return (hydrated, real_capital, stale) from canonical CapitalAuthority."""
+    """Return (hydrated, real_capital, stale_or_unaccepted) from CapitalAuthority."""
     try:
         try:
             from bot.capital_authority import get_capital_authority
@@ -72,7 +72,11 @@ def _authority_snapshot() -> tuple[bool, float | None, bool]:
         if callable(publication_reader):
             try:
                 publication = publication_reader()
-                stale = bool(getattr(publication, "stale", True))
+                publication_stale = bool(getattr(publication, "stale", True))
+                publication_accepted = bool(
+                    getattr(publication, "accepted", not publication_stale)
+                )
+                stale = bool(publication_stale or not publication_accepted)
             except Exception:
                 stale = True
         else:
@@ -120,11 +124,19 @@ def _sync_coordinator_inputs(coordinator: Any) -> None:
         balance=capital,
         stale=stale,
     )
+    if readiness:
+        readiness_table = readiness
+        readiness_complete = bool(all(readiness.values()))
+    else:
+        # An empty/unavailable table must never satisfy
+        # StartupConvergenceSnapshot.pending_readiness by vacuous truth.
+        readiness_table = {"canonical_sync_available": False}
+        readiness_complete = False
     coordinator.record_readiness(
         key="__canonical_sync__",
-        value=bool(readiness and all(readiness.values())),
+        value=readiness_complete,
         version=readiness_version,
-        table=readiness,
+        table=readiness_table,
     )
     LOGGER.info(
         "ACTIVATION_CAPITAL_CANONICAL_SYNC marker=%s bootstrap=%s capital=%s "
@@ -136,7 +148,7 @@ def _sync_coordinator_inputs(coordinator: Any) -> None:
         capital,
         stale,
         readiness_version,
-        sorted(key for key, value in readiness.items() if not value),
+        sorted(key for key, value in readiness_table.items() if not value),
     )
 
 
@@ -183,7 +195,7 @@ def _patch_three_venue(module: ModuleType) -> bool:
             hydrated, capital, stale = _authority_snapshot()
             LOGGER.warning(
                 "THREE_VENUE_CANONICAL_CAPITAL_NOT_READY marker=%s hydrated=%s "
-                "capital=%s stale=%s env_handoff_ignored=true",
+                "capital=%s stale_or_unaccepted=%s env_handoff_ignored=true",
                 MARKER,
                 hydrated,
                 capital,

--- a/bot/activation_capital_convergence_v62_patch.py
+++ b/bot/activation_capital_convergence_v62_patch.py
@@ -1,0 +1,259 @@
+"""Canonical activation/capital state convergence repair v62.
+
+This repair closes two fail-closed startup races without manufacturing authority:
+
+1. Compatibility activation requests can reach ``StartupCoordinator`` before its
+   cached bootstrap/capital/readiness fields have been refreshed from the
+   canonical FSMs. The coordinator then correctly rejects at ``capital.running``
+   even though CapitalBootstrapStateMachine is already READY. Before evaluating a
+   compatibility request, mirror the current canonical bootstrap, capital, and
+   readiness snapshots into the coordinator using its normal ``record_*`` APIs.
+
+2. ``three_venue_execution_readiness`` historically allowed environment handoff
+   flags to override CapitalAuthority staleness. Replace that observer with a
+   canonical check: hydrated authority, positive real capital, and a current
+   non-stale publication are all required.
+
+No writer, nonce, kill-switch, dispatch-health, risk, or freshness gate is
+bypassed. The coordinator's existing readiness proof remains the final authority.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.activation_capital_convergence_v62")
+MARKER = "20260812-activation-capital-convergence-v62"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_ACTIVATION_CAPITAL_CONVERGENCE_V62_IMPORT_HOOK"
+_COORD_PATCH = "_nija_activation_capital_convergence_v62"
+_CAPITAL_PATCH = "_nija_canonical_capital_observer_v62"
+
+
+def _state_value(module_name: str, getter_name: str) -> str:
+    try:
+        module = __import__(module_name, fromlist=[getter_name])
+        getter = getattr(module, getter_name)
+        state = getattr(getter(), "state", None)
+        return str(getattr(state, "value", state) or "UNAVAILABLE")
+    except Exception:
+        return "UNAVAILABLE"
+
+
+def _authority_snapshot() -> tuple[bool, float | None, bool]:
+    """Return (hydrated, real_capital, stale) from canonical CapitalAuthority."""
+    try:
+        try:
+            from bot.capital_authority import get_capital_authority
+        except ImportError:
+            from capital_authority import get_capital_authority  # type: ignore[import]
+        authority = get_capital_authority()
+        if authority is None:
+            return False, None, True
+
+        hydrated_value = getattr(authority, "is_hydrated", False)
+        hydrated = bool(
+            hydrated_value() if callable(hydrated_value) else hydrated_value
+        )
+
+        capital_reader = getattr(authority, "get_real_capital", None)
+        capital = float(capital_reader()) if callable(capital_reader) else float(
+            getattr(authority, "total_capital", 0.0) or 0.0
+        )
+
+        stale = True
+        publication_reader = getattr(authority, "get_snapshot_publication_status", None)
+        if callable(publication_reader):
+            try:
+                publication = publication_reader()
+                stale = bool(getattr(publication, "stale", True))
+            except Exception:
+                stale = True
+        else:
+            stale_reader = getattr(authority, "is_stale", None)
+            if callable(stale_reader):
+                try:
+                    stale = bool(stale_reader())
+                except TypeError:
+                    stale = bool(stale_reader(ttl_s=90.0))
+                except Exception:
+                    stale = True
+
+        return hydrated, capital, stale
+    except Exception:
+        return False, None, True
+
+
+def _readiness_snapshot() -> tuple[int, dict[str, bool]]:
+    try:
+        try:
+            from bot.readiness_table import snapshot_with_version
+        except ImportError:
+            from readiness_table import snapshot_with_version  # type: ignore[import]
+        version, table = snapshot_with_version()
+        return int(version or 0), dict(table or {})
+    except Exception:
+        return 0, {}
+
+
+def _sync_coordinator_inputs(coordinator: Any) -> None:
+    """Mirror canonical state into StartupCoordinator without granting authority."""
+    bootstrap_state = _state_value(
+        "bot.bootstrap_state_machine", "get_bootstrap_fsm"
+    )
+    capital_state = _state_value(
+        "bot.capital_flow_state_machine", "get_capital_bootstrap_fsm"
+    )
+    hydrated, capital, stale = _authority_snapshot()
+    readiness_version, readiness = _readiness_snapshot()
+
+    coordinator.record_bootstrap_state(bootstrap_state)
+    coordinator.record_capital_state(
+        state=capital_state,
+        hydrated=hydrated,
+        balance=capital,
+        stale=stale,
+    )
+    coordinator.record_readiness(
+        key="__canonical_sync__",
+        value=bool(readiness and all(readiness.values())),
+        version=readiness_version,
+        table=readiness,
+    )
+    LOGGER.info(
+        "ACTIVATION_CAPITAL_CANONICAL_SYNC marker=%s bootstrap=%s capital=%s "
+        "hydrated=%s balance=%s stale=%s readiness_v=%s pending=%s",
+        MARKER,
+        bootstrap_state,
+        capital_state,
+        hydrated,
+        capital,
+        stale,
+        readiness_version,
+        sorted(key for key, value in readiness.items() if not value),
+    )
+
+
+def _patch_startup_coordinator(module: ModuleType) -> bool:
+    cls = getattr(module, "StartupCoordinator", None)
+    original = getattr(cls, "force_activate_bypass", None) if isinstance(cls, type) else None
+    if not callable(original):
+        return False
+    if getattr(original, _COORD_PATCH, False):
+        return True
+
+    @wraps(original)
+    def force_activate_with_canonical_sync(self: Any, reason: str) -> int:
+        _sync_coordinator_inputs(self)
+        return original(self, reason)
+
+    setattr(force_activate_with_canonical_sync, _COORD_PATCH, True)
+    setattr(force_activate_with_canonical_sync, "__wrapped__", original)
+    cls.force_activate_bypass = force_activate_with_canonical_sync
+    LOGGER.critical(
+        "ACTIVATION_COORDINATOR_CANONICAL_SYNC_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _canonical_capital_ready() -> bool:
+    hydrated, capital, stale = _authority_snapshot()
+    return bool(hydrated and capital is not None and capital > 0.0 and not stale)
+
+
+def _patch_three_venue(module: ModuleType) -> bool:
+    current = getattr(module, "_capital_ready", None)
+    if not callable(current):
+        return False
+    if getattr(current, _CAPITAL_PATCH, False):
+        return True
+
+    @wraps(current)
+    def canonical_capital_ready() -> bool:
+        ready = _canonical_capital_ready()
+        if not ready:
+            hydrated, capital, stale = _authority_snapshot()
+            LOGGER.warning(
+                "THREE_VENUE_CANONICAL_CAPITAL_NOT_READY marker=%s hydrated=%s "
+                "capital=%s stale=%s env_handoff_ignored=true",
+                MARKER,
+                hydrated,
+                capital,
+                stale,
+            )
+        return ready
+
+    setattr(canonical_capital_ready, _CAPITAL_PATCH, True)
+    setattr(canonical_capital_ready, "__wrapped__", current)
+    module._capital_ready = canonical_capital_ready
+    LOGGER.critical(
+        "THREE_VENUE_CANONICAL_CAPITAL_OBSERVER_PATCHED marker=%s module=%s",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in ("bot.startup_coordinator", "startup_coordinator"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_startup_coordinator(module) or changed
+    for name in ("three_venue_execution_readiness", "bot.three_venue_execution_readiness"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_three_venue(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if (
+                    "startup_coordinator" in str(name)
+                    or "three_venue_execution_readiness" in str(name)
+                ):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_ACTIVATION_CAPITAL_CONVERGENCE_V62_READY"] = "1"
+        LOGGER.critical(
+            "ACTIVATION_CAPITAL_CONVERGENCE_V62_INSTALLED marker=%s "
+            "canonical_state_sync=true canonical_capital_freshness=true bypass=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_capital_ready",
+    "_sync_coordinator_inputs",
+]

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260808-canonical-fast-entrypoint-v57-v34"
+_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v62"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -42,6 +42,14 @@ _FAST_PATH_INSTALLERS = (
     ("bot.okx_order_instid_payload_repair_patch", "OKX_ORDER_INSTID_PAYLOAD_REPAIR"),
     ("bot.okx_final_order_submission_bridge_patch", "OKX_FINAL_ORDER_SUBMISSION_BRIDGE"),
     ("bot.stalled_writer_release_guard_v22", "STALLED_WRITER_RELEASE_GUARD_V22"),
+    # Keep synchronous capital publication inside the canonical freshness TTL.
+    # Slow venue workers continue asynchronously and can contribute on a later
+    # refresh once their observations are still fresh.
+    ("bot.capital_refresh_live_continuity_v78_patch", "CAPITAL_REFRESH_FRESHNESS_BOUNDED_V78"),
+    # Synchronize canonical bootstrap/capital/readiness state before any
+    # compatibility activation proof is evaluated. This is state convergence,
+    # not a bypass; all writer/nonce/risk/kill-switch gates remain authoritative.
+    ("bot.activation_capital_convergence_v62_patch", "ACTIVATION_CAPITAL_CONVERGENCE_V62"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation
     # monitors. It guards v60's request boundary and makes v16 readiness reflect

--- a/bot/capital_refresh_live_continuity_v78_patch.py
+++ b/bot/capital_refresh_live_continuity_v78_patch.py
@@ -1,19 +1,21 @@
-"""Slow-broker capital refresh continuity v78.
+"""Freshness-bounded slow-broker capital refresh continuity v78.
 
-A healthy Coinbase authenticated balance read has been observed taking longer
-than the historical 180 second capital-refresh deadline.  v37 correctly refuses
-to reuse an observation after the normal freshness TTL, but the short live-fetch
-deadline can therefore collapse a healthy multi-broker snapshot to one venue.
+Capital refresh workers may legitimately take longer than the canonical capital
+freshness TTL. Waiting synchronously for those workers beyond the TTL creates a
+liveness contradiction: the refresh pipeline remains occupied while the last
+accepted CapitalAuthority snapshot becomes stale, so activation must fail closed.
 
-v78 changes the *live request budget*, not the capital freshness contract:
-* increase the bounded per-broker/cycle fetch budget to a configurable 420s;
-* reuse a still-running in-flight request within that bounded cycle rather than
-  starting a second request;
-* preserve v37's existing fresh-observation fallback exactly as-is;
-* never convert timeout to zero unless both live fetch and fresh fallback fail;
-* never extend the freshness TTL or authorize trading from stale balances.
+v78 keeps slow requests alive in their existing daemon workers but bounds the
+*synchronous batch wait* so a refresh can publish from brokers that completed in
+time. Late workers may populate the guard's observation cache for a later cycle;
+that cache remains subject to the existing freshness checks.
 
-The guard remains fail closed after the extended bounded deadline.
+Safety properties:
+* the synchronous cycle deadline is always strictly inside the freshness TTL;
+* no per-broker timeout is lengthened and no stale fallback is authorized;
+* still-running workers are not cancelled or duplicated;
+* optional slow venues cannot hold the whole capital publication path past TTL;
+* the guard remains fail closed when no fresh broker result is available.
 """
 from __future__ import annotations
 
@@ -27,7 +29,7 @@ from types import ModuleType
 from typing import Any
 
 LOGGER = logging.getLogger("nija.capital_refresh_live_continuity_v78")
-MARKER = "20260809-capital-refresh-live-continuity-v78"
+MARKER = "20260812-capital-refresh-freshness-bounded-v78"
 _LOCK = threading.RLock()
 _PATCH_ATTR = "_nija_capital_refresh_live_continuity_v78"
 _HOOK_FLAG = "_NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_IMPORT_HOOK"
@@ -38,12 +40,38 @@ _GUARD_NAMES = (
 )
 
 
-def fetch_budget_seconds() -> float:
+def _freshness_ttl_seconds() -> float:
     try:
-        value = float(os.environ.get("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", "420") or 420.0)
+        return max(
+            10.0,
+            float(os.environ.get("NIJA_CAPITAL_FRESHNESS_TTL_S", "90.0") or 90.0),
+        )
     except (TypeError, ValueError):
-        value = 420.0
-    return max(180.0, min(600.0, value))
+        return 90.0
+
+
+def fetch_budget_seconds() -> float:
+    """Return a synchronous publish budget that cannot outlive capital freshness."""
+    ttl_s = _freshness_ttl_seconds()
+    try:
+        requested = float(
+            os.environ.get("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", "60.0")
+            or 60.0
+        )
+    except (TypeError, ValueError):
+        requested = 60.0
+
+    try:
+        margin_s = float(
+            os.environ.get("NIJA_CAPITAL_REFRESH_PUBLISH_MARGIN_SECONDS", "15.0")
+            or 15.0
+        )
+    except (TypeError, ValueError):
+        margin_s = 15.0
+
+    margin_s = max(5.0, min(margin_s, max(5.0, ttl_s / 2.0)))
+    ceiling = max(5.0, ttl_s - margin_s)
+    return max(5.0, min(requested, ceiling))
 
 
 def _patch_guard(module: ModuleType) -> bool:
@@ -58,45 +86,34 @@ def _patch_guard(module: ModuleType) -> bool:
 
     @wraps(original_init)
     def init_v78(self: Any, broker_map: dict[str, Any]) -> None:
+        original_init(self, broker_map)
         budget = fetch_budget_seconds()
-        # v35/v36 read their timeout configuration while constructing the batch.
-        # Set only the dedicated capital-refresh variable and restore the caller's
-        # environment immediately after construction.
-        key = "NIJA_CAPITAL_REFRESH_BROKER_TIMEOUT_SECONDS"
-        previous = os.environ.get(key)
-        try:
-            os.environ[key] = str(budget)
-            original_init(self, broker_map)
-        finally:
-            if previous is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = previous
 
-        # Some historical guard revisions materialize timeout values before
-        # consulting the environment. Raise only values that are clearly the
-        # old <=180s default; never shorten a stricter operator configuration.
-        for flight in dict(getattr(self, "_flights", {}) or {}).values():
+        # v35/v36 use _batch_started; a few compatibility revisions used
+        # _cycle_started. Support both without mutating immutable _Flight tuples.
+        started = 0.0
+        for attr in ("_batch_started", "_cycle_started"):
             try:
-                current = float(getattr(flight, "timeout_s", 0.0) or 0.0)
+                candidate = float(getattr(self, attr, 0.0) or 0.0)
             except (TypeError, ValueError):
-                current = 0.0
-            if current <= 180.0:
-                try:
-                    setattr(flight, "timeout_s", budget)
-                except Exception:
-                    pass
-        try:
-            cycle_started = float(getattr(self, "_cycle_started", 0.0) or 0.0)
-            cycle_deadline = float(getattr(self, "_cycle_deadline", 0.0) or 0.0)
-            if cycle_started > 0.0 and cycle_deadline - cycle_started <= 180.0:
-                setattr(self, "_cycle_deadline", cycle_started + budget)
-        except Exception:
-            pass
+                candidate = 0.0
+            if candidate > 0.0:
+                started = candidate
+                break
+
+        if started > 0.0:
+            current_deadline = float(getattr(self, "_cycle_deadline", 0.0) or 0.0)
+            bounded_deadline = started + budget
+            # Only shorten an overlong batch. Never lengthen a stricter deadline.
+            if current_deadline <= 0.0 or current_deadline > bounded_deadline:
+                setattr(self, "_cycle_deadline", bounded_deadline)
+
         LOGGER.info(
-            "CAPITAL_REFRESH_V78_BATCH_BUDGET marker=%s budget_s=%.1f brokers=%s freshness_ttl_unchanged=true",
+            "CAPITAL_REFRESH_V78_BATCH_BUDGET marker=%s budget_s=%.1f ttl_s=%.1f "
+            "brokers=%s late_workers_async=true stale_fallback_extension=false",
             MARKER,
             budget,
+            _freshness_ttl_seconds(),
             sorted(str(name).lower() for name in broker_map),
         )
 
@@ -104,7 +121,8 @@ def _patch_guard(module: ModuleType) -> bool:
     setattr(init_v78, "__wrapped__", original_init)
     batch_cls.__init__ = init_v78
     LOGGER.critical(
-        "CAPITAL_REFRESH_V78_GUARD_PATCHED marker=%s module=%s max_budget_s=600 stale_fallback_extension=false",
+        "CAPITAL_REFRESH_V78_GUARD_PATCHED marker=%s module=%s "
+        "freshness_bounded=true stale_fallback_extension=false",
         MARKER,
         module.__name__,
     )
@@ -139,9 +157,11 @@ def install_import_hook() -> bool:
             setattr(builtins, _HOOK_FLAG, True)
         os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] = "1"
         LOGGER.critical(
-            "CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED marker=%s budget_s=%.1f freshness_ttl_unchanged=true",
+            "CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED marker=%s budget_s=%.1f "
+            "ttl_s=%.1f freshness_bounded=true",
             MARKER,
             fetch_budget_seconds(),
+            _freshness_ttl_seconds(),
         )
         return True
 
@@ -150,4 +170,9 @@ def install() -> bool:
     return install_import_hook()
 
 
-__all__ = ["MARKER", "fetch_budget_seconds", "install", "install_import_hook"]
+__all__ = [
+    "MARKER",
+    "fetch_budget_seconds",
+    "install",
+    "install_import_hook",
+]

--- a/bot/tests/test_activation_capital_convergence_v62.py
+++ b/bot/tests/test_activation_capital_convergence_v62.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from enum import Enum
+
+
+class _State(Enum):
+    RUNNING_SUPERVISED = "RUNNING_SUPERVISED"
+    READY = "READY"
+
+
+class ActivationCapitalConvergenceV62Tests(unittest.TestCase):
+    def setUp(self):
+        self.mod = importlib.import_module("bot.activation_capital_convergence_v62_patch")
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "bot.bootstrap_state_machine",
+                "bot.capital_flow_state_machine",
+                "bot.capital_authority",
+                "bot.readiness_table",
+            )
+        }
+        self.saved_env = {
+            key: os.environ.get(key)
+            for key in ("CAPITAL_SYSTEM_READY", "NIJA_CAPITAL_READY")
+        }
+
+    def tearDown(self):
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        for key, value in self.saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def _install_canonical_fakes(self, *, stale: bool = False, capital: float = 300.0):
+        bootstrap = types.ModuleType("bot.bootstrap_state_machine")
+        bootstrap.get_bootstrap_fsm = lambda: types.SimpleNamespace(
+            state=_State.RUNNING_SUPERVISED
+        )
+        sys.modules[bootstrap.__name__] = bootstrap
+
+        capital_fsm = types.ModuleType("bot.capital_flow_state_machine")
+        capital_fsm.get_capital_bootstrap_fsm = lambda: types.SimpleNamespace(
+            state=_State.READY
+        )
+        sys.modules[capital_fsm.__name__] = capital_fsm
+
+        authority = types.SimpleNamespace(
+            is_hydrated=True,
+            get_real_capital=lambda: capital,
+            get_snapshot_publication_status=lambda: types.SimpleNamespace(stale=stale),
+        )
+        authority_mod = types.ModuleType("bot.capital_authority")
+        authority_mod.get_capital_authority = lambda: authority
+        sys.modules[authority_mod.__name__] = authority_mod
+
+        readiness = types.ModuleType("bot.readiness_table")
+        readiness.snapshot_with_version = lambda: (
+            9,
+            {
+                "broker_connected": True,
+                "balance_hydrated": True,
+                "capital_ready": True,
+            },
+        )
+        sys.modules[readiness.__name__] = readiness
+
+    def test_sync_copies_canonical_running_capital_before_compatibility_proof(self):
+        self._install_canonical_fakes(stale=False, capital=300.17)
+        calls = {}
+
+        class Coordinator:
+            def record_bootstrap_state(self, state):
+                calls["bootstrap"] = state
+
+            def record_capital_state(self, **kwargs):
+                calls["capital"] = kwargs
+
+            def record_readiness(self, **kwargs):
+                calls["readiness"] = kwargs
+
+        self.mod._sync_coordinator_inputs(Coordinator())
+        self.assertEqual(calls["bootstrap"], "RUNNING_SUPERVISED")
+        self.assertEqual(calls["capital"]["state"], "READY")
+        self.assertTrue(calls["capital"]["hydrated"])
+        self.assertEqual(calls["capital"]["balance"], 300.17)
+        self.assertFalse(calls["capital"]["stale"])
+        self.assertTrue(calls["readiness"]["value"])
+
+    def test_canonical_capital_observer_rejects_stale_snapshot_even_with_env_handoff(self):
+        self._install_canonical_fakes(stale=True, capital=300.17)
+        os.environ["CAPITAL_SYSTEM_READY"] = "1"
+        os.environ["NIJA_CAPITAL_READY"] = "1"
+        self.assertFalse(self.mod._canonical_capital_ready())
+
+    def test_canonical_capital_observer_accepts_fresh_positive_hydrated_snapshot(self):
+        self._install_canonical_fakes(stale=False, capital=155.21)
+        self.assertTrue(self.mod._canonical_capital_ready())
+
+    def test_canonical_capital_observer_rejects_zero_capital(self):
+        self._install_canonical_fakes(stale=False, capital=0.0)
+        self.assertFalse(self.mod._canonical_capital_ready())
+
+    def test_force_activation_wrapper_syncs_before_original_proof(self):
+        self._install_canonical_fakes(stale=False, capital=300.17)
+        fake = types.ModuleType("startup_coordinator_v62_fake")
+        events = []
+
+        class StartupCoordinator:
+            def record_bootstrap_state(self, state):
+                events.append(("bootstrap", state))
+
+            def record_capital_state(self, **kwargs):
+                events.append(("capital", kwargs["state"]))
+
+            def record_readiness(self, **kwargs):
+                events.append(("readiness", kwargs["value"]))
+
+            def force_activate_bypass(self, reason):
+                events.append(("original", reason))
+                return 77
+
+        fake.StartupCoordinator = StartupCoordinator
+        self.assertTrue(self.mod._patch_startup_coordinator(fake))
+        result = StartupCoordinator().force_activate_bypass("bridge")
+        self.assertEqual(result, 77)
+        self.assertEqual(events[-1], ("original", "bridge"))
+        self.assertIn(("capital", "READY"), events[:-1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_capital_refresh_live_continuity_v78.py
+++ b/bot/tests/test_capital_refresh_live_continuity_v78.py
@@ -9,25 +9,39 @@ import unittest
 class CapitalRefreshLiveContinuityV78Tests(unittest.TestCase):
     def setUp(self):
         self.mod = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
-        self.previous = os.environ.get("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS")
+        self.keys = (
+            "NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS",
+            "NIJA_CAPITAL_REFRESH_PUBLISH_MARGIN_SECONDS",
+            "NIJA_CAPITAL_FRESHNESS_TTL_S",
+        )
+        self.previous = {key: os.environ.get(key) for key in self.keys}
+        for key in self.keys:
+            os.environ.pop(key, None)
 
     def tearDown(self):
-        if self.previous is None:
-            os.environ.pop("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", None)
-        else:
-            os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = self.previous
+        for key, value in self.previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
-    def test_default_budget_exceeds_observed_180_second_timeout(self):
-        os.environ.pop("NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS", None)
-        self.assertEqual(self.mod.fetch_budget_seconds(), 420.0)
+    def test_default_budget_stays_inside_default_freshness_ttl(self):
+        self.assertEqual(self.mod.fetch_budget_seconds(), 60.0)
+        self.assertLess(
+            self.mod.fetch_budget_seconds(),
+            self.mod._freshness_ttl_seconds(),
+        )
 
-    def test_budget_is_bounded(self):
+    def test_operator_budget_cannot_outlive_freshness(self):
         os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "9999"
-        self.assertEqual(self.mod.fetch_budget_seconds(), 600.0)
-        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "10"
-        self.assertEqual(self.mod.fetch_budget_seconds(), 180.0)
+        os.environ["NIJA_CAPITAL_FRESHNESS_TTL_S"] = "90"
+        os.environ["NIJA_CAPITAL_REFRESH_PUBLISH_MARGIN_SECONDS"] = "15"
+        self.assertEqual(self.mod.fetch_budget_seconds(), 75.0)
 
-    def test_patch_extends_old_batch_deadline_without_touching_freshness(self):
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "10"
+        self.assertEqual(self.mod.fetch_budget_seconds(), 10.0)
+
+    def test_patch_shortens_cycle_deadline_but_leaves_worker_timeout_unchanged(self):
         fake = types.ModuleType("capital_guard_v78_fake")
 
         class Flight:
@@ -36,37 +50,49 @@ class CapitalRefreshLiveContinuityV78Tests(unittest.TestCase):
 
         class Batch:
             def __init__(self, broker_map):
-                self._cycle_started = 1000.0
-                self._cycle_deadline = 1180.0
+                self._batch_started = 1000.0
+                self._cycle_deadline = 1185.0
                 self._flights = {name: Flight() for name in broker_map}
 
         fake._BalanceFetchBatch = Batch
-        fake._freshness_ttl_seconds = lambda: 120.0
-        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "420"
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "60"
         self.assertTrue(self.mod._patch_guard(fake))
         batch = Batch({"coinbase": object(), "okx": object()})
-        self.assertEqual(batch._flights["coinbase"].timeout_s, 420.0)
-        self.assertEqual(batch._cycle_deadline, 1420.0)
-        self.assertEqual(fake._freshness_ttl_seconds(), 120.0)
 
-    def test_operator_larger_timeout_is_not_shortened(self):
-        fake = types.ModuleType("capital_guard_v78_large_fake")
+        # Slow workers remain alive under their original broker-specific timeout;
+        # only the synchronous publication deadline is shortened.
+        self.assertEqual(batch._flights["coinbase"].timeout_s, 180.0)
+        self.assertEqual(batch._cycle_deadline, 1060.0)
 
-        class Flight:
-            def __init__(self):
-                self.timeout_s = 500.0
+    def test_stricter_existing_cycle_deadline_is_not_lengthened(self):
+        fake = types.ModuleType("capital_guard_v78_strict_fake")
 
         class Batch:
             def __init__(self, broker_map):
-                self._cycle_started = 1000.0
-                self._cycle_deadline = 1500.0
-                self._flights = {name: Flight() for name in broker_map}
+                self._batch_started = 1000.0
+                self._cycle_deadline = 1030.0
+                self._flights = {}
 
         fake._BalanceFetchBatch = Batch
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "60"
         self.mod._patch_guard(fake)
         batch = Batch({"coinbase": object()})
-        self.assertEqual(batch._flights["coinbase"].timeout_s, 500.0)
-        self.assertEqual(batch._cycle_deadline, 1500.0)
+        self.assertEqual(batch._cycle_deadline, 1030.0)
+
+    def test_cycle_started_compatibility_field_is_supported(self):
+        fake = types.ModuleType("capital_guard_v78_compat_fake")
+
+        class Batch:
+            def __init__(self, broker_map):
+                self._cycle_started = 2000.0
+                self._cycle_deadline = 2200.0
+                self._flights = {}
+
+        fake._BalanceFetchBatch = Batch
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "45"
+        self.mod._patch_guard(fake)
+        batch = Batch({"okx": object()})
+        self.assertEqual(batch._cycle_deadline, 2045.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep synchronous capital refresh publication inside the canonical freshness TTL while allowing slow broker workers to finish asynchronously
- synchronize canonical bootstrap/capital/readiness state into StartupCoordinator before compatibility activation proof evaluation
- make three-venue capital readiness honor canonical CapitalAuthority freshness instead of environment handoff flags
- install the convergence repairs before v58/v61/v59/v60 activation monitors
- add regression coverage for stale-capital rejection and the `capital.running` startup race

## Production evidence
The reported runtime reached `RUNNING_SUPERVISED`, had healthy writer heartbeat/authority, and showed a fully ready readiness table, yet the activation bridge was rejected at `capital.running`. A later v61 attempt correctly failed closed after broker/balance/capital proof aged out. The previous v78 refresh policy could wait 420 seconds synchronously while capital freshness expires after 90 seconds.

## Safety
No writer, nonce, kill-switch, risk, dispatch-health, or freshness gate is bypassed. Stale fallback remains prohibited; the changes only converge canonical state sooner and stop optional slow broker calls from monopolizing the publication path beyond freshness.