### PR TITLE
Bound startup position sync and unblock core handoff

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -64,6 +64,10 @@ _FAST_PATH_INSTALLERS = (
     # across importlib, expose publication expiry dynamically, and reclaim scan
     # ownership only when the recorded owner thread is actually gone.
     ("bot.production_freshness_scan_convergence_v93_patch", "PRODUCTION_FRESHNESS_SCAN_V93"),
+    # Bound startup position snapshots so a slow venue cannot hold the main
+    # startup thread indefinitely. v95 also makes position-sync completion a
+    # fail-closed activation prerequisite rather than pre-latching success.
+    ("bot.position_sync_core_handoff_v95_patch", "POSITION_SYNC_CORE_HANDOFF_V95"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation
     # monitors. It guards v60's request boundary and makes v16 readiness reflect

--- a/bot/position_sync_core_handoff_v95_patch.py
+++ b/bot/position_sync_core_handoff_v95_patch.py
@@ -1,0 +1,347 @@
+"""Bound startup position synchronization without weakening activation safety.
+
+Production deployment 8e4ba829 showed capital and writer convergence succeeding,
+then the process remained in THREADS_STARTING with no registered core. The last
+forward-progress message was EXCHANGE_POSITION_SYNC starting with three connected
+platform brokers and no subsequent per-broker completion. The historical startup
+hook performs that reconciliation synchronously inside refresh_capital_authority
+and may pre-latch _startup_position_sync_done before broker.get_positions returns.
+
+v95 repairs the liveness/safety split:
+* broker get_positions calls are bounded single-flight operations; a timed-out
+  request stays in one daemon worker and later callers reuse that same flight;
+* a timeout raises TimeoutError so startup_position_sync never interprets it as
+  a valid empty position snapshot;
+* the manager's _startup_position_sync_done flag is recomputed from the actual
+  _startup_position_sync_adopted state of every connected broker;
+* v61 activation remains fail closed until every currently connected broker has
+  completed a real position snapshot.
+
+No readiness key, writer/nonce authority, kill switch, risk gate, or execution
+permission is synthesized by this patch.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.position_sync_core_handoff_v95")
+MARKER = "20260814-position-sync-core-handoff-v95"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_POSITION_SYNC_CORE_HANDOFF_V95_IMPORT_HOOK"
+_GET_POSITIONS_ATTR = "_nija_position_sync_core_handoff_v95"
+_REFRESH_ATTR = "_nija_position_sync_core_handoff_v95"
+_V61_ATTR = "_nija_position_sync_core_handoff_v95"
+_FLIGHTS: dict[int, dict[str, Any]] = {}
+
+
+def _timeout_s() -> float:
+    try:
+        return max(0.1, float(os.environ.get("NIJA_POSITION_FETCH_TIMEOUT_S", "5") or 5.0))
+    except (TypeError, ValueError):
+        return 5.0
+
+
+def _connected_brokers(manager: Any) -> dict[str, Any]:
+    brokers: dict[str, Any] = {}
+    try:
+        platform = getattr(manager, "platform_brokers", {}) or {}
+        if callable(platform):
+            platform = platform()
+        for broker_type, broker in dict(platform or {}).items():
+            if broker is None or not bool(getattr(broker, "connected", False)):
+                continue
+            name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+            brokers[f"platform:{name}"] = broker
+    except Exception:
+        pass
+
+    try:
+        users = getattr(manager, "user_brokers", {}) or {}
+        for user_id, mapping in dict(users or {}).items():
+            for broker_type, broker in dict(mapping or {}).items():
+                if broker is None or not bool(getattr(broker, "connected", False)):
+                    continue
+                name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+                brokers[f"user:{user_id}:{name}"] = broker
+    except Exception:
+        pass
+    return brokers
+
+
+def position_sync_status(manager: Any) -> tuple[bool, list[str], dict[str, bool]]:
+    brokers = _connected_brokers(manager)
+    status = {
+        name: bool(getattr(broker, "_startup_position_sync_adopted", False))
+        for name, broker in brokers.items()
+    }
+    pending = sorted(name for name, synced in status.items() if not synced)
+    return not pending, pending, status
+
+
+def _finish_flight(key: int, flight: dict[str, Any], method: Callable[..., Any], self: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+    try:
+        flight["result"] = method(self, *args, **kwargs)
+    except BaseException as exc:
+        flight["error"] = exc
+    finally:
+        flight["finished_at"] = time.monotonic()
+        flight["event"].set()
+
+
+def _bounded_get_positions(method: Callable[..., Any], broker_name: str) -> Callable[..., Any]:
+    @wraps(method)
+    def get_positions_v95(self: Any, *args: Any, **kwargs: Any):
+        key = id(self)
+        with _LOCK:
+            flight = _FLIGHTS.get(key)
+            if flight is None:
+                event = threading.Event()
+                flight = {
+                    "event": event,
+                    "result": None,
+                    "error": None,
+                    "started_at": time.monotonic(),
+                    "finished_at": 0.0,
+                    "broker_name": broker_name,
+                }
+                _FLIGHTS[key] = flight
+                thread = threading.Thread(
+                    target=_finish_flight,
+                    args=(key, flight, method, self, args, dict(kwargs)),
+                    name=f"position-fetch-v95-{broker_name}",
+                    daemon=True,
+                )
+                flight["thread"] = thread
+                thread.start()
+                started_new = True
+            else:
+                started_new = False
+
+        timeout = _timeout_s()
+        if not flight["event"].wait(timeout=timeout):
+            age = max(0.0, time.monotonic() - float(flight.get("started_at", 0.0) or 0.0))
+            LOGGER.critical(
+                "POSITION_FETCH_V95_TIMEOUT marker=%s broker=%s timeout_s=%.2f age_s=%.2f "
+                "single_flight_reused=%s synthetic_empty_snapshot=false",
+                MARKER,
+                broker_name,
+                timeout,
+                age,
+                str(not started_new).lower(),
+            )
+            raise TimeoutError(
+                f"position snapshot timed out for {broker_name} after {timeout:.2f}s"
+            )
+
+        error = flight.get("error")
+        result = flight.get("result")
+        with _LOCK:
+            if _FLIGHTS.get(key) is flight:
+                _FLIGHTS.pop(key, None)
+        if error is not None:
+            raise error
+        return result
+
+    setattr(get_positions_v95, _GET_POSITIONS_ATTR, True)
+    setattr(get_positions_v95, "__wrapped__", method)
+    return get_positions_v95
+
+
+def _patch_broker_manager(module: ModuleType) -> bool:
+    changed = False
+    for class_name in ("CoinbaseBroker", "KrakenBroker", "OKXBroker", "AlpacaBroker"):
+        cls = getattr(module, class_name, None)
+        if not isinstance(cls, type):
+            continue
+        current = getattr(cls, "get_positions", None)
+        if not callable(current):
+            continue
+        if getattr(current, _GET_POSITIONS_ATTR, False):
+            continue
+        cls.get_positions = _bounded_get_positions(current, class_name.replace("Broker", "").lower())
+        changed = True
+        LOGGER.critical(
+            "POSITION_FETCH_V95_BROKER_PATCHED marker=%s broker_class=%s timeout_s=%.2f",
+            MARKER,
+            class_name,
+            _timeout_s(),
+        )
+    return changed
+
+
+def _patch_mabm(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _REFRESH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def refresh_capital_authority_v95(self: Any, *args: Any, **kwargs: Any):
+        result = current(self, *args, **kwargs)
+        ready, pending, status = position_sync_status(self)
+        setattr(self, "_startup_position_sync_done", bool(ready))
+        os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "1" if ready else "0"
+        if pending:
+            LOGGER.warning(
+                "POSITION_SYNC_V95_PENDING marker=%s pending=%s status=%s activation_blocked=true",
+                MARKER,
+                pending,
+                status,
+            )
+        return result
+
+    setattr(refresh_capital_authority_v95, _REFRESH_ATTR, True)
+    setattr(refresh_capital_authority_v95, "__wrapped__", current)
+    cls.refresh_capital_authority = refresh_capital_authority_v95
+    LOGGER.critical(
+        "POSITION_SYNC_V95_MABM_PATCHED marker=%s false_pre_latch_corrected=true",
+        MARKER,
+    )
+    return True
+
+
+def _canonical_manager() -> Any:
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        getter = getattr(module, "get_broker_manager", None)
+        if callable(getter):
+            try:
+                manager = getter()
+                if manager is not None:
+                    return manager
+            except Exception:
+                pass
+        manager = getattr(module, "multi_account_broker_manager", None)
+        if manager is not None:
+            return manager
+    return None
+
+
+def _patch_v61(module: ModuleType) -> bool:
+    current = getattr(module, "_activation_prerequisites", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V61_ATTR, False):
+        return True
+
+    @wraps(current)
+    def activation_prerequisites_v95():
+        ready, blockers, details = current()
+        if not ready:
+            return ready, blockers, details
+
+        manager = _canonical_manager()
+        if manager is None:
+            details = dict(details or {})
+            details["position_sync"] = {"ready": False, "reason": "manager_unavailable"}
+            os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "0"
+            return False, ["position_sync.manager_unavailable"], details
+
+        sync_ready, pending, status = position_sync_status(manager)
+        details = dict(details or {})
+        details["position_sync"] = {
+            "ready": sync_ready,
+            "pending": pending,
+            "status": status,
+        }
+        os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "1" if sync_ready else "0"
+        if not sync_ready:
+            LOGGER.warning(
+                "POSITION_SYNC_V95_ACTIVATION_BLOCK marker=%s pending=%s status=%s trading_fail_closed=true",
+                MARKER,
+                pending,
+                status,
+            )
+            return False, [f"position_sync:{name}" for name in pending], details
+        return True, [], details
+
+    setattr(activation_prerequisites_v95, _V61_ATTR, True)
+    setattr(activation_prerequisites_v95, "__wrapped__", current)
+    module._activation_prerequisites = activation_prerequisites_v95
+    LOGGER.critical(
+        "POSITION_SYNC_V95_ACTIVATION_GUARD_PATCHED marker=%s all_connected_brokers_require_snapshot=true",
+        MARKER,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in ("bot.broker_manager", "broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_broker_manager(module) or changed
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_mabm(module) or changed
+    for name in ("bot.final_production_activation_repair_v61_patch", "final_production_activation_repair_v61_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_v61(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                text = str(name or "")
+                if any(token in text for token in (
+                    "broker_manager",
+                    "multi_account_broker_manager",
+                    "final_production_activation_repair_v61_patch",
+                )):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_POSITION_SYNC_CORE_HANDOFF_V95_INSTALLED"] = "1"
+        LOGGER.critical(
+            "POSITION_SYNC_CORE_HANDOFF_V95_INSTALLED marker=%s position_fetch_timeout_s=%.2f "
+            "synthetic_empty_snapshot=false activation_requires_position_sync=true",
+            MARKER,
+            _timeout_s(),
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "position_sync_status",
+    "_bounded_get_positions",
+    "_patch_broker_manager",
+    "_patch_mabm",
+    "_patch_v61",
+]

--- a/bot/tests/test_position_sync_core_handoff_v95.py
+++ b/bot/tests/test_position_sync_core_handoff_v95.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import types
+import unittest
+from enum import Enum
+
+from bot import position_sync_core_handoff_v95_patch as v95
+
+
+class _BrokerType(Enum):
+    KRAKEN = "kraken"
+    COINBASE = "coinbase"
+
+
+class PositionSyncCoreHandoffV95Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_timeout = os.environ.get("NIJA_POSITION_FETCH_TIMEOUT_S")
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "bot.multi_account_broker_manager",
+                "multi_account_broker_manager",
+            )
+        }
+        v95._FLIGHTS.clear()
+
+    def tearDown(self) -> None:
+        if self.saved_timeout is None:
+            os.environ.pop("NIJA_POSITION_FETCH_TIMEOUT_S", None)
+        else:
+            os.environ["NIJA_POSITION_FETCH_TIMEOUT_S"] = self.saved_timeout
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        v95._FLIGHTS.clear()
+
+    def test_bounded_fetch_reuses_single_flight_and_consumes_completed_result(self) -> None:
+        class SlowBroker:
+            connected = True
+
+            def __init__(self) -> None:
+                self.calls = 0
+                self.release = threading.Event()
+
+            def get_positions(self):
+                self.calls += 1
+                self.release.wait(2.0)
+                return [{"symbol": "BTC-USD", "quantity": 1.0}]
+
+        SlowBroker.get_positions = v95._bounded_get_positions(
+            SlowBroker.get_positions,
+            "slow",
+        )
+        broker = SlowBroker()
+        os.environ["NIJA_POSITION_FETCH_TIMEOUT_S"] = "0.1"
+
+        for _ in range(2):
+            started = time.monotonic()
+            with self.assertRaises(TimeoutError):
+                broker.get_positions()
+            self.assertLess(time.monotonic() - started, 0.5)
+
+        self.assertEqual(broker.calls, 1)
+        broker.release.set()
+        time.sleep(0.05)
+        result = broker.get_positions()
+        self.assertEqual(result[0]["symbol"], "BTC-USD")
+        self.assertEqual(broker.calls, 1)
+
+    def test_position_sync_status_requires_every_connected_broker(self) -> None:
+        class Broker:
+            def __init__(self, synced: bool) -> None:
+                self.connected = True
+                self._startup_position_sync_adopted = synced
+
+        manager = types.SimpleNamespace(
+            platform_brokers={
+                _BrokerType.KRAKEN: Broker(True),
+                _BrokerType.COINBASE: Broker(False),
+            },
+            user_brokers={},
+        )
+
+        ready, pending, status = v95.position_sync_status(manager)
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:coinbase"])
+        self.assertTrue(status["platform:kraken"])
+        self.assertFalse(status["platform:coinbase"])
+
+    def test_v61_activation_blocks_until_position_sync_completes(self) -> None:
+        class Broker:
+            connected = True
+
+            def __init__(self, synced: bool) -> None:
+                self._startup_position_sync_adopted = synced
+
+        kraken = Broker(True)
+        coinbase = Broker(False)
+        manager = types.SimpleNamespace(
+            platform_brokers={
+                _BrokerType.KRAKEN: kraken,
+                _BrokerType.COINBASE: coinbase,
+            },
+            user_brokers={},
+        )
+        mabm = types.ModuleType("bot.multi_account_broker_manager")
+        mabm.get_broker_manager = lambda: manager
+        mabm.multi_account_broker_manager = manager
+        sys.modules["bot.multi_account_broker_manager"] = mabm
+        sys.modules["multi_account_broker_manager"] = mabm
+
+        v61 = types.ModuleType("bot.final_production_activation_repair_v61_patch")
+        v61._activation_prerequisites = lambda: (
+            True,
+            [],
+            {"core_registered": True, "core_alive": True},
+        )
+        self.assertTrue(v95._patch_v61(v61))
+
+        ready, blockers, details = v61._activation_prerequisites()
+        self.assertFalse(ready)
+        self.assertEqual(blockers, ["position_sync:platform:coinbase"])
+        self.assertFalse(details["position_sync"]["ready"])
+
+        coinbase._startup_position_sync_adopted = True
+        ready, blockers, details = v61._activation_prerequisites()
+        self.assertTrue(ready)
+        self.assertEqual(blockers, [])
+        self.assertTrue(details["position_sync"]["ready"])
+
+    def test_mabm_refresh_corrects_false_pre_latch(self) -> None:
+        class Broker:
+            connected = True
+            _startup_position_sync_adopted = False
+
+        class Manager:
+            def __init__(self) -> None:
+                self.platform_brokers = {_BrokerType.KRAKEN: Broker()}
+                self.user_brokers = {}
+                self._startup_position_sync_done = True
+
+            def refresh_capital_authority(self, *args, **kwargs):
+                return {"ready": 1.0, "total_capital": 100.0}
+
+        module = types.ModuleType("bot.multi_account_broker_manager")
+        module.MultiAccountBrokerManager = Manager
+        self.assertTrue(v95._patch_mabm(module))
+
+        manager = Manager()
+        manager.refresh_capital_authority()
+        self.assertFalse(manager._startup_position_sync_done)
+
+        manager.platform_brokers[_BrokerType.KRAKEN]._startup_position_sync_adopted = True
+        manager.refresh_capital_authority()
+        self.assertTrue(manager._startup_position_sync_done)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- add v95 bounded single-flight `get_positions()` wrappers for Coinbase/Kraken/OKX/Alpaca during startup position reconciliation
- a timed-out position fetch raises `TimeoutError` and is never converted into a synthetic empty-position snapshot
- later retries reuse the same in-flight request instead of duplicating exchange calls
- correct the historical `_startup_position_sync_done=True` pre-latch by recomputing it from each connected broker's `_startup_position_sync_adopted` truth
- extend v61 activation prerequisites so every currently connected broker must have completed an authoritative position snapshot before activation may proceed
- install v95 before v61 on the canonical fast path

## Production evidence
Deployment `8e4ba82920b22e7b29c588f29e3cd7453c03ee89` now shows the previous capital/writer repairs working: Kraken and OKX capital hydrate, the capital bootstrap reaches READY, startup lock releases, writer generation is 3782, and BootstrapFSM reaches `THREADS_STARTING`. The runtime then remains there with `core_registered=False` and `core_alive=False`.

The last forward-progress startup messages are:
- `EXCHANGE_POSITION_SYNC starting startup position synchronisation`
- `EXCHANGE_POSITION_SYNC connected_broker_count=3 brokers=['platform:coinbase','platform:kraken','platform:okx']`

No per-broker `EXCHANGE_POSITION_SYNC broker=... fetched=...` or sync-complete line follows before the observed window ends, while writer renewal continues. This isolates the next synchronous startup choke point to a broker `get_positions()` call inside the startup position sync.

## Safety
- no writer, nonce, authority, kill-switch, risk, strategy, capital, or dispatch gate is weakened
- no readiness key is synthesized
- a position timeout does not mean "no positions"; the broker remains unsynchronized and activation remains blocked
- a live in-flight position fetch is never duplicated
- core startup can continue after the bounded reconciliation attempt, but v61 will not allow activation until connected brokers have actually completed position snapshots

## Validation
- local `py_compile` passes for v95
- focused behavior harness passes bounded timeout, same-flight reuse, completed-result reuse, activation refusal for an unsynced broker, and false pre-latch correction
- branch is 3 commits ahead of `8e4ba829...` and not behind main
