### PR TITLE
Recover canonical TradingStrategy class before publication

### DIFF
--- a/bot/canonical_strategy_class_recovery_v100_patch.py
+++ b/bot/canonical_strategy_class_recovery_v100_patch.py
@@ -1,0 +1,283 @@
+"""Recover canonical TradingStrategy publication from a partial import safely.
+
+Production deployment 89f94744 on 2026-08-15 reached Step 2.5 with live capital
+and writer authority, then failed closed because strategy_publication_patch saw
+``TradingStrategy`` as unavailable. The same logs show trading_strategy had begun
+importing (it emitted the NIJAApexStrategyV71 degraded-mode warning), which means
+publication raced a partial/stale module surface rather than proving that the
+strategy source was absent.
+
+v100 repairs only class publication convergence:
+* wait briefly for an actively-initializing canonical trading_strategy module;
+* if a trading_strategy module is present but no longer initializing and still
+  lacks TradingStrategy, perform at most one controlled importlib.reload();
+* consume only the real TradingStrategy class from the canonical module object;
+* preserve the existing class_unavailable fail-closed result if recovery fails.
+
+No readiness key, execution authority, writer/nonce state, risk gate, position
+state, broker connectivity, or trading state is synthesized by this patch.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable, Optional
+
+LOGGER = logging.getLogger("nija.canonical_strategy_class_recovery_v100")
+MARKER = "20260815-canonical-strategy-class-recovery-v100"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_CANONICAL_STRATEGY_CLASS_RECOVERY_V100_IMPORT_HOOK"
+_PATCH_ATTR = "_nija_canonical_strategy_class_recovery_v100"
+_RELOAD_ATTEMPTED: set[int] = set()
+
+
+def _timeout_s() -> float:
+    try:
+        return max(
+            0.1,
+            float(os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", "6") or 6.0),
+        )
+    except (TypeError, ValueError):
+        return 6.0
+
+
+def _poll_s() -> float:
+    try:
+        return max(
+            0.01,
+            min(
+                0.5,
+                float(os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S", "0.05") or 0.05),
+            ),
+        )
+    except (TypeError, ValueError):
+        return 0.05
+
+
+def _candidate_modules() -> list[tuple[str, ModuleType]]:
+    out: list[tuple[str, ModuleType]] = []
+    seen: set[int] = set()
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            out.append((name, module))
+    return out
+
+
+def _real_strategy_class() -> tuple[Optional[type], str]:
+    for name, module in _candidate_modules():
+        cls = getattr(module, "TradingStrategy", None)
+        if isinstance(cls, type):
+            return cls, name
+    return None, ""
+
+
+def _initializing(module: ModuleType) -> bool:
+    spec = getattr(module, "__spec__", None)
+    return bool(getattr(spec, "_initializing", False))
+
+
+def _diagnostics() -> str:
+    details: list[str] = []
+    for name, module in _candidate_modules():
+        spec = getattr(module, "__spec__", None)
+        details.append(
+            f"{name}:id={id(module)};file={getattr(module, '__file__', None)!r};"
+            f"class={isinstance(getattr(module, 'TradingStrategy', None), type)};"
+            f"initializing={bool(getattr(spec, '_initializing', False))};"
+            f"keys={len(vars(module))}"
+        )
+    return " | ".join(details) or "none"
+
+
+def _reload_stale_candidate_once() -> tuple[Optional[type], str]:
+    """Reload one demonstrably non-initializing partial canonical module."""
+    for name, module in _candidate_modules():
+        if _initializing(module):
+            continue
+        if isinstance(getattr(module, "TradingStrategy", None), type):
+            return getattr(module, "TradingStrategy"), name
+        key = id(module)
+        if key in _RELOAD_ATTEMPTED:
+            continue
+        _RELOAD_ATTEMPTED.add(key)
+        try:
+            reloaded = importlib.reload(module)
+            cls = getattr(reloaded, "TradingStrategy", None)
+            if isinstance(cls, type):
+                LOGGER.critical(
+                    "CANONICAL_STRATEGY_CLASS_V100_RELOADED marker=%s module=%s "
+                    "same_object=%s class=%s",
+                    MARKER,
+                    name,
+                    str(reloaded is module).lower(),
+                    cls.__name__,
+                )
+                return cls, name
+            LOGGER.warning(
+                "CANONICAL_STRATEGY_CLASS_V100_RELOAD_INCOMPLETE marker=%s module=%s diagnostics=%s",
+                MARKER,
+                name,
+                _diagnostics(),
+            )
+        except BaseException as exc:
+            LOGGER.warning(
+                "CANONICAL_STRATEGY_CLASS_V100_RELOAD_FAILED marker=%s module=%s error=%s:%s "
+                "trading_fail_closed=true diagnostics=%s",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+                _diagnostics(),
+            )
+    return None, ""
+
+
+def _bounded_strategy_class(original: Callable[[], Any]) -> Optional[type]:
+    """Return the real TradingStrategy class or None without synthesizing one."""
+    try:
+        cls = original()
+    except BaseException as exc:
+        cls = None
+        LOGGER.warning(
+            "CANONICAL_STRATEGY_CLASS_V100_ORIGINAL_ERROR marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+    if isinstance(cls, type):
+        return cls
+
+    cls, source = _real_strategy_class()
+    if cls is not None:
+        return cls
+
+    deadline = time.monotonic() + _timeout_s()
+    reload_checked = False
+    while time.monotonic() < deadline:
+        candidates = _candidate_modules()
+        actively_initializing = any(_initializing(module) for _, module in candidates)
+
+        cls, source = _real_strategy_class()
+        if cls is not None:
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_CLASS_V100_CONVERGED marker=%s source=%s mode=wait",
+                MARKER,
+                source,
+            )
+            return cls
+
+        # A non-initializing module missing TradingStrategy is stale/partial,
+        # not an import currently making forward progress. Reload once only.
+        if candidates and not actively_initializing and not reload_checked:
+            reload_checked = True
+            cls, source = _reload_stale_candidate_once()
+            if cls is not None:
+                return cls
+
+        try:
+            cls = original()
+        except BaseException:
+            cls = None
+        if isinstance(cls, type):
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_CLASS_V100_CONVERGED marker=%s source=original mode=retry",
+                MARKER,
+            )
+            return cls
+
+        time.sleep(_poll_s())
+
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_CLASS_V100_UNAVAILABLE marker=%s timeout_s=%.2f "
+        "trading_fail_closed=true diagnostics=%s",
+        MARKER,
+        _timeout_s(),
+        _diagnostics(),
+    )
+    return None
+
+
+def _patch_publication_module(module: ModuleType) -> bool:
+    current = getattr(module, "_strategy_class", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def strategy_class_v100() -> Optional[type]:
+        return _bounded_strategy_class(current)
+
+    setattr(strategy_class_v100, _PATCH_ATTR, True)
+    setattr(strategy_class_v100, "__wrapped__", current)
+    module._strategy_class = strategy_class_v100
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_CLASS_RECOVERY_V100_PATCHED marker=%s module=%s "
+        "timeout_s=%.2f fail_closed=true",
+        MARKER,
+        getattr(module, "__name__", "<unknown>"),
+        _timeout_s(),
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    ready = True
+    found = False
+    seen: set[int] = set()
+    for name in ("bot.strategy_publication_patch", "strategy_publication_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            found = True
+            ready = _patch_publication_module(module) and ready
+    return ready if found else True
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        if not _patch_loaded():
+            return False
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if "strategy_publication_patch" in str(name or ""):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_CANONICAL_STRATEGY_CLASS_RECOVERY_V100_INSTALLED"] = "1"
+        LOGGER.critical(
+            "CANONICAL_STRATEGY_CLASS_RECOVERY_V100_INSTALLED marker=%s "
+            "bounded_wait=true stale_reload_once=true safety_gates_unchanged=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_bounded_strategy_class",
+    "_patch_publication_module",
+    "_reload_stale_candidate_once",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -8,7 +8,9 @@ broker startup.
 v98 changes only the *default* timeout to 12 seconds. An explicit
 NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
-position snapshots while each user execution path remains fail closed.
+position snapshots while each user execution path remains fail closed. v100
+uses that same early fast-path slot to install bounded canonical TradingStrategy
+class recovery before Step 2.5 publication can consume a stale partial module.
 """
 from __future__ import annotations
 
