### PR TITLE
Recover heartbeat-owned emergency stops safely

### DIFF
--- a/bot/precore_authority_heartbeat_v63_patch.py
+++ b/bot/precore_authority_heartbeat_v63_patch.py
@@ -1,26 +1,22 @@
-"""Pre-core authority heartbeat contract repair v63.
+"""Pre-core authority heartbeat and owned-lockdown recovery repair v64.
 
 The canonical writer authority intentionally publishes ``NIJA_CORE_THREAD_ALIVE=0``
 while the process still owns a healthy writer lease but the real trading core has
-not been launched/registered yet.  ``authority_heartbeat._check_authority_once``
-previously treated that temporary value as an already-dead core and could enter
-lockdown (including a SEAK emergency halt) before ``bot_main`` reached the engine
-handoff.
+not been launched/registered yet.  The independent authority heartbeat must not
+interpret that documented pre-core state as a dead core.
 
-This guard aligns the independent heartbeat with the writer runtime's existing
-startup-grace contract.  It suppresses only the pre-core liveness flag while all
-of the following remain true:
+v64 preserves the narrow v63 startup grace and closes two follow-on races:
 
-* the canonical writer singleton exists and still has no core thread;
-* core registration has not occurred;
-* the scan-start deadline has not expired;
-* startup has not completed;
-* no terminal startup failure or shutdown request exists.
+* the temporary pre-core environment suppression never overwrites a concurrent
+  core-registration write (for example ``NIJA_CORE_THREAD_ALIVE=1``);
+* when AuthorityHeartbeatMonitor recovers from a transient lockdown while the
+  canonical writer still owns a healthy lease, the heartbeat-owned FSM/SEAK
+  latches are released only after a fresh strict authority proof and a clear
+  kill switch.  Recovery returns the trading FSM to OFF, never LIVE_ACTIVE, so
+  normal activation gates must reconverge before any new dispatch is possible.
 
