### PR TITLE
Avoid re-entering TradingStrategy import during publication

### DIFF
--- a/bot/canonical_strategy_class_recovery_v102_patch.py
+++ b/bot/canonical_strategy_class_recovery_v102_patch.py
@@ -1,0 +1,285 @@
+"""Passively converge canonical TradingStrategy publication during active imports.
+
+Production deployment 8d85b3ea on 2026-08-15 proved v100 still failed closed
+with bot.trading_strategy genuinely ``__spec__._initializing=True``. The v100
+wrapper retried the original strategy resolver inside its bounded loop. That
+resolver calls ``importlib.import_module``; when another thread owns the module
+lock, the retry itself can consume the recovery budget instead of observing the
+in-progress import.
+
+v102 supersedes only the class resolver behavior:
+* if no candidate module exists, perform one normal canonical import attempt;
+* if a candidate exists and is initializing, never re-enter importlib for that
+  module; passively poll sys.modules for the real TradingStrategy class;
+* if initialization completes without the class, perform at most one controlled
+  reload of that non-initializing stale module;
+* return only a real TradingStrategy type, otherwise None so publication remains
+  fail closed.
+
+No readiness key, broker state, execution authority, writer/nonce proof, risk
+state, positions, or trading state is fabricated or bypassed.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Optional
+
+LOGGER = logging.getLogger("nija.canonical_strategy_class_recovery_v102")
+MARKER = "20260815-canonical-strategy-class-recovery-v102"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_CANONICAL_STRATEGY_CLASS_RECOVERY_V102_IMPORT_HOOK"
+_PATCH_ATTR = "_nija_canonical_strategy_class_recovery_v102"
+_RELOAD_ATTEMPTED: set[int] = set()
+
+
+def _timeout_s() -> float:
+    try:
+        return max(0.1, float(os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", "12") or 12.0))
+    except (TypeError, ValueError):
+        return 12.0
+
+
+def _poll_s() -> float:
+    try:
+        return max(0.01, min(0.25, float(os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S", "0.05") or 0.05)))
+    except (TypeError, ValueError):
+        return 0.05
+
+
+def _candidates() -> list[tuple[str, ModuleType]]:
+    out: list[tuple[str, ModuleType]] = []
+    seen: set[int] = set()
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            out.append((name, module))
+    return out
+
+
+def _initializing(module: ModuleType) -> bool:
+    return bool(getattr(getattr(module, "__spec__", None), "_initializing", False))
+
+
+def _real_class() -> tuple[Optional[type], str]:
+    for name, module in _candidates():
+        cls = getattr(module, "TradingStrategy", None)
+        if isinstance(cls, type):
+            return cls, name
+    return None, ""
+
+
+def _diagnostics() -> str:
+    parts: list[str] = []
+    for name, module in _candidates():
+        parts.append(
+            f"{name}:id={id(module)};file={getattr(module, '__file__', None)!r};"
+            f"class={isinstance(getattr(module, 'TradingStrategy', None), type)};"
+            f"initializing={_initializing(module)};keys={len(vars(module))}"
+        )
+    return " | ".join(parts) or "none"
+
+
+def _import_once_if_absent() -> tuple[Optional[type], str]:
+    if _candidates():
+        return _real_class()
+    errors: list[str] = []
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        try:
+            module = importlib.import_module(name)
+            cls = getattr(module, "TradingStrategy", None)
+            if isinstance(cls, type):
+                return cls, name
+            errors.append(f"{name}:class_missing")
+        except Exception as exc:
+            errors.append(f"{name}:{type(exc).__name__}:{exc}")
+    LOGGER.warning(
+        "CANONICAL_STRATEGY_CLASS_V102_INITIAL_IMPORT_FAILED marker=%s errors=%s",
+        MARKER,
+        errors,
+    )
+    return None, ""
+
+
+def _reload_stale_once() -> tuple[Optional[type], str]:
+    for name, module in _candidates():
+        if _initializing(module):
+            continue
+        cls = getattr(module, "TradingStrategy", None)
+        if isinstance(cls, type):
+            return cls, name
+        key = id(module)
+        if key in _RELOAD_ATTEMPTED:
+            continue
+        _RELOAD_ATTEMPTED.add(key)
+        try:
+            reloaded = importlib.reload(module)
+            cls = getattr(reloaded, "TradingStrategy", None)
+            if isinstance(cls, type):
+                LOGGER.critical(
+                    "CANONICAL_STRATEGY_CLASS_V102_RELOADED marker=%s module=%s class=%s",
+                    MARKER,
+                    name,
+                    cls.__name__,
+                )
+                return cls, name
+        except BaseException as exc:
+            LOGGER.warning(
+                "CANONICAL_STRATEGY_CLASS_V102_RELOAD_FAILED marker=%s module=%s error=%s:%s diagnostics=%s",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+                _diagnostics(),
+            )
+    return None, ""
+
+
+def _passive_strategy_class() -> Optional[type]:
+    cls, source = _real_class()
+    if cls is not None:
+        return cls
+
+    if not _candidates():
+        cls, source = _import_once_if_absent()
+        if cls is not None:
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_CLASS_V102_CONVERGED marker=%s mode=initial_import source=%s",
+                MARKER,
+                source,
+            )
+            return cls
+
+    deadline = time.monotonic() + _timeout_s()
+    stale_reload_checked = False
+    saw_initializing = False
+
+    while time.monotonic() < deadline:
+        cls, source = _real_class()
+        if cls is not None:
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_CLASS_V102_CONVERGED marker=%s mode=passive_wait source=%s saw_initializing=%s",
+                MARKER,
+                source,
+                str(saw_initializing).lower(),
+            )
+            return cls
+
+        candidates = _candidates()
+        initializing = any(_initializing(module) for _, module in candidates)
+        if initializing:
+            saw_initializing = True
+            # Critical invariant: do not call import_module/reload while an
+            # existing canonical candidate owns an active import lifecycle.
+            time.sleep(_poll_s())
+            continue
+
+        if candidates and not stale_reload_checked:
+            stale_reload_checked = True
+            cls, source = _reload_stale_once()
+            if cls is not None:
+                return cls
+
+        if not candidates:
+            # Module disappeared after a failed import. One bounded fresh import
+            # attempt is safe because no active candidate owns the module lock.
+            cls, source = _import_once_if_absent()
+            if cls is not None:
+                return cls
+
+        time.sleep(_poll_s())
+
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_CLASS_V102_UNAVAILABLE marker=%s timeout_s=%.2f "
+        "saw_initializing=%s trading_fail_closed=true diagnostics=%s",
+        MARKER,
+        _timeout_s(),
+        str(saw_initializing).lower(),
+        _diagnostics(),
+    )
+    return None
+
+
+def _patch_publication(module: ModuleType) -> bool:
+    current = getattr(module, "_strategy_class", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def strategy_class_v102() -> Optional[type]:
+        return _passive_strategy_class()
+
+    setattr(strategy_class_v102, _PATCH_ATTR, True)
+    setattr(strategy_class_v102, "__wrapped__", current)
+    module._strategy_class = strategy_class_v102
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_CLASS_RECOVERY_V102_PATCHED marker=%s module=%s "
+        "passive_during_initialization=true timeout_s=%.2f fail_closed=true",
+        MARKER,
+        getattr(module, "__name__", "<unknown>"),
+        _timeout_s(),
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    found = False
+    ready = True
+    seen: set[int] = set()
+    for name in ("bot.strategy_publication_patch", "strategy_publication_patch"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            found = True
+            ready = _patch_publication(module) and ready
+    return ready if found else True
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        if not _patch_loaded():
+            return False
+        if not getattr(builtins, _HOOK_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if "strategy_publication_patch" in str(name or ""):
+                    _patch_loaded()
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _HOOK_FLAG, True)
+
+        os.environ["NIJA_CANONICAL_STRATEGY_CLASS_RECOVERY_V102_INSTALLED"] = "1"
+        LOGGER.critical(
+            "CANONICAL_STRATEGY_CLASS_RECOVERY_V102_INSTALLED marker=%s "
+            "passive_import_observer=true stale_reload_once=true safety_gates_unchanged=true",
+            MARKER,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_passive_strategy_class",
+    "_patch_publication",
+    "_reload_stale_once",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -9,8 +9,9 @@ v98 changes only the *default* timeout to 12 seconds. An explicit
 NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
 position snapshots while each user execution path remains fail closed. v100
-uses that same early fast-path slot to install bounded canonical TradingStrategy
-class recovery before Step 2.5 publication can consume a stale partial module.
+adds bounded canonical TradingStrategy class recovery, and v102 supersedes the
+active-import retry behavior with a passive observer that never re-enters the
+canonical module import while it is still initializing.
 """
 from __future__ import annotations
 
