### PR TITLE
Fix pre-core authority heartbeat lockdown race

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v62"
+_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v63"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -32,6 +32,11 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_authority_generation_convergence_v57_patch", "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
+    # The writer heartbeat truthfully publishes CORE_THREAD_ALIVE=0 before the
+    # real core is launched. Keep the independent authority heartbeat aligned
+    # with that documented startup grace while preserving post-core fail-closed
+    # liveness checks.
+    ("bot.precore_authority_heartbeat_v63_patch", "PRECORE_AUTHORITY_HEARTBEAT_V63"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),
     ("bot.okx_patch_churn_guard_patch", "OKX_PATCH_CHURN_GUARD"),

--- a/bot/precore_authority_heartbeat_v63_patch.py
+++ b/bot/precore_authority_heartbeat_v63_patch.py
@@ -1,0 +1,171 @@
+"""Pre-core authority heartbeat contract repair v63.
+
+The canonical writer authority intentionally publishes ``NIJA_CORE_THREAD_ALIVE=0``
+while the process still owns a healthy writer lease but the real trading core has
+not been launched/registered yet.  ``authority_heartbeat._check_authority_once``
+previously treated that temporary value as an already-dead core and could enter
+lockdown (including a SEAK emergency halt) before ``bot_main`` reached the engine
+handoff.
+
+This guard aligns the independent heartbeat with the writer runtime's existing
+startup-grace contract.  It suppresses only the pre-core liveness flag while all
+of the following remain true:
+
+* the canonical writer singleton exists and still has no core thread;
+* core registration has not occurred;
+* the scan-start deadline has not expired;
+* startup has not completed;
+* no terminal startup failure or shutdown request exists.
+
+After any of those conditions change, ``NIJA_CORE_THREAD_ALIVE=0`` is passed to
+the original heartbeat unchanged and remains fail-closed.  Redis fencing,
+generation, heartbeat-loop, kill-switch, nonce, and execution gates are never
+bypassed.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.precore_authority_heartbeat_v63")
+MARKER = "20260812-precore-authority-heartbeat-v63"
+_LOCK = threading.RLock()
+_PATCH_ATTR = "_nija_precore_authority_heartbeat_v63"
+_HOOK_FLAG = "_NIJA_PRECORE_AUTHORITY_HEARTBEAT_V63_IMPORT_HOOK"
+_MODULE_NAMES = ("bot.authority_heartbeat", "authority_heartbeat")
+
+
+def _canonical_writer_runtime() -> Any:
+    for name in ("bot.entrypoint_writer_authority", "entrypoint_writer_authority"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:
+                return None
+    return None
+
+
+def _precore_grace_active() -> tuple[bool, str]:
+    runtime = _canonical_writer_runtime()
+    if runtime is None:
+        return False, "writer_runtime_unavailable"
+
+    if bool(getattr(runtime, "lost", False)):
+        return False, "writer_lost"
+    if str(getattr(runtime, "terminal_startup_failure_reason", "") or "").strip():
+        return False, "terminal_startup_failure"
+    if bool(getattr(runtime, "_scan_deadline_exceeded", False)):
+        return False, "scan_deadline_exceeded"
+
+    core = getattr(runtime, "_core_thread", None)
+    registered = bool(getattr(runtime, "_core_thread_registered", False))
+    if core is not None or registered:
+        return False, "core_handoff_started"
+
+    bot_main = sys.modules.get("bot.bot_main") or sys.modules.get("bot_main")
+    if isinstance(bot_main, ModuleType):
+        shutdown = getattr(bot_main, "_shutdown_event", None)
+        if shutdown is not None and callable(getattr(shutdown, "is_set", None)):
+            try:
+                if shutdown.is_set():
+                    return False, "shutdown_requested"
+            except Exception:
+                return False, "shutdown_state_unavailable"
+        if bool(getattr(bot_main, "_startup_complete", False)):
+            return False, "startup_complete_without_core"
+
+    return True, "startup_not_registered"
+
+
+def _patch_authority_heartbeat(module: ModuleType) -> bool:
+    current = getattr(module, "_check_authority_once", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def check_authority_once_v63(timeout_s: float):
+        raw = str(os.environ.get("NIJA_CORE_THREAD_ALIVE", "") or "").strip().lower()
+        if raw and raw not in {"1", "true", "yes", "on", "enabled"}:
+            grace, reason = _precore_grace_active()
+            if grace:
+                previous = os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+                try:
+                    result = current(timeout_s)
+                finally:
+                    if previous is not None:
+                        os.environ["NIJA_CORE_THREAD_ALIVE"] = previous
+                LOGGER.info(
+                    "PRECORE_AUTHORITY_HEARTBEAT_GRACE marker=%s reason=%s "
+                    "core_alive_signal=%s other_authority_gates_unchanged=true",
+                    MARKER,
+                    reason,
+                    raw,
+                )
+                return result
+        return current(timeout_s)
+
+    setattr(check_authority_once_v63, _PATCH_ATTR, True)
+    setattr(check_authority_once_v63, "__wrapped__", current)
+    module._check_authority_once = check_authority_once_v63
+    LOGGER.critical(
+        "PRECORE_AUTHORITY_HEARTBEAT_V63_PATCHED marker=%s module=%s "
+        "precore_zero_grace=true postcore_fail_closed=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in _MODULE_NAMES:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_authority_heartbeat(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if "authority_heartbeat" in str(name):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_PRECORE_AUTHORITY_HEARTBEAT_V63_READY"] = "1"
+        LOGGER.critical(
+            "PRECORE_AUTHORITY_HEARTBEAT_V63_INSTALLED marker=%s "
+            "precore_grace_only=true authority_bypass=false",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_precore_grace_active"]

--- a/bot/tests/test_precore_authority_heartbeat_v63.py
+++ b/bot/tests/test_precore_authority_heartbeat_v63.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+
+
+class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = importlib.import_module("bot.precore_authority_heartbeat_v63_patch")
+        self.saved_env = {
+            "NIJA_CORE_THREAD_ALIVE": os.environ.get("NIJA_CORE_THREAD_ALIVE"),
+        }
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "bot.entrypoint_writer_authority",
+                "entrypoint_writer_authority",
+                "bot.bot_main",
+                "bot_main",
+            )
+        }
+
+    def tearDown(self) -> None:
+        os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+        if self.saved_env["NIJA_CORE_THREAD_ALIVE"] is not None:
+            os.environ["NIJA_CORE_THREAD_ALIVE"] = self.saved_env["NIJA_CORE_THREAD_ALIVE"]
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    def _install_runtime(
+        self,
+        *,
+        core=None,
+        registered: bool = False,
+        lost: bool = False,
+        deadline_exceeded: bool = False,
+        terminal_reason: str = "",
+        startup_complete: bool = False,
+        shutdown: bool = False,
+    ):
+        runtime = SimpleNamespace(
+            lost=lost,
+            terminal_startup_failure_reason=terminal_reason,
+            _scan_deadline_exceeded=deadline_exceeded,
+            _core_thread=core,
+            _core_thread_registered=registered,
+        )
+        writer_module = types.ModuleType("bot.entrypoint_writer_authority")
+        writer_module.get_entrypoint_writer_authority = lambda: runtime
+        sys.modules["bot.entrypoint_writer_authority"] = writer_module
+        sys.modules.pop("entrypoint_writer_authority", None)
+
+        shutdown_event = SimpleNamespace(is_set=lambda: shutdown)
+        bot_main = types.ModuleType("bot.bot_main")
+        bot_main._startup_complete = startup_complete
+        bot_main._shutdown_event = shutdown_event
+        sys.modules["bot.bot_main"] = bot_main
+        sys.modules.pop("bot_main", None)
+        return runtime
+
+    def test_precore_zero_signal_qualifies_for_startup_grace(self) -> None:
+        self._install_runtime()
+        active, reason = self.mod._precore_grace_active()
+        self.assertTrue(active)
+        self.assertEqual(reason, "startup_not_registered")
+
+    def test_grace_ends_when_core_handoff_has_started(self) -> None:
+        self._install_runtime(core=object())
+        active, reason = self.mod._precore_grace_active()
+        self.assertFalse(active)
+        self.assertEqual(reason, "core_handoff_started")
+
+    def test_grace_ends_when_scan_deadline_expires(self) -> None:
+        self._install_runtime(deadline_exceeded=True)
+        active, reason = self.mod._precore_grace_active()
+        self.assertFalse(active)
+        self.assertEqual(reason, "scan_deadline_exceeded")
+
+    def test_grace_ends_when_startup_completed_without_core(self) -> None:
+        self._install_runtime(startup_complete=True)
+        active, reason = self.mod._precore_grace_active()
+        self.assertFalse(active)
+        self.assertEqual(reason, "startup_complete_without_core")
+
+    def test_wrapper_hides_only_precore_zero_from_original_check(self) -> None:
+        self._install_runtime()
+        fake = types.ModuleType("authority_heartbeat_v63_fake")
+        seen = []
+
+        def original(timeout_s: float):
+            seen.append((timeout_s, os.environ.get("NIJA_CORE_THREAD_ALIVE")))
+            return True, ""
+
+        fake._check_authority_once = original
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        self.assertTrue(self.mod._patch_authority_heartbeat(fake))
+
+        ok, reason = fake._check_authority_once(1.25)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+        self.assertEqual(seen, [(1.25, None)])
+        self.assertEqual(os.environ.get("NIJA_CORE_THREAD_ALIVE"), "0")
+
+    def test_wrapper_keeps_postcore_zero_fail_closed(self) -> None:
+        self._install_runtime(core=object(), registered=True)
+        fake = types.ModuleType("authority_heartbeat_v63_postcore_fake")
+        seen = []
+
+        def original(timeout_s: float):
+            seen.append(os.environ.get("NIJA_CORE_THREAD_ALIVE"))
+            return False, "core_thread_dead"
+
+        fake._check_authority_once = original
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        self.assertTrue(self.mod._patch_authority_heartbeat(fake))
+
+        ok, reason = fake._check_authority_once(1.0)
+        self.assertFalse(ok)
+        self.assertEqual(reason, "core_thread_dead")
+        self.assertEqual(seen, ["0"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- align the independent authority heartbeat with the canonical writer runtime's documented pre-core startup grace
- prevent an intentional pre-core `NIJA_CORE_THREAD_ALIVE=0` from being misclassified as a dead core while the writer lease is healthy and the engine handoff has not begun
- preserve fail-closed behavior after core handoff, scan-start deadline expiry, startup completion, terminal startup failure, shutdown, or writer loss
- install the v63 compatibility guard before activation monitors
- add focused regression tests for both startup-grace and post-core failure behavior

## Production evidence
The deployed PR #2500 capital fix is working: the freshness-bounded v78 refresh collects all three brokers and publishes a fresh accepted CapitalAuthority snapshot. The remaining production blocker shows the writer lease renewing successfully with `core_thread_reason=startup_not_registered`, while v61 simultaneously observes SEAK already halted and continues deferring activation at `core_registered/core_alive/bootstrap_state:CAPITAL_READY`.

The writer authority intentionally publishes `NIJA_CORE_THREAD_ALIVE=0` during this pre-core phase. The independent authority heartbeat treated any explicit `0` as a dead core and could reach lockdown before `bot_main` launched and registered the core.

## Safety
This does not bypass writer ownership, Redis fencing, generation, nonce, risk, kill-switch, capital freshness, or execution gates. It only suppresses the temporary pre-core liveness flag during the writer runtime's existing startup grace. Once that grace ends, the original `CORE_THREAD_ALIVE=0` failure path is unchanged.