### PR TITLE
Recover disconnected Kraken user brokers safely

### DIFF
--- a/bot/kraken_user_connection_convergence_v90_patch.py
+++ b/bot/kraken_user_connection_convergence_v90_patch.py
@@ -1,0 +1,278 @@
+"""Converge registered Kraken user accounts onto real authenticated brokers.
+
+This patch extends v86 without weakening its writer/nonce/capital safeguards.
+The missing case in v86 is a registered user whose broker object is absent, or
+whose broker was constructed before credentials became available.  In those
+states v86 returns ``broker_unavailable`` / ``credentials_not_configured`` and
+never asks the canonical manager to reconstruct the broker.
+
+v90 performs a bounded reconstruction through
+``MultiAccountBrokerManager.add_user_broker``.  That canonical API constructs
+the isolated per-user broker and performs its real authenticated ``connect()``.
+No connected flag, credential, balance, trading eligibility, execution
+authority, or kill-switch state is synthesized here.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+from bot import kraken_all_account_supervision_v86 as v86
+
+
+LOGGER = logging.getLogger("nija.kraken_user_connection_convergence_v90")
+MARKER = "20260814-kraken-user-connection-convergence-v90"
+_LOCK = threading.RLock()
+_PATCHED = False
+_MONITOR_STARTED = False
+_ORIGINAL_SCHEDULE = None
+_NEXT_REBUILD: dict[str, float] = {}
+_REBUILD_FAILURES: dict[str, int] = {}
+_LAST_MONITOR_SIGNATURE = ""
+
+
+def _rebuild_delay(failures: int) -> float:
+    try:
+        base = max(15.0, float(os.environ.get("NIJA_KRAKEN_USER_REBUILD_BASE_S", "30") or 30))
+    except (TypeError, ValueError):
+        base = 30.0
+    try:
+        ceiling = max(base, float(os.environ.get("NIJA_KRAKEN_USER_REBUILD_MAX_S", "300") or 300))
+    except (TypeError, ValueError):
+        ceiling = 300.0
+    return min(ceiling, base * (2 ** max(0, min(failures - 1, 4))))
+
+
+def _set_rebuild_backoff(account_id: str, *, failed: bool) -> None:
+    with _LOCK:
+        if failed:
+            failures = _REBUILD_FAILURES.get(account_id, 0) + 1
+            _REBUILD_FAILURES[account_id] = failures
+        else:
+            failures = 1
+            _REBUILD_FAILURES.pop(account_id, None)
+        _NEXT_REBUILD[account_id] = time.monotonic() + _rebuild_delay(failures)
+
+
+def _rebuild_due(account_id: str) -> bool:
+    with _LOCK:
+        return time.monotonic() >= _NEXT_REBUILD.get(account_id, 0.0)
+
+
+def _recover_broker(
+    manager: Any,
+    account_id: str,
+    user_id: str,
+    broker_type: Any,
+) -> tuple[Any, str]:
+    """Reconstruct one user broker through the canonical manager, fail closed."""
+    if not _rebuild_due(account_id):
+        return None, "rebuild_backoff"
+
+    proof_ok, proof_reason = v86._writer_proof()
+    if not proof_ok:
+        _set_rebuild_backoff(account_id, failed=False)
+        LOGGER.warning(
+            "KRAKEN_USER_BROKER_REBUILD_BLOCKED marker=%s account=%s reason=%s "
+            "broker_io=false fail_closed=true",
+            MARKER,
+            account_id,
+            proof_reason,
+        )
+        return None, f"writer_proof_blocked:{proof_reason}"
+
+    config = v86._recover_user_config(manager, user_id)
+    if config is None:
+        _set_rebuild_backoff(account_id, failed=True)
+        LOGGER.warning(
+            "KRAKEN_USER_BROKER_REBUILD_BLOCKED marker=%s account=%s "
+            "reason=user_config_unavailable broker_io=false fail_closed=true",
+            MARKER,
+            account_id,
+        )
+        return None, "user_config_unavailable"
+
+    add_user_broker = getattr(manager, "add_user_broker", None)
+    if not callable(add_user_broker):
+        _set_rebuild_backoff(account_id, failed=True)
+        return None, "canonical_add_user_broker_unavailable"
+
+    try:
+        broker = add_user_broker(user_id, broker_type)
+    except Exception as exc:
+        _set_rebuild_backoff(account_id, failed=True)
+        LOGGER.warning(
+            "KRAKEN_USER_BROKER_REBUILD_FAILED marker=%s account=%s error=%s:%s isolated=true",
+            MARKER,
+            account_id,
+            type(exc).__name__,
+            exc,
+        )
+        return None, f"broker_rebuild_failed:{type(exc).__name__}"
+
+    if broker is None:
+        _set_rebuild_backoff(account_id, failed=True)
+        LOGGER.warning(
+            "KRAKEN_USER_BROKER_REBUILD_FAILED marker=%s account=%s "
+            "reason=canonical_manager_returned_none isolated=true",
+            MARKER,
+            account_id,
+        )
+        return None, "broker_rebuild_returned_none"
+
+    key = (user_id, broker_type)
+    all_users = getattr(manager, "_all_user_brokers", None)
+    if isinstance(all_users, dict):
+        all_users[key] = broker
+
+    if bool(getattr(broker, "connected", False)):
+        v86._mark_connected(manager, user_id, broker_type, broker)
+        with _LOCK:
+            _REBUILD_FAILURES.pop(account_id, None)
+            _NEXT_REBUILD.pop(account_id, None)
+        LOGGER.critical(
+            "KRAKEN_USER_BROKER_REBUILT_CONNECTED marker=%s account=%s "
+            "authenticated=true fabricated_connected=false",
+            MARKER,
+            account_id,
+        )
+        return broker, "connected"
+
+    if getattr(broker, "credentials_configured", None) is False:
+        missing = getattr(manager, "_users_without_credentials", None)
+        if isinstance(missing, dict):
+            missing[key] = True
+        _set_rebuild_backoff(account_id, failed=False)
+        LOGGER.warning(
+            "KRAKEN_USER_BROKER_REBUILT_DISCONNECTED marker=%s account=%s "
+            "reason=credentials_not_configured fabricated_credentials=false",
+            MARKER,
+            account_id,
+        )
+        return broker, "credentials_not_configured"
+
+    failed = getattr(manager, "_failed_user_connections", None)
+    if isinstance(failed, dict):
+        failed[key] = "reconstructed_broker_authenticated_connect_not_confirmed"
+    _set_rebuild_backoff(account_id, failed=False)
+    LOGGER.warning(
+        "KRAKEN_USER_BROKER_REBUILT_DISCONNECTED marker=%s account=%s "
+        "reason=authenticated_connect_not_confirmed next=v86_reconnect fabricated_connected=false",
+        MARKER,
+        account_id,
+    )
+    return broker, "broker_recovered_reconnect_pending"
+
+
+def _schedule_v90(manager: Any, record: tuple[str, str, Any, Any]) -> str:
+    account_id, user_id, broker_type, broker = record
+    original = _ORIGINAL_SCHEDULE or v86._schedule
+
+    missing_object = broker is None
+    stale_credentials = broker is not None and getattr(broker, "credentials_configured", None) is False
+    if not missing_object and not stale_credentials:
+        return original(manager, record)
+
+    recovered, state = _recover_broker(manager, account_id, user_id, broker_type)
+    if state == "connected":
+        return "connected"
+    if recovered is not None and bool(getattr(recovered, "connected", False)):
+        return "connected"
+
+    # Do not immediately call connect a second time after canonical reconstruction.
+    # The next v86 pass owns serialized reconnect/retry for a real broker object.
+    if recovered is not None:
+        return state
+
+    if state == "rebuild_backoff":
+        return "credentials_not_configured" if stale_credentials else "broker_unavailable"
+    return state
+
+
+def _monitor() -> None:
+    global _LAST_MONITOR_SIGNATURE
+    try:
+        interval = max(2.0, float(os.environ.get("NIJA_KRAKEN_USER_V90_POLL_S", "5") or 5))
+    except (TypeError, ValueError):
+        interval = 5.0
+    while True:
+        time.sleep(interval)
+        try:
+            state = v86.reconcile_once()
+            states = state.get("states", {}) if isinstance(state, dict) else {}
+            signature = repr((
+                state.get("registered", 0) if isinstance(state, dict) else 0,
+                state.get("connected", 0) if isinstance(state, dict) else 0,
+                state.get("disconnected", 0) if isinstance(state, dict) else 0,
+                sorted(states.items()) if isinstance(states, dict) else [],
+            ))
+            if signature == _LAST_MONITOR_SIGNATURE:
+                continue
+            _LAST_MONITOR_SIGNATURE = signature
+            ready = bool(state.get("ok")) if isinstance(state, dict) else False
+            os.environ["NIJA_KRAKEN_USER_CONNECTIONS_READY"] = "1" if ready else "0"
+            log = LOGGER.critical if ready else LOGGER.warning
+            log(
+                "KRAKEN_USER_CONNECTION_CONVERGENCE_V90 marker=%s registered=%s connected=%s "
+                "disconnected=%s states=%s authenticated_only=true fabricated_readiness=false",
+                MARKER,
+                state.get("registered", 0) if isinstance(state, dict) else 0,
+                state.get("connected", 0) if isinstance(state, dict) else 0,
+                state.get("disconnected", 0) if isinstance(state, dict) else 0,
+                states,
+            )
+        except Exception as exc:
+            os.environ["NIJA_KRAKEN_USER_CONNECTIONS_READY"] = "0"
+            LOGGER.warning(
+                "KRAKEN_USER_CONNECTION_CONVERGENCE_V90_ERROR marker=%s error=%s:%s isolated=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def install_import_hook() -> bool:
+    global _PATCHED, _MONITOR_STARTED, _ORIGINAL_SCHEDULE
+    with _LOCK:
+        if not _PATCHED:
+            current = getattr(v86, "_schedule", None)
+            if not callable(current):
+                raise RuntimeError("v86_schedule_unavailable")
+            if getattr(current, "_nija_v90_user_connection_convergence", False):
+                _PATCHED = True
+            else:
+                _ORIGINAL_SCHEDULE = current
+                setattr(_schedule_v90, "_nija_v90_user_connection_convergence", True)
+                v86._schedule = _schedule_v90
+                _PATCHED = True
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_monitor,
+                name="KrakenUserConnectionConvergenceV90",
+                daemon=True,
+            ).start()
+    os.environ["NIJA_KRAKEN_USER_CONNECTION_CONVERGENCE_V90_INSTALLED"] = "1"
+    LOGGER.critical(
+        "KRAKEN_USER_CONNECTION_CONVERGENCE_V90_INSTALLED marker=%s "
+        "canonical_rebuild=true authenticated_only=true exact_writer_proof=true "
+        "capital_eligibility_unchanged=true kill_switch_unchanged=true",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_recover_broker",
+    "_schedule_v90",
+]

--- a/bot/production_runtime_convergence_v88_patch.py
+++ b/bot/production_runtime_convergence_v88_patch.py
@@ -151,13 +151,20 @@ def _install_kraken_user_supervision() -> bool:
     try:
         from bot import kraken_all_account_supervision_v86 as v86
         installed = bool(v86.install())
+        if installed:
+            from bot import kraken_user_connection_convergence_v90_patch as v90
+            installed = bool(v90.install_import_hook())
     except Exception as exc:
         LOGGER.warning("KRAKEN_USER_SUPERVISION_V88_INSTALL_FAILED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
         return False
     if installed:
         with _LOCK:
             _KRAKEN_SUPERVISION_INSTALLED = True
-        LOGGER.critical("KRAKEN_USER_SUPERVISION_V88_CHAINED marker=%s source=v86 authenticated_reconnect_only=true writer_scoped=true", MARKER)
+        LOGGER.critical(
+            "KRAKEN_USER_SUPERVISION_V88_CHAINED marker=%s source=v86+v90 "
+            "authenticated_reconnect_only=true canonical_rebuild=true writer_scoped=true",
+            MARKER,
+        )
     return installed
 
 
@@ -220,7 +227,8 @@ def install_import_hook() -> bool:
     os.environ["NIJA_PRODUCTION_RUNTIME_CONVERGENCE_V88_INSTALLED"] = "1"
     LOGGER.critical(
         "PRODUCTION_RUNTIME_CONVERGENCE_V88_INSTALLED marker=%s circuit_classification=true "
-        "kraken_user_supervision=true stale_log_filter=true risk_gates_unchanged=true nonce_gates_unchanged=true",
+        "kraken_user_supervision=true kraken_user_rebuild_v90=true stale_log_filter=true "
+        "risk_gates_unchanged=true nonce_gates_unchanged=true",
         MARKER,
     )
     return True

--- a/bot/tests/test_kraken_user_connection_convergence_v90.py
+++ b/bot/tests/test_kraken_user_connection_convergence_v90.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from bot import kraken_all_account_supervision_v86 as v86
+from bot import kraken_user_connection_convergence_v90_patch as v90
+
+
+class _BrokerType:
+    value = "kraken"
+
+
+class _Broker:
+    def __init__(self, *, connected: bool, configured: bool = True) -> None:
+        self.connected = connected
+        self.credentials_configured = configured
+
+
+class KrakenUserConnectionConvergenceV90Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        with v90._LOCK:
+            v90._NEXT_REBUILD.clear()
+            v90._REBUILD_FAILURES.clear()
+
+    def tearDown(self) -> None:
+        with v90._LOCK:
+            v90._NEXT_REBUILD.clear()
+            v90._REBUILD_FAILURES.clear()
+        os.environ.pop("NIJA_KRAKEN_USER_CONNECTIONS_READY", None)
+
+    def _manager(self):
+        config = SimpleNamespace(user_id="alice")
+        return SimpleNamespace(
+            user_configs={"alice": config},
+            user_brokers={},
+            _all_user_brokers={},
+            _failed_user_connections={("alice", _BrokerType): "startup_failed"},
+            _users_without_credentials={},
+            _capital_blocked_users={},
+            _user_metadata={"alice": {"brokers": {_BrokerType: False}}},
+            _audit_user_trading_capital=lambda *args: (True, {"usable_balance": 100.0}, ""),
+        )
+
+    def test_missing_broker_rebuilds_through_canonical_manager_and_requires_real_connection(self) -> None:
+        manager = self._manager()
+        broker = _Broker(connected=True)
+        calls = []
+
+        def add_user_broker(user_id, broker_type):
+            calls.append((user_id, broker_type))
+            manager._all_user_brokers[(user_id, broker_type)] = broker
+            return broker
+
+        manager.add_user_broker = add_user_broker
+        with patch.object(v86, "_writer_proof", return_value=(True, "exact")):
+            recovered, state = v90._recover_broker(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+            )
+
+        self.assertIs(recovered, broker)
+        self.assertEqual(state, "connected")
+        self.assertEqual(calls, [("alice", _BrokerType)])
+        self.assertIs(manager.user_brokers["alice"][_BrokerType], broker)
+        self.assertTrue(manager._user_metadata["alice"]["brokers"][_BrokerType])
+        self.assertEqual(manager._failed_user_connections, {})
+
+    def test_missing_broker_never_rebuilds_without_exact_writer_proof(self) -> None:
+        manager = self._manager()
+        manager.add_user_broker = lambda *_args: self.fail("broker IO must not run")
+
+        with patch.object(v86, "_writer_proof", return_value=(False, "metadata_stale")):
+            recovered, state = v90._recover_broker(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+            )
+
+        self.assertIsNone(recovered)
+        self.assertEqual(state, "writer_proof_blocked:metadata_stale")
+        self.assertGreater(v90._NEXT_REBUILD["user:alice:kraken"], time.monotonic())
+
+    def test_rebuilt_broker_with_missing_credentials_remains_fail_closed(self) -> None:
+        manager = self._manager()
+        broker = _Broker(connected=False, configured=False)
+        manager.add_user_broker = lambda *_args: broker
+
+        with patch.object(v86, "_writer_proof", return_value=(True, "exact")):
+            recovered, state = v90._recover_broker(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+            )
+
+        self.assertIs(recovered, broker)
+        self.assertEqual(state, "credentials_not_configured")
+        self.assertIn(("alice", _BrokerType), manager._users_without_credentials)
+        self.assertFalse(manager._user_metadata["alice"]["brokers"][_BrokerType])
+
+    def test_rebuilt_disconnected_broker_is_left_for_v86_serialized_reconnect(self) -> None:
+        manager = self._manager()
+        broker = _Broker(connected=False, configured=True)
+        manager.add_user_broker = lambda *_args: broker
+
+        with patch.object(v86, "_writer_proof", return_value=(True, "exact")):
+            recovered, state = v90._recover_broker(
+                manager,
+                "user:alice:kraken",
+                "alice",
+                _BrokerType,
+            )
+
+        self.assertIs(recovered, broker)
+        self.assertEqual(state, "broker_recovered_reconnect_pending")
+        self.assertIn(("alice", _BrokerType), manager._failed_user_connections)
+        self.assertGreater(v90._NEXT_REBUILD["user:alice:kraken"], time.monotonic())
+
+    def test_schedule_reports_connected_only_after_authenticated_broker_truth(self) -> None:
+        manager = self._manager()
+        broker = _Broker(connected=True)
+        manager.add_user_broker = lambda *_args: broker
+        record = ("user:alice:kraken", "alice", _BrokerType, None)
+
+        with patch.object(v86, "_writer_proof", return_value=(True, "exact")):
+            state = v90._schedule_v90(manager, record)
+
+        self.assertEqual(state, "connected")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add v90 user-connection convergence for registered Kraken users whose broker object is missing or stale
- reconstruct only through canonical `MultiAccountBrokerManager.add_user_broker()` after exact writer proof
- require real authenticated `broker.connected` truth; never synthesize credentials, connectivity, balances, eligibility, execution authority, or kill-switch state
- re-use v86 serialized reconnect and capital eligibility reconciliation after reconstruction
- add per-user convergence telemetry so disconnect causes are visible
- chain v90 automatically from production runtime convergence v88

## Safety
- missing/invalid credentials remain fail-closed
- writer-proof failures perform no broker I/O
- capital eligibility remains authoritative
- canonical kill switch / EMERGENCY_STOP behavior is unchanged and is not auto-cleared

## Tests
Adds focused v90 tests for real connected recovery, writer-proof blocking, missing credentials, disconnected recovery handoff, and truthful connected-state reporting.