### PR TITLE
Break canonical strategy startup import cycle

### DIFF
--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -8,16 +8,16 @@ broker startup.
 v98 changes only the *default* timeout to 12 seconds. An explicit
 NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
-position snapshots while each user execution path remains fail closed. v100
-adds bounded canonical TradingStrategy class recovery, v102 supersedes the
-active-import retry behavior with a passive observer, and v103 extends that
-passive convergence window while preventing recursive runtime reconciliation.
+position snapshots while each user execution path remains fail closed. v104 is
+installed before strategy recovery so optional APEX/core-loop imports cannot
+hold the canonical TradingStrategy module in a partial initialization cycle.
+v100/v102 retain bounded fail-closed class recovery, and v103 retains the
+runtime reconciliation single-flight guard.
 """
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any
 
 LOGGER = logging.getLogger("nija.position_sync_timeout_v98")
 MARKER = "20260815-position-sync-timeout-v98"
@@ -41,6 +41,17 @@ def _install_v99() -> bool:
     except ImportError:
         import position_sync_account_isolation_v99_patch as v99  # type: ignore[import]
     installer = getattr(v99, "install_import_hook", None) or getattr(v99, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
+def _install_v104() -> bool:
+    try:
+        from bot import startup_strategy_import_cycle_v104_patch as v104
+    except ImportError:
+        import startup_strategy_import_cycle_v104_patch as v104  # type: ignore[import]
+    installer = getattr(v104, "install_import_hook", None) or getattr(v104, "install", None)
     if not callable(installer):
         return False
     return installer() is not False
@@ -94,6 +105,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v104():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V104_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
     if not _install_v100():
         LOGGER.critical(
             "POSITION_SYNC_TIMEOUT_V98_V100_INSTALL_FAILED marker=%s trading_fail_closed=true",
@@ -121,8 +138,9 @@ def install() -> bool:
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
-        "strategy_class_recovery_v100=true passive_strategy_recovery_v102=true "
-        "startup_convergence_v103=true safety_gates_unchanged=true",
+        "strategy_import_cycle_v104=true strategy_class_recovery_v100=true "
+        "passive_strategy_recovery_v102=true startup_convergence_v103=true "
+        "safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/startup_strategy_import_cycle_v104_patch.py
+++ b/bot/startup_strategy_import_cycle_v104_patch.py
@@ -1,0 +1,99 @@
+"""Break the canonical TradingStrategy startup import cycle without bypassing safety.
+
+Production on 2026-08-16 showed ``bot.trading_strategy`` remaining
+``__spec__._initializing=True`` for the full v102/v103 observation window.  The
+module eagerly imports APEX and the core loop before defining TradingStrategy,
+while APEX also imports the core loop.  Those dependencies are optional in
+``trading_strategy`` and are already designed to degrade on ImportError.
+
+v104 installs a very narrow builtins import guard before TradingStrategy wiring:
+when (and only when) trading_strategy itself is actively initializing, imports of
+APEX or the core loop requested by that module fail immediately with ImportError.
+That allows TradingStrategy to finish defining.  Once initialization completes,
+the guard becomes transparent and the existing APEX/core-loop wiring may hydrate
+those dependencies normally.
+
+No broker, balance, readiness, authority, nonce, position, risk, kill-switch, or
+execution state is synthesized or bypassed.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.startup_strategy_import_cycle_v104")
+MARKER = "20260816-startup-strategy-import-cycle-v104"
+_LOCK = threading.RLock()
+_HOOK_FLAG = "_NIJA_STARTUP_STRATEGY_IMPORT_CYCLE_V104"
+_ORIGINAL_ATTR = "_NIJA_STARTUP_STRATEGY_IMPORT_CYCLE_V104_ORIGINAL"
+
+_BLOCKED = {
+    "bot.nija_apex_strategy_v71",
+    "nija_apex_strategy_v71",
+    "bot.nija_core_loop",
+    "nija_core_loop",
+}
+_CALLERS = {"bot.trading_strategy", "trading_strategy"}
+
+
+def _initializing(module: ModuleType | None) -> bool:
+    return bool(
+        isinstance(module, ModuleType)
+        and getattr(getattr(module, "__spec__", None), "_initializing", False)
+    )
+
+
+def _caller_is_initializing(globals_dict: Any) -> bool:
+    if not isinstance(globals_dict, dict):
+        return False
+    caller = str(globals_dict.get("__name__", "") or "")
+    if caller not in _CALLERS:
+        return False
+    return _initializing(sys.modules.get(caller))
+
+
+def install() -> bool:
+    with _LOCK:
+        if getattr(builtins, _HOOK_FLAG, False):
+            return True
+
+        original_import = builtins.__import__
+
+        @wraps(original_import)
+        def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            requested = str(name or "")
+            if requested in _BLOCKED and _caller_is_initializing(globals):
+                LOGGER.warning(
+                    "STARTUP_STRATEGY_IMPORT_V104_DEFERRED marker=%s caller=%s dependency=%s "
+                    "reason=canonical_strategy_initializing fail_closed=true",
+                    MARKER,
+                    globals.get("__name__", "unknown") if isinstance(globals, dict) else "unknown",
+                    requested,
+                )
+                raise ImportError(
+                    f"{requested} deferred while canonical TradingStrategy is initializing"
+                )
+            return original_import(name, globals, locals, fromlist, level)
+
+        setattr(builtins, _ORIGINAL_ATTR, original_import)
+        builtins.__import__ = importing
+        setattr(builtins, _HOOK_FLAG, True)
+
+    LOGGER.critical(
+        "STARTUP_STRATEGY_IMPORT_CYCLE_V104_INSTALLED marker=%s "
+        "scope=trading_strategy_initialization_only safety_gates_unchanged=true",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/tests/test_startup_strategy_import_cycle_v104.py
+++ b/bot/tests/test_startup_strategy_import_cycle_v104.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import sys
+from types import ModuleType
+
+
+def test_v104_defers_only_optional_strategy_dependencies_while_initializing(monkeypatch):
+    from bot import startup_strategy_import_cycle_v104_patch as v104
+
+    # Reset the hook to a known baseline for this isolated test process.
+    current = builtins.__import__
+    original = getattr(builtins, v104._ORIGINAL_ATTR, current)
+    monkeypatch.setattr(builtins, "__import__", original)
+    monkeypatch.setattr(builtins, v104._HOOK_FLAG, False, raising=False)
+
+    module = ModuleType("bot.trading_strategy")
+    spec = importlib.util.spec_from_loader("bot.trading_strategy", loader=None)
+    assert spec is not None
+    spec._initializing = True  # type: ignore[attr-defined]
+    module.__spec__ = spec
+    monkeypatch.setitem(sys.modules, "bot.trading_strategy", module)
+
+    assert v104.install() is True
+
+    caller_globals = {"__name__": "bot.trading_strategy"}
+    try:
+        builtins.__import__("bot.nija_apex_strategy_v71", caller_globals, {}, (), 0)
+    except ImportError as exc:
+        assert "deferred while canonical TradingStrategy is initializing" in str(exc)
+    else:
+        raise AssertionError("APEX import should be deferred during canonical strategy initialization")
+
+    # Unrelated imports remain transparent.
+    assert builtins.__import__("math", caller_globals, {}, (), 0).__name__ == "math"
+
+    # Once TradingStrategy initialization completes, v104 must become transparent.
+    spec._initializing = False  # type: ignore[attr-defined]
+    imported = builtins.__import__("bot.nija_core_loop", caller_globals, {}, (), 0)
+    assert imported is not None
+
+
+def test_v104_installs_before_strategy_recovery_chain():
+    from pathlib import Path
+
+    source = (Path(__file__).parents[1] / "position_sync_timeout_v98_patch.py").read_text()
+    assert "_install_v104" in source
+    assert source.index("if not _install_v104()") < source.index("if not _install_v100()")
+    assert source.index("if not _install_v104()") < source.index("if not _install_v102()")


### PR DESCRIPTION
## What changed

- Add `startup_strategy_import_cycle_v104_patch` to break the canonical `TradingStrategy` partial-import deadlock seen in production.
- Install v104 from the existing canonical v98 startup slot before v100/v102 strategy-class recovery.
- During **only** `trading_strategy`'s active module initialization, optional imports of APEX and the core loop fail fast with `ImportError`; once initialization completes, the hook becomes transparent and existing wiring can hydrate those dependencies normally.
- Keep v103's capital-refresh single-flight protection and all existing fail-closed readiness, writer, nonce, position-sync, risk, kill-switch, and execution gates unchanged.
- Add regression tests for v104 scope and installation ordering.

## Root cause

Production showed `trading_strategy` remaining `__spec__._initializing=True` through the entire 45-second v102/v103 recovery window. `trading_strategy.py` eagerly imports APEX and `nija_core_loop` before defining `TradingStrategy`, while APEX also imports the core loop. Extending the observation timeout cannot resolve that import cycle; the optional dependency edge must be deferred until the canonical strategy module has finished defining its class.

## Safety

This change does not synthesize broker connectivity, balances, capital, positions, readiness, writer authority, nonce state, or execution authority. It only changes import timing for two dependencies that `trading_strategy.py` already treats as optional/degraded on `ImportError`. Trading remains fail closed until the existing canonical gates pass.