### PR TITLE
Stabilize runtime startup convergence

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260815-canonical-fast-entrypoint-v66"
+_FAST_PATH_MARKER = "20260815-canonical-fast-entrypoint-v67"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -71,12 +71,14 @@ _FAST_PATH_INSTALLERS = (
     # Publish position-sync truth into canonical readiness so an unsynced
     # connected broker also revokes any stale coordinator dispatch commit.
     ("bot.position_sync_dispatch_authority_v96_patch", "POSITION_SYNC_DISPATCH_AUTHORITY_V96"),
+    # Install v97 before the legacy APEX wiring module. v97 owns the import hooks
+    # that recover a partial APEX module directly from canonical source and
+    # prevent the flat-module fallback from recursing during startup.
+    ("bot.runtime_truth_convergence_v97_patch", "RUNTIME_TRUTH_CONVERGENCE_V97"),
     # The production core invokes TradingStrategy directly. These guards must be
-    # present on the canonical fast path. v97 additionally repairs partial APEX
-    # module truth, position-sync failure latches, and scan lifecycle handoff.
+    # present on the canonical fast path after v97's recovery hooks are active.
     ("bot.trading_engine_strategy_wrapper_patch", "TRADING_ENGINE_STRATEGY_WRAPPER"),
     ("bot.trading_strategy_apex_wiring_patch", "TRADING_STRATEGY_APEX_WIRING"),
-    ("bot.runtime_truth_convergence_v97_patch", "RUNTIME_TRUTH_CONVERGENCE_V97"),
     ("bot.strategy_runtime_integrity_patch", "STRATEGY_RUNTIME_INTEGRITY"),
     ("bot.final_production_activation_repair_v58_patch", "FINAL_PRODUCTION_ACTIVATION_V58"),
     # v61 must install before v59/v60 start their reconciliation/activation

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ import sys
 from typing import Iterable
 
 logger = logging.getLogger("nija.bot_entrypoint")
-_FAST_PATH_MARKER = "20260815-canonical-fast-entrypoint-v67"
+_FAST_PATH_MARKER = "20260815-canonical-fast-entrypoint-v68"
 
 _FAST_PATH_INSTALLERS = (
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
@@ -68,6 +68,10 @@ _FAST_PATH_INSTALLERS = (
     # startup thread indefinitely. v95 also makes position-sync completion a
     # fail-closed activation prerequisite rather than pre-latching success.
     ("bot.position_sync_core_handoff_v95_patch", "POSITION_SYNC_CORE_HANDOFF_V95"),
+    # Production Kraken snapshots exceeded the historical five-second default.
+    # v98 raises only the default wait budget; explicit env overrides and all
+    # fail-closed position/readiness/dispatch gates remain authoritative.
+    ("bot.position_sync_timeout_v98_patch", "POSITION_SYNC_TIMEOUT_V98"),
     # Publish position-sync truth into canonical readiness so an unsynced
     # connected broker also revokes any stale coordinator dispatch commit.
     ("bot.position_sync_dispatch_authority_v96_patch", "POSITION_SYNC_DISPATCH_AUTHORITY_V96"),

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -1,0 +1,61 @@
+"""Tune startup position-fetch timeout without weakening position-sync safety.
+
+Production logs on 2026-08-15 showed authoritative Kraken position snapshots
+crossing the v95 five-second default. v95 correctly failed closed, but the
+short default caused repeated timeout/invalidation during otherwise healthy
+broker startup.
+
+v98 changes only the *default* timeout to 12 seconds. An explicit
+NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. All v95/v96/v97
+position-sync, readiness, dispatch, writer, nonce, risk, and kill-switch gates
+remain unchanged.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+LOGGER = logging.getLogger("nija.position_sync_timeout_v98")
+MARKER = "20260815-position-sync-timeout-v98"
+_DEFAULT_TIMEOUT_S = 12.0
+_INSTALLED = False
+
+
+def _timeout_s_v98() -> float:
+    raw = os.environ.get("NIJA_POSITION_FETCH_TIMEOUT_S")
+    if raw is None or not str(raw).strip():
+        return _DEFAULT_TIMEOUT_S
+    try:
+        return max(0.1, float(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_TIMEOUT_S
+
+
+def install() -> bool:
+    global _INSTALLED
+    if _INSTALLED:
+        return True
+
+    try:
+        from bot import position_sync_core_handoff_v95_patch as v95
+    except ImportError:
+        import position_sync_core_handoff_v95_patch as v95  # type: ignore[import]
+
+    setattr(v95, "_timeout_s", _timeout_s_v98)
+    os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
+    _INSTALLED = True
+    LOGGER.critical(
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
+        "explicit_env_override_preserved=true safety_gates_unchanged=true",
+        MARKER,
+        _DEFAULT_TIMEOUT_S,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_timeout_s_v98"]

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -93,7 +93,17 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     assert "okx_final_order_submission_bridge_patch" in fast_block
     assert "startup_authority_prereq_repair_patch" in fast_block
     assert "stalled_writer_release_guard_v22" in fast_block
-    assert "trading_engine_strategy_wrapper_patch" not in fast_block
+
+    # The canonical production core now invokes TradingStrategy directly, so
+    # the wrapper/wiring guards belong on the fast path. Preserve the safety
+    # ordering that prevents a partial APEX module from falling into recursive
+    # flat-module imports: runtime-truth recovery must be active before wiring.
+    assert "trading_engine_strategy_wrapper_patch" in fast_block
+    assert "trading_strategy_apex_wiring_patch" in fast_block
+    assert "runtime_truth_convergence_v97_patch" in fast_block
+    assert fast_block.index("runtime_truth_convergence_v97_patch") < fast_block.index(
+        "trading_strategy_apex_wiring_patch"
+    )
     assert "canonical_broker_main_entry_guard_v20" not in fast_block
 
 

--- a/bot/tests/test_fast_entrypoint_guard_order_v98.py
+++ b/bot/tests/test_fast_entrypoint_guard_order_v98.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _installer_modules() -> list[str]:
+    source = Path(__file__).resolve().parents[1].joinpath("bot.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_FAST_PATH_INSTALLERS":
+                    assert isinstance(node.value, ast.Tuple)
+                    return [
+                        item.elts[0].value
+                        for item in node.value.elts
+                        if isinstance(item, ast.Tuple)
+                        and item.elts
+                        and isinstance(item.elts[0], ast.Constant)
+                    ]
+    raise AssertionError("_FAST_PATH_INSTALLERS not found")
+
+
+def test_runtime_truth_recovery_precedes_apex_wiring():
+    modules = _installer_modules()
+    assert modules.index("bot.runtime_truth_convergence_v97_patch") < modules.index(
+        "bot.trading_strategy_apex_wiring_patch"
+    )
+
+
+def test_position_timeout_installs_between_v95_and_v96():
+    modules = _installer_modules()
+    assert modules.index("bot.position_sync_core_handoff_v95_patch") < modules.index(
+        "bot.position_sync_timeout_v98_patch"
+    ) < modules.index("bot.position_sync_dispatch_authority_v96_patch")

--- a/bot/tests/test_position_sync_timeout_v98.py
+++ b/bot/tests/test_position_sync_timeout_v98.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_default_timeout_is_widened_without_env(monkeypatch):
+    monkeypatch.delenv("NIJA_POSITION_FETCH_TIMEOUT_S", raising=False)
+    module = importlib.import_module("bot.position_sync_timeout_v98_patch")
+    assert module._timeout_s_v98() == 12.0
+
+
+def test_explicit_timeout_override_is_preserved(monkeypatch):
+    monkeypatch.setenv("NIJA_POSITION_FETCH_TIMEOUT_S", "7.5")
+    module = importlib.import_module("bot.position_sync_timeout_v98_patch")
+    assert module._timeout_s_v98() == 7.5
+
+
+def test_invalid_timeout_falls_back_to_safe_default(monkeypatch):
+    monkeypatch.setenv("NIJA_POSITION_FETCH_TIMEOUT_S", "not-a-number")
+    module = importlib.import_module("bot.position_sync_timeout_v98_patch")
+    assert module._timeout_s_v98() == 12.0
+
+
+def test_install_patches_v95_timeout_only(monkeypatch):
+    monkeypatch.delenv("NIJA_POSITION_FETCH_TIMEOUT_S", raising=False)
+    v95 = importlib.import_module("bot.position_sync_core_handoff_v95_patch")
+    v98 = importlib.import_module("bot.position_sync_timeout_v98_patch")
+
+    monkeypatch.setattr(v98, "_INSTALLED", False)
+    assert v98.install() is True
+    assert v95._timeout_s() == 12.0
+    assert v95.position_sync_status is not None


### PR DESCRIPTION
## What changed

- Preserve the APEX recursion repair by requiring `runtime_truth_convergence_v97_patch` to install before legacy APEX wiring.
- Keep the guarded TradingStrategy wrapper/wiring on the canonical fast path, matching the current production architecture on `main`.
- Raise only the default startup position-fetch wait from 5s to 12s while preserving `NIJA_POSITION_FETCH_TIMEOUT_S` overrides.
- Keep position-sync, readiness, dispatch, writer, nonce, risk, and kill-switch gates fail closed.
- Update the stale canonical-fast-entrypoint regression assertion so it verifies the current safety ordering instead of forbidding a guard that is already present on `main`.
- Use a branch name that satisfies repository branch policy.

## Root cause

PR #2527 was blocked by two repository-contract issues rather than a syntax failure: an outdated test asserted that `trading_engine_strategy_wrapper_patch` must not be on the fast path even though `main` already includes it, and the `agent/...` branch name violates the repository's allowed branch-name regex.

## Safety

No readiness, positions, execution authority, or broker connectivity are synthesized. Risk thresholds and writer/nonce/kill-switch gates are unchanged. Position fetch failures remain fail closed.

## Validation

The previous PR run reached 160/161 focused runtime tests and 14/15 canonical launcher tests; both failures were the same stale fast-path assertion. This replacement updates that assertion and uses a policy-compliant branch so GitHub Actions can validate the complete change set.