-After any of those conditions change, ``NIJA_CORE_THREAD_ALIVE=0`` is passed to
-the original heartbeat unchanged and remains fail-closed.  Redis fencing,
-generation, heartbeat-loop, kill-switch, nonce, and execution gates are never
-bypassed.
+Operator/kill-switch emergency stops and SEAK halts with any non-heartbeat reason
+remain untouched and fail closed.
 """
 from __future__ import annotations
 
@@ -34,11 +30,20 @@ from types import ModuleType
 from typing import Any
 
 LOGGER = logging.getLogger("nija.precore_authority_heartbeat_v63")
-MARKER = "20260812-precore-authority-heartbeat-v63"
+MARKER = "20260812-precore-authority-heartbeat-v64"
 _LOCK = threading.RLock()
-_PATCH_ATTR = "_nija_precore_authority_heartbeat_v63"
-_HOOK_FLAG = "_NIJA_PRECORE_AUTHORITY_HEARTBEAT_V63_IMPORT_HOOK"
+_PATCH_ATTR = "_nija_precore_authority_heartbeat_v64"
+_START_PATCH_ATTR = "_nija_authority_heartbeat_owned_recovery_v64"
+_CALLBACK_PATCH_ATTR = "_nija_authority_heartbeat_owned_callback_v64"
+_HOOK_FLAG = "_NIJA_PRECORE_AUTHORITY_HEARTBEAT_V64_IMPORT_HOOK"
 _MODULE_NAMES = ("bot.authority_heartbeat", "authority_heartbeat")
+_OWNED_STOP_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"
+_OWNED_REASON_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP_REASON"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
 
 
 def _canonical_writer_runtime() -> Any:
@@ -55,11 +60,28 @@ def _canonical_writer_runtime() -> Any:
     return None
 
 
+def _core_live(runtime: Any) -> bool:
+    if runtime is None or not bool(getattr(runtime, "_core_thread_registered", False)):
+        return False
+    core = getattr(runtime, "_core_thread", None)
+    alive = getattr(core, "is_alive", None) if core is not None else None
+    if not callable(alive):
+        return False
+    try:
+        return bool(alive())
+    except Exception:
+        return False
+
+
 def _precore_grace_active() -> tuple[bool, str]:
     runtime = _canonical_writer_runtime()
     if runtime is None:
         return False, "writer_runtime_unavailable"
 
+    # Grace is meaningful only after the canonical distributed writer has
+    # actually been acquired.  A merely-instantiated singleton is not authority.
+    if not bool(getattr(runtime, "acquired", False)):
+        return False, "writer_not_acquired"
     if bool(getattr(runtime, "lost", False)):
         return False, "writer_lost"
     if str(getattr(runtime, "terminal_startup_failure_reason", "") or "").strip():
@@ -87,45 +109,238 @@ def _precore_grace_active() -> tuple[bool, str]:
     return True, "startup_not_registered"
 
 
-def _patch_authority_heartbeat(module: ModuleType) -> bool:
-    current = getattr(module, "_check_authority_once", None)
-    if not callable(current):
-        return False
-    if getattr(current, _PATCH_ATTR, False):
-        return True
+def _kill_switch_clear() -> tuple[bool, str]:
+    try:
+        try:
+            from bot.kill_switch import get_kill_switch
+        except ImportError:
+            from kill_switch import get_kill_switch  # type: ignore[import]
+        if bool(get_kill_switch().is_active()):
+            return False, "kill_switch_active"
+        return True, "kill_switch_clear"
+    except Exception as exc:
+        return False, f"kill_switch_probe_failed:{type(exc).__name__}:{exc}"
 
-    @wraps(current)
-    def check_authority_once_v63(timeout_s: float):
-        raw = str(os.environ.get("NIJA_CORE_THREAD_ALIVE", "") or "").strip().lower()
-        if raw and raw not in {"1", "true", "yes", "on", "enabled"}:
-            grace, reason = _precore_grace_active()
-            if grace:
-                previous = os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
-                try:
-                    result = current(timeout_s)
-                finally:
-                    if previous is not None:
-                        os.environ["NIJA_CORE_THREAD_ALIVE"] = previous
-                LOGGER.info(
-                    "PRECORE_AUTHORITY_HEARTBEAT_GRACE marker=%s reason=%s "
-                    "core_alive_signal=%s other_authority_gates_unchanged=true",
-                    MARKER,
-                    reason,
-                    raw,
-                )
-                return result
-        return current(timeout_s)
 
-    setattr(check_authority_once_v63, _PATCH_ATTR, True)
-    setattr(check_authority_once_v63, "__wrapped__", current)
-    module._check_authority_once = check_authority_once_v63
+def _seak_status() -> tuple[Any, bool, str]:
+    try:
+        try:
+            from bot.single_execution_authority_kernel import get_seak
+        except ImportError:
+            from single_execution_authority_kernel import get_seak  # type: ignore[import]
+        seak = get_seak()
+        halted = bool(getattr(seak, "is_halted", False))
+        reason = ""
+        snapshot = getattr(seak, "snapshot", None)
+        if callable(snapshot):
+            try:
+                payload = snapshot() or {}
+                if isinstance(payload, dict):
+                    reason = str(payload.get("halt_reason") or "")
+            except Exception:
+                pass
+        if not reason:
+            reason = str(getattr(seak, "_halt_reason", "") or "")
+        return seak, halted, reason
+    except Exception as exc:
+        return None, True, f"seak_probe_failed:{type(exc).__name__}:{exc}"
+
+
+def _trading_state_machine() -> tuple[Any, Any, str]:
+    try:
+        try:
+            from bot.trading_state_machine import get_state_machine, TradingState
+        except ImportError:
+            from trading_state_machine import get_state_machine, TradingState  # type: ignore[import]
+        sm = get_state_machine()
+        state = sm.get_current_state()
+        value = str(getattr(state, "value", state) or "").strip().upper()
+        return sm, TradingState, value
+    except Exception as exc:
+        return None, None, f"UNAVAILABLE:{type(exc).__name__}:{exc}"
+
+
+def _recover_heartbeat_owned_stop(module: ModuleType, monitor: Any = None) -> tuple[bool, str]:
+    """Release only a transient stop created by AuthorityHeartbeatMonitor.
+
+    The monitor's built-in restart path restores heartbeat environment signals
+    when the canonical writer still owns the lease.  Before releasing the FSM
+    and SEAK latches created by the earlier lockdown, re-prove the complete
+    authority check and current core liveness.  The FSM is returned to OFF so
+    all normal activation/nonce/readiness gates must run again.
+    """
+
+    if not _truthy(_OWNED_STOP_ENV):
+        return False, "heartbeat_owned_stop_marker_missing"
+
+    runtime = _canonical_writer_runtime()
+    if runtime is None or not bool(getattr(runtime, "acquired", False)):
+        return False, "writer_not_acquired"
+    if bool(getattr(runtime, "lost", False)):
+        return False, "writer_lost"
+    if not _core_live(runtime):
+        return False, "core_not_live"
+
+    try:
+        timeout_s = max(
+            0.1,
+            float(os.environ.get("NIJA_AUTHORITY_HEARTBEAT_TIMEOUT_S", "5") or 5.0),
+        )
+    except (TypeError, ValueError):
+        timeout_s = 5.0
+
+    checker = getattr(module, "_check_authority_once", None)
+    if not callable(checker):
+        return False, "authority_checker_missing"
+    try:
+        authority_ok, authority_reason = checker(timeout_s)
+    except Exception as exc:
+        return False, f"authority_check_failed:{type(exc).__name__}:{exc}"
+    if not bool(authority_ok):
+        return False, f"authority_not_ready:{authority_reason or 'unknown'}"
+
+    kill_clear, kill_reason = _kill_switch_clear()
+    if not kill_clear:
+        return False, kill_reason
+
+    seak, seak_halted, seak_reason = _seak_status()
+    if seak_halted and not str(seak_reason).startswith("AUTHORITY_HEARTBEAT_EXPIRED:"):
+        return False, f"seak_halt_not_heartbeat_owned:{seak_reason or 'unknown'}"
+
+    sm, TradingState, state_value = _trading_state_machine()
+    if sm is None or TradingState is None:
+        return False, state_value
+
+    if state_value == "EMERGENCY_STOP":
+        try:
+            sm.transition_to(
+                TradingState.OFF,
+                f"authority heartbeat recovered; reactivation required marker={MARKER}",
+            )
+        except Exception as exc:
+            return False, f"fsm_recovery_failed:{type(exc).__name__}:{exc}"
+    elif state_value not in {"OFF", "LIVE_PENDING_CONFIRMATION", "LIVE_ACTIVE"}:
+        # Unknown/nonstandard states are not rewritten by this recovery path.
+        return False, f"fsm_state_not_recoverable:{state_value or 'unknown'}"
+
+    # Resume SEAK only after the FSM is safely OFF (or already left the stale
+    # emergency state).  This keeps order dispatch closed while normal activation
+    # proofs reconverge.
+    if seak_halted:
+        resume = getattr(seak, "resume", None)
+        if not callable(resume):
+            return False, "seak_resume_missing"
+        try:
+            resume(caller="authority_heartbeat_recovery_v64")
+        except Exception as exc:
+            return False, f"seak_resume_failed:{type(exc).__name__}:{exc}"
+
+    os.environ.pop(_OWNED_STOP_ENV, None)
+    os.environ.pop(_OWNED_REASON_ENV, None)
     LOGGER.critical(
-        "PRECORE_AUTHORITY_HEARTBEAT_V63_PATCHED marker=%s module=%s "
-        "precore_zero_grace=true postcore_fail_closed=true",
+        "AUTHORITY_HEARTBEAT_OWNED_STOP_RECOVERED marker=%s "
+        "writer_acquired=true core_live=true authority_proof=true kill_switch_clear=true "
+        "fsm_reactivated=false seak_resumed=%s",
         MARKER,
-        module.__name__,
+        str(bool(seak_halted)).lower(),
     )
-    return True
+    return True, "heartbeat_owned_stop_recovered_to_fail_closed_off"
+
+
+def _patch_authority_heartbeat(module: ModuleType) -> bool:
+    changed = False
+
+    current = getattr(module, "_check_authority_once", None)
+    if callable(current) and not getattr(current, _PATCH_ATTR, False):
+        @wraps(current)
+        def check_authority_once_v64(timeout_s: float):
+            raw = str(os.environ.get("NIJA_CORE_THREAD_ALIVE", "") or "").strip().lower()
+            if raw and raw not in _TRUE:
+                grace, reason = _precore_grace_active()
+                if grace:
+                    previous = os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+                    try:
+                        result = current(timeout_s)
+                    finally:
+                        # Never clobber a concurrent core-registration/liveness
+                        # publication.  Restore the old pre-core value only if no
+                        # writer has published a newer signal while the check ran.
+                        if previous is not None and "NIJA_CORE_THREAD_ALIVE" not in os.environ:
+                            os.environ["NIJA_CORE_THREAD_ALIVE"] = previous
+                    LOGGER.info(
+                        "PRECORE_AUTHORITY_HEARTBEAT_GRACE marker=%s reason=%s "
+                        "core_alive_signal=%s other_authority_gates_unchanged=true",
+                        MARKER,
+                        reason,
+                        raw,
+                    )
+                    return result
+            return current(timeout_s)
+
+        setattr(check_authority_once_v64, _PATCH_ATTR, True)
+        setattr(check_authority_once_v64, "__wrapped__", current)
+        module._check_authority_once = check_authority_once_v64
+        changed = True
+
+    callback = getattr(module, "_default_lockdown_callback", None)
+    if callable(callback) and not getattr(callback, _CALLBACK_PATCH_ATTR, False):
+        @wraps(callback)
+        def heartbeat_owned_lockdown(reason: str):
+            os.environ[_OWNED_STOP_ENV] = "1"
+            os.environ[_OWNED_REASON_ENV] = str(reason or "unknown")
+            return callback(reason)
+
+        setattr(heartbeat_owned_lockdown, _CALLBACK_PATCH_ATTR, True)
+        setattr(heartbeat_owned_lockdown, "__wrapped__", callback)
+        module._default_lockdown_callback = heartbeat_owned_lockdown
+        existing = getattr(module, "_monitor_instance", None)
+        if existing is not None and getattr(existing, "_lockdown_callback", None) is callback:
+            existing._lockdown_callback = heartbeat_owned_lockdown
+        changed = True
+
+    cls = getattr(module, "AuthorityHeartbeatMonitor", None)
+    original_start = getattr(cls, "start", None) if isinstance(cls, type) else None
+    if callable(original_start) and not getattr(original_start, _START_PATCH_ATTR, False):
+        @wraps(original_start)
+        def start_with_owned_recovery(self: Any, *args: Any, **kwargs: Any):
+            was_locked_down = bool(getattr(self, "_locked_down", False))
+            result = original_start(self, *args, **kwargs)
+            recovered_monitor = was_locked_down and not bool(getattr(self, "_locked_down", False))
+            if recovered_monitor and _truthy(_OWNED_STOP_ENV):
+                recovered, reason = _recover_heartbeat_owned_stop(module, self)
+                if not recovered:
+                    # The original monitor restart path is optimistic: it resets
+                    # locked_down when the writer singleton still owns the lease.
+                    # If the strict v64 proof fails, immediately restore lockdown
+                    # signals so the process remains fail closed.
+                    try:
+                        self._locked_down = True
+                    except Exception:
+                        pass
+                    os.environ["NIJA_WRITER_HEARTBEAT_ACTIVE"] = "0"
+                    os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = "0"
+                    LOGGER.critical(
+                        "AUTHORITY_HEARTBEAT_OWNED_STOP_RECOVERY_BLOCKED marker=%s "
+                        "reason=%s trading_remains_fail_closed=true",
+                        MARKER,
+                        reason,
+                    )
+            return result
+
+        setattr(start_with_owned_recovery, _START_PATCH_ATTR, True)
+        setattr(start_with_owned_recovery, "__wrapped__", original_start)
+        cls.start = start_with_owned_recovery
+        changed = True
+
+    if changed:
+        LOGGER.critical(
+            "PRECORE_AUTHORITY_HEARTBEAT_V64_PATCHED marker=%s module=%s "
+            "precore_zero_grace=true concurrent_core_signal_preserved=true "
+            "heartbeat_owned_recovery_fail_closed=true",
+            MARKER,
+            module.__name__,
+        )
+    return bool(changed or getattr(getattr(module, "_check_authority_once", None), _PATCH_ATTR, False))
 
 
 def _patch_loaded() -> bool:
@@ -155,10 +370,13 @@ def install_import_hook() -> bool:
             builtins.__import__ = importing
             setattr(builtins, _HOOK_FLAG, True)
 
+        # Keep the v63 readiness flag for callers already depending on it while
+        # publishing a distinct v64 marker for rollout verification.
         os.environ["NIJA_PRECORE_AUTHORITY_HEARTBEAT_V63_READY"] = "1"
+        os.environ["NIJA_PRECORE_AUTHORITY_HEARTBEAT_V64_READY"] = "1"
         LOGGER.critical(
-            "PRECORE_AUTHORITY_HEARTBEAT_V63_INSTALLED marker=%s "
-            "precore_grace_only=true authority_bypass=false",
+            "PRECORE_AUTHORITY_HEARTBEAT_V64_INSTALLED marker=%s "
+            "precore_grace_only=true authority_bypass=false owned_stop_recovery=true",
             MARKER,
         )
         return True
@@ -168,4 +386,10 @@ def install() -> bool:
     return install_import_hook()
 
 
-__all__ = ["MARKER", "install", "install_import_hook", "_precore_grace_active"]
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_precore_grace_active",
+    "_recover_heartbeat_owned_stop",
+]

--- a/bot/precore_authority_heartbeat_v63_patch.py
+++ b/bot/precore_authority_heartbeat_v63_patch.py
@@ -217,15 +217,18 @@ def _recover_heartbeat_owned_stop(module: ModuleType, monitor: Any = None) -> tu
                 TradingState.OFF,
                 f"authority heartbeat recovered; reactivation required marker={MARKER}",
             )
+            state = sm.get_current_state()
+            state_value = str(getattr(state, "value", state) or "").strip().upper()
         except Exception as exc:
             return False, f"fsm_recovery_failed:{type(exc).__name__}:{exc}"
-    elif state_value not in {"OFF", "LIVE_PENDING_CONFIRMATION", "LIVE_ACTIVE"}:
-        # Unknown/nonstandard states are not rewritten by this recovery path.
-        return False, f"fsm_state_not_recoverable:{state_value or 'unknown'}"
 
-    # Resume SEAK only after the FSM is safely OFF (or already left the stale
-    # emergency state).  This keeps order dispatch closed while normal activation
-    # proofs reconverge.
+    # SEAK may only be resumed after the heartbeat-owned emergency latch has
+    # definitively landed in OFF.  LIVE_PENDING_CONFIRMATION/LIVE_ACTIVE (or any
+    # other state) must keep the halt in place until normal activation code
+    # explicitly re-establishes the full execution contract.
+    if state_value != "OFF":
+        return False, f"fsm_not_off_after_recovery:{state_value or 'unknown'}"
+
     if seak_halted:
         resume = getattr(seak, "resume", None)
         if not callable(resume):

--- a/bot/tests/test_precore_authority_heartbeat_v63.py
+++ b/bot/tests/test_precore_authority_heartbeat_v63.py
@@ -8,11 +8,22 @@ import unittest
 from types import SimpleNamespace
 
 
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
 class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
     def setUp(self) -> None:
         self.mod = importlib.import_module("bot.precore_authority_heartbeat_v63_patch")
         self.saved_env = {
-            "NIJA_CORE_THREAD_ALIVE": os.environ.get("NIJA_CORE_THREAD_ALIVE"),
+            name: os.environ.get(name)
+            for name in (
+                "NIJA_CORE_THREAD_ALIVE",
+                "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP",
+                "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP_REASON",
+                "NIJA_RUNTIME_TRADING_STATE",
+            )
         }
         self.saved_modules = {
             name: sys.modules.get(name)
@@ -21,13 +32,20 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
                 "entrypoint_writer_authority",
                 "bot.bot_main",
                 "bot_main",
+                "bot.kill_switch",
+                "kill_switch",
+                "bot.single_execution_authority_kernel",
+                "single_execution_authority_kernel",
+                "bot.trading_state_machine",
+                "trading_state_machine",
             )
         }
 
     def tearDown(self) -> None:
-        os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
-        if self.saved_env["NIJA_CORE_THREAD_ALIVE"] is not None:
-            os.environ["NIJA_CORE_THREAD_ALIVE"] = self.saved_env["NIJA_CORE_THREAD_ALIVE"]
+        for name, value in self.saved_env.items():
+            os.environ.pop(name, None)
+            if value is not None:
+                os.environ[name] = value
         for name, module in self.saved_modules.items():
             if module is None:
                 sys.modules.pop(name, None)
@@ -37,6 +55,7 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
     def _install_runtime(
         self,
         *,
+        acquired: bool = True,
         core=None,
         registered: bool = False,
         lost: bool = False,
@@ -46,6 +65,7 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         shutdown: bool = False,
     ):
         runtime = SimpleNamespace(
+            acquired=acquired,
             lost=lost,
             terminal_startup_failure_reason=terminal_reason,
             _scan_deadline_exceeded=deadline_exceeded,
@@ -70,6 +90,12 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         active, reason = self.mod._precore_grace_active()
         self.assertTrue(active)
         self.assertEqual(reason, "startup_not_registered")
+
+    def test_precore_grace_requires_acquired_writer(self) -> None:
+        self._install_runtime(acquired=False)
+        active, reason = self.mod._precore_grace_active()
+        self.assertFalse(active)
+        self.assertEqual(reason, "writer_not_acquired")
 
     def test_grace_ends_when_core_handoff_has_started(self) -> None:
         self._install_runtime(core=object())
@@ -108,8 +134,27 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         self.assertEqual(seen, [(1.25, None)])
         self.assertEqual(os.environ.get("NIJA_CORE_THREAD_ALIVE"), "0")
 
+    def test_wrapper_preserves_concurrent_core_registration_signal(self) -> None:
+        self._install_runtime()
+        fake = types.ModuleType("authority_heartbeat_v64_concurrent_fake")
+
+        def original(_timeout_s: float):
+            # Simulate register_core_thread publishing a newer liveness signal
+            # while the v64 heartbeat wrapper has temporarily hidden pre-core 0.
+            os.environ["NIJA_CORE_THREAD_ALIVE"] = "1"
+            return True, ""
+
+        fake._check_authority_once = original
+        os.environ["NIJA_CORE_THREAD_ALIVE"] = "0"
+        self.assertTrue(self.mod._patch_authority_heartbeat(fake))
+
+        ok, reason = fake._check_authority_once(1.0)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+        self.assertEqual(os.environ.get("NIJA_CORE_THREAD_ALIVE"), "1")
+
     def test_wrapper_keeps_postcore_zero_fail_closed(self) -> None:
-        self._install_runtime(core=object(), registered=True)
+        self._install_runtime(core=_AliveThread(), registered=True)
         fake = types.ModuleType("authority_heartbeat_v63_postcore_fake")
         seen = []
 
@@ -125,6 +170,93 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(reason, "core_thread_dead")
         self.assertEqual(seen, ["0"])
+
+    def _install_recovery_dependencies(self, *, seak_reason: str):
+        self._install_runtime(core=_AliveThread(), registered=True)
+
+        kill = types.ModuleType("bot.kill_switch")
+        kill.get_kill_switch = lambda: SimpleNamespace(is_active=lambda: False)
+        sys.modules["bot.kill_switch"] = kill
+        sys.modules.pop("kill_switch", None)
+
+        class FakeSeak:
+            def __init__(self):
+                self.is_halted = True
+                self._halt_reason = seak_reason
+                self.resumed = False
+
+            def snapshot(self):
+                return {"halted": self.is_halted, "halt_reason": self._halt_reason}
+
+            def resume(self, caller: str = "operator"):
+                self.is_halted = False
+                self._halt_reason = ""
+                self.resumed = caller == "authority_heartbeat_recovery_v64"
+
+        seak = FakeSeak()
+        seak_mod = types.ModuleType("bot.single_execution_authority_kernel")
+        seak_mod.get_seak = lambda: seak
+        sys.modules["bot.single_execution_authority_kernel"] = seak_mod
+        sys.modules.pop("single_execution_authority_kernel", None)
+
+        class FakeTradingState:
+            EMERGENCY_STOP = "EMERGENCY_STOP"
+            OFF = "OFF"
+            LIVE_PENDING_CONFIRMATION = "LIVE_PENDING_CONFIRMATION"
+            LIVE_ACTIVE = "LIVE_ACTIVE"
+
+        class FakeStateMachine:
+            def __init__(self):
+                self.state = FakeTradingState.EMERGENCY_STOP
+                self.transitions = []
+
+            def get_current_state(self):
+                return self.state
+
+            def transition_to(self, target, reason: str):
+                self.transitions.append((target, reason))
+                self.state = target
+
+        sm = FakeStateMachine()
+        tsm = types.ModuleType("bot.trading_state_machine")
+        tsm.get_state_machine = lambda: sm
+        tsm.TradingState = FakeTradingState
+        sys.modules["bot.trading_state_machine"] = tsm
+        sys.modules.pop("trading_state_machine", None)
+        return seak, sm
+
+    def test_recovery_releases_only_heartbeat_owned_emergency_stop(self) -> None:
+        seak, sm = self._install_recovery_dependencies(
+            seak_reason="AUTHORITY_HEARTBEAT_EXPIRED: transient core startup race"
+        )
+        fake = types.ModuleType("authority_heartbeat_v64_recovery_fake")
+        fake._check_authority_once = lambda _timeout_s: (True, "")
+
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"] = "1"
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP_REASON"] = "transient core startup race"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "EMERGENCY_STOP"
+
+        recovered, reason = self.mod._recover_heartbeat_owned_stop(fake)
+        self.assertTrue(recovered)
+        self.assertEqual(reason, "heartbeat_owned_stop_recovered_to_fail_closed_off")
+        self.assertEqual(sm.state, "OFF")
+        self.assertTrue(seak.resumed)
+        self.assertFalse(seak.is_halted)
+        self.assertNotIn("NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP", os.environ)
+        # Recovery never force-activates trading.
+        self.assertNotEqual(os.environ.get("NIJA_RUNTIME_TRADING_STATE"), "LIVE_ACTIVE")
+
+    def test_recovery_does_not_resume_nonheartbeat_seak_halt(self) -> None:
+        seak, sm = self._install_recovery_dependencies(seak_reason="operator emergency halt")
+        fake = types.ModuleType("authority_heartbeat_v64_nonowned_fake")
+        fake._check_authority_once = lambda _timeout_s: (True, "")
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"] = "1"
+
+        recovered, reason = self.mod._recover_heartbeat_owned_stop(fake)
+        self.assertFalse(recovered)
+        self.assertTrue(reason.startswith("seak_halt_not_heartbeat_owned:"))
+        self.assertTrue(seak.is_halted)
+        self.assertEqual(sm.state, "EMERGENCY_STOP")
 
 
 if __name__ == "__main__":

--- a/bot/tests/test_precore_authority_heartbeat_v63.py
+++ b/bot/tests/test_precore_authority_heartbeat_v63.py
@@ -139,8 +139,6 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         fake = types.ModuleType("authority_heartbeat_v64_concurrent_fake")
 
         def original(_timeout_s: float):
-            # Simulate register_core_thread publishing a newer liveness signal
-            # while the v64 heartbeat wrapper has temporarily hidden pre-core 0.
             os.environ["NIJA_CORE_THREAD_ALIVE"] = "1"
             return True, ""
 
@@ -171,7 +169,7 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         self.assertEqual(reason, "core_thread_dead")
         self.assertEqual(seen, ["0"])
 
-    def _install_recovery_dependencies(self, *, seak_reason: str):
+    def _install_recovery_dependencies(self, *, seak_reason: str, initial_state: str = "EMERGENCY_STOP"):
         self._install_runtime(core=_AliveThread(), registered=True)
 
         kill = types.ModuleType("bot.kill_switch")
@@ -207,7 +205,7 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
 
         class FakeStateMachine:
             def __init__(self):
-                self.state = FakeTradingState.EMERGENCY_STOP
+                self.state = initial_state
                 self.transitions = []
 
             def get_current_state(self):
@@ -243,7 +241,6 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         self.assertTrue(seak.resumed)
         self.assertFalse(seak.is_halted)
         self.assertNotIn("NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP", os.environ)
-        # Recovery never force-activates trading.
         self.assertNotEqual(os.environ.get("NIJA_RUNTIME_TRADING_STATE"), "LIVE_ACTIVE")
 
     def test_recovery_does_not_resume_nonheartbeat_seak_halt(self) -> None:
@@ -257,6 +254,23 @@ class PrecoreAuthorityHeartbeatV63Tests(unittest.TestCase):
         self.assertTrue(reason.startswith("seak_halt_not_heartbeat_owned:"))
         self.assertTrue(seak.is_halted)
         self.assertEqual(sm.state, "EMERGENCY_STOP")
+
+    def test_recovery_does_not_resume_seak_until_fsm_is_off(self) -> None:
+        seak, sm = self._install_recovery_dependencies(
+            seak_reason="AUTHORITY_HEARTBEAT_EXPIRED: recovered monitor",
+            initial_state="LIVE_PENDING_CONFIRMATION",
+        )
+        fake = types.ModuleType("authority_heartbeat_v64_fsm_not_off_fake")
+        fake._check_authority_once = lambda _timeout_s: (True, "")
+        os.environ["NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"] = "1"
+
+        recovered, reason = self.mod._recover_heartbeat_owned_stop(fake)
+        self.assertFalse(recovered)
+        self.assertEqual(reason, "fsm_not_off_after_recovery:LIVE_PENDING_CONFIRMATION")
+        self.assertTrue(seak.is_halted)
+        self.assertFalse(seak.resumed)
+        self.assertEqual(sm.state, "LIVE_PENDING_CONFIRMATION")
+        self.assertIn("NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP", os.environ)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Production failure

The current deployment can recover its canonical writer lease/heartbeat after a transient authority-heartbeat lockdown while the TradingStateMachine remains latched in `EMERGENCY_STOP` and SEAK remains halted. Production then shows a healthy renewed writer/core/heartbeat but v61 continually revokes `authority_ready` and `execution_ready`.

## Fix

- preserve concurrent `NIJA_CORE_THREAD_ALIVE=1` publications while the pre-core heartbeat shim temporarily hides startup `0`
- require an actually acquired canonical writer before pre-core grace applies
- mark lockdowns created specifically by `AuthorityHeartbeatMonitor`
- on monitor recovery, release only a heartbeat-owned stale FSM/SEAK stop after:
  - canonical writer is still acquired and not lost
  - registered core is currently alive
  - a fresh full authority heartbeat check passes
  - kill switch is clear
  - any SEAK halt reason is explicitly `AUTHORITY_HEARTBEAT_EXPIRED:*`
- return the FSM to `OFF`, never force `LIVE_ACTIVE`; normal activation/readiness/nonce/risk/capital gates must reconverge
- leave operator/kill-switch/non-heartbeat emergency halts untouched and fail closed

## Tests

Adds coverage for writer-acquisition gating, concurrent core registration during the pre-core check, safe recovery of heartbeat-owned stops, and refusal to resume a non-heartbeat SEAK halt.