### PR TITLE
Fix kill-switch module identity blocking live activation

### DIFF
--- a/bot/tests/test_kill_switch_import_identity.py
+++ b/bot/tests/test_kill_switch_import_identity.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_legacy_kill_switch_import_reuses_canonical_module():
+    canonical = importlib.import_module("bot.kill_switch")
+
+    # Exercise the compatibility path as a fresh legacy import.
+    sys.modules.pop("kill_switch", None)
+    legacy = importlib.import_module("kill_switch")
+
+    assert legacy is canonical
+    assert sys.modules["kill_switch"] is sys.modules["bot.kill_switch"]
+    assert legacy.get_kill_switch is canonical.get_kill_switch
+
+
+def test_legacy_and_canonical_imports_share_singleton():
+    canonical = importlib.import_module("bot.kill_switch")
+    legacy = importlib.import_module("kill_switch")
+
+    assert legacy.get_kill_switch() is canonical.get_kill_switch()

--- a/kill_switch.py
+++ b/kill_switch.py
@@ -1,0 +1,21 @@
+"""Legacy import compatibility for NIJA's canonical global kill switch.
+
+The canonical implementation lives in :mod:`bot.kill_switch`.  Historically,
+some runtime paths imported the same implementation as top-level
+``kill_switch`` while others used ``bot.kill_switch``.  Loading the file under
+both names creates two module objects and therefore two independent singleton
+kill-switch instances, which can make activation/readiness consumers disagree.
+
+This module deliberately owns no state.  It aliases the legacy import name to
+the canonical module object so both import paths share exactly one singleton.
+A genuine ``EMERGENCY_STOP`` file and all existing fail-closed behavior remain
+unchanged in ``bot.kill_switch``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+_canonical = importlib.import_module("bot.kill_switch")
+sys.modules[__name__] = _canonical


### PR DESCRIPTION
## Summary
- add a top-level `kill_switch` compatibility alias that resolves to the canonical `bot.kill_switch` module object
- ensure legacy and package imports share one process-wide kill-switch singleton
- add regression tests for module identity and singleton identity

## Why
The August 14 production log shows healthy writer heartbeat, live capital, and all three venues ready, while activation consumers report `kill_switch_active` even though the startup coordinator reports `kill_switch=False`. The existing activation bridge probes both `bot.kill_switch` and legacy `kill_switch`; loading the implementation under both names can create independent module-level singleton state and produce contradictory readiness truth.

## Safety
This does not disable, clear, or bypass the kill switch. `bot.kill_switch` remains canonical and continues to honor a real `EMERGENCY_STOP` file and all existing fail-closed behavior. The change only removes duplicate module/singleton identity for the legacy import path.

## Validation
- branch is 2 commits ahead of `main` and 0 behind
- regression tests added under `bot/tests/test_kill_switch_import_identity.py`
- CI requested by opening this draft PR
