### PR TITLE
Fix canonical live strategy runtime integrity

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,6 +32,10 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_authority_generation_convergence_v57_patch", "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
+    # The writer heartbeat truthfully publishes CORE_THREAD_ALIVE=0 before the
+    # real core is launched. Keep the independent authority heartbeat aligned
+    # with that documented startup grace while preserving post-core fail-closed
+    # liveness checks.
     ("bot.precore_authority_heartbeat_v63_patch", "PRECORE_AUTHORITY_HEARTBEAT_V63"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),
@@ -43,11 +47,29 @@ _FAST_PATH_INSTALLERS = (
     ("bot.okx_order_instid_payload_repair_patch", "OKX_ORDER_INSTID_PAYLOAD_REPAIR"),
     ("bot.okx_final_order_submission_bridge_patch", "OKX_FINAL_ORDER_SUBMISSION_BRIDGE"),
     ("bot.stalled_writer_release_guard_v22", "STALLED_WRITER_RELEASE_GUARD_V22"),
+    # Keep synchronous capital publication inside the canonical freshness TTL.
+    # Slow venue workers continue asynchronously and can contribute on a later
+    # refresh once their observations are still fresh.
     ("bot.capital_refresh_live_continuity_v78_patch", "CAPITAL_REFRESH_FRESHNESS_BOUNDED_V78"),
+    # Synchronize canonical bootstrap/capital/readiness state before any
+    # compatibility activation proof is evaluated. This is state convergence,
+    # not a bypass; all writer/nonce/risk/kill-switch gates remain authoritative.
     ("bot.activation_capital_convergence_v62_patch", "ACTIVATION_CAPITAL_CONVERGENCE_V62"),
+    # Keep every post-activation observer and new-risk dispatch path on the same
+    # canonical CapitalAuthority freshness contract. Protective reduce/exit
+    # intents remain available when freshness is lost.
     ("bot.live_capital_freshness_v64_patch", "LIVE_CAPITAL_FRESHNESS_V64"),
+    # Close the remaining production liveness gaps without weakening execution:
+    # bound watchdog-driven refresh completion inside freshness, bridge v64
+    # across importlib, expose publication expiry dynamically, and reclaim scan
+    # ownership only when the recorded owner thread is actually gone.
     ("bot.production_freshness_scan_convergence_v93_patch", "PRODUCTION_FRESHNESS_SCAN_V93"),
+    # Bound startup position snapshots so a slow venue cannot hold the main
+    # startup thread indefinitely. v95 also makes position-sync completion a
+    # fail-closed activation prerequisite rather than pre-latching success.
     ("bot.position_sync_core_handoff_v95_patch", "POSITION_SYNC_CORE_HANDOFF_V95"),
+    # Publish position-sync truth into canonical readiness so an unsynced
+    # connected broker also revokes any stale coordinator dispatch commit.
     ("bot.position_sync_dispatch_authority_v96_patch", "POSITION_SYNC_DISPATCH_AUTHORITY_V96"),
     # The production core invokes TradingStrategy directly. These three guards
     # must be present on the canonical fast path, not only the legacy path:
@@ -57,9 +79,15 @@ _FAST_PATH_INSTALLERS = (
     ("bot.trading_strategy_apex_wiring_patch", "TRADING_STRATEGY_APEX_WIRING"),
     ("bot.strategy_runtime_integrity_patch", "STRATEGY_RUNTIME_INTEGRITY"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
+    # v61 must install before v59/v60 start their reconciliation/activation
+    # monitors. It guards v60's request boundary and makes v16 readiness reflect
+    # current proof truth before any activation attempt is permitted.
     ("bot.final_production_activation_repair_v61_patch", "FINAL_PRODUCTION_ACTIVATION_V61"),
     ("bot.final_production_activation_repair_v59_patch", "FINAL_PRODUCTION_ACTIVATION_V59"),
     ("bot.final_production_activation_repair_v60_patch", "FINAL_PRODUCTION_ACTIVATION_V60"),
+    # A local LIVE_ACTIVE state is not sufficient for broker order dispatch.
+    # Require the canonical StartupCoordinator dispatch commit as well; v92
+    # repairs only that commit after the existing readiness proof passes.
     ("bot.live_active_dispatch_commit_v92_patch", "LIVE_ACTIVE_DISPATCH_COMMIT_V92"),
 )
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260812-canonical-fast-entrypoint-v64"
+_FAST_PATH_MARKER = "20260815-canonical-fast-entrypoint-v65"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -32,10 +32,6 @@ _FAST_PATH_INSTALLERS = (
     ("bot.writer_authority_generation_convergence_v57_patch", "WRITER_AUTHORITY_GENERATION_CONVERGENCE_V57"),
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
-    # The writer heartbeat truthfully publishes CORE_THREAD_ALIVE=0 before the
-    # real core is launched. Keep the independent authority heartbeat aligned
-    # with that documented startup grace while preserving post-core fail-closed
-    # liveness checks.
     ("bot.precore_authority_heartbeat_v63_patch", "PRECORE_AUTHORITY_HEARTBEAT_V63"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),
@@ -47,40 +43,23 @@ _FAST_PATH_INSTALLERS = (
     ("bot.okx_order_instid_payload_repair_patch", "OKX_ORDER_INSTID_PAYLOAD_REPAIR"),
     ("bot.okx_final_order_submission_bridge_patch", "OKX_FINAL_ORDER_SUBMISSION_BRIDGE"),
     ("bot.stalled_writer_release_guard_v22", "STALLED_WRITER_RELEASE_GUARD_V22"),
-    # Keep synchronous capital publication inside the canonical freshness TTL.
-    # Slow venue workers continue asynchronously and can contribute on a later
-    # refresh once their observations are still fresh.
     ("bot.capital_refresh_live_continuity_v78_patch", "CAPITAL_REFRESH_FRESHNESS_BOUNDED_V78"),
-    # Synchronize canonical bootstrap/capital/readiness state before any
-    # compatibility activation proof is evaluated. This is state convergence,
-    # not a bypass; all writer/nonce/risk/kill-switch gates remain authoritative.
     ("bot.activation_capital_convergence_v62_patch", "ACTIVATION_CAPITAL_CONVERGENCE_V62"),
-    # Keep every post-activation observer and new-risk dispatch path on the same
-    # canonical CapitalAuthority freshness contract. Protective reduce/exit
-    # intents remain available when freshness is lost.
     ("bot.live_capital_freshness_v64_patch", "LIVE_CAPITAL_FRESHNESS_V64"),
-    # Close the remaining production liveness gaps without weakening execution:
-    # bound watchdog-driven refresh completion inside freshness, bridge v64
-    # across importlib, expose publication expiry dynamically, and reclaim scan
-    # ownership only when the recorded owner thread is actually gone.
     ("bot.production_freshness_scan_convergence_v93_patch", "PRODUCTION_FRESHNESS_SCAN_V93"),
-    # Bound startup position snapshots so a slow venue cannot hold the main
-    # startup thread indefinitely. v95 also makes position-sync completion a
-    # fail-closed activation prerequisite rather than pre-latching success.
     ("bot.position_sync_core_handoff_v95_patch", "POSITION_SYNC_CORE_HANDOFF_V95"),
-    # Publish position-sync truth into canonical readiness so an unsynced
-    # connected broker also revokes any stale coordinator dispatch commit.
     ("bot.position_sync_dispatch_authority_v96_patch", "POSITION_SYNC_DISPATCH_AUTHORITY_V96"),
+    # The production core invokes TradingStrategy directly. These three guards
+    # must be present on the canonical fast path, not only the legacy path:
+    # wrapper creates the runtime, APEX wiring repairs missing backrefs, and
+    # integrity refuses to publish an incomplete live strategy.
+    ("bot.trading_engine_strategy_wrapper_patch", "TRADING_ENGINE_STRATEGY_WRAPPER"),
+    ("bot.trading_strategy_apex_wiring_patch", "TRADING_STRATEGY_APEX_WIRING"),
+    ("bot.strategy_runtime_integrity_patch", "STRATEGY_RUNTIME_INTEGRITY"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
-    # v61 must install before v59/v60 start their reconciliation/activation
-    # monitors. It guards v60's request boundary and makes v16 readiness reflect
-    # current proof truth before any activation attempt is permitted.
     ("bot.final_production_activation_repair_v61_patch", "FINAL_PRODUCTION_ACTIVATION_V61"),
     ("bot.final_production_activation_repair_v59_patch", "FINAL_PRODUCTION_ACTIVATION_V59"),
     ("bot.final_production_activation_repair_v60_patch", "FINAL_PRODUCTION_ACTIVATION_V60"),
-    # A local LIVE_ACTIVE state is not sufficient for broker order dispatch.
-    # Require the canonical StartupCoordinator dispatch commit as well; v92
-    # repairs only that commit after the existing readiness proof passes.
     ("bot.live_active_dispatch_commit_v92_patch", "LIVE_ACTIVE_DISPATCH_COMMIT_V92"),
 )
 
@@ -94,8 +73,6 @@ _FAST_PATH_COMPAT_OPTIONAL_GUARDS = frozenset(
 _LEGACY_INSTALLERS = (
     *_FAST_PATH_INSTALLERS,
     ("bot.bootstrap_i12_capital_authority_repair_patch", "BOOTSTRAP_I12_CAPITAL_AUTHORITY_REPAIR"),
-    ("bot.trading_engine_strategy_wrapper_patch", "TRADING_ENGINE_STRATEGY_WRAPPER"),
-    ("bot.strategy_runtime_integrity_patch", "STRATEGY_RUNTIME_INTEGRITY"),
     ("bot.live_entry_scan_adoption_timeout_patch", "SCAN_POSITION_ADOPTION_TIMEOUT"),
     ("bot.writer_heartbeat_stale_repair_patch", "WRITER_HEARTBEAT_STALE_REPAIR"),
     ("bot.ecel_okx_synthetic_contract_patch", "ECEL_OKX_SYNTHETIC_CONTRACT"),

--- a/bot/tests/test_canonical_fast_path_strategy_integrity_v65.py
+++ b/bot/tests/test_canonical_fast_path_strategy_integrity_v65.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _fast_path_installers() -> list[tuple[str, str]]:
+    source = (Path(__file__).resolve().parents[1] / "bot.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_FAST_PATH_INSTALLERS":
+                    value = ast.literal_eval(node.value)
+                    return list(value)
+    raise AssertionError("_FAST_PATH_INSTALLERS not found")
+
+
+def test_canonical_fast_path_installs_strategy_execution_integrity_before_activation() -> None:
+    installers = _fast_path_installers()
+    modules = [module for module, _label in installers]
+
+    wrapper = modules.index("bot.trading_engine_strategy_wrapper_patch")
+    wiring = modules.index("bot.trading_strategy_apex_wiring_patch")
+    integrity = modules.index("bot.strategy_runtime_integrity_patch")
+    activation = modules.index("bot.final_production_activation_repair_v61_patch")
+
+    assert wrapper < wiring < integrity < activation
+
+
+def test_strategy_integrity_guards_are_not_optional_on_canonical_path() -> None:
+    source = (Path(__file__).resolve().parents[1] / "bot.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    optional: set[str] | None = None
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_FAST_PATH_COMPAT_OPTIONAL_GUARDS":
+                    call = node.value
+                    assert isinstance(call, ast.Call)
+                    optional = set(ast.literal_eval(call.args[0]))
+    assert optional is not None
+    assert "TRADING_ENGINE_STRATEGY_WRAPPER" not in optional
+    assert "TRADING_STRATEGY_APEX_WIRING" not in optional
+    assert "STRATEGY_RUNTIME_INTEGRITY" not in optional


### PR DESCRIPTION
## What changed

- Install the trading-engine strategy wrapper on the canonical fast startup path.
- Install the TradingStrategy APEX/CoreLoop back-reference repair on that path.
- Install strategy runtime integrity before production activation so an incomplete strategy cannot reach the live loop.
- Keep all three guards mandatory rather than compatibility-optional.
- Add a regression test that asserts wrapper -> wiring -> integrity ordering before v61 activation.

## Root cause

Production was reaching `LIVE_ACTIVE` with readiness marked true, but the canonical fast entrypoint omitted the strategy runtime guards that the legacy path already installed. That allowed the core loop to invoke a `TradingStrategy` whose `apex` reference remained `None`, producing `RUN_CYCLE_BLOCKED_MISSING_REF`.

## Safety

This does not lower risk thresholds, bypass nonce/writer/kill-switch gates, synthesize positions, or submit orders directly. It fails closed if the mandatory strategy-integrity installers cannot initialize.

## Validation

Added `bot/tests/test_canonical_fast_path_strategy_integrity_v65.py` to lock the canonical installer set and activation ordering.