### PR TITLE
Fail closed on stale live capital

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v63"
+_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v64"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -55,6 +55,10 @@ _FAST_PATH_INSTALLERS = (
     # compatibility activation proof is evaluated. This is state convergence,
     # not a bypass; all writer/nonce/risk/kill-switch gates remain authoritative.
     ("bot.activation_capital_convergence_v62_patch", "ACTIVATION_CAPITAL_CONVERGENCE_V62"),
+    # Keep every post-activation observer and new-risk dispatch path on the same
+    # canonical CapitalAuthority freshness contract. Protective reduce/exit
+    # intents remain available when freshness is lost.
+    ("bot.live_capital_freshness_v64_patch", "LIVE_CAPITAL_FRESHNESS_V64"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation
     # monitors. It guards v60's request boundary and makes v16 readiness reflect

--- a/bot/live_capital_freshness_v64_patch.py
+++ b/bot/live_capital_freshness_v64_patch.py
@@ -1,0 +1,386 @@
+"""Canonical live-capital freshness enforcement v64.
+
+Production activation can remain LIVE_ACTIVE while the capital refresh worker is
+between publications.  Every observer and new-risk dispatch path must therefore
+use the same CapitalAuthority freshness contract instead of treating the static
+LIVE_CAPITAL_VERIFIED mode flag as proof that current capital is still usable.
+
+v64 makes three narrow repairs:
+
+* preactivation v16 reads the canonical capital freshness TTL (default 90s)
+  instead of CapitalAuthority.is_stale()'s legacy 60s default;
+* the historical LIVE_ACTIVE compatibility gate no longer accepts
+  LIVE_CAPITAL_VERIFIED as a substitute for a fresh funded CapitalAuthority;
+* ExecutionPipeline rejects new-risk entries when current authoritative capital
+  is unavailable, stale, unfunded, or broker-incomplete, while reduce/exit
+  intents remain available for protective risk reduction.
+
+No writer, nonce, kill-switch, risk, strategy, or execution-authority gate is
+weakened by this patch.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.live_capital_freshness_v64")
+MARKER = "20260812-live-capital-freshness-v64"
+_LOCK = threading.RLock()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_V16_ATTR = "_nija_live_capital_freshness_v64"
+_LIVE_GATE_ATTR = "_nija_live_capital_freshness_v64"
+_PIPELINE_ATTR = "_nija_live_capital_freshness_v64"
+_HOOK_FLAG = "_NIJA_LIVE_CAPITAL_FRESHNESS_V64_IMPORT_HOOK"
+_TARGET_NAMES = {
+    "preactivation_readiness_convergence_v16_patch",
+    "bot.preactivation_readiness_convergence_v16_patch",
+    "bot.live_active_execution_gate_final_patch",
+    "live_active_execution_gate_final_patch",
+    "bot.execution_pipeline",
+    "execution_pipeline",
+}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default) or "").strip().lower() in _TRUE
+
+
+def _ttl_s() -> float:
+    raw = os.environ.get("NIJA_CAPITAL_FRESHNESS_TTL_S", "90")
+    try:
+        return max(1.0, float(raw or 90.0))
+    except (TypeError, ValueError):
+        return 90.0
+
+
+def _capital_authority() -> Any:
+    for name in ("bot.capital_authority", "capital_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            getter = getattr(module, "get_capital_authority", None)
+            if callable(getter):
+                try:
+                    return getter()
+                except Exception:
+                    return None
+    try:
+        import importlib
+
+        module = importlib.import_module("bot.capital_authority")
+        getter = getattr(module, "get_capital_authority", None)
+        return getter() if callable(getter) else None
+    except Exception:
+        return None
+
+
+def _real_capital(authority: Any) -> float:
+    values: list[float] = []
+    for name in ("get_real_capital", "get_total_capital", "get_usable_capital"):
+        method = getattr(authority, name, None)
+        if callable(method):
+            try:
+                values.append(float(method() or 0.0))
+            except Exception:
+                pass
+    for name in ("total_capital", "real_capital", "available_capital"):
+        try:
+            values.append(float(getattr(authority, name, 0.0) or 0.0))
+        except Exception:
+            pass
+    return max(values or [0.0])
+
+
+def _registered_count(authority: Any) -> int:
+    counts: list[int] = []
+    for name in ("registered_broker_count", "valid_broker_count"):
+        try:
+            counts.append(int(getattr(authority, name, 0) or 0))
+        except Exception:
+            pass
+    values = getattr(authority, "broker_values", None) or getattr(authority, "values", None)
+    if isinstance(values, dict):
+        counts.append(len(values))
+    return max(counts or [0])
+
+
+def _canonical_capital_status() -> tuple[bool, str, dict[str, Any]]:
+    """Return current authoritative capital usability for NEW risk only."""
+    authority = _capital_authority()
+    ttl = _ttl_s()
+    details: dict[str, Any] = {"ttl_s": ttl}
+    if authority is None:
+        return False, "capital_authority_unavailable", details
+
+    hydrated = bool(getattr(authority, "is_hydrated", False))
+    real = _real_capital(authority)
+    registered = _registered_count(authority)
+    details.update(
+        {
+            "hydrated": hydrated,
+            "real_capital": real,
+            "registered": registered,
+        }
+    )
+
+    is_fresh = getattr(authority, "is_fresh", None)
+    if callable(is_fresh):
+        try:
+            fresh = bool(is_fresh(ttl_s=ttl))
+        except TypeError:
+            try:
+                fresh = bool(is_fresh(ttl))
+            except Exception:
+                fresh = False
+        except Exception:
+            fresh = False
+    else:
+        is_stale = getattr(authority, "is_stale", None)
+        if callable(is_stale):
+            try:
+                fresh = not bool(is_stale(ttl_s=ttl))
+            except TypeError:
+                try:
+                    fresh = not bool(is_stale(ttl))
+                except Exception:
+                    fresh = False
+            except Exception:
+                fresh = False
+        else:
+            fresh = False
+    details["fresh"] = fresh
+
+    complete = True
+    is_complete = getattr(authority, "is_brokers_complete", None)
+    if callable(is_complete):
+        try:
+            complete = bool(is_complete())
+        except Exception:
+            complete = False
+    details["brokers_complete"] = complete
+
+    if not hydrated:
+        return False, "capital_not_hydrated", details
+    if real <= 0.0:
+        return False, "capital_not_funded", details
+    if registered <= 0:
+        return False, "capital_no_registered_brokers", details
+    if not fresh:
+        return False, "capital_snapshot_stale", details
+    if not complete:
+        return False, "capital_brokers_incomplete", details
+    return True, "capital_fresh_funded_complete", details
+
+
+def _patch_v16(module: ModuleType) -> bool:
+    current = getattr(module, "_capital_snapshot", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V16_ATTR, False):
+        return True
+
+    @wraps(current)
+    def capital_snapshot_v64() -> dict[str, Any]:
+        result = dict(current() or {})
+        authority = _capital_authority()
+        if authority is None:
+            result["stale"] = True
+            result["v64_freshness_reason"] = "capital_authority_unavailable"
+            result["v64_freshness_ttl_s"] = _ttl_s()
+            return result
+
+        ttl = _ttl_s()
+        fresh = False
+        is_fresh = getattr(authority, "is_fresh", None)
+        if callable(is_fresh):
+            try:
+                fresh = bool(is_fresh(ttl_s=ttl))
+            except TypeError:
+                try:
+                    fresh = bool(is_fresh(ttl))
+                except Exception:
+                    fresh = False
+            except Exception:
+                fresh = False
+        else:
+            is_stale = getattr(authority, "is_stale", None)
+            if callable(is_stale):
+                try:
+                    fresh = not bool(is_stale(ttl_s=ttl))
+                except TypeError:
+                    try:
+                        fresh = not bool(is_stale(ttl))
+                    except Exception:
+                        fresh = False
+                except Exception:
+                    fresh = False
+
+        result["stale"] = not fresh
+        result["v64_freshness_ttl_s"] = ttl
+        result["v64_freshness_reason"] = "canonical_is_fresh" if fresh else "canonical_stale"
+        return result
+
+    setattr(capital_snapshot_v64, _V16_ATTR, True)
+    module._capital_snapshot = capital_snapshot_v64
+    LOGGER.critical(
+        "LIVE_CAPITAL_FRESHNESS_V64_V16_PATCHED marker=%s module=%s canonical_ttl=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_live_active_gate(module: ModuleType) -> bool:
+    current = getattr(module, "_capital_ready", None)
+    if not callable(current):
+        return False
+    if getattr(current, _LIVE_GATE_ATTR, False):
+        return True
+
+    @wraps(current)
+    def capital_ready_v64() -> bool:
+        ready, reason, details = _canonical_capital_status()
+        if not ready:
+            LOGGER.warning(
+                "LIVE_CAPITAL_FRESHNESS_V64_COMPAT_BLOCK marker=%s reason=%s details=%s live_capital_verified=%s",
+                MARKER,
+                reason,
+                details,
+                _truthy("LIVE_CAPITAL_VERIFIED"),
+            )
+        return ready
+
+    setattr(capital_ready_v64, _LIVE_GATE_ATTR, True)
+    module._capital_ready = capital_ready_v64
+    LOGGER.critical(
+        "LIVE_CAPITAL_FRESHNESS_V64_COMPAT_PATCHED marker=%s module=%s static_live_flag_bypass=false",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _is_protective_intent(request: Any) -> bool:
+    intent = str(getattr(request, "intent_type", "") or "entry").strip().lower()
+    if intent in {"reduce", "exit", "close", "liquidate"}:
+        return True
+    try:
+        if bool(getattr(request, "reduce_only", False)):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _patch_execution_pipeline(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_enforce_execution_gate", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PIPELINE_ATTR, False):
+        return True
+
+    @wraps(current)
+    def enforce_execution_gate_v64(self: Any, request: Any, t_start: float):
+        existing = current(self, request, t_start)
+        if existing is not None:
+            return existing
+        if _is_protective_intent(request):
+            return None
+
+        ready, reason, details = _canonical_capital_status()
+        if ready:
+            return None
+
+        LOGGER.critical(
+            "LIVE_CAPITAL_FRESHNESS_V64_ENTRY_BLOCK marker=%s reason=%s symbol=%s side=%s details=%s protective=false",
+            MARKER,
+            reason,
+            getattr(request, "symbol", "?"),
+            getattr(request, "side", "?"),
+            details,
+        )
+        deny = getattr(self, "_deny", None)
+        if callable(deny):
+            return deny(
+                request,
+                t_start,
+                f"Capital freshness deny: {reason}",
+            )
+        return existing
+
+    setattr(enforce_execution_gate_v64, _PIPELINE_ATTR, True)
+    cls._enforce_execution_gate = enforce_execution_gate_v64
+    LOGGER.critical(
+        "LIVE_CAPITAL_FRESHNESS_V64_PIPELINE_PATCHED marker=%s module=%s new_entries_fail_closed=true protective_exits_bypass=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen: set[int] = set()
+    for name in tuple(_TARGET_NAMES):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        if "preactivation_readiness_convergence_v16_patch" in name:
+            patched = _patch_v16(module) or patched
+        elif "live_active_execution_gate_final_patch" in name:
+            patched = _patch_live_active_gate(module) or patched
+        elif name.endswith("execution_pipeline"):
+            patched = _patch_execution_pipeline(module) or patched
+    return patched
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                text = str(name or "")
+                if any(target in text for target in (
+                    "preactivation_readiness_convergence_v16_patch",
+                    "live_active_execution_gate_final_patch",
+                    "execution_pipeline",
+                )):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_LIVE_CAPITAL_FRESHNESS_V64_READY"] = "1"
+        LOGGER.critical(
+            "LIVE_CAPITAL_FRESHNESS_V64_INSTALLED marker=%s canonical_ttl_s=%.1f new_entries_fail_closed=true protective_exits_preserved=true",
+            MARKER,
+            _ttl_s(),
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_capital_status",
+    "_is_protective_intent",
+]

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -9,6 +9,7 @@ state into one another.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -24,6 +25,15 @@ _KILL_SWITCH_ARTIFACTS = [
     _REPO_ROOT / ".nija_kill_switch_state.json",
     _REPO_ROOT / "data" / "exchange_kill_switch_state.json",
 ]
+
+# Some writer-authority tests intentionally exercise the production path that
+# arms a daemon fallback restart timer. In production the default grace is 15s
+# and the callback terminates the process with os._exit(75). Leaving that real
+# timer armed during pytest kills the test runner before pytest can print the
+# assertion summary. Give only the test process a long default grace; tests that
+# verify the timer value explicitly override this environment variable locally.
+_WRITER_RESTART_GRACE_ENV = "NIJA_WRITER_AUTHORITY_FALLBACK_RESTART_GRACE_S"
+_TEST_WRITER_RESTART_GRACE_S = "3600"
 
 
 def _remove_kill_switch_artifacts() -> None:
@@ -52,10 +62,25 @@ def _clean_kill_switch_state():
     Auto-use fixture: remove kill-switch state files and reset process-global
     readiness authority before and after every test so runtime state does not
     bleed into unrelated tests.
+
+    The fixture also prevents production fallback restart timers intentionally
+    exercised by writer-authority tests from terminating the pytest process.
+    This changes test-process timing only; production defaults are untouched.
     """
     _remove_kill_switch_artifacts()
     _reset_readiness_authority_state()
+
+    previous_restart_grace = os.environ.get(_WRITER_RESTART_GRACE_ENV)
+    if previous_restart_grace is None:
+        os.environ[_WRITER_RESTART_GRACE_ENV] = _TEST_WRITER_RESTART_GRACE_S
+
     yield
+
+    if previous_restart_grace is None:
+        os.environ.pop(_WRITER_RESTART_GRACE_ENV, None)
+    else:
+        os.environ[_WRITER_RESTART_GRACE_ENV] = previous_restart_grace
+
     _remove_kill_switch_artifacts()
     _reset_readiness_authority_state()
 

--- a/bot/tests/test_live_capital_freshness_v64.py
+++ b/bot/tests/test_live_capital_freshness_v64.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+
+from bot import live_capital_freshness_v64_patch as v64
+
+
+class _Authority:
+    def __init__(
+        self,
+        *,
+        hydrated: bool = True,
+        real: float = 100.0,
+        registered: int = 1,
+        fresh: bool = True,
+        complete: bool = True,
+    ) -> None:
+        self.is_hydrated = hydrated
+        self._real = real
+        self.registered_broker_count = registered
+        self.valid_broker_count = registered if real > 0 else 0
+        self._fresh = fresh
+        self._complete = complete
+        self.freshness_calls: list[float] = []
+
+    @property
+    def total_capital(self) -> float:
+        return self._real
+
+    def get_real_capital(self) -> float:
+        return self._real
+
+    def get_total_capital(self) -> float:
+        return self._real
+
+    def get_usable_capital(self) -> float:
+        return max(0.0, self._real * 0.98)
+
+    def is_fresh(self, ttl_s: float = 90.0) -> bool:
+        self.freshness_calls.append(float(ttl_s))
+        return self._fresh
+
+    def is_brokers_complete(self) -> bool:
+        return self._complete
+
+
+class LiveCapitalFreshnessV64Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_env = {
+            key: os.environ.get(key)
+            for key in (
+                "LIVE_CAPITAL_VERIFIED",
+                "NIJA_CAPITAL_FRESHNESS_TTL_S",
+            )
+        }
+        os.environ["LIVE_CAPITAL_VERIFIED"] = "true"
+        os.environ.pop("NIJA_CAPITAL_FRESHNESS_TTL_S", None)
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "bot.capital_authority",
+                "capital_authority",
+            )
+        }
+
+    def tearDown(self) -> None:
+        for key, value in self.saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    def _install_authority(self, authority: _Authority) -> None:
+        module = types.ModuleType("bot.capital_authority")
+        module.get_capital_authority = lambda: authority
+        sys.modules["bot.capital_authority"] = module
+        sys.modules["capital_authority"] = module
+
+    def test_canonical_status_uses_90_second_default_ttl(self):
+        authority = _Authority(fresh=True)
+        self._install_authority(authority)
+
+        ready, reason, details = v64._canonical_capital_status()
+
+        self.assertTrue(ready)
+        self.assertEqual(reason, "capital_fresh_funded_complete")
+        self.assertEqual(details["ttl_s"], 90.0)
+        self.assertEqual(authority.freshness_calls, [90.0])
+
+    def test_canonical_status_honors_configured_ttl(self):
+        os.environ["NIJA_CAPITAL_FRESHNESS_TTL_S"] = "75"
+        authority = _Authority(fresh=True)
+        self._install_authority(authority)
+
+        ready, _, details = v64._canonical_capital_status()
+
+        self.assertTrue(ready)
+        self.assertEqual(details["ttl_s"], 75.0)
+        self.assertEqual(authority.freshness_calls, [75.0])
+
+    def test_v16_snapshot_replaces_legacy_60_second_stale_result(self):
+        authority = _Authority(fresh=True)
+        self._install_authority(authority)
+        module = types.ModuleType("preactivation_readiness_convergence_v16_patch")
+        module._capital_snapshot = lambda: {
+            "hydrated": True,
+            "stale": True,
+            "real": 100.0,
+            "registered": 1,
+        }
+
+        self.assertTrue(v64._patch_v16(module))
+        result = module._capital_snapshot()
+
+        self.assertFalse(result["stale"])
+        self.assertEqual(result["v64_freshness_ttl_s"], 90.0)
+        self.assertEqual(authority.freshness_calls, [90.0])
+
+    def test_live_compat_gate_rejects_stale_capital_despite_live_mode_flag(self):
+        authority = _Authority(fresh=False)
+        self._install_authority(authority)
+        module = types.ModuleType("bot.live_active_execution_gate_final_patch")
+        module._capital_ready = lambda: True
+
+        self.assertTrue(v64._patch_live_active_gate(module))
+
+        self.assertFalse(module._capital_ready())
+        self.assertEqual(authority.freshness_calls, [90.0])
+
+    def test_live_compat_gate_accepts_fresh_funded_complete_authority(self):
+        authority = _Authority(fresh=True, real=250.0, registered=2, complete=True)
+        self._install_authority(authority)
+        module = types.ModuleType("bot.live_active_execution_gate_final_patch")
+        module._capital_ready = lambda: False
+
+        self.assertTrue(v64._patch_live_active_gate(module))
+
+        self.assertTrue(module._capital_ready())
+
+    def test_pipeline_blocks_new_entry_when_capital_is_stale(self):
+        authority = _Authority(fresh=False)
+        self._install_authority(authority)
+        module = types.ModuleType("bot.execution_pipeline")
+
+        class Pipeline:
+            def _enforce_execution_gate(self, request, t_start):
+                return None
+
+            def _deny(self, request, t_start, reason):
+                return {"blocked": True, "reason": reason}
+
+        module.ExecutionPipeline = Pipeline
+        self.assertTrue(v64._patch_execution_pipeline(module))
+
+        pipeline = Pipeline()
+        request = types.SimpleNamespace(
+            intent_type="entry",
+            reduce_only=False,
+            symbol="BTC-USD",
+            side="buy",
+        )
+        result = pipeline._enforce_execution_gate(request, 0.0)
+
+        self.assertEqual(
+            result,
+            {"blocked": True, "reason": "Capital freshness deny: capital_snapshot_stale"},
+        )
+
+    def test_pipeline_preserves_reduce_and_exit_during_stale_capital(self):
+        authority = _Authority(fresh=False)
+        self._install_authority(authority)
+        module = types.ModuleType("bot.execution_pipeline")
+
+        class Pipeline:
+            def _enforce_execution_gate(self, request, t_start):
+                return None
+
+            def _deny(self, request, t_start, reason):
+                return {"blocked": True, "reason": reason}
+
+        module.ExecutionPipeline = Pipeline
+        self.assertTrue(v64._patch_execution_pipeline(module))
+        pipeline = Pipeline()
+
+        for intent in ("reduce", "exit"):
+            with self.subTest(intent=intent):
+                request = types.SimpleNamespace(
+                    intent_type=intent,
+                    reduce_only=True,
+                    symbol="BTC-USD",
+                    side="sell",
+                )
+                self.assertIsNone(pipeline._enforce_execution_gate(request, 0.0))
+
+    def test_pipeline_fails_closed_when_capital_authority_is_unavailable(self):
+        sys.modules.pop("bot.capital_authority", None)
+        sys.modules.pop("capital_authority", None)
+        module = types.ModuleType("bot.execution_pipeline")
+
+        class Pipeline:
+            def _enforce_execution_gate(self, request, t_start):
+                return None
+
+            def _deny(self, request, t_start, reason):
+                return reason
+
+        module.ExecutionPipeline = Pipeline
+        self.assertTrue(v64._patch_execution_pipeline(module))
+        request = types.SimpleNamespace(
+            intent_type="entry",
+            reduce_only=False,
+            symbol="ETH-USD",
+            side="buy",
+        )
+
+        # Force the import path itself to fail closed rather than accidentally
+        # resolving a previously imported singleton from another test.
+        original = v64._capital_authority
+        try:
+            v64._capital_authority = lambda: None
+            result = Pipeline()._enforce_execution_gate(request, 0.0)
+        finally:
+            v64._capital_authority = original
+
+        self.assertEqual(result, "Capital freshness deny: capital_authority_unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- align preactivation v16 capital proof freshness with the canonical `NIJA_CAPITAL_FRESHNESS_TTL_S` contract (default 90s)
- remove the historical `LIVE_CAPITAL_VERIFIED` shortcut from the LIVE_ACTIVE compatibility capital gate
- add a final ExecutionPipeline guard that blocks new-risk entries when CapitalAuthority is unavailable, stale, unfunded, or broker-incomplete
- preserve protective `reduce` / `exit` intents when capital refresh is stale
- contain the production fallback restart timer inside pytest so CI can report real assertions instead of being terminated with exit code 75

## Production evidence
Deployment `b5aca6fc...` is now fully `LIVE_ACTIVE`: core registration and writer heartbeat are healthy and every readiness-table key is true. However v61 still reports `broker_connected`, `balance_hydrated`, and `capital_ready` as current proof failures while LIVE_ACTIVE because v16 calls `CapitalAuthority.is_stale()` with its legacy 60-second default, whereas the canonical capital freshness contract is 90 seconds.

A code audit also found that the older LIVE_ACTIVE compatibility gate treats `LIVE_CAPITAL_VERIFIED=true` as sufficient capital readiness, which can restore dispatch without proving the current CapitalAuthority snapshot is fresh. v64 closes that post-activation gap without weakening exits or other safety gates.

## Safety
- new-risk entries fail closed on stale or unavailable authoritative capital
- exits/reductions remain available for risk reduction
- writer authority, nonce, kill switch, risk, strategy, broker completeness, and execution gates remain enforced
- production restart timing is unchanged; the long restart grace applies only within pytest
