### PR TITLE
Bind position sync to canonical dispatch authority

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -68,6 +68,9 @@ _FAST_PATH_INSTALLERS = (
     # startup thread indefinitely. v95 also makes position-sync completion a
     # fail-closed activation prerequisite rather than pre-latching success.
     ("bot.position_sync_core_handoff_v95_patch", "POSITION_SYNC_CORE_HANDOFF_V95"),
+    # Publish position-sync truth into canonical readiness so an unsynced
+    # connected broker also revokes any stale coordinator dispatch commit.
+    ("bot.position_sync_dispatch_authority_v96_patch", "POSITION_SYNC_DISPATCH_AUTHORITY_V96"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation
     # monitors. It guards v60's request boundary and makes v16 readiness reflect

--- a/bot/position_sync_dispatch_authority_v96_patch.py
+++ b/bot/position_sync_dispatch_authority_v96_patch.py
@@ -1,0 +1,212 @@
+"""Bind startup position synchronization into canonical dispatch authority.
+
+v95 bounded broker position snapshots and blocked fresh activation while any
+connected broker lacked an authoritative startup snapshot. Production evidence
+then showed a pre-existing StartupCoordinator dispatch commit could remain live
+because position-sync truth was not part of the canonical readiness table.
+
+v96 publishes a dynamic ``position_sync_ready`` readiness key. The coordinator
+already treats every readiness-table entry as part of its execution proof, so a
+false value immediately makes execution non-permitted; a true-to-false
+regression also advances the global epoch and revokes an existing activation
+commit through the canonical coordinator path.
+
+No writer, nonce, capital, risk, strategy, kill-switch, or execution authority is
+synthesized here. Readiness becomes true only when at least one broker is
+connected and every currently connected platform/user broker has completed an
+authoritative startup position snapshot.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.position_sync_dispatch_authority_v96")
+MARKER = "20260814-position-sync-dispatch-authority-v96"
+READINESS_KEY = "position_sync_ready"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_POSITION_SYNC_DISPATCH_AUTHORITY_V96_IMPORT_HOOK"
+_MABM_ATTR = "_nija_position_sync_dispatch_authority_v96"
+_SYNC_ATTR = "_nija_position_sync_dispatch_authority_v96"
+
+
+def _readiness_module() -> ModuleType:
+    try:
+        import bot.readiness_table as readiness_table
+    except ImportError:
+        import readiness_table  # type: ignore[import]
+    return readiness_table
+
+
+def _v95_module() -> ModuleType:
+    try:
+        import bot.position_sync_core_handoff_v95_patch as v95
+    except ImportError:
+        import position_sync_core_handoff_v95_patch as v95  # type: ignore[import]
+    return v95
+
+
+def _manager_from_strategy(strategy: Any) -> Any:
+    manager = getattr(strategy, "multi_account_manager", None)
+    if manager is not None:
+        return manager
+    try:
+        return _v95_module()._canonical_manager()
+    except Exception:
+        return None
+
+
+def publish_position_sync_readiness(manager: Any, *, source: str) -> tuple[bool, list[str], dict[str, bool]]:
+    """Publish current position-sync truth into canonical readiness authority."""
+    ready = False
+    pending: list[str] = []
+    status: dict[str, bool] = {}
+    if manager is not None:
+        try:
+            raw_ready, pending, status = _v95_module().position_sync_status(manager)
+            # Never treat an empty connected-broker set as dispatch-ready.
+            ready = bool(status) and bool(raw_ready)
+        except Exception as exc:
+            LOGGER.warning(
+                "POSITION_SYNC_V96_STATUS_ERROR marker=%s source=%s error=%s:%s fail_closed=true",
+                MARKER,
+                source,
+                type(exc).__name__,
+                exc,
+            )
+
+    readiness = _readiness_module()
+    readiness.set_ready(READINESS_KEY, bool(ready), allow_regression=True)
+    os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "1" if ready else "0"
+    os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "1" if ready else "0"
+
+    log = LOGGER.critical if not ready else LOGGER.info
+    log(
+        "POSITION_SYNC_V96_READINESS marker=%s source=%s ready=%s pending=%s status=%s "
+        "canonical_readiness=true stale_commit_revocation=true",
+        MARKER,
+        source,
+        str(bool(ready)).lower(),
+        pending,
+        status,
+    )
+    return bool(ready), pending, status
+
+
+def _patch_mabm(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _MABM_ATTR, False):
+        return True
+
+    @wraps(current)
+    def refresh_capital_authority_v96(self: Any, *args: Any, **kwargs: Any):
+        result = current(self, *args, **kwargs)
+        publish_position_sync_readiness(self, source="refresh_capital_authority")
+        return result
+
+    setattr(refresh_capital_authority_v96, _MABM_ATTR, True)
+    setattr(refresh_capital_authority_v96, "__wrapped__", current)
+    cls.refresh_capital_authority = refresh_capital_authority_v96
+    LOGGER.critical(
+        "POSITION_SYNC_V96_MABM_PATCHED marker=%s canonical_readiness_key=%s",
+        MARKER,
+        READINESS_KEY,
+    )
+    return True
+
+
+def _patch_startup_sync(module: ModuleType) -> bool:
+    current = getattr(module, "sync_exchange_positions_on_startup", None)
+    if not callable(current):
+        return False
+    if getattr(current, _SYNC_ATTR, False):
+        return True
+
+    @wraps(current)
+    def sync_exchange_positions_on_startup_v96(strategy: Any, *args: Any, **kwargs: Any):
+        result = current(strategy, *args, **kwargs)
+        manager = _manager_from_strategy(strategy)
+        publish_position_sync_readiness(manager, source="startup_position_sync_complete")
+        return result
+
+    setattr(sync_exchange_positions_on_startup_v96, _SYNC_ATTR, True)
+    setattr(sync_exchange_positions_on_startup_v96, "__wrapped__", current)
+    module.sync_exchange_positions_on_startup = sync_exchange_positions_on_startup_v96
+    LOGGER.critical(
+        "POSITION_SYNC_V96_STARTUP_SYNC_PATCHED marker=%s canonical_readiness_key=%s",
+        MARKER,
+        READINESS_KEY,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    changed = False
+    seen: set[int] = set()
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_mabm(module) or changed
+    for name in ("bot.startup_position_sync", "startup_position_sync"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            changed = _patch_startup_sync(module) or changed
+    return changed
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        # Establish the fail-closed key before activation can consume an old
+        # coordinator commit. An absent/empty broker set is intentionally false.
+        publish_position_sync_readiness(None, source="install_fail_closed")
+        _patch_loaded()
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                text = str(name or "")
+                if "multi_account_broker_manager" in text or "startup_position_sync" in text:
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_POSITION_SYNC_DISPATCH_AUTHORITY_V96_INSTALLED"] = "1"
+        LOGGER.critical(
+            "POSITION_SYNC_DISPATCH_AUTHORITY_V96_INSTALLED marker=%s readiness_key=%s "
+            "fail_closed=true stale_commit_revocation=true safety_gates_unchanged=true",
+            MARKER,
+            READINESS_KEY,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "READINESS_KEY",
+    "install",
+    "install_import_hook",
+    "publish_position_sync_readiness",
+    "_patch_mabm",
+    "_patch_startup_sync",
+]

--- a/bot/tests/test_position_sync_dispatch_authority_v96.py
+++ b/bot/tests/test_position_sync_dispatch_authority_v96.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import types
+import unittest
+from unittest import mock
+
+from bot import position_sync_dispatch_authority_v96_patch as v96
+
+
+class PositionSyncDispatchAuthorityV96Tests(unittest.TestCase):
+    def tearDown(self) -> None:
+        os.environ.pop("NIJA_POSITION_SYNC_ACTIVATION_READY", None)
+        os.environ.pop("NIJA_POSITION_SYNC_DISPATCH_READY", None)
+
+    def test_publish_is_fail_closed_without_connected_brokers(self) -> None:
+        calls = []
+        readiness = types.SimpleNamespace(
+            set_ready=lambda key, value, allow_regression=False: calls.append(
+                (key, value, allow_regression)
+            )
+        )
+        v95 = types.SimpleNamespace(position_sync_status=lambda manager: (True, [], {}))
+        with mock.patch.object(v96, "_readiness_module", return_value=readiness), mock.patch.object(
+            v96, "_v95_module", return_value=v95
+        ):
+            ready, pending, status = v96.publish_position_sync_readiness(
+                object(), source="test"
+            )
+
+        self.assertFalse(ready)
+        self.assertEqual(pending, [])
+        self.assertEqual(status, {})
+        self.assertEqual(calls, [(v96.READINESS_KEY, False, True)])
+        self.assertEqual(os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"], "0")
+
+    def test_publish_tracks_all_connected_broker_truth_and_regression(self) -> None:
+        calls = []
+        readiness = types.SimpleNamespace(
+            set_ready=lambda key, value, allow_regression=False: calls.append(
+                (key, value, allow_regression)
+            )
+        )
+        states = iter(
+            [
+                (True, [], {"platform:kraken": True, "user:tania:kraken": True}),
+                (
+                    False,
+                    ["user:tania:kraken"],
+                    {"platform:kraken": True, "user:tania:kraken": False},
+                ),
+            ]
+        )
+        v95 = types.SimpleNamespace(position_sync_status=lambda manager: next(states))
+        with mock.patch.object(v96, "_readiness_module", return_value=readiness), mock.patch.object(
+            v96, "_v95_module", return_value=v95
+        ):
+            self.assertTrue(v96.publish_position_sync_readiness(object(), source="ready")[0])
+            self.assertFalse(v96.publish_position_sync_readiness(object(), source="regressed")[0])
+
+        self.assertEqual(
+            calls,
+            [
+                (v96.READINESS_KEY, True, True),
+                (v96.READINESS_KEY, False, True),
+            ],
+        )
+        self.assertEqual(os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"], "0")
+
+    def test_startup_sync_wrapper_publishes_after_reconciliation(self) -> None:
+        manager = object()
+        strategy = types.SimpleNamespace(multi_account_manager=manager)
+        module = types.ModuleType("bot.startup_position_sync")
+        events = []
+
+        def sync(current_strategy):
+            events.append(("sync", current_strategy))
+            return 7
+
+        module.sync_exchange_positions_on_startup = sync
+        self.assertTrue(v96._patch_startup_sync(module))
+
+        with mock.patch.object(
+            v96,
+            "publish_position_sync_readiness",
+            side_effect=lambda current_manager, source: events.append(
+                ("publish", current_manager, source)
+            ),
+        ):
+            result = module.sync_exchange_positions_on_startup(strategy)
+
+        self.assertEqual(result, 7)
+        self.assertEqual(events[0], ("sync", strategy))
+        self.assertEqual(events[1], ("publish", manager, "startup_position_sync_complete"))
+
+    def test_mabm_refresh_publishes_after_existing_refresh(self) -> None:
+        events = []
+
+        class Manager:
+            def refresh_capital_authority(self):
+                events.append("refresh")
+                return {"ready": True}
+
+        module = types.ModuleType("bot.multi_account_broker_manager")
+        module.MultiAccountBrokerManager = Manager
+        self.assertTrue(v96._patch_mabm(module))
+
+        manager = Manager()
+        with mock.patch.object(
+            v96,
+            "publish_position_sync_readiness",
+            side_effect=lambda current_manager, source: events.append(
+                ("publish", current_manager, source)
+            ),
+        ):
+            result = manager.refresh_capital_authority()
+
+        self.assertEqual(result, {"ready": True})
+        self.assertEqual(events[0], "refresh")
+        self.assertEqual(events[1], ("publish", manager, "refresh_capital_authority"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- add v96 position-sync dispatch-authority convergence guard
- publish dynamic `position_sync_ready` into the canonical readiness table
- start fail-closed when no connected broker snapshot is authoritative
- republish after capital refresh and startup position reconciliation
- install v96 immediately after v95 and before activation workers
- add focused regression tests for empty broker sets, ready-to-not-ready regression, startup-sync publication, and manager-refresh publication

## Root cause
v95 correctly blocked fresh activation while a connected broker lacked an authoritative position snapshot, but position-sync truth was not part of `StartupCoordinator`'s canonical readiness table. A previously committed dispatch snapshot could therefore remain eligible while v95 simultaneously reported an activation block.

## Safety
This does not synthesize writer, nonce, capital, risk, strategy, kill-switch, or execution authority. `position_sync_ready` is true only when at least one broker is connected and every connected platform/user broker has an authoritative startup snapshot. A regression is published with `allow_regression=True`, allowing the existing coordinator path to revoke stale dispatch authority.
