### PR TITLE
Fix writer readiness convergence for live activation

### DIFF
--- a/bot/final_production_activation_repair_v59_patch.py
+++ b/bot/final_production_activation_repair_v59_patch.py
@@ -3,6 +3,8 @@
 Addresses regressions observed after PR #2494:
 - canonical stalled-writer monitor must never own BootstrapFSM/runtime authority;
 - writer core registration must not synchronously wait on broker readiness I/O;
+- readiness triggers that arrive during an in-flight reconciliation must be
+  coalesced and replayed instead of being silently dropped;
 - v16 proof monitor must actually run on the canonical fast path;
 - accepted fresh CapitalAuthority snapshot must reach TradingStateMachine's
   first-snapshot latch through the existing fail-closed activation bridge.
@@ -91,37 +93,64 @@ def _patch_writer_reconciliation_async() -> bool:
         return True
 
     def notify_async(self: Any, trigger: str) -> None:
-        """Never block lease/core registration on exchange/readiness I/O."""
+        """Never block lease/core registration and never drop a readiness edge.
+
+        Reconciliation can contain slow broker I/O, so there is still at most
+        one worker. If a new trigger arrives while that worker is active, retain
+        the latest trigger and replay one follow-up pass before the worker exits.
+        This preserves single-flight behavior without losing the heartbeat or
+        authority transition that may make the v61 current-proof table ready.
+        """
         lock = getattr(self, "_runtime_reconcile_lock", None)
         if lock is None:
             lock = threading.Lock()
             self._runtime_reconcile_lock = lock
 
+        trigger = str(trigger or "unspecified")
         with lock:
             worker = getattr(self, "_runtime_reconcile_thread", None)
             if worker is not None and worker.is_alive():
+                self._runtime_reconcile_pending_trigger = trigger
                 logger.info(
-                    "WRITER_READINESS_RECONCILE_DEDUPED marker=%s trigger=%s existing_worker=true",
+                    "WRITER_READINESS_RECONCILE_COALESCED marker=%s trigger=%s "
+                    "existing_worker=true replay_pending=true",
                     MARKER,
                     trigger,
                 )
                 return
 
+            self._runtime_reconcile_pending_trigger = None
+
             def _worker() -> None:
-                try:
-                    runner = getattr(self, "_run_runtime_reconciliation", None)
-                    if callable(runner):
-                        runner(trigger)
-                except Exception:
-                    logger.exception(
-                        "WRITER_READINESS_RECONCILE_ASYNC_FAILED marker=%s trigger=%s",
-                        MARKER,
-                        trigger,
-                    )
-                finally:
+                next_trigger = trigger
+                while next_trigger:
+                    try:
+                        runner = getattr(self, "_run_runtime_reconciliation", None)
+                        if callable(runner):
+                            runner(next_trigger)
+                    except Exception:
+                        logger.exception(
+                            "WRITER_READINESS_RECONCILE_ASYNC_FAILED marker=%s trigger=%s",
+                            MARKER,
+                            next_trigger,
+                        )
+
                     with lock:
