### PR TITLE
Preserve runtime truth after masked broker failures

### DIFF
--- a/bot/empty_position_sync_success_patch.py
+++ b/bot/empty_position_sync_success_patch.py
@@ -1,8 +1,11 @@
-"""Mark a connected broker with a successful empty snapshot as synchronized.
+"""Preserve successful empty-position snapshots without refetching brokers.
 
-Zero open positions is a valid broker state, not a synchronization failure. The
-legacy startup reconciler left ``_startup_position_sync_adopted=False`` whenever
-``get_positions()`` returned an empty list, causing perpetual ``all_synced=False``.
+The canonical startup reconciler already marks a connected broker synchronized
+when its authoritative ``get_positions()`` call succeeds with an empty list.
+This compatibility patch therefore must not issue a second broker fetch: an
+outer runtime wrapper may intentionally convert a failed inner fetch to ``[]``
+for balance/equity classification, and treating that fallback as authoritative
+would incorrectly turn a timeout into synchronization success.
 """
 from __future__ import annotations
 
@@ -14,8 +17,8 @@ from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.empty_position_sync_success")
-_MARKER = "20260715-empty-position-sync-v1"
-_ATTR = "_nija_empty_position_sync_success_v1"
+_MARKER = "20260815-empty-position-sync-v2"
+_ATTR = "_nija_empty_position_sync_success_v2"
 _LOCK = threading.RLock()
 
 
@@ -28,25 +31,19 @@ def _patch(module: ModuleType) -> bool:
 
     @wraps(current)
     def adopt(broker: Any, broker_name: str, eps: Any) -> int:
+        # Delegate exactly once to the canonical reconciler. It owns the
+        # authoritative fetch and already treats a genuine empty snapshot as
+        # synchronized. Never refetch here and never manufacture success from
+        # a compatibility-layer empty fallback.
         result = int(current(broker, broker_name, eps) or 0)
-        if bool(getattr(broker, "_startup_position_sync_adopted", False)):
-            return result
-        if not bool(getattr(broker, "connected", False)):
-            return result
-        getter = getattr(broker, "get_positions", None)
-        if not callable(getter):
-            return result
-        try:
-            snapshot = getter()
-        except Exception:
-            return result
-        if isinstance(snapshot, list) and not snapshot:
-            setattr(broker, "_startup_position_sync_adopted", True)
-            setattr(broker, "_startup_position_sync_symbols", tuple())
-            logger.info(
-                "EMPTY_POSITION_SNAPSHOT_SYNCED marker=%s broker=%s connected=true positions=0",
+        fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None)
+        if fetch_ok is False:
+            setattr(broker, "_startup_position_sync_adopted", False)
+            logger.warning(
+                "EMPTY_POSITION_SYNC_FAILURE_PRESERVED marker=%s broker=%s error=%s authoritative_empty=false",
                 _MARKER,
                 broker_name,
+                getattr(broker, "_startup_position_sync_error", "position_fetch_failed"),
             )
         return result
 
@@ -54,7 +51,10 @@ def _patch(module: ModuleType) -> bool:
     adopt.__wrapped__ = current
     module._adopt_broker_positions = adopt
     os.environ["NIJA_EMPTY_POSITION_SYNC_READY"] = "1"
-    logger.critical("EMPTY_POSITION_SYNC_SUCCESS_PATCHED marker=%s", _MARKER)
+    logger.critical(
+        "EMPTY_POSITION_SYNC_SUCCESS_PATCHED marker=%s refetch=false masked_failure_preserved=true",
+        _MARKER,
+    )
     return True
 
 

--- a/bot/runtime_truth_convergence_v97_patch.py
+++ b/bot/runtime_truth_convergence_v97_patch.py
@@ -1,20 +1,19 @@
 """Converge live runtime truth after strategy/readiness bootstrap.
 
-Production deployment 39560bb showed three stale-truth failures after the
+Production deployments exposed four stale-truth failure modes after the
 canonical strategy-integrity guards were enabled:
 