@@ -43,6 +45,17 @@ def _install_v99() -> bool:
     return installer() is not False
 
 
+def _install_v100() -> bool:
+    try:
+        from bot import canonical_strategy_class_recovery_v100_patch as v100
+    except ImportError:
+        import canonical_strategy_class_recovery_v100_patch as v100  # type: ignore[import]
+    installer = getattr(v100, "install_import_hook", None) or getattr(v100, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
 def install() -> bool:
     global _INSTALLED
 
@@ -58,6 +71,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v100():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V100_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
 
     if _INSTALLED:
         return True
@@ -67,7 +86,7 @@ def install() -> bool:
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
-        "safety_gates_unchanged=true",
+        "strategy_class_recovery_v100=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_canonical_strategy_class_recovery_v100.py
+++ b/bot/tests/test_canonical_strategy_class_recovery_v100.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+from bot import canonical_strategy_class_recovery_v100_patch as v100
+
+
+class CanonicalStrategyClassRecoveryV100Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("bot.trading_strategy", "trading_strategy")
+        }
+        self.saved_timeout = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S")
+        self.saved_poll = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S")
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "0.5"
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_POLL_S"] = "0.01"
+        v100._RELOAD_ATTEMPTED.clear()
+        sys.modules.pop("bot.trading_strategy", None)
+        sys.modules.pop("trading_strategy", None)
+
+    def tearDown(self) -> None:
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        if self.saved_timeout is None:
+            os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", None)
+        else:
+            os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = self.saved_timeout
+        if self.saved_poll is None:
+            os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S", None)
+        else:
+            os.environ["NIJA_STRATEGY_CLASS_RECOVERY_POLL_S"] = self.saved_poll
+        v100._RELOAD_ATTEMPTED.clear()
+
+    def test_waits_for_real_class_from_initializing_module(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=True)
+        sys.modules["bot.trading_strategy"] = module
+
+        class TradingStrategy:
+            pass
+
+        def publish_class() -> None:
+            time.sleep(0.05)
+            module.TradingStrategy = TradingStrategy
+            module.__spec__._initializing = False
+
+        worker = threading.Thread(target=publish_class, daemon=True)
+        worker.start()
+        resolved = v100._bounded_strategy_class(lambda: None)
+        worker.join(timeout=1.0)
+
+        self.assertIs(resolved, TradingStrategy)
+        self.assertEqual(v100._RELOAD_ATTEMPTED, set())
+
+    def test_reloads_stale_partial_module_once(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=False)
+        sys.modules["bot.trading_strategy"] = module
+
+        class TradingStrategy:
+            pass
+
+        reload_calls = []
+
+        def fake_reload(candidate):
+            reload_calls.append(candidate)
+            candidate.TradingStrategy = TradingStrategy
+            return candidate
+
+        with mock.patch.object(v100.importlib, "reload", side_effect=fake_reload):
+            resolved = v100._bounded_strategy_class(lambda: None)
+
+        self.assertIs(resolved, TradingStrategy)
+        self.assertEqual(reload_calls, [module])
+
+    def test_unrecoverable_module_remains_fail_closed(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=False)
+        sys.modules["bot.trading_strategy"] = module
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "0.08"
+
+        with mock.patch.object(v100.importlib, "reload", side_effect=ImportError("still broken")):
+            resolved = v100._bounded_strategy_class(lambda: None)
+
+        self.assertIsNone(resolved)
+        self.assertFalse(hasattr(module, "TradingStrategy"))
+
+    def test_patch_wraps_strategy_publication_without_marking_readiness(self) -> None:
+        publication = types.ModuleType("bot.strategy_publication_patch")
+        publication._strategy_class = lambda: None
+        self.assertTrue(v100._patch_publication_module(publication))
+        self.assertTrue(getattr(publication._strategy_class, v100._PATCH_ATTR, False))
+        self.assertNotIn("NIJA_RUNTIME_EXECUTION_AUTHORITY", publication.__dict__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Add v100 bounded canonical `TradingStrategy` class recovery.
- Wait briefly when `bot.trading_strategy` is still actively initializing.
- If a loaded trading-strategy module is demonstrably stale/partial (not initializing and still missing the class), perform at most one controlled `importlib.reload()`.
- Consume only a real `TradingStrategy` class from the canonical module.
- Preserve the existing `class_unavailable` fail-closed path if the class still cannot be recovered.
- Install v100 from the existing canonical fast-path v98 slot so the guard is active before Step 2.5 strategy publication.

## Production evidence

Deployment `89f947440e734d2f2757479488d31e9d8339240d` (merged PR #2529) reaches live-capital/writer bootstrap but logs `NIJAApexStrategyV71 not available — strategy will run in degraded mode`, then Step 2.5 exits with `CANONICAL_STRATEGY_PUBLICATION_FAILED detail=class_unavailable` and exit code 1.

That sequence shows the trading-strategy module has begun importing, while strategy publication later sees no `TradingStrategy` class. The failure is therefore consistent with a partial/stale module surface rather than a missing source file.

## Safety

This is not a strategy-readiness bypass. v100 does not set `strategy_ready`, `execution_ready`, runtime execution authority, writer/nonce state, broker connectivity, position state, or trading state. If the real class cannot be recovered within the bounded window, publication still returns `None` and startup remains fail closed.

## Tests

Adds regression coverage for:
- actively-initializing module publishes the real class within the bounded wait;
- stale non-initializing partial module is reloaded exactly once;
- unrecoverable module still returns `None`;
- patching strategy publication does not synthesize execution authority.