-                        if getattr(self, "_runtime_reconcile_thread", None) is threading.current_thread():
-                            self._runtime_reconcile_thread = None
+                        pending = str(
+                            getattr(self, "_runtime_reconcile_pending_trigger", "") or ""
+                        ).strip()
+                        self._runtime_reconcile_pending_trigger = None
+                        if not pending:
+                            if getattr(self, "_runtime_reconcile_thread", None) is threading.current_thread():
+                                self._runtime_reconcile_thread = None
+                            return
+                        next_trigger = pending
+                        logger.critical(
+                            "WRITER_READINESS_RECONCILE_REPLAY marker=%s trigger=%s "
+                            "reason=coalesced_trigger single_flight=true",
+                            MARKER,
+                            next_trigger,
+                        )
 
             worker = threading.Thread(
                 target=_worker,
@@ -132,7 +161,7 @@ def _patch_writer_reconciliation_async() -> bool:
             worker.start()
             logger.critical(
                 "WRITER_READINESS_RECONCILE_ASYNC_DISPATCHED marker=%s trigger=%s "
-                "core_registration_blocked=false",
+                "core_registration_blocked=false coalescing=true",
                 MARKER,
                 trigger,
             )
@@ -141,7 +170,8 @@ def _patch_writer_reconciliation_async() -> bool:
     notify_async.__wrapped__ = current  # type: ignore[attr-defined]
     cls._notify_runtime_reconciliation = notify_async
     logger.critical(
-        "FINAL_ACTIVATION_V59_WRITER_RECONCILE_PATCHED marker=%s all_triggers_async=true",
+        "FINAL_ACTIVATION_V59_WRITER_RECONCILE_PATCHED marker=%s "
+        "all_triggers_async=true coalescing=true dropped_triggers=false",
         MARKER,
     )
     return True

--- a/bot/tests/test_final_production_activation_repair_v59.py
+++ b/bot/tests/test_final_production_activation_repair_v59.py
@@ -47,6 +47,49 @@ def test_writer_registration_reconciliation_dispatches_async(monkeypatch):
         assert elapsed < 0.25
         assert started.wait(timeout=1.0)
         release.set()
+        worker = runtime._runtime_reconcile_thread
+        if worker is not None:
+            worker.join(timeout=1.0)
+    finally:
+        module.EntrypointWriterAuthority._notify_runtime_reconciliation = original
+
+
+def test_writer_reconciliation_coalesces_and_replays_latest_trigger(monkeypatch):
+    import bot.entrypoint_writer_authority as module
+
+    original = module.EntrypointWriterAuthority._notify_runtime_reconciliation
+    try:
+        assert repair._patch_writer_reconciliation_async() is True
+        runtime = module.EntrypointWriterAuthority()
+        first_started = threading.Event()
+        release_first = threading.Event()
+        replay_finished = threading.Event()
+        calls: list[str] = []
+
+        def reconcile(trigger: str) -> None:
+            calls.append(trigger)
+            if len(calls) == 1:
+                first_started.set()
+                release_first.wait(timeout=2.0)
+            else:
+                replay_finished.set()
+
+        runtime._run_runtime_reconciliation = reconcile
+        runtime._notify_runtime_reconciliation("watchdog")
+        assert first_started.wait(timeout=1.0)
+
+        runtime._notify_runtime_reconciliation("heartbeat_renewed")
+        runtime._notify_runtime_reconciliation("writer_authority_active")
+        release_first.set()
+
+        assert replay_finished.wait(timeout=1.0)
+        worker = runtime._runtime_reconcile_thread
+        if worker is not None:
+            worker.join(timeout=1.0)
+
+        assert calls == ["watchdog", "writer_authority_active"]
+        assert runtime._runtime_reconcile_thread is None
+        assert getattr(runtime, "_runtime_reconcile_pending_trigger", None) is None
     finally:
         module.EntrypointWriterAuthority._notify_runtime_reconciliation = original
 


### PR DESCRIPTION
## What changed
- Reworked the v59 writer readiness reconciliation wrapper to preserve single-flight asynchronous reconciliation without dropping triggers that arrive while a worker is active.
- Coalesce in-flight readiness triggers and replay the latest trigger before the worker exits.
- Added a regression test that reproduces the production failure mode where heartbeat/authority events arrive during a slow readiness pass.

## Root cause
The v59 compatibility wrapper replaced the newer canonical reconciliation behavior and returned immediately whenever a reconciliation thread was already running. That kept lease renewal nonblocking, but it silently discarded the event that could make v61 authority/execution proofs current. The readiness table then stayed fail-closed even after the writer became ACTIVE.

## Safety
This does not force LIVE_ACTIVE, does not fabricate readiness, does not weaken risk/nonce/SEAK/kill-switch checks, and does not bypass the execution gate. It only guarantees that current proof events are eventually reconciled.

## Expected production behavior
After a valid writer heartbeat/authority transition, one coalesced follow-up reconciliation runs if another pass was already in flight. v61 can then republish current authority/execution proofs and allow normal activation when every existing safety gate passes.