-* ``bot.nija_apex_strategy_v71`` existed in ``sys.modules`` but was a partial
-  module object without ``NIJAApexStrategyV71``.  The wiring repair repeatedly
-  observed ``class_missing`` and the live cycle remained blocked with
-  ``strategy.apex is None``.
-* position fetches that timed out could leave a previous
-  ``_startup_position_sync_adopted=True`` latch intact, so v96 could publish
-  ``position_sync_ready=true`` even though the current reconciliation failed.
-* the writer scan-start watchdog was never handed the actual core scan lifecycle,
-  so it could emit ``SCAN_STARTED_DEADLINE_EXCEEDED`` while the core thread was
-  alive and real trading cycles were already executing.
+* ``bot.nija_apex_strategy_v71`` could exist in ``sys.modules`` as a partial
+  module object without ``NIJAApexStrategyV71``.
+* the APEX wiring patch can also be source-loaded under compatibility aliases,
+  so name-only patching can miss the resolver that is actually executing.
+* position fetches that time out can be caught by an outer compatibility layer
+  and returned as ``[]``; a masked failure must never become an empty-snapshot
+  synchronization success.
+* the writer scan-start watchdog needs the actual core scan lifecycle rather
+  than merely core-thread liveness.
 
-v97 repairs only those truth handoffs.  It does not lower risk thresholds,
+This patch repairs only those truth handoffs. It does not lower risk thresholds,
 bypass writer/nonce/kill-switch gates, synthesize positions, or submit orders.
 """
 from __future__ import annotations
@@ -29,57 +28,129 @@ import threading
 from functools import wraps
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 LOGGER = logging.getLogger("nija.runtime_truth_convergence_v97")
-MARKER = "20260815-runtime-truth-convergence-v97"
+MARKER = "20260815-runtime-truth-convergence-v97b"
 _LOCK = threading.RLock()
 _HOOK_FLAG = "_NIJA_RUNTIME_TRUTH_CONVERGENCE_V97_IMPORT_HOOK"
+_IMPORT_MODULE_FLAG = "_NIJA_RUNTIME_TRUTH_CONVERGENCE_V97_IMPORT_MODULE_HOOK"
 _APEX_ATTR = "_nija_runtime_truth_convergence_v97_apex"
 _POSITION_ATTR = "_nija_runtime_truth_convergence_v97_position"
+_POSITION_SYNC_ATTR = "_nija_runtime_truth_convergence_v97_startup_sync"
 _SCAN_ATTR = "_nija_runtime_truth_convergence_v97_scan"
 _RECOVERY_MODULE = "bot._nija_apex_strategy_v71_recovery_v97"
+_WIRING_BASENAME = "trading_strategy_apex_wiring_patch.py"
+_APEX_BASENAME = "nija_apex_strategy_v71.py"
+_STARTUP_SYNC_BASENAME = "startup_position_sync.py"
 _RECOVERED_APEX_CLASS: Any = None
 
 
+def _module_basename(module: Any) -> str:
+    if not isinstance(module, ModuleType):
+        return ""
+    try:
+        return Path(str(getattr(module, "__file__", "") or "")).name
+    except Exception:
+        return ""
+
+
+def _iter_loaded_modules(*, names: tuple[str, ...] = (), basenames: tuple[str, ...] = ()):
+    seen: set[int] = set()
+    for name in names:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            yield name, module
+    wanted = set(basenames)
+    if wanted:
+        for name, module in tuple(sys.modules.items()):
+            if not isinstance(module, ModuleType) or id(module) in seen:
+                continue
+            if _module_basename(module) not in wanted:
+                continue
+            seen.add(id(module))
+            yield str(name), module
+
+
+def _apex_module_diagnostics() -> str:
+    details: list[str] = []
+    for name, module in _iter_loaded_modules(
+        names=("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71", _RECOVERY_MODULE),
+        basenames=(_APEX_BASENAME,),
+    ):
+        spec = getattr(module, "__spec__", None)
+        details.append(
+            f"{name}:id={id(module)};file={getattr(module, '__file__', None)!r};"
+            f"class={hasattr(module, 'NIJAApexStrategyV71')};"
+            f"spec={getattr(spec, 'name', None)!r};"
+            f"initializing={getattr(spec, '_initializing', None)!r};"
+            f"keys={len(vars(module))}"
+        )
+    return " | ".join(details) or "none"
+
+
+def _loaded_apex_class() -> tuple[Any | None, str]:
+    for name, module in _iter_loaded_modules(
+        names=("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71", _RECOVERY_MODULE),
+        basenames=(_APEX_BASENAME,),
+    ):
+        cls = getattr(module, "NIJAApexStrategyV71", None)
+        if cls is not None:
+            return cls, name
+    return None, ""
+
+
+def _partial_apex_module_present() -> bool:
+    found = False
+    for _name, module in _iter_loaded_modules(
+        names=("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"),
+        basenames=(_APEX_BASENAME,),
+    ):
+        found = True
+        if getattr(module, "NIJAApexStrategyV71", None) is not None:
+            return False
+    return found
+
+
 def _bind_apex_class(cls: Any) -> None:
-    """Publish a recovered class onto already-loaded canonical module surfaces."""
+    """Publish a recovered class onto every loaded APEX/strategy surface."""
     if cls is None:
         return
-    for name in ("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            try:
-                setattr(module, "NIJAApexStrategyV71", cls)
-            except Exception:
-                pass
-    for name in ("bot.trading_strategy", "trading_strategy"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            try:
-                setattr(module, "NIJAApexStrategyV71", cls)
-                setattr(module, "_APEX_AVAILABLE", True)
-            except Exception:
-                pass
+    for _name, module in _iter_loaded_modules(
+        names=("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71", _RECOVERY_MODULE),
+        basenames=(_APEX_BASENAME,),
+    ):
+        try:
+            setattr(module, "NIJAApexStrategyV71", cls)
+        except Exception:
+            pass
+    for _name, module in _iter_loaded_modules(
+        names=("bot.trading_strategy", "trading_strategy"),
+        basenames=("trading_strategy.py",),
+    ):
+        try:
+            setattr(module, "NIJAApexStrategyV71", cls)
+            setattr(module, "_APEX_AVAILABLE", True)
+        except Exception:
+            pass
 
 
 def _recover_apex_class_from_source(wiring_module: ModuleType) -> tuple[Any | None, str]:
-    """Recover the canonical v7.1 class without replacing a partial module object."""
+    """Recover v7.1 from canonical source without replacing a partial module."""
     global _RECOVERED_APEX_CLASS
     if _RECOVERED_APEX_CLASS is not None:
         _bind_apex_class(_RECOVERED_APEX_CLASS)
         return _RECOVERED_APEX_CLASS, _RECOVERY_MODULE
 
-    for name in ("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71"):
-        module = sys.modules.get(name)
-        cls = getattr(module, "NIJAApexStrategyV71", None) if isinstance(module, ModuleType) else None
-        if cls is not None:
-            _RECOVERED_APEX_CLASS = cls
-            _bind_apex_class(cls)
-            return cls, name
+    loaded, loaded_from = _loaded_apex_class()
+    if loaded is not None:
+        _RECOVERED_APEX_CLASS = loaded
+        _bind_apex_class(loaded)
+        return loaded, loaded_from
 
     try:
-        source_path = Path(str(getattr(wiring_module, "__file__", "") or "")).resolve().parent / "nija_apex_strategy_v71.py"
+        source_path = Path(str(getattr(wiring_module, "__file__", "") or "")).resolve().parent / _APEX_BASENAME
     except Exception as exc:
         return None, f"source_path_error:{type(exc).__name__}:{exc}"
     if not source_path.is_file():
@@ -111,7 +182,7 @@ def _recover_apex_class_from_source(wiring_module: ModuleType) -> tuple[Any | No
         _RECOVERED_APEX_CLASS = cls
         _bind_apex_class(cls)
         LOGGER.critical(
-            "APEX_CLASS_V97_RECOVERED marker=%s source=%s poisoned_module_replaced=false class=%s",
+            "APEX_CLASS_V97B_RECOVERED marker=%s source=%s poisoned_module_replaced=false class=%s",
             MARKER,
             source_path,
             getattr(cls, "__name__", type(cls).__name__),
@@ -119,10 +190,11 @@ def _recover_apex_class_from_source(wiring_module: ModuleType) -> tuple[Any | No
         return cls, _RECOVERY_MODULE
     except BaseException as exc:
         LOGGER.critical(
-            "APEX_CLASS_V97_RECOVERY_FAILED marker=%s error=%s:%s fail_closed=true",
+            "APEX_CLASS_V97B_RECOVERY_FAILED marker=%s error=%s:%s fail_closed=true diagnostics=%s",
             MARKER,
             type(exc).__name__,
             exc,
+            _apex_module_diagnostics(),
             exc_info=True,
         )
         return None, f"recovery_failed:{type(exc).__name__}:{exc}"
@@ -137,9 +209,37 @@ def _patch_apex_wiring(module: ModuleType) -> bool:
 
     @wraps(current)
     def resolve_apex_class_v97():
-        cls, source = current()
+        loaded, loaded_from = _loaded_apex_class()
+        if loaded is not None:
+            _bind_apex_class(loaded)
+            return loaded, loaded_from
+
+        # A partial canonical module is exactly the production failure mode. Do
+        # not call the legacy canonical->flat resolver first: its flat fallback
+        # can recurse through compatibility import hooks. Recover directly from
+        # the source adjacent to the wiring module instead.
+        if _partial_apex_module_present():
+            LOGGER.warning(
+                "APEX_CLASS_V97B_PARTIAL_MODULE_DETECTED marker=%s wiring_module=%s diagnostics=%s",
+                MARKER,
+                getattr(module, "__name__", "<unknown>"),
+                _apex_module_diagnostics(),
+            )
+            recovered, recovery_source = _recover_apex_class_from_source(module)
+            if recovered is not None:
+                return recovered, recovery_source
+            return None, f"partial_module_recovery_failed:{recovery_source}"
+
+        try:
+            cls, source = current()
+        except RecursionError as exc:
+            cls, source = None, f"legacy_resolver_recursion:{exc}"
+        except Exception as exc:
+            cls, source = None, f"legacy_resolver_error:{type(exc).__name__}:{exc}"
         if cls is not None:
+            _bind_apex_class(cls)
             return cls, source
+
         recovered, recovery_source = _recover_apex_class_from_source(module)
         if recovered is not None:
             return recovered, recovery_source
@@ -149,19 +249,28 @@ def _patch_apex_wiring(module: ModuleType) -> bool:
     setattr(resolve_apex_class_v97, "__wrapped__", current)
     module._resolve_apex_class = resolve_apex_class_v97
     LOGGER.critical(
-        "APEX_CLASS_V97_RESOLVER_PATCHED marker=%s module=%s partial_module_recovery=true",
+        "APEX_CLASS_V97B_RESOLVER_PATCHED marker=%s module=%s file=%s alias_independent=true recovery_preempts_partial=true",
         MARKER,
         getattr(module, "__name__", "<unknown>"),
+        getattr(module, "__file__", None),
     )
     return True
+
+
+def _set_fetch_proof(broker: Any, value: Any, error: str | None = None) -> None:
+    try:
+        setattr(broker, "_startup_position_sync_fetch_ok", value)
+        setattr(broker, "_startup_position_sync_error", error)
+    except Exception:
+        pass
 
 
 def _invalidate_position_sync(broker: Any, *, reason: str) -> None:
     try:
         setattr(broker, "_startup_position_sync_adopted", False)
-        setattr(broker, "_startup_position_sync_error", str(reason or "position_fetch_failed"))
     except Exception:
         pass
+    _set_fetch_proof(broker, False, str(reason or "position_fetch_failed"))
     os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "0"
     os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "0"
 
@@ -170,12 +279,25 @@ def _wrap_position_fetch(method: Callable[..., Any], broker_label: str) -> Calla
     @wraps(method)
     def get_positions_v97(self: Any, *args: Any, **kwargs: Any):
         try:
-            return method(self, *args, **kwargs)
+            depth = int(getattr(self, "_startup_position_sync_fetch_depth", 0) or 0)
+        except Exception:
+            depth = 0
+        try:
+            setattr(self, "_startup_position_sync_fetch_depth", depth + 1)
+        except Exception:
+            pass
+        if depth == 0:
+            _set_fetch_proof(self, None, None)
+        try:
+            result = method(self, *args, **kwargs)
+            # A nested v97 wrapper may have observed a real failure that an
+            # outer compatibility wrapper converted to []. Never overwrite that
+            # failure proof merely because the outer call returned normally.
+            if getattr(self, "_startup_position_sync_fetch_ok", None) is not False:
+                _set_fetch_proof(self, True, None)
+            return result
         except BaseException as exc:
-            _invalidate_position_sync(
-                self,
-                reason=f"{type(exc).__name__}:{exc}",
-            )
+            _invalidate_position_sync(self, reason=f"{type(exc).__name__}:{exc}")
             LOGGER.warning(
                 "POSITION_SYNC_V97_INVALIDATED marker=%s broker=%s error=%s:%s stale_success_reused=false",
                 MARKER,
@@ -184,6 +306,14 @@ def _wrap_position_fetch(method: Callable[..., Any], broker_label: str) -> Calla
                 exc,
             )
             raise
+        finally:
+            try:
+                if depth > 0:
+                    setattr(self, "_startup_position_sync_fetch_depth", depth)
+                else:
+                    setattr(self, "_startup_position_sync_fetch_depth", 0)
+            except Exception:
+                pass
 
     setattr(get_positions_v97, _POSITION_ATTR, True)
     setattr(get_positions_v97, "__wrapped__", method)
@@ -202,11 +332,44 @@ def _patch_position_broker_module(module: ModuleType) -> bool:
         changed = True
     if changed:
         LOGGER.critical(
-            "POSITION_SYNC_V97_BROKERS_PATCHED marker=%s module=%s failure_invalidates_previous_success=true",
+            "POSITION_SYNC_V97_BROKERS_PATCHED marker=%s module=%s failure_invalidates_previous_success=true nested_failure_proof=true",
             MARKER,
             getattr(module, "__name__", "<unknown>"),
         )
     return changed
+
+
+def _patch_startup_sync_module(module: ModuleType) -> bool:
+    current = getattr(module, "_adopt_broker_positions", None)
+    if not callable(current):
+        return False
+    if getattr(current, _POSITION_SYNC_ATTR, False):
+        return True
+
+    @wraps(current)
+    def adopt_broker_positions_v97(broker: Any, broker_name: str, eps: Any) -> int:
+        _set_fetch_proof(broker, None, None)
+        result = int(current(broker, broker_name, eps) or 0)
+        if getattr(broker, "_startup_position_sync_fetch_ok", None) is False:
+            reason = str(getattr(broker, "_startup_position_sync_error", "position_fetch_failed") or "position_fetch_failed")
+            _invalidate_position_sync(broker, reason=reason)
+            LOGGER.critical(
+                "POSITION_SYNC_V97B_MASKED_FAILURE_REJECTED marker=%s broker=%s error=%s empty_or_cached_snapshot_not_authoritative=true activation_blocked=true",
+                MARKER,
+                broker_name,
+                reason,
+            )
+        return result
+
+    setattr(adopt_broker_positions_v97, _POSITION_SYNC_ATTR, True)
+    setattr(adopt_broker_positions_v97, "__wrapped__", current)
+    module._adopt_broker_positions = adopt_broker_positions_v97
+    LOGGER.critical(
+        "POSITION_SYNC_V97B_STARTUP_GUARD_PATCHED marker=%s module=%s masked_failure_rejection=true",
+        MARKER,
+        getattr(module, "__name__", "<unknown>"),
+    )
+    return True
 
 
 def _writer_runtime() -> Any:
@@ -270,40 +433,72 @@ def _patch_core_loop(module: ModuleType) -> bool:
 
 def _patch_loaded() -> bool:
     changed = False
-    seen: set[int] = set()
-    for name in ("bot.trading_strategy_apex_wiring_patch", "trading_strategy_apex_wiring_patch"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType) and id(module) not in seen:
-            seen.add(id(module))
-            changed = _patch_apex_wiring(module) or changed
-    for name in ("bot.broker_manager", "broker_manager"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType) and id(module) not in seen:
-            seen.add(id(module))
-            changed = _patch_position_broker_module(module) or changed
-    for name in ("bot.nija_core_loop", "nija_core_loop"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType) and id(module) not in seen:
-            seen.add(id(module))
-            changed = _patch_core_loop(module) or changed
+    for _name, module in _iter_loaded_modules(
+        names=(
+            "bot.trading_strategy_apex_wiring_patch",
+            "trading_strategy_apex_wiring_patch",
+            "nija_trading_strategy_apex_wiring_patch",
+        ),
+        basenames=(_WIRING_BASENAME,),
+    ):
+        changed = _patch_apex_wiring(module) or changed
+    for _name, module in _iter_loaded_modules(
+        names=("bot.broker_manager", "broker_manager"),
+        basenames=("broker_manager.py",),
+    ):
+        changed = _patch_position_broker_module(module) or changed
+    for _name, module in _iter_loaded_modules(
+        names=("bot.startup_position_sync", "startup_position_sync"),
+        basenames=(_STARTUP_SYNC_BASENAME,),
+    ):
+        changed = _patch_startup_sync_module(module) or changed
+    for _name, module in _iter_loaded_modules(
+        names=("bot.nija_core_loop", "nija_core_loop"),
+        basenames=("nija_core_loop.py",),
+    ):
+        changed = _patch_core_loop(module) or changed
     return changed
+
+
+def _relevant_import(name: Any) -> bool:
+    text = str(name or "")
+    return any(
+        token in text
+        for token in (
+            "trading_strategy_apex_wiring_patch",
+            "broker_manager",
+            "startup_position_sync",
+            "empty_position_sync_success_patch",
+            "kraken_equity_runtime_patch",
+            "nija_core_loop",
+        )
+    )
 
 
 def install_import_hook() -> bool:
     with _LOCK:
         _patch_loaded()
+
+        if not getattr(importlib, _IMPORT_MODULE_FLAG, False):
+            original_import_module = importlib.import_module
+
+            @wraps(original_import_module)
+            def import_module_v97(name: str, package: str | None = None):
+                result = original_import_module(name, package)
+                if _relevant_import(name):
+                    _patch_loaded()
+                return result
+
+            importlib.import_module = import_module_v97  # type: ignore[assignment]
+            setattr(importlib, _IMPORT_MODULE_FLAG, True)
+
         if not getattr(builtins, _HOOK_FLAG, False):
             original_import = builtins.__import__
 
             @wraps(original_import)
             def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
                 result = original_import(name, globals, locals, fromlist, level)
-                text = str(name or "")
-                if any(token in text for token in (
-                    "trading_strategy_apex_wiring_patch",
-                    "broker_manager",
-                    "nija_core_loop",
-                )):
+                if _relevant_import(name):
                     _patch_loaded()
                 return result
 
@@ -311,9 +506,11 @@ def install_import_hook() -> bool:
             setattr(builtins, _HOOK_FLAG, True)
 
         os.environ["NIJA_RUNTIME_TRUTH_CONVERGENCE_V97_INSTALLED"] = "1"
+        os.environ["NIJA_RUNTIME_TRUTH_CONVERGENCE_V97B_INSTALLED"] = "1"
         LOGGER.critical(
-            "RUNTIME_TRUTH_CONVERGENCE_V97_INSTALLED marker=%s apex_partial_recovery=true "
-            "position_failure_invalidates=true scan_lifecycle_bridge=true safety_gates_unchanged=true",
+            "RUNTIME_TRUTH_CONVERGENCE_V97B_INSTALLED marker=%s apex_alias_independent=true "
+            "partial_recovery_preempts_legacy=true position_failure_invalidates=true "
+            "masked_position_failure_rejected=true scan_lifecycle_bridge=true safety_gates_unchanged=true",
             MARKER,
         )
         return True
@@ -329,6 +526,7 @@ __all__ = [
     "install_import_hook",
     "_patch_apex_wiring",
     "_patch_position_broker_module",
+    "_patch_startup_sync_module",
     "_patch_core_loop",
     "_recover_apex_class_from_source",
 ]

--- a/bot/tests/test_runtime_truth_convergence_v97.py
+++ b/bot/tests/test_runtime_truth_convergence_v97.py
@@ -7,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from bot import empty_position_sync_success_patch as empty_sync_patch
 from bot import runtime_truth_convergence_v97_patch as patch
 
 
@@ -33,6 +34,7 @@ def test_apex_recovery_loads_class_from_source_when_partial_module_has_no_class(
     wiring.__file__ = str(tmp_path / "trading_strategy_apex_wiring_patch.py")
 
     partial = ModuleType("bot.nija_apex_strategy_v71")
+    partial.__file__ = str(source)
     monkeypatch.setitem(sys.modules, "bot.nija_apex_strategy_v71", partial)
     monkeypatch.delitem(sys.modules, "nija_apex_strategy_v71", raising=False)
     monkeypatch.delitem(sys.modules, patch._RECOVERY_MODULE, raising=False)
@@ -44,6 +46,61 @@ def test_apex_recovery_loads_class_from_source_when_partial_module_has_no_class(
     assert cls.__name__ == "NIJAApexStrategyV71"
     assert recovered_from == patch._RECOVERY_MODULE
     assert getattr(partial, "NIJAApexStrategyV71") is cls
+
+
+def test_partial_apex_preempts_recursive_legacy_resolver_on_source_loaded_alias(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "nija_apex_strategy_v71.py"
+    source.write_text("class NIJAApexStrategyV71:\n    pass\n", encoding="utf-8")
+
+    calls: list[str] = []
+    wiring = ModuleType("nija_trading_strategy_apex_wiring_patch")
+    wiring.__file__ = str(tmp_path / "trading_strategy_apex_wiring_patch.py")
+
+    def recursive_legacy_resolver():
+        calls.append("legacy")
+        raise RecursionError("flat alias loop")
+
+    wiring._resolve_apex_class = recursive_legacy_resolver
+    partial = ModuleType("bot.nija_apex_strategy_v71")
+    partial.__file__ = str(source)
+
+    monkeypatch.setitem(sys.modules, "nija_trading_strategy_apex_wiring_patch", wiring)
+    monkeypatch.setitem(sys.modules, "bot.nija_apex_strategy_v71", partial)
+    monkeypatch.delitem(sys.modules, "nija_apex_strategy_v71", raising=False)
+    monkeypatch.delitem(sys.modules, patch._RECOVERY_MODULE, raising=False)
+    monkeypatch.setattr(patch, "_RECOVERED_APEX_CLASS", None)
+
+    assert patch._patch_apex_wiring(wiring)
+    cls, recovered_from = wiring._resolve_apex_class()
+
+    assert cls is not None
+    assert cls.__name__ == "NIJAApexStrategyV71"
+    assert recovered_from == patch._RECOVERY_MODULE
+    assert calls == []
+    assert getattr(partial, "NIJAApexStrategyV71") is cls
+
+
+def test_patch_loaded_discovers_source_loaded_wiring_alias_by_file(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "nija_apex_strategy_v71.py"
+    source.write_text("class NIJAApexStrategyV71:\n    pass\n", encoding="utf-8")
+
+    wiring = ModuleType("runtime_alias_which_does_not_match_canonical_name")
+    wiring.__file__ = str(tmp_path / "trading_strategy_apex_wiring_patch.py")
+    wiring._resolve_apex_class = lambda: (None, "legacy_missing")
+    partial = ModuleType("bot.nija_apex_strategy_v71")
+    partial.__file__ = str(source)
+
+    monkeypatch.setitem(sys.modules, wiring.__name__, wiring)
+    monkeypatch.setitem(sys.modules, "bot.nija_apex_strategy_v71", partial)
+    monkeypatch.delitem(sys.modules, patch._RECOVERY_MODULE, raising=False)
+    monkeypatch.setattr(patch, "_RECOVERED_APEX_CLASS", None)
+
+    patch._patch_loaded()
+
+    assert getattr(wiring._resolve_apex_class, patch._APEX_ATTR, False) is True
+    cls, _source = wiring._resolve_apex_class()
+    assert cls is not None
+    assert cls.__name__ == "NIJAApexStrategyV71"
 
 
 def test_position_fetch_failure_revokes_previous_sync_success(monkeypatch) -> None:
@@ -66,9 +123,112 @@ def test_position_fetch_failure_revokes_previous_sync_success(monkeypatch) -> No
         broker.get_positions()
 
     assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
     assert "TimeoutError" in broker._startup_position_sync_error
     assert patch.os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] == "0"
     assert patch.os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] == "0"
+
+
+def test_nested_position_wrapper_preserves_failure_masked_as_empty(monkeypatch) -> None:
+    class KrakenBroker:
+        def __init__(self) -> None:
+            self._startup_position_sync_adopted = True
+
+    def raw_get_positions(self):
+        raise TimeoutError("slow exchange")
+
+    inner = patch._wrap_position_fetch(raw_get_positions, "kraken")
+
+    def compatibility_equity_wrapper(self):
+        try:
+            return inner(self)
+        except TimeoutError:
+            return []
+
+    outer = patch._wrap_position_fetch(compatibility_equity_wrapper, "kraken")
+    broker = KrakenBroker()
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_DISPATCH_READY", "1")
+
+    assert outer(broker) == []
+    assert broker._startup_position_sync_fetch_ok is False
+    assert broker._startup_position_sync_adopted is False
+    assert "TimeoutError" in broker._startup_position_sync_error
+    assert patch.os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] == "0"
+    assert patch.os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] == "0"
+
+
+def test_startup_sync_guard_rejects_masked_empty_success(monkeypatch) -> None:
+    class Broker:
+        _startup_position_sync_adopted = False
+        _startup_position_sync_fetch_ok = None
+        _startup_position_sync_error = None
+
+    def canonical_adopt(broker, broker_name, eps):
+        broker._startup_position_sync_fetch_ok = False
+        broker._startup_position_sync_error = "TimeoutError:slow exchange"
+        broker._startup_position_sync_adopted = True
+        return 0
+
+    module = ModuleType("bot.startup_position_sync")
+    module._adopt_broker_positions = canonical_adopt
+    assert patch._patch_startup_sync_module(module)
+
+    broker = Broker()
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_DISPATCH_READY", "1")
+    assert module._adopt_broker_positions(broker, "platform:kraken", None) == 0
+
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert patch.os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] == "0"
+    assert patch.os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] == "0"
+
+
+def test_empty_sync_compatibility_wrapper_never_refetches_broker() -> None:
+    calls: list[str] = []
+
+    class Broker:
+        connected = True
+        _startup_position_sync_adopted = False
+        _startup_position_sync_fetch_ok = True
+
+        def get_positions(self):
+            raise AssertionError("compatibility wrapper must not refetch")
+
+    def canonical_adopt(broker, broker_name, eps):
+        calls.append(broker_name)
+        broker._startup_position_sync_adopted = True
+        return 0
+
+    module = ModuleType("bot.startup_position_sync")
+    module._adopt_broker_positions = canonical_adopt
+    assert empty_sync_patch._patch(module)
+
+    broker = Broker()
+    assert module._adopt_broker_positions(broker, "platform:kraken", None) == 0
+    assert calls == ["platform:kraken"]
+    assert broker._startup_position_sync_adopted is True
+
+
+def test_empty_sync_compatibility_wrapper_preserves_failure_proof() -> None:
+    class Broker:
+        connected = True
+        _startup_position_sync_adopted = False
+        _startup_position_sync_fetch_ok = False
+        _startup_position_sync_error = "TimeoutError:slow exchange"
+
+    def canonical_adopt(broker, broker_name, eps):
+        broker._startup_position_sync_adopted = True
+        return 0
+
+    module = ModuleType("bot.startup_position_sync")
+    module._adopt_broker_positions = canonical_adopt
+    assert empty_sync_patch._patch(module)
+
+    broker = Broker()
+    assert module._adopt_broker_positions(broker, "platform:kraken", None) == 0
+    assert broker._startup_position_sync_adopted is False
 
 
 def test_scan_phase_records_writer_lifecycle(monkeypatch) -> None:


### PR DESCRIPTION
Superseded by a branch-policy-compliant PR using the identical head commit. This PR used the `agent/*` prefix, which the repository branch-policy workflow rejects. No code was discarded.