### PR TITLE
Isolate user position sync from platform activation

### DIFF
--- a/bot/position_sync_account_isolation_v99_patch.py
+++ b/bot/position_sync_account_isolation_v99_patch.py
@@ -1,0 +1,237 @@
+"""Keep platform startup readiness independent from per-user position sync.
+
+Production deployment ed2001a7 on 2026-08-15 showed all three platform venues
+fully synchronized while a connected Kraken user account repeatedly exceeded the
+bounded position-fetch timeout. v95/v96 correctly failed closed, but their
+all-connected-brokers rule allowed one user account to hold the entire platform
+in LIVE_PENDING_CONFIRMATION.
+
+NIJA's account architecture is explicitly isolated: platform trading must not be
+blocked by a user account failure, while that user must remain fail closed until
+its own positions are authoritative. v99 enforces that split:
+
+* global activation/readiness consumes only connected platform-broker snapshots;
+* the original all-account status function remains available for diagnostics;
+* CopyTradeEngine order submission is blocked for an unsynchronized user broker;
+* the recurring runtime reconciler remains unchanged and can later promote the
+  user broker after a real position snapshot succeeds.
+
+No position-sync success, broker connectivity, execution authority, risk state,
+writer/nonce authority, or kill-switch state is fabricated.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.position_sync_account_isolation_v99")
+MARKER = "20260815-position-sync-account-isolation-v99"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_POSITION_SYNC_ACCOUNT_ISOLATION_V99_IMPORT_HOOK"
+_COPY_ATTR = "_nija_position_sync_account_isolation_v99"
+_ORIGINAL_STATUS: Callable[[Any], tuple[bool, list[str], dict[str, bool]]] | None = None
+_LAST_USER_SIGNATURE = ""
+
+
+def _v95_module() -> ModuleType:
+    try:
+        import bot.position_sync_core_handoff_v95_patch as v95
+    except ImportError:
+        import position_sync_core_handoff_v95_patch as v95  # type: ignore[import]
+    return v95
+
+
+def _all_account_status(manager: Any) -> tuple[bool, list[str], dict[str, bool]]:
+    global _ORIGINAL_STATUS
+    v95 = _v95_module()
+    original = _ORIGINAL_STATUS
+    if original is None:
+        candidate = getattr(v95, "position_sync_status", None)
+        if not callable(candidate):
+            return False, ["position_sync_status_unavailable"], {}
+        original = candidate
+        _ORIGINAL_STATUS = original
+    return original(manager)
+
+
+def _platform_position_sync_status(manager: Any) -> tuple[bool, list[str], dict[str, bool]]:
+    """Return fail-closed global readiness for connected platform brokers only."""
+    v95 = _v95_module()
+    try:
+        brokers = dict(v95._connected_brokers(manager) or {})
+    except Exception:
+        brokers = {}
+    platform = {
+        name: broker
+        for name, broker in brokers.items()
+        if str(name).startswith("platform:")
+    }
+    status = {
+        name: bool(getattr(broker, "_startup_position_sync_adopted", False))
+        for name, broker in platform.items()
+    }
+    pending = sorted(name for name, synced in status.items() if not synced)
+    # Empty platform set is never globally ready.
+    return bool(status) and not pending, pending, status
+
+
+def _publish_user_diagnostics(manager: Any) -> None:
+    global _LAST_USER_SIGNATURE
+    try:
+        _ready, _pending, status = _all_account_status(manager)
+    except Exception:
+        return
+    user_status = {
+        name: synced for name, synced in status.items()
+        if str(name).startswith("user:")
+    }
+    pending_users = sorted(name for name, synced in user_status.items() if not synced)
+    signature = repr((pending_users, sorted(user_status.items())))
+    os.environ["NIJA_USER_POSITION_SYNC_PENDING"] = ",".join(pending_users)
+    os.environ["NIJA_USER_POSITION_SYNC_READY"] = "1" if user_status and not pending_users else "0"
+    if signature == _LAST_USER_SIGNATURE:
+        return
+    _LAST_USER_SIGNATURE = signature
+    log = LOGGER.warning if pending_users else LOGGER.info
+    log(
+        "USER_POSITION_SYNC_V99_STATUS marker=%s pending=%s status=%s "
+        "global_activation_isolated=true user_execution_fail_closed=true",
+        MARKER,
+        pending_users,
+        user_status,
+    )
+
+
+def position_sync_status_v99(manager: Any) -> tuple[bool, list[str], dict[str, bool]]:
+    """Replacement consumed by v95/v96 global activation paths."""
+    ready, pending, status = _platform_position_sync_status(manager)
+    _publish_user_diagnostics(manager)
+    return ready, pending, status
+
+
+def _patch_v95() -> bool:
+    global _ORIGINAL_STATUS
+    v95 = _v95_module()
+    current = getattr(v95, "position_sync_status", None)
+    if not callable(current):
+        return False
+    if current is position_sync_status_v99:
+        return True
+    if _ORIGINAL_STATUS is None:
+        _ORIGINAL_STATUS = current
+    setattr(v95, "all_account_position_sync_status", _ORIGINAL_STATUS)
+    setattr(v95, "platform_position_sync_status", _platform_position_sync_status)
+    setattr(v95, "position_sync_status", position_sync_status_v99)
+    LOGGER.critical(
+        "POSITION_SYNC_V99_GLOBAL_SCOPE_PATCHED marker=%s scope=platform_only "
+        "all_account_diagnostics_preserved=true user_fail_closed=true",
+        MARKER,
+    )
+    return True
+
+
+def _guard_submitter(current: Callable[..., Any]) -> Callable[..., Any]:
+    """Block CopyTradeEngine user orders until that broker has a real snapshot."""
+    if getattr(current, _COPY_ATTR, False):
+        return current
+
+    @wraps(current)
+    def submit_guarded(*args: Any, **kwargs: Any):
+        broker = kwargs.get("broker")
+        if broker is None and args:
+            broker = args[0]
+        if broker is None or not bool(getattr(broker, "_startup_position_sync_adopted", False)):
+            LOGGER.warning(
+                "USER_COPY_TRADE_POSITION_SYNC_BLOCK marker=%s broker=%s "
+                "position_sync_ready=false broker_io=false",
+                MARKER,
+                type(broker).__name__ if broker is not None else "none",
+            )
+            return {
+                "status": "skipped",
+                "error": "user position sync incomplete; copy trade remains fail closed",
+                "position_sync_ready": False,
+            }
+        return current(*args, **kwargs)
+
+    setattr(submit_guarded, _COPY_ATTR, True)
+    setattr(submit_guarded, "__wrapped__", current)
+    return submit_guarded
+
+
+def _patch_copy_trade_engine(module: ModuleType) -> bool:
+    current = getattr(module, "submit_market_order_via_pipeline", None)
+    if current is None:
+        # The copy engine already fails closed when the submit helper is absent.
+        return True
+    if not callable(current):
+        return False
+    if getattr(current, _COPY_ATTR, False):
+        return True
+    module.submit_market_order_via_pipeline = _guard_submitter(current)
+    LOGGER.critical(
+        "POSITION_SYNC_V99_COPY_TRADE_GUARD_PATCHED marker=%s "
+        "user_position_sync_required=true direct_fallback=false",
+        MARKER,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    ready = _patch_v95()
+    seen: set[int] = set()
+    for name in ("bot.copy_trade_engine", "copy_trade_engine"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            ready = _patch_copy_trade_engine(module) and ready
+    return ready
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        if not _patch_loaded():
+            return False
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                text = str(name or "")
+                if "copy_trade_engine" in text or "position_sync_core_handoff_v95_patch" in text:
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_POSITION_SYNC_ACCOUNT_ISOLATION_V99_INSTALLED"] = "1"
+        LOGGER.critical(
+            "POSITION_SYNC_ACCOUNT_ISOLATION_V99_INSTALLED marker=%s "
+            "global_scope=platform user_scope=account_local safety_gates_unchanged=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "position_sync_status_v99",
+    "_all_account_status",
+    "_platform_position_sync_status",
+    "_guard_submitter",
+    "_patch_copy_trade_engine",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -6,9 +6,9 @@ short default caused repeated timeout/invalidation during otherwise healthy
 broker startup.
 
 v98 changes only the *default* timeout to 12 seconds. An explicit
-NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. All v95/v96/v97
-position-sync, readiness, dispatch, writer, nonce, risk, and kill-switch gates
-remain unchanged.
+NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
+from the same canonical slot so platform readiness is isolated from slow user
+position snapshots while each user execution path remains fail closed.
 """
 from __future__ import annotations
 
