### PR TITLE
Harden startup convergence after v102 production failure

### DIFF
--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -9,9 +9,9 @@ v98 changes only the *default* timeout to 12 seconds. An explicit
 NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
 position snapshots while each user execution path remains fail closed. v100
-adds bounded canonical TradingStrategy class recovery, and v102 supersedes the
-active-import retry behavior with a passive observer that never re-enters the
-canonical module import while it is still initializing.
+adds bounded canonical TradingStrategy class recovery, v102 supersedes the
+active-import retry behavior with a passive observer, and v103 extends that
+passive convergence window while preventing recursive runtime reconciliation.
 """
 from __future__ import annotations
 
@@ -68,6 +68,17 @@ def _install_v102() -> bool:
     return installer() is not False
 
 
+def _install_v103() -> bool:
+    try:
+        from bot import startup_convergence_v103_patch as v103
+    except ImportError:
+        import startup_convergence_v103_patch as v103  # type: ignore[import]
+    installer = getattr(v103, "install_import_hook", None) or getattr(v103, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
 def install() -> bool:
     global _INSTALLED
 
@@ -95,6 +106,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v103():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V103_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
 
     if _INSTALLED:
         return True
@@ -105,7 +122,7 @@ def install() -> bool:
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
         "strategy_class_recovery_v100=true passive_strategy_recovery_v102=true "
-        "safety_gates_unchanged=true",
+        "startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/startup_convergence_v103_patch.py
+++ b/bot/startup_convergence_v103_patch.py
@@ -1,0 +1,125 @@
+"""Bound startup convergence without weakening live-trading safety gates.
+
+Production deployment 28200b7b on 2026-08-15 exposed two independent startup
+failure modes:
+
+1. canonical TradingStrategy recovery v102 remained safely passive but its
+   12-second observation window expired while the real module was still
+   ``__spec__._initializing=True``;
+2. runtime_execution_convergence_v32 re-entered its own capital reconciliation
+   path through refresh callbacks, producing RecursionError during both periodic
+   convergence and writer-acquired reconciliation.
+
+v103 addresses only those convergence mechanics:
+* extend the passive class-observation default to 45 seconds while preserving an
+  explicit NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S override;
+* wrap v32 runtime reconciliation in a process-local non-blocking single-flight
+  guard so nested refresh callbacks are coalesced instead of recursively entered;
+* preserve every existing readiness, capital, writer/nonce, risk, broker,
+  position, and execution gate. No readiness state is synthesized.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.startup_convergence_v103")
+MARKER = "20260815-startup-convergence-v103"
+_DEFAULT_STRATEGY_TIMEOUT_S = 45.0
+_LOCK = threading.RLock()
+_RECONCILE_GUARD = threading.Lock()
+_INSTALLED = False
+
+
+def _strategy_timeout_s() -> float:
+    raw = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S")
+    if raw is None or not str(raw).strip():
+        return _DEFAULT_STRATEGY_TIMEOUT_S
+    try:
+        return max(0.1, float(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_STRATEGY_TIMEOUT_S
+
+
+def _patch_v102_timeout() -> bool:
+    try:
+        from bot import canonical_strategy_class_recovery_v102_patch as v102
+    except ImportError:
+        import canonical_strategy_class_recovery_v102_patch as v102  # type: ignore[import]
+
+    setattr(v102, "_timeout_s", _strategy_timeout_s)
+    LOGGER.critical(
+        "STARTUP_CONVERGENCE_V103_STRATEGY_TIMEOUT marker=%s default_timeout_s=%.1f "
+        "explicit_env_override_preserved=true passive_observer_unchanged=true",
+        MARKER,
+        _DEFAULT_STRATEGY_TIMEOUT_S,
+    )
+    return True
+
+
+def _patch_v32_reconciliation() -> bool:
+    try:
+        from bot import runtime_execution_convergence_v32 as v32
+    except ImportError:
+        import runtime_execution_convergence_v32 as v32  # type: ignore[import]
+
+    current = getattr(v32, "_request_runtime_reconciliation", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_startup_convergence_v103", False):
+        return True
+
+    @wraps(current)
+    def single_flight(trigger: str, *args: Any, **kwargs: Any) -> bool:
+        if not _RECONCILE_GUARD.acquire(blocking=False):
+            LOGGER.warning(
+                "STARTUP_CONVERGENCE_V103_RECONCILE_COALESCED marker=%s trigger=%s "
+                "nested_refresh_skipped=true fail_closed=true",
+                MARKER,
+                trigger,
+            )
+            return False
+        try:
+            return bool(current(trigger, *args, **kwargs))
+        finally:
+            _RECONCILE_GUARD.release()
+
+    setattr(single_flight, "_nija_startup_convergence_v103", True)
+    setattr(single_flight, "__wrapped__", current)
+    setattr(v32, "_request_runtime_reconciliation", single_flight)
+    LOGGER.critical(
+        "STARTUP_CONVERGENCE_V103_RECONCILE_GUARD marker=%s single_flight=true "
+        "nested_refresh_coalesced=true safety_gates_unchanged=true",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return True
+        if not _patch_v102_timeout():
+            return False
+        if not _patch_v32_reconciliation():
+            return False
+        os.environ["NIJA_STARTUP_CONVERGENCE_V103_INSTALLED"] = "1"
+        _INSTALLED = True
+    LOGGER.critical(
+        "STARTUP_CONVERGENCE_V103_INSTALLED marker=%s strategy_timeout_s=%.1f "
+        "runtime_reconcile_single_flight=true fail_closed=true",
+        MARKER,
+        _strategy_timeout_s(),
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_strategy_timeout_s"]

--- a/bot/tests/test_startup_convergence_v103.py
+++ b/bot/tests/test_startup_convergence_v103.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import threading
+import types
+import unittest
+from unittest import mock
+
+from bot import startup_convergence_v103_patch as v103
+
+
+class StartupConvergenceV103Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_timeout = os.environ.get("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S")
+
+    def tearDown(self) -> None:
+        if self.saved_timeout is None:
+            os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", None)
+        else:
+            os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = self.saved_timeout
+
+    def test_strategy_timeout_defaults_to_45_seconds(self) -> None:
+        os.environ.pop("NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S", None)
+        self.assertEqual(v103._strategy_timeout_s(), 45.0)
+
+    def test_strategy_timeout_preserves_explicit_override(self) -> None:
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "17.5"
+        self.assertEqual(v103._strategy_timeout_s(), 17.5)
+
+    def test_strategy_timeout_invalid_override_falls_back(self) -> None:
+        os.environ["NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S"] = "not-a-number"
+        self.assertEqual(v103._strategy_timeout_s(), 45.0)
+
+    def test_reconciliation_guard_coalesces_nested_call(self) -> None:
+        calls: list[str] = []
+        fake_v32 = types.SimpleNamespace()
+
+        def original(trigger: str) -> bool:
+            calls.append(trigger)
+            nested = fake_v32._request_runtime_reconciliation("nested")
+            self.assertFalse(nested)
+            return True
+
+        fake_v32._request_runtime_reconciliation = original
+
+        with mock.patch.dict("sys.modules", {"bot.runtime_execution_convergence_v32": fake_v32}):
+            self.assertTrue(v103._patch_v32_reconciliation())
+            patched = fake_v32._request_runtime_reconciliation
+            self.assertTrue(patched("outer"))
+
+        self.assertEqual(calls, ["outer"])
+
+    def test_reconciliation_guard_releases_after_exception(self) -> None:
+        fake_v32 = types.SimpleNamespace()
+        attempt = {"count": 0}
+
+        def original(trigger: str) -> bool:
+            attempt["count"] += 1
+            if attempt["count"] == 1:
+                raise RuntimeError("boom")
+            return True
+
+        fake_v32._request_runtime_reconciliation = original
+
+        with mock.patch.dict("sys.modules", {"bot.runtime_execution_convergence_v32": fake_v32}):
+            self.assertTrue(v103._patch_v32_reconciliation())
+            patched = fake_v32._request_runtime_reconciliation
+            with self.assertRaises(RuntimeError):
+                patched("first")
+            self.assertTrue(patched("second"))
+
+        self.assertEqual(attempt["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Production deployment `28200b7b1bec70934039baa7dcc68daf6c174e31` exposed two independent startup convergence failures after v102:

1. `CANONICAL_STRATEGY_CLASS_V102_UNAVAILABLE ... timeout_s=12.00 saw_initializing=true ... class=False;initializing=True` — v102 behaved correctly and never re-entered the active import, but the real `trading_strategy` import graph still exceeded the bounded 12-second observation window.
2. `CAPITAL_REFRESH_DEFERRED ... RecursionError:maximum recursion depth exceeded` — runtime execution convergence was recursively re-entering its capital reconciliation path through refresh callbacks.

This PR adds v103 without weakening any live-trading safety gate.

### Strategy class convergence

- Keep v102's passive observer behavior unchanged.
- Change only the default bounded observation window from 12s to 45s.
- Preserve an explicit `NIJA_STRATEGY_CLASS_RECOVERY_TIMEOUT_S` operator override.
- Still return unavailable/fail closed if the real class never appears.

### Runtime capital reconciliation

- Wrap `runtime_execution_convergence_v32._request_runtime_reconciliation` in a non-blocking process-local single-flight guard.
- Nested refresh callbacks are coalesced and return `False` instead of recursively re-entering the reconciliation stack.
- Guard is always released in `finally`, including exception paths.

### Safety

No readiness keys, balances, broker state, positions, execution authority, writer/nonce proof, risk state, or trading state are synthesized or bypassed. Existing fail-closed behavior remains authoritative.

### Tests

Adds focused regression tests covering:

- 45-second strategy timeout default;
- explicit timeout override preservation;
- invalid override fallback;
- nested reconciliation coalescing;
- single-flight guard release after an exception.