@@ -56,6 +57,17 @@ def _install_v100() -> bool:
     return installer() is not False
 
 
+def _install_v102() -> bool:
+    try:
+        from bot import canonical_strategy_class_recovery_v102_patch as v102
+    except ImportError:
+        import canonical_strategy_class_recovery_v102_patch as v102  # type: ignore[import]
+    installer = getattr(v102, "install_import_hook", None) or getattr(v102, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
 def install() -> bool:
     global _INSTALLED
 
@@ -77,6 +89,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v102():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V102_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
 
     if _INSTALLED:
         return True
@@ -86,7 +104,8 @@ def install() -> bool:
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
-        "strategy_class_recovery_v100=true safety_gates_unchanged=true",
+        "strategy_class_recovery_v100=true passive_strategy_recovery_v102=true "
+        "safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_canonical_strategy_class_recovery_v102.py
+++ b/bot/tests/test_canonical_strategy_class_recovery_v102.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+from bot import canonical_strategy_class_recovery_v102_patch as v102
+
+
+class CanonicalStrategyClassRecoveryV102Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("bot.trading_strategy", "trading_strategy")
+        }
+        self.saved_timeout = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S")
+        self.saved_poll = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S")
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "0.4"
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_POLL_S"] = "0.01"
+        v102._RELOAD_ATTEMPTED.clear()
+        sys.modules.pop("bot.trading_strategy", None)
+        sys.modules.pop("trading_strategy", None)
+
+    def tearDown(self) -> None:
+        for name, module in self.saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        if self.saved_timeout is None:
+            os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", None)
+        else:
+            os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = self.saved_timeout
+        if self.saved_poll is None:
+            os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_POLL_S", None)
+        else:
+            os.environ["NIJA_STRATEGY_CLASS_RECOVERY_POLL_S"] = self.saved_poll
+        v102._RELOAD_ATTEMPTED.clear()
+
+    def test_active_import_is_observed_without_reentering_importlib(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=True)
+        sys.modules["bot.trading_strategy"] = module
+
+        class TradingStrategy:
+            pass
+
+        def finish_import() -> None:
+            time.sleep(0.05)
+            module.TradingStrategy = TradingStrategy
+            module.__spec__._initializing = False
+
+        worker = threading.Thread(target=finish_import, daemon=True)
+        worker.start()
+        with mock.patch.object(v102.importlib, "import_module", side_effect=AssertionError("must not re-enter importlib")):
+            resolved = v102._passive_strategy_class()
+        worker.join(timeout=1.0)
+        self.assertIs(resolved, TradingStrategy)
+
+    def test_stale_partial_module_reloads_once(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=False)
+        sys.modules["bot.trading_strategy"] = module
+
+        class TradingStrategy:
+            pass
+
+        calls = []
+
+        def fake_reload(target):
+            calls.append(target)
+            target.TradingStrategy = TradingStrategy
+            return target
+
+        with mock.patch.object(v102.importlib, "reload", side_effect=fake_reload):
+            resolved = v102._passive_strategy_class()
+
+        self.assertIs(resolved, TradingStrategy)
+        self.assertEqual(calls, [module])
+
+    def test_unrecoverable_active_import_remains_fail_closed(self) -> None:
+        module = types.ModuleType("bot.trading_strategy")
+        module.__file__ = "/app/bot/trading_strategy.py"
+        module.__spec__ = types.SimpleNamespace(_initializing=True)
+        sys.modules["bot.trading_strategy"] = module
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "0.05"
+
+        with mock.patch.object(v102.importlib, "import_module", side_effect=AssertionError("must not re-enter importlib")):
+            resolved = v102._passive_strategy_class()
+
+        self.assertIsNone(resolved)
+        self.assertTrue(module.__spec__._initializing)
+
+    def test_patch_replaces_v100_style_resolver_without_calling_it(self) -> None:
+        publication = types.ModuleType("bot.strategy_publication_patch")
+        calls = []
+
+        def old_resolver():
+            calls.append("old")
+            raise AssertionError("superseded resolver must not be called")
+
+        publication._strategy_class = old_resolver
+        self.assertTrue(v102._patch_publication(publication))
+
+        strategy_module = types.ModuleType("bot.trading_strategy")
+        strategy_module.__spec__ = types.SimpleNamespace(_initializing=False)
+
+        class TradingStrategy:
+            pass
+
+        strategy_module.TradingStrategy = TradingStrategy
+        sys.modules["bot.trading_strategy"] = strategy_module
+
+        self.assertIs(publication._strategy_class(), TradingStrategy)
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Add v102 passive canonical `TradingStrategy` recovery.
- When `bot.trading_strategy` already exists with `__spec__._initializing=True`, do **not** call `importlib.import_module()` again.
- Passively observe `sys.modules` until the real `TradingStrategy` class appears or the bounded recovery window expires.
- If initialization completes but the module is stale/partial and still lacks the class, allow at most one controlled reload.
- Preserve the existing `class_unavailable` fail-closed result if no real class becomes available.
- Install v102 immediately after v100 from the existing canonical fast-path v98 slot so v102 supersedes v100's active-import retry behavior before Step 2.5 publication.

## Production evidence

Deployment `8d85b3ea93b90c261ff780cbbdf720254e6b45c4` logs:

- `NIJAApexStrategyV71 not available — strategy will run in degraded mode`
- `CANONICAL_STRATEGY_CLASS_V100_UNAVAILABLE ... diagnostics=bot.trading_strategy:...class=False;initializing=True;keys=36`
- `CANONICAL_STRATEGY_PUBLICATION_FAILED detail=class_unavailable`

This proves v100 was active, but the canonical module was still genuinely importing. v100 retries the original resolver from inside its loop; that resolver calls `importlib.import_module`, which may block on Python's module lock while another thread owns the in-progress import. The retry can therefore consume the recovery budget instead of observing forward progress.

## Safety

v102 does not synthesize a strategy class or alter readiness, writer/nonce authority, broker state, execution authority, risk gates, positions, or trading state. It only changes how the existing real class is observed during import. If the class still cannot be obtained, startup remains fail closed.

## Tests

Adds regression coverage proving:

- an actively-initializing module can publish the real class without any re-entry into `importlib.import_module`;
- a stale non-initializing partial module reloads at most once;
- an unrecoverable active import still returns `None`;
- v102 supersedes a v100-style resolver without invoking it when the real class is already present.