### PR TITLE
Repair live activation and runtime convergence

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -59,6 +59,11 @@ _FAST_PATH_INSTALLERS = (
     # canonical CapitalAuthority freshness contract. Protective reduce/exit
     # intents remain available when freshness is lost.
     ("bot.live_capital_freshness_v64_patch", "LIVE_CAPITAL_FRESHNESS_V64"),
+    # Close the remaining production liveness gaps without weakening execution:
+    # bound watchdog-driven refresh completion inside freshness, bridge v64
+    # across importlib, expose publication expiry dynamically, and reclaim scan
+    # ownership only when the recorded owner thread is actually gone.
+    ("bot.production_freshness_scan_convergence_v93_patch", "PRODUCTION_FRESHNESS_SCAN_V93"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation
     # monitors. It guards v60's request boundary and makes v16 readiness reflect

--- a/bot/live_active_dispatch_commit_v92_patch.py
+++ b/bot/live_active_dispatch_commit_v92_patch.py
@@ -8,8 +8,11 @@ dispatch orders.
 
 v92 does not force activation or weaken any gate. It only treats LIVE_ACTIVE as
 complete after StartupCoordinator.finalize_activation_commit() accepts the current
-canonical readiness proof. Failed or stale proofs remain fail closed and are
-retried by the existing v60 single-flight activation loop.
+canonical readiness proof. When the sole substantive blocker is a stale activation
+epoch, v92 re-records the canonical activation request to align activation_epoch to
+global_epoch, rebuilds the immutable readiness proof, and commits only if that
+fresh proof passes. Failed capital, readiness, authority, nonce, dispatch-health,
+or kill-switch gates remain fail closed.
 """
 from __future__ import annotations
 
@@ -31,6 +34,7 @@ _INSTALLED = False
 _HOOK_FLAG = "_NIJA_LIVE_ACTIVE_DISPATCH_COMMIT_V92_IMPORT_HOOK"
 _TSM_ATTR = "_nija_live_active_dispatch_commit_v92"
 _V60_ATTR = "_nija_live_active_dispatch_commit_v92"
+_EPOCH_RECOVERABLE_GATES = frozenset({"epoch.current", "runtime_authority.authorized"})
 
 
 def _truthy(name: str, default: str = "false") -> bool:
@@ -59,9 +63,100 @@ def _snapshot_details(snapshot: Any) -> dict[str, Any]:
         "runtime_authority_state": str(getattr(snapshot, "runtime_authority_state", "") or ""),
         "runtime_authority_reason": str(getattr(snapshot, "runtime_authority_reason", "") or ""),
         "execution_permitted": bool(getattr(snapshot, "execution_permitted", False)),
+        "activation_epoch": int(getattr(snapshot, "activation_epoch", 0) or 0),
+        "global_epoch": int(getattr(snapshot, "global_epoch", 0) or 0),
         "capital_stale": bool(getattr(snapshot, "capital_stale", False)),
+        "kill_switch_active": bool(getattr(snapshot, "kill_switch_active", False)),
+        "authority_ready": bool(getattr(snapshot, "authority_ready", False)),
+        "nonce_ready": bool(getattr(snapshot, "nonce_ready", False)),
+        "dispatch_health_ready": bool(getattr(snapshot, "dispatch_health_ready", False)),
         "pending_readiness": list(getattr(snapshot, "pending_readiness", []) or []),
     }
+
+
+def _proof_details(proof: Any) -> dict[str, Any]:
+    return {
+        "passed": bool(getattr(proof, "passed", False)),
+        "first_blocking_gate": str(getattr(proof, "first_blocking_gate", "") or ""),
+        "failed_gates": list(getattr(proof, "failed_gates", []) or []),
+        "gate_results": dict(getattr(proof, "gate_results", {}) or {}),
+    }
+
+
+def _maybe_reanchor_activation_epoch(
+    coordinator: Any,
+    snapshot: Any,
+    *,
+    source: str,
+) -> tuple[Any, bool, str, dict[str, Any]]:
+    """Re-anchor only the canonical activation request when epoch is stale.
+
+    This is intentionally narrow. It may run only when:
+    - no dispatch commit exists,
+    - the coordinator reports global_epoch_stale,
+    - epoch.current is failed,
+    - every failed gate is either epoch.current or the derived
+      runtime_authority.authorized gate.
+
+    The coordinator then rebuilds and re-evaluates the full readiness proof.
+    No other failed gate is repaired, marked ready, or bypassed here.
+    """
+    details: dict[str, Any] = {"attempted": False}
+    evaluator = getattr(coordinator, "evaluate_system_readiness_proof", None)
+    recorder = getattr(coordinator, "record_activation_requested", None)
+    if not callable(evaluator) or not callable(recorder):
+        return snapshot, False, "canonical_epoch_api_unavailable", details
+
+    try:
+        proof = evaluator(snapshot)
+    except Exception as exc:
+        details["proof_error"] = f"{type(exc).__name__}:{exc}"
+        return snapshot, False, "readiness_proof_unavailable", details
+
+    proof_info = _proof_details(proof)
+    details["before_proof"] = proof_info
+    if proof_info["passed"]:
+        return snapshot, False, "readiness_proof_already_passed", details
+
+    failed = set(proof_info["failed_gates"])
+    if "epoch.current" not in failed:
+        return snapshot, False, "epoch_not_blocking", details
+    if not failed.issubset(_EPOCH_RECOVERABLE_GATES):
+        details["non_epoch_blockers"] = sorted(failed - _EPOCH_RECOVERABLE_GATES)
+        return snapshot, False, "non_epoch_blockers_present", details
+    if int(getattr(snapshot, "last_committed_snapshot_version", 0) or 0) > 0:
+        return snapshot, False, "dispatch_commit_already_present", details
+    if str(getattr(snapshot, "runtime_authority_reason", "") or "") != "global_epoch_stale":
+        return snapshot, False, "epoch_failure_not_global_epoch_stale", details
+    if bool(getattr(snapshot, "kill_switch_active", False)):
+        return snapshot, False, "kill_switch_active", details
+
+    details["attempted"] = True
+    recorder(
+        requested=True,
+        source=f"{MARKER}:{source}:epoch_reanchor",
+    )
+    refreshed = coordinator.build_snapshot(
+        trading_state="LIVE_ACTIVE",
+        activation_intent=True,
+    )
+    refreshed_proof = evaluator(refreshed)
+    details["after_snapshot"] = _snapshot_details(refreshed)
+    details["after_proof"] = _proof_details(refreshed_proof)
+    if not bool(getattr(refreshed_proof, "passed", False)):
+        first = str(getattr(refreshed_proof, "first_blocking_gate", "unknown") or "unknown")
+        return refreshed, False, f"epoch_reanchor_proof_failed:{first}", details
+
+    LOGGER.critical(
+        "LIVE_ACTIVE_ACTIVATION_EPOCH_REANCHORED marker=%s source=%s "
+        "activation_epoch=%s global_epoch=%s canonical_proof_passed=true "
+        "safety_gates_preserved=true",
+        MARKER,
+        source,
+        getattr(refreshed, "activation_epoch", 0),
+        getattr(refreshed, "global_epoch", 0),
+    )
+    return refreshed, True, "activation_epoch_reanchored", details
 
 
 def _ensure_coordinator_dispatch_commit(
@@ -73,7 +168,7 @@ def _ensure_coordinator_dispatch_commit(
 
     The coordinator's own readiness proof remains the authority. This helper
     never mutates trading state, readiness keys, risk thresholds, nonce state,
-    or kill-switch state.
+    dispatch-health state, or kill-switch state.
     """
     state = _state_value(sm)
     details: dict[str, Any] = {"state": state, "source": source}
@@ -100,7 +195,20 @@ def _ensure_coordinator_dispatch_commit(
         ):
             return True, "dispatch_commit_already_current", details
 
-        coordinator.finalize_activation_commit(before)
+        commit_snapshot, reanchored, reanchor_reason, reanchor_details = (
+            _maybe_reanchor_activation_epoch(
+                coordinator,
+                before,
+                source=source,
+            )
+        )
+        details["epoch_reanchor"] = {
+            "reanchored": bool(reanchored),
+            "reason": reanchor_reason,
+            **reanchor_details,
+        }
+
+        coordinator.finalize_activation_commit(commit_snapshot)
         after = coordinator.build_snapshot(
             trading_state="LIVE_ACTIVE",
             activation_intent=True,
@@ -111,11 +219,13 @@ def _ensure_coordinator_dispatch_commit(
         if committed and permitted:
             LOGGER.critical(
                 "LIVE_ACTIVE_DISPATCH_COMMIT_REPAIRED marker=%s source=%s "
-                "commit_version=%s runtime_authority=%s safety_gates_preserved=true",
+                "commit_version=%s runtime_authority=%s epoch_reanchored=%s "
+                "safety_gates_preserved=true",
                 MARKER,
                 source,
                 getattr(after, "last_committed_snapshot_version", 0),
                 getattr(after, "runtime_authority_state", "unknown"),
+                bool(reanchored),
             )
             return True, "dispatch_commit_repaired", details
         return False, "dispatch_commit_not_executing_after_finalize", details
@@ -309,6 +419,7 @@ __all__ = [
     "install",
     "install_import_hook",
     "_ensure_coordinator_dispatch_commit",
+    "_maybe_reanchor_activation_epoch",
     "_patch_trading_state_machine",
     "_patch_v60_worker",
 ]

--- a/bot/production_freshness_scan_convergence_v93_patch.py
+++ b/bot/production_freshness_scan_convergence_v93_patch.py
@@ -1,0 +1,382 @@
+"""Production freshness and scan-owner convergence hardening v93.
+
+Production evidence on 2026-08-14 exposed two independent liveness gaps while
+all execution safety gates correctly remained fail closed:
+
+1. Capital refresh is triggered by a 10s watchdog after a 30s stale threshold,
+   but v78 allowed the synchronous balance batch to wait up to 60s. A refresh
+   that begins near 40s of snapshot age can therefore finish after the canonical
+   90s freshness TTL. The older preactivation v16 observer can also be loaded
+   through ``importlib.import_module`` after v64 installs, bypassing v64's
+   builtins-only import hook and reintroducing the legacy 60s freshness view.
+2. Duplicate account scans can wait 300s for an existing scan owner. A live but
+   slow Coinbase owner was observed at >780s age, tying up a second caller for
+   the full five minutes. Blindly replacing a state owned by a live thread would
+   be unsafe because it could create concurrent scans for the same account.
+
+v93 closes those gaps without authorizing execution. It bounds the synchronous
+capital publication budget against watchdog timing, bridges v64 across
+``importlib.import_module``, makes snapshot-publication expiry observable, caps
+duplicate scan-result waits, and reclaims scan state only when the recorded
+owner thread is actually gone. A live stalled owner is never force-unlocked or
+replaced.
+"""
+from __future__ import annotations
+
+import builtins
+from datetime import datetime, timezone
+from functools import wraps
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.production_freshness_scan_convergence_v93")
+MARKER = "20260814-production-freshness-scan-convergence-v93"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_MONITOR_STARTED = False
+_LAST_STALL_WARNING: dict[str, float] = {}
+_IMPORTLIB_HOOK_FLAG = "_NIJA_PRODUCTION_FRESHNESS_SCAN_V93_IMPORTLIB_HOOK"
+_BUILTINS_HOOK_FLAG = "_NIJA_PRODUCTION_FRESHNESS_SCAN_V93_BUILTINS_HOOK"
+_V78_ATTR = "_nija_production_freshness_scan_v93"
+_CA_ATTR = "_nija_production_freshness_scan_v93"
+
+
+def _float_env(name: str, default: float, *, minimum: float = 0.0) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        value = float(default)
+    return max(float(minimum), value)
+
+
+def _freshness_ttl_s() -> float:
+    return _float_env("NIJA_CAPITAL_FRESHNESS_TTL_S", 90.0, minimum=10.0)
+
+
+def _watchdog_interval_s() -> float:
+    return _float_env("NIJA_CAPITAL_WATCHDOG_INTERVAL_S", 10.0, minimum=1.0)
+
+
+def _stale_trigger_s() -> float:
+    return _float_env("NIJA_CAPITAL_STALE_TIMEOUT_S", 30.0, minimum=1.0)
+
+
+def _publish_headroom_s() -> float:
+    return _float_env("NIJA_CAPITAL_REFRESH_FINALIZE_HEADROOM_S", 5.0, minimum=2.0)
+
+
+def continuity_budget_ceiling_s() -> float:
+    """Latest safe synchronous fetch budget for the watchdog-driven refresh.
+
+    Worst-case refresh start is one watchdog interval after the stale trigger.
+    Reserve a small finalization headroom for snapshot construction/publication.
+    The result is fail-closed and never extends v78's existing budget.
+    """
+    ttl = _freshness_ttl_s()
+    worst_start_age = _stale_trigger_s() + _watchdog_interval_s()
+    return max(5.0, ttl - worst_start_age - _publish_headroom_s())
+
+
+def _bound_runtime_cadence_env() -> dict[str, float]:
+    """Prevent operator cadence values from making freshness mathematically impossible."""
+    ttl = _freshness_ttl_s()
+    stale = min(_stale_trigger_s(), max(10.0, ttl / 3.0))
+    watchdog = min(_watchdog_interval_s(), max(2.0, ttl / 9.0))
+    os.environ["NIJA_CAPITAL_STALE_TIMEOUT_S"] = f"{stale:.6f}"
+    os.environ["NIJA_CAPITAL_WATCHDOG_INTERVAL_S"] = f"{watchdog:.6f}"
+
+    duplicate_wait = _float_env("NIJA_DUPLICATE_SCAN_RESULT_WAIT_S", 15.0, minimum=5.0)
+    duplicate_wait = min(duplicate_wait, 15.0)
+    os.environ["NIJA_DUPLICATE_SCAN_RESULT_WAIT_S"] = f"{duplicate_wait:.6f}"
+    return {
+        "ttl_s": ttl,
+        "stale_trigger_s": stale,
+        "watchdog_interval_s": watchdog,
+        "duplicate_scan_wait_s": duplicate_wait,
+    }
+
+
+def _patch_v78(module: ModuleType) -> bool:
+    current = getattr(module, "fetch_budget_seconds", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V78_ATTR, False):
+        return True
+
+    @wraps(current)
+    def fetch_budget_seconds_v93() -> float:
+        base_budget = max(5.0, float(current()))
+        ceiling = continuity_budget_ceiling_s()
+        return max(5.0, min(base_budget, ceiling))
+
+    setattr(fetch_budget_seconds_v93, _V78_ATTR, True)
+    setattr(fetch_budget_seconds_v93, "__wrapped__", current)
+    module.fetch_budget_seconds = fetch_budget_seconds_v93
+    LOGGER.critical(
+        "CAPITAL_REFRESH_V93_BUDGET_PATCHED marker=%s effective_budget_s=%.1f "
+        "continuity_ceiling_s=%.1f ttl_s=%.1f stale_trigger_s=%.1f watchdog_s=%.1f",
+        MARKER,
+        fetch_budget_seconds_v93(),
+        continuity_budget_ceiling_s(),
+        _freshness_ttl_s(),
+        _stale_trigger_s(),
+        _watchdog_interval_s(),
+    )
+    return True
+
+
+def _patch_v64_bridge(module: ModuleType) -> bool:
+    """Apply v64 to already-loaded targets; future importlib loads use our bridge."""
+    patch_loaded = getattr(module, "_patch_loaded", None)
+    if not callable(patch_loaded):
+        return False
+    patch_loaded()
+    return True
+
+
+def _normalize_expiry(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _patch_capital_authority(module: ModuleType) -> bool:
+    """Make publication status report expiry dynamically instead of latched-false forever."""
+    cls = getattr(module, "CapitalAuthority", None)
+    status_cls = getattr(module, "SnapshotPublicationStatus", None)
+    if not isinstance(cls, type) or status_cls is None:
+        return False
+    current = getattr(cls, "get_snapshot_publication_status", None)
+    if not callable(current):
+        return False
+    if getattr(current, _CA_ATTR, False):
+        return True
+
+    @wraps(current)
+    def get_snapshot_publication_status_v93(self: Any):
+        status = current(self)
+        if bool(getattr(status, "stale", False)):
+            return status
+        expiry = _normalize_expiry(getattr(status, "expiry", None))
+        if expiry is None or datetime.now(timezone.utc) < expiry:
+            return status
+        try:
+            return status_cls(
+                accepted=bool(getattr(status, "accepted", False)),
+                stale=True,
+                reason="snapshot_expired",
+                timestamp=getattr(status, "timestamp", None),
+                expiry=getattr(status, "expiry", None),
+            )
+        except Exception:
+            return status
+
+    setattr(get_snapshot_publication_status_v93, _CA_ATTR, True)
+    setattr(get_snapshot_publication_status_v93, "__wrapped__", current)
+    cls.get_snapshot_publication_status = get_snapshot_publication_status_v93
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_STATUS_V93_PATCHED marker=%s dynamic_expiry=true",
+        MARKER,
+    )
+    return True
+
+
+def _thread_ident_alive(ident: Any) -> bool:
+    try:
+        target = int(ident)
+    except (TypeError, ValueError):
+        return False
+    if target <= 0:
+        return False
+    return any(
+        bool(thread.is_alive()) and thread.ident == target
+        for thread in threading.enumerate()
+    )
+
+
+def _scan_module() -> ModuleType | None:
+    for name in ("scan_wrapper_convergence_repair_patch", "nija.scan_wrapper_convergence_repair_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    return None
+
+
+def _sweep_scan_states_once(module: ModuleType | None = None) -> dict[str, int]:
+    """Reclaim only orphaned scan ownership; never replace a live owner's state."""
+    module = module or _scan_module()
+    result = {"live_stalled": 0, "orphan_reset": 0}
+    if module is None:
+        return result
+    states = getattr(module, "_SCAN_STATES", None)
+    guard = getattr(module, "_SCAN_STATES_GUARD", None)
+    state_cls = getattr(module, "ScanState", None)
+    if not isinstance(states, dict) or guard is None or not isinstance(state_cls, type):
+        return result
+
+    min_orphan_age = _float_env("NIJA_SCAN_ORPHAN_RESET_MIN_AGE_S", 60.0, minimum=30.0)
+    stall_warn_age = _float_env("NIJA_SCAN_LIVE_OWNER_WARN_AGE_S", 180.0, minimum=60.0)
+    now = time.monotonic()
+    with guard:
+        for key, state in list(states.items()):
+            owner = getattr(state, "owner_thread_id", None)
+            started = float(getattr(state, "started_at", 0.0) or 0.0)
+            if owner is None or started <= 0.0:
+                continue
+            age = max(0.0, now - started)
+            alive = _thread_ident_alive(owner)
+            if not alive and age >= min_orphan_age:
+                # Re-check identity while holding the canonical state-map guard;
+                # replace only the exact state object we inspected.
+                if states.get(key) is state and getattr(state, "owner_thread_id", None) == owner:
+                    states[key] = state_cls()
+                    result["orphan_reset"] += 1
+                    LOGGER.critical(
+                        "SCAN_ORPHAN_OWNER_RESET marker=%s identity=%s owner_thread=%s "
+                        "age_s=%.2f concurrent_scan_created=false next_cycle_retry=true",
+                        MARKER,
+                        key,
+                        owner,
+                        age,
+                    )
+                continue
+            if alive and age >= stall_warn_age:
+                result["live_stalled"] += 1
+                last = float(_LAST_STALL_WARNING.get(str(key), 0.0) or 0.0)
+                if (now - last) >= 60.0:
+                    _LAST_STALL_WARNING[str(key)] = now
+                    LOGGER.critical(
+                        "SCAN_LIVE_OWNER_STALLED marker=%s identity=%s owner_thread=%s "
+                        "age_s=%.2f action=preserve_owner fail_closed=true",
+                        MARKER,
+                        key,
+                        owner,
+                        age,
+                    )
+    return result
+
+
+def _scan_owner_monitor() -> None:
+    while True:
+        try:
+            _sweep_scan_states_once()
+        except Exception as exc:
+            LOGGER.debug("SCAN_OWNER_V93_MONITOR_ERROR error=%s:%s", type(exc).__name__, exc)
+        time.sleep(5.0)
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    for name in ("bot.capital_refresh_live_continuity_v78_patch", "capital_refresh_live_continuity_v78_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_v78(module) or changed
+    for name in ("bot.live_capital_freshness_v64_patch", "live_capital_freshness_v64_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_v64_bridge(module) or changed
+    for name in ("bot.capital_authority", "capital_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            changed = _patch_capital_authority(module) or changed
+    return changed
+
+
+def _install_import_hooks() -> None:
+    if not getattr(importlib.import_module, _IMPORTLIB_HOOK_FLAG, False):
+        original_import_module = importlib.import_module
+
+        @wraps(original_import_module)
+        def import_module_v93(name: str, package: str | None = None):
+            result = original_import_module(name, package)
+            text = str(name or "")
+            if any(token in text for token in (
+                "preactivation_readiness_convergence_v16_patch",
+                "live_capital_freshness_v64_patch",
+                "capital_refresh_live_continuity_v78_patch",
+                "capital_authority",
+            )):
+                _patch_loaded()
+                v64 = sys.modules.get("bot.live_capital_freshness_v64_patch") or sys.modules.get("live_capital_freshness_v64_patch")
+                if isinstance(v64, ModuleType):
+                    patch_loaded = getattr(v64, "_patch_loaded", None)
+                    if callable(patch_loaded):
+                        patch_loaded()
+            return result
+
+        setattr(import_module_v93, _IMPORTLIB_HOOK_FLAG, True)
+        setattr(import_module_v93, "__wrapped__", original_import_module)
+        importlib.import_module = import_module_v93
+
+    if not getattr(builtins, _BUILTINS_HOOK_FLAG, False):
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def importing_v93(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            result = original_import(name, globals, locals, fromlist, level)
+            if any(token in str(name or "") for token in (
+                "preactivation_readiness_convergence_v16_patch",
+                "capital_authority",
+            )):
+                _patch_loaded()
+            return result
+
+        builtins.__import__ = importing_v93
+        setattr(builtins, _BUILTINS_HOOK_FLAG, True)
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED, _MONITOR_STARTED
+    with _LOCK:
+        cadence = _bound_runtime_cadence_env()
+        _patch_loaded()
+        _install_import_hooks()
+        _patch_loaded()
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_scan_owner_monitor,
+                name="ProductionFreshnessScanV93",
+                daemon=True,
+            ).start()
+        _INSTALLED = True
+        os.environ["NIJA_PRODUCTION_FRESHNESS_SCAN_V93_INSTALLED"] = "1"
+        os.environ["NIJA_PRODUCTION_FRESHNESS_SCAN_V93_READY"] = "1"
+        LOGGER.critical(
+            "PRODUCTION_FRESHNESS_SCAN_V93_INSTALLED marker=%s ttl_s=%.1f "
+            "stale_trigger_s=%.1f watchdog_s=%.1f fetch_budget_ceiling_s=%.1f "
+            "duplicate_scan_wait_s=%.1f live_scan_owner_force_reset=false",
+            MARKER,
+            cadence["ttl_s"],
+            cadence["stale_trigger_s"],
+            cadence["watchdog_interval_s"],
+            continuity_budget_ceiling_s(),
+            cadence["duplicate_scan_wait_s"],
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "continuity_budget_ceiling_s",
+    "install",
+    "install_import_hook",
+    "_bound_runtime_cadence_env",
+    "_patch_capital_authority",
+    "_patch_v64_bridge",
+    "_patch_v78",
+    "_sweep_scan_states_once",
+    "_thread_ident_alive",
+]

--- a/bot/tests/test_live_active_dispatch_commit_v92_epoch.py
+++ b/bot/tests/test_live_active_dispatch_commit_v92_epoch.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import types
+
+from bot import live_active_dispatch_commit_v92_patch as repair
+
+
+class _LiveSM:
+    def get_current_state(self):
+        return "LIVE_ACTIVE"
+
+
+class _Snapshot:
+    def __init__(
+        self,
+        *,
+        runtime_authority_reason: str,
+        activation_epoch: int,
+        global_epoch: int,
+        capital_stale: bool = False,
+    ):
+        self.last_committed_snapshot_version = 0
+        self.execution_permitted = False
+        self.runtime_authority_state = "DEGRADED"
+        self.runtime_authority_reason = runtime_authority_reason
+        self.activation_epoch = activation_epoch
+        self.global_epoch = global_epoch
+        self.capital_stale = capital_stale
+        self.kill_switch_active = False
+        self.authority_ready = True
+        self.nonce_ready = True
+        self.dispatch_health_ready = True
+        self.pending_readiness = []
+
+
+class _Proof:
+    def __init__(self, passed: bool, failed_gates=()):
+        self.passed = bool(passed)
+        self.failed_gates = list(failed_gates)
+        self.first_blocking_gate = self.failed_gates[0] if self.failed_gates else "none"
+        self.gate_results = {name: False for name in self.failed_gates}
+
+
+def _enable_live_mode(monkeypatch):
+    monkeypatch.setenv("LIVE_CAPITAL_VERIFIED", "1")
+    monkeypatch.delenv("DRY_RUN_MODE", raising=False)
+    monkeypatch.delenv("PAPER_MODE", raising=False)
+
+
+def _patch_coordinator_module(monkeypatch, coordinator):
+    fake_module = types.SimpleNamespace(get_startup_coordinator=lambda: coordinator)
+    real_import = repair.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.startup_coordinator":
+            return fake_module
+        return real_import(name)
+
+    monkeypatch.setattr(repair.importlib, "import_module", fake_import)
+
+
+def test_epoch_only_stale_live_state_reanchors_then_commits(monkeypatch):
+    _enable_live_mode(monkeypatch)
+    before = _Snapshot(
+        runtime_authority_reason="global_epoch_stale",
+        activation_epoch=4,
+        global_epoch=5,
+    )
+    refreshed = types.SimpleNamespace(
+        last_committed_snapshot_version=0,
+        execution_permitted=False,
+        runtime_authority_state="AUTHORIZED",
+        runtime_authority_reason="authority_converged",
+        activation_epoch=5,
+        global_epoch=5,
+        capital_stale=False,
+        kill_switch_active=False,
+        authority_ready=True,
+        nonce_ready=True,
+        dispatch_health_ready=True,
+        pending_readiness=[],
+    )
+    after = types.SimpleNamespace(
+        last_committed_snapshot_version=29,
+        execution_permitted=True,
+        runtime_authority_state="EXECUTING",
+        runtime_authority_reason="dispatch_committed",
+        activation_epoch=5,
+        global_epoch=5,
+        capital_stale=False,
+        kill_switch_active=False,
+        authority_ready=True,
+        nonce_ready=True,
+        dispatch_health_ready=True,
+        pending_readiness=[],
+    )
+
+    class Coordinator:
+        def __init__(self):
+            self.phase = 0
+            self.reanchor_calls = 0
+            self.finalize_calls = 0
+
+        def build_snapshot(self, *, trading_state, activation_intent):
+            assert trading_state == "LIVE_ACTIVE"
+            assert activation_intent is True
+            return (before, refreshed, after)[self.phase]
+
+        def evaluate_system_readiness_proof(self, snapshot):
+            if snapshot is before:
+                return _Proof(False, ("epoch.current", "runtime_authority.authorized"))
+            return _Proof(True)
+
+        def record_activation_requested(self, *, requested, source):
+            assert requested is True
+            assert "epoch_reanchor" in source
+            self.reanchor_calls += 1
+            self.phase = 1
+            return 1
+
+        def finalize_activation_commit(self, snapshot):
+            assert snapshot is refreshed
+            self.finalize_calls += 1
+            self.phase = 2
+            return 2
+
+    coordinator = Coordinator()
+    _patch_coordinator_module(monkeypatch, coordinator)
+    ok, reason, details = repair._ensure_coordinator_dispatch_commit(
+        _LiveSM(), source="test_epoch"
+    )
+
+    assert ok is True
+    assert reason == "dispatch_commit_repaired"
+    assert coordinator.reanchor_calls == 1
+    assert coordinator.finalize_calls == 1
+    assert details["epoch_reanchor"]["reanchored"] is True
+    assert details["after"]["commit_version"] == 29
+
+
+def test_epoch_reanchor_refuses_non_epoch_blocker(monkeypatch):
+    _enable_live_mode(monkeypatch)
+    before = _Snapshot(
+        runtime_authority_reason="global_epoch_stale",
+        activation_epoch=8,
+        global_epoch=9,
+        capital_stale=True,
+    )
+
+    class Coordinator:
+        def __init__(self):
+            self.reanchor_calls = 0
+
+        def build_snapshot(self, *, trading_state, activation_intent):
+            return before
+
+        def evaluate_system_readiness_proof(self, _snapshot):
+            return _Proof(
+                False,
+                ("capital.not_stale", "epoch.current", "runtime_authority.authorized"),
+            )
+
+        def record_activation_requested(self, **_kwargs):
+            self.reanchor_calls += 1
+            raise AssertionError("must not reanchor through a capital blocker")
+
+        def finalize_activation_commit(self, _snapshot):
+            raise RuntimeError(
+                "LIVE commit blocked: system readiness proof failed at capital.not_stale"
+            )
+
+    coordinator = Coordinator()
+    _patch_coordinator_module(monkeypatch, coordinator)
+    ok, reason, details = repair._ensure_coordinator_dispatch_commit(
+        _LiveSM(), source="test_non_epoch_blocker"
+    )
+
+    assert ok is False
+    assert reason == "dispatch_commit_deferred:RuntimeError"
+    assert coordinator.reanchor_calls == 0
+    assert details["epoch_reanchor"]["reason"] == "non_epoch_blockers_present"
+    assert details["epoch_reanchor"]["non_epoch_blockers"] == ["capital.not_stale"]
+
+
+def test_epoch_reanchor_requires_global_epoch_stale_reason(monkeypatch):
+    _enable_live_mode(monkeypatch)
+    before = _Snapshot(
+        runtime_authority_reason="authority_regressed",
+        activation_epoch=3,
+        global_epoch=4,
+    )
+
+    class Coordinator:
+        def __init__(self):
+            self.reanchor_calls = 0
+
+        def build_snapshot(self, *, trading_state, activation_intent):
+            return before
+
+        def evaluate_system_readiness_proof(self, _snapshot):
+            return _Proof(False, ("epoch.current", "runtime_authority.authorized"))
+
+        def record_activation_requested(self, **_kwargs):
+            self.reanchor_calls += 1
+            raise AssertionError("must not reanchor unrelated authority regression")
+
+        def finalize_activation_commit(self, _snapshot):
+            raise RuntimeError(
+                "LIVE commit blocked: system readiness proof failed at epoch.current"
+            )
+
+    coordinator = Coordinator()
+    _patch_coordinator_module(monkeypatch, coordinator)
+    ok, _reason, details = repair._ensure_coordinator_dispatch_commit(
+        _LiveSM(), source="test_wrong_reason"
+    )
+
+    assert ok is False
+    assert coordinator.reanchor_calls == 0
+    assert details["epoch_reanchor"]["reason"] == "epoch_failure_not_global_epoch_stale"

--- a/bot/tests/test_production_freshness_scan_convergence_v93.py
+++ b/bot/tests/test_production_freshness_scan_convergence_v93.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import os
+import threading
+import time
+import types
+import unittest
+
+from bot import production_freshness_scan_convergence_v93_patch as v93
+
+
+class ProductionFreshnessScanConvergenceV93Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.keys = (
+            "NIJA_CAPITAL_FRESHNESS_TTL_S",
+            "NIJA_CAPITAL_STALE_TIMEOUT_S",
+            "NIJA_CAPITAL_WATCHDOG_INTERVAL_S",
+            "NIJA_CAPITAL_REFRESH_FINALIZE_HEADROOM_S",
+            "NIJA_DUPLICATE_SCAN_RESULT_WAIT_S",
+            "NIJA_SCAN_ORPHAN_RESET_MIN_AGE_S",
+            "NIJA_SCAN_LIVE_OWNER_WARN_AGE_S",
+        )
+        self.previous = {key: os.environ.get(key) for key in self.keys}
+        for key in self.keys:
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        for key, value in self.previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_default_refresh_budget_ceiling_finishes_before_freshness_expiry(self):
+        self.assertEqual(v93.continuity_budget_ceiling_s(), 45.0)
+
+    def test_v78_budget_is_only_shortened(self):
+        fake = types.ModuleType("fake_v78")
+        fake.fetch_budget_seconds = lambda: 60.0
+        self.assertTrue(v93._patch_v78(fake))
+        self.assertEqual(fake.fetch_budget_seconds(), 45.0)
+
+        os.environ["NIJA_CAPITAL_REFRESH_FETCH_BUDGET_SECONDS"] = "10"
+        fake2 = types.ModuleType("fake_v78_2")
+        fake2.fetch_budget_seconds = lambda: 10.0
+        self.assertTrue(v93._patch_v78(fake2))
+        self.assertEqual(fake2.fetch_budget_seconds(), 10.0)
+
+    def test_runtime_cadence_is_bounded_but_never_relaxes_freshness(self):
+        os.environ["NIJA_CAPITAL_FRESHNESS_TTL_S"] = "90"
+        os.environ["NIJA_CAPITAL_STALE_TIMEOUT_S"] = "80"
+        os.environ["NIJA_CAPITAL_WATCHDOG_INTERVAL_S"] = "50"
+        os.environ["NIJA_DUPLICATE_SCAN_RESULT_WAIT_S"] = "300"
+
+        values = v93._bound_runtime_cadence_env()
+
+        self.assertLessEqual(values["stale_trigger_s"], 30.0)
+        self.assertLessEqual(values["watchdog_interval_s"], 10.0)
+        self.assertLessEqual(values["duplicate_scan_wait_s"], 15.0)
+        self.assertGreaterEqual(v93.continuity_budget_ceiling_s(), 5.0)
+
+    def test_capital_publication_status_expires_dynamically(self):
+        class Status:
+            def __init__(self, accepted, stale, reason, timestamp, expiry):
+                self.accepted = accepted
+                self.stale = stale
+                self.reason = reason
+                self.timestamp = timestamp
+                self.expiry = expiry
+
+        class Authority:
+            def __init__(self, status):
+                self.status = status
+
+            def get_snapshot_publication_status(self):
+                return self.status
+
+        fake = types.ModuleType("fake_capital_authority")
+        fake.SnapshotPublicationStatus = Status
+        fake.CapitalAuthority = Authority
+        self.assertTrue(v93._patch_capital_authority(fake))
+
+        now = datetime.now(timezone.utc)
+        authority = Authority(Status(True, False, "accepted", now - timedelta(seconds=100), now - timedelta(seconds=1)))
+        expired = authority.get_snapshot_publication_status()
+        self.assertTrue(expired.stale)
+        self.assertEqual(expired.reason, "snapshot_expired")
+
+        authority.status = Status(True, False, "accepted", now, now + timedelta(seconds=30))
+        fresh = authority.get_snapshot_publication_status()
+        self.assertFalse(fresh.stale)
+        self.assertEqual(fresh.reason, "accepted")
+
+    def test_orphaned_scan_owner_is_reclaimed_only_when_thread_is_dead(self):
+        class ScanState:
+            def __init__(self):
+                self.lock = threading.Lock()
+                self.complete = threading.Event()
+                self.result = None
+                self.owner_thread_id = None
+                self.started_at = 0.0
+
+        fake = types.ModuleType("fake_scan")
+        fake.ScanState = ScanState
+        fake._SCAN_STATES_GUARD = threading.RLock()
+        dead = ScanState()
+        dead.owner_thread_id = 999999999
+        dead.started_at = time.monotonic() - 120.0
+        fake._SCAN_STATES = {"platform:coinbase": dead}
+
+        result = v93._sweep_scan_states_once(fake)
+
+        self.assertEqual(result["orphan_reset"], 1)
+        self.assertIsNot(fake._SCAN_STATES["platform:coinbase"], dead)
+        self.assertIsNone(fake._SCAN_STATES["platform:coinbase"].owner_thread_id)
+
+    def test_live_scan_owner_is_never_replaced(self):
+        class ScanState:
+            def __init__(self):
+                self.lock = threading.Lock()
+                self.complete = threading.Event()
+                self.result = None
+                self.owner_thread_id = threading.get_ident()
+                self.started_at = time.monotonic() - 240.0
+
+        fake = types.ModuleType("fake_scan_live")
+        fake.ScanState = ScanState
+        fake._SCAN_STATES_GUARD = threading.RLock()
+        state = ScanState()
+        fake._SCAN_STATES = {"platform:coinbase": state}
+
+        result = v93._sweep_scan_states_once(fake)
+
+        self.assertEqual(result["orphan_reset"], 0)
+        self.assertEqual(result["live_stalled"], 1)
+        self.assertIs(fake._SCAN_STATES["platform:coinbase"], state)
+
+    def test_v64_bridge_reapplies_loaded_target_patches(self):
+        fake = types.ModuleType("fake_v64")
+        calls = []
+        fake._patch_loaded = lambda: calls.append("patched") or True
+
+        self.assertTrue(v93._patch_v64_bridge(fake))
+        self.assertEqual(calls, ["patched"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- safely re-anchor an already-LIVE_ACTIVE activation epoch only when `epoch.current` is the sole substantive coordinator blocker
- require the complete canonical readiness proof to pass again before finalizing the dispatch commit
- bound watchdog-driven synchronous capital refresh so publication can finish before the canonical capital freshness TTL expires
- bridge live-capital freshness v64 across `importlib.import_module` so late-loaded preactivation modules cannot fall back to the legacy 60-second stale view
- make `CapitalAuthority.get_snapshot_publication_status()` report expiration dynamically once its stored expiry is crossed
- cap duplicate scan-result waiting to 15 seconds and reclaim scan state only when the recorded owner thread is no longer alive
- preserve live stalled scan owners rather than force-unlocking them, preventing concurrent scans for the same account
- add focused regression coverage for epoch recovery, non-epoch fail-closed behavior, capital timing, dynamic publication expiry, and orphan/live scan ownership

## Production evidence
Deployment `0ae28f84977c033290da0db10dfeb38d41592790` showed three independent liveness defects while the safety gates stayed fail closed:

1. `LIVE_ACTIVE` could exist with coordinator `commit_version=0` because activation epoch was stale.
2. Current preactivation capital proof repeatedly reported `broker_connected`, `balance_hydrated`, and `capital_ready` pending even while writer heartbeat remained healthy and the sticky readiness table was all true.
3. Coinbase produced `SCAN_OWNER_TIMEOUT` with an owner age above 780 seconds after a second caller waited the full 300 seconds.

The capital timing contradiction was structural: watchdog defaults are 30 seconds stale threshold + up to 10 seconds polling, while v78 allowed a 60-second synchronous fetch budget against a 90-second freshness TTL. v93 caps that synchronous budget to 45 seconds by default, retaining finalization headroom and never extending an existing stricter budget.

## Safety
- no force activation
- no readiness key is synthesized or marked ready by the new repair
- no writer, authority, nonce, risk, strategy, capital, dispatch-health, or kill-switch gate is bypassed
- stale/incomplete/unfunded capital still blocks new entries
- protective reduce/exit intents remain available under existing v64 behavior
- live scan owners are never force-reset; only orphaned state whose owner thread is gone can be reclaimed
- activation epoch re-anchor uses only `StartupCoordinator.record_activation_requested()` and then re-runs the full proof

## Validation
- this PR points at the exact same tested head as superseded PR #2517, but uses a repository-compliant `fix/*` branch name
- branch is five commits ahead of deployed `0ae28f...` and not behind main
- changed scope is limited to `bot/bot.py`, v92 activation convergence, new v93 runtime convergence, and focused tests
- focused tests cover epoch-only recovery, refusal with real safety blockers, capital timing bounds, publication expiry, and dead-vs-live scan ownership
- GitHub Actions will be re-evaluated on this compliant branch