@@ -32,10 +32,19 @@ def _timeout_s_v98() -> float:
         return _DEFAULT_TIMEOUT_S
 
 
+def _install_v99() -> bool:
+    try:
+        from bot import position_sync_account_isolation_v99_patch as v99
+    except ImportError:
+        import position_sync_account_isolation_v99_patch as v99  # type: ignore[import]
+    installer = getattr(v99, "install_import_hook", None) or getattr(v99, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
 def install() -> bool:
     global _INSTALLED
-    if _INSTALLED:
-        return True
 
     try:
         from bot import position_sync_core_handoff_v95_patch as v95
@@ -43,11 +52,22 @@ def install() -> bool:
         import position_sync_core_handoff_v95_patch as v95  # type: ignore[import]
 
     setattr(v95, "_timeout_s", _timeout_s_v98)
+    if not _install_v99():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V99_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
+
+    if _INSTALLED:
+        return True
+
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
-        "explicit_env_override_preserved=true safety_gates_unchanged=true",
+        "explicit_env_override_preserved=true account_isolation_v99=true "
+        "safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_position_sync_account_isolation_v99.py
+++ b/bot/tests/test_position_sync_account_isolation_v99.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import types
+import unittest
+from enum import Enum
+
+from bot import position_sync_account_isolation_v99_patch as v99
+from bot import position_sync_core_handoff_v95_patch as v95
+
+
+class _BrokerType(Enum):
+    KRAKEN = "kraken"
+    COINBASE = "coinbase"
+
+
+class _Broker:
+    connected = True
+
+    def __init__(self, synced: bool) -> None:
+        self._startup_position_sync_adopted = synced
+
+
+class PositionSyncAccountIsolationV99Tests(unittest.TestCase):
+    def test_platform_ready_is_not_blocked_by_unsynced_user(self) -> None:
+        manager = types.SimpleNamespace(
+            platform_brokers={
+                _BrokerType.KRAKEN: _Broker(True),
+                _BrokerType.COINBASE: _Broker(True),
+            },
+            user_brokers={
+                "daivon_frazier": {_BrokerType.KRAKEN: _Broker(False)},
+            },
+        )
+
+        platform_ready, platform_pending, platform_status = v99._platform_position_sync_status(manager)
+        self.assertTrue(platform_ready)
+        self.assertEqual(platform_pending, [])
+        self.assertEqual(
+            platform_status,
+            {"platform:kraken": True, "platform:coinbase": True},
+        )
+
+        all_ready, all_pending, all_status = v95.position_sync_status(manager)
+        self.assertFalse(all_ready)
+        self.assertEqual(all_pending, ["user:daivon_frazier:kraken"])
+        self.assertFalse(all_status["user:daivon_frazier:kraken"])
+
+    def test_unsynced_platform_still_blocks_global_readiness(self) -> None:
+        manager = types.SimpleNamespace(
+            platform_brokers={
+                _BrokerType.KRAKEN: _Broker(True),
+                _BrokerType.COINBASE: _Broker(False),
+            },
+            user_brokers={
+                "daivon_frazier": {_BrokerType.KRAKEN: _Broker(True)},
+            },
+        )
+
+        ready, pending, status = v99._platform_position_sync_status(manager)
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:coinbase"])
+        self.assertFalse(status["platform:coinbase"])
+
+    def test_empty_platform_set_is_fail_closed(self) -> None:
+        manager = types.SimpleNamespace(
+            platform_brokers={},
+            user_brokers={
+                "daivon_frazier": {_BrokerType.KRAKEN: _Broker(True)},
+            },
+        )
+        ready, pending, status = v99._platform_position_sync_status(manager)
+        self.assertFalse(ready)
+        self.assertEqual(pending, [])
+        self.assertEqual(status, {})
+
+    def test_copy_trade_submitter_blocks_only_until_user_sync_is_real(self) -> None:
+        calls: list[dict] = []
+
+        def submitter(*args, **kwargs):
+            calls.append(dict(kwargs))
+            return {"status": "filled", "order_id": "ok"}
+
+        guarded = v99._guard_submitter(submitter)
+        broker = _Broker(False)
+
+        blocked = guarded(
+            broker=broker,
+            symbol="BTC/USD",
+            side="buy",
+            quantity=10.0,
+            size_type="quote",
+            strategy="CopyTradeEngine",
+        )
+        self.assertEqual(blocked["status"], "skipped")
+        self.assertFalse(blocked["position_sync_ready"])
+        self.assertEqual(calls, [])
+
+        broker._startup_position_sync_adopted = True
+        allowed = guarded(
+            broker=broker,
+            symbol="BTC/USD",
+            side="buy",
+            quantity=10.0,
+            size_type="quote",
+            strategy="CopyTradeEngine",
+        )
+        self.assertEqual(allowed["status"], "filled")
+        self.assertEqual(len(calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Add v99 account-isolated position-sync readiness.
- Keep global activation/readiness fail closed on connected **platform** broker snapshots only.
- Preserve the original all-account position-sync status for diagnostics.
- Block CopyTradeEngine submission for any user broker whose authoritative position snapshot has not completed.
- Keep the recurring runtime reconciler unchanged so timed-out user accounts retry and can later become eligible after a real snapshot succeeds.
- Keep the existing 12-second bounded fetch timeout; do not stretch startup further.

## Production evidence

Deployment `ed2001a7cdcbabb45166968622f96929ea8faf0f` shows platform Kraken/Coinbase/OKX synchronized and capital hydrated, while `user:daivon_frazier:kraken` exceeds the 12-second bounded position fetch. That leaves `position_sync_ready=false` and globally blocks activation even though the platform brokers are healthy.

The same runtime also shows the canonical core thread successfully starting and registering, so writer/core readiness is transient rather than the persistent blocker. The prior APEX recursion failure is absent; the remaining APEX hydration timeout occurs before the canonical core handoff and does not crash startup.

## Safety

This is not a readiness bypass. Unsynced platform brokers still block global activation. Unsynced user brokers remain unable to receive copy-trade orders, and their user trading loop already fails closed on position-adoption failure. No broker connectivity, position-sync success, execution authority, risk state, nonce/writer authority, or kill-switch state is fabricated.

## Tests

Adds regression coverage for:
- healthy platform + unsynced user => platform global readiness may proceed;
- any unsynced platform broker => global readiness remains blocked;
- no connected platform broker => fail closed;
- copy-trade submitter does no broker I/O until the user broker has real position-sync proof.
