### PR TITLE
Converge strategy publication and bootstrap startup

### DIFF
--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -8,11 +8,12 @@ broker startup.
 v98 changes only the *default* timeout to 12 seconds. An explicit
 NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
-position snapshots while each user execution path remains fail closed. v104 is
-installed before strategy recovery so optional APEX/core-loop imports cannot
-hold the canonical TradingStrategy module in a partial initialization cycle.
-v100/v102 retain bounded fail-closed class recovery, and v103 retains the
-runtime reconciliation single-flight guard.
+position snapshots while each user execution path remains fail closed. v105 is
+installed before strategy recovery so the canonical TradingStrategy class is
+published before cycle-prone optional dependencies are hydrated and the
+platform-ready capital callback is single-flight. v104 remains as the narrow
+legacy import-cycle guard. v100/v102 retain bounded fail-closed class recovery,
+and v103 retains the runtime reconciliation single-flight guard.
 """
 from __future__ import annotations
 
@@ -41,6 +42,17 @@ def _install_v99() -> bool:
     except ImportError:
         import position_sync_account_isolation_v99_patch as v99  # type: ignore[import]
     installer = getattr(v99, "install_import_hook", None) or getattr(v99, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
+def _install_v105() -> bool:
+    try:
+        from bot import startup_publication_bootstrap_v105_patch as v105
+    except ImportError:
+        import startup_publication_bootstrap_v105_patch as v105  # type: ignore[import]
+    installer = getattr(v105, "install_import_hook", None) or getattr(v105, "install", None)
     if not callable(installer):
         return False
     return installer() is not False
@@ -105,6 +117,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v105():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V105_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
     if not _install_v104():
         LOGGER.critical(
             "POSITION_SYNC_TIMEOUT_V98_V104_INSTALL_FAILED marker=%s trading_fail_closed=true",
@@ -138,9 +156,9 @@ def install() -> bool:
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
-        "strategy_import_cycle_v104=true strategy_class_recovery_v100=true "
-        "passive_strategy_recovery_v102=true startup_convergence_v103=true "
-        "safety_gates_unchanged=true",
+        "startup_publication_bootstrap_v105=true strategy_import_cycle_v104=true "
+        "strategy_class_recovery_v100=true passive_strategy_recovery_v102=true "
+        "startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/startup_publication_bootstrap_v105_patch.py
+++ b/bot/startup_publication_bootstrap_v105_patch.py
@@ -1,0 +1,240 @@
+"""Converge canonical strategy publication and break capital bootstrap recursion.
+
+Production logs on 2026-08-16 showed two remaining startup blockers after v104:
+
+1. ``bot.trading_strategy`` could still remain partially initialized because
+   additional optional broker/runtime dependencies were imported before the
+   ``TradingStrategy`` class definition.
+2. A successful CapitalAuthority refresh could synchronize platform connection
+   state, fire ``MultiAccountBrokerManager._on_platform_ready()``, and re-enter
+   ``refresh_capital_authority()`` recursively until ``RecursionError``.
+
+v105 keeps all safety gates intact.  It only defers optional TradingStrategy
+startup imports until after the canonical class is defined, then hydrates those
+optional dependencies before the first TradingStrategy instance is initialized.
+It also makes the platform-ready capital callback single-flight per manager so a
+capital refresh cannot recursively trigger itself.
+
+No broker connectivity, balance, position, strategy readiness, execution
+authority, nonce, bootstrap, risk, or kill-switch state is synthesized.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.startup_publication_bootstrap_v105")
+MARKER = "20260816-startup-publication-bootstrap-v105"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_HOOK_FLAG = "_NIJA_STARTUP_PUBLICATION_BOOTSTRAP_V105"
+_ORIGINAL_ATTR = "_NIJA_STARTUP_PUBLICATION_BOOTSTRAP_V105_ORIGINAL"
+
+_CALLERS = {"bot.trading_strategy", "trading_strategy"}
+_DEFERRED_IMPORTS = {
+    "bot.nija_apex_strategy_v71",
+    "nija_apex_strategy_v71",
+    "bot.nija_core_loop",
+    "nija_core_loop",
+    "bot.broker_manager",
+    "broker_manager",
+    "bot.multi_account_broker_manager",
+    "multi_account_broker_manager",
+    "bot.independent_broker_trader",
+    "independent_broker_trader",
+    "bot.pipeline_order_submitter",
+    "pipeline_order_submitter",
+    "bot.market_readiness_gate",
+    "market_readiness_gate",
+}
+
+
+def _initializing(module: ModuleType | None) -> bool:
+    return bool(
+        isinstance(module, ModuleType)
+        and getattr(getattr(module, "__spec__", None), "_initializing", False)
+    )
+
+
+def _caller_is_initializing(globals_dict: Any) -> tuple[bool, str]:
+    if not isinstance(globals_dict, dict):
+        return False, ""
+    caller = str(globals_dict.get("__name__", "") or "")
+    if caller not in _CALLERS:
+        return False, caller
+    return _initializing(sys.modules.get(caller)), caller
+
+
+def _import_first(*names: str) -> ModuleType | None:
+    for name in names:
+        try:
+            return importlib.import_module(name)
+        except ImportError:
+            continue
+    return None
+
+
+def _hydrate_strategy_dependencies(module: ModuleType) -> None:
+    """Hydrate optional TradingStrategy globals after class publication."""
+    apex = _import_first("bot.nija_apex_strategy_v71", "nija_apex_strategy_v71")
+    apex_cls = getattr(apex, "NIJAApexStrategyV71", None) if apex else None
+    setattr(module, "NIJAApexStrategyV71", apex_cls)
+    setattr(module, "_APEX_AVAILABLE", apex_cls is not None)
+
+    broker = _import_first("bot.broker_manager", "broker_manager")
+    if broker is not None:
+        for name in ("BrokerType", "KrakenBroker", "CoinbaseBroker", "BaseBroker", "BrokerManager"):
+            if hasattr(broker, name):
+                setattr(module, name, getattr(broker, name))
+        setattr(module, "_BROKER_MANAGER_AVAILABLE", all(hasattr(broker, n) for n in ("BrokerType", "KrakenBroker", "CoinbaseBroker", "BaseBroker")))
+        setattr(module, "_BM_AVAILABLE", hasattr(broker, "BrokerManager"))
+
+    mabm = _import_first("bot.multi_account_broker_manager", "multi_account_broker_manager")
+    mabm_cls = getattr(mabm, "MultiAccountBrokerManager", None) if mabm else None
+    setattr(module, "MultiAccountBrokerManager", mabm_cls)
+    setattr(module, "_MABM_AVAILABLE", mabm_cls is not None)
+
+    ibt = _import_first("bot.independent_broker_trader", "independent_broker_trader")
+    ibt_cls = getattr(ibt, "IndependentBrokerTrader", None) if ibt else None
+    setattr(module, "IndependentBrokerTrader", ibt_cls)
+    setattr(module, "_IBT_AVAILABLE", ibt_cls is not None)
+
+    core = _import_first("bot.nija_core_loop", "nija_core_loop")
+    core_getter = getattr(core, "get_nija_core_loop", None) if core else None
+    setattr(module, "get_nija_core_loop", core_getter)
+    setattr(module, "_CORE_LOOP_AVAILABLE", callable(core_getter))
+
+    pipeline = _import_first("bot.pipeline_order_submitter", "pipeline_order_submitter")
+    submitter = getattr(pipeline, "submit_market_order_via_pipeline", None) if pipeline else None
+    setattr(module, "submit_market_order_via_pipeline", submitter)
+
+    market = _import_first("bot.market_readiness_gate", "market_readiness_gate")
+    market_cls = getattr(market, "MarketReadinessGate", None) if market else None
+    setattr(module, "MarketReadinessGate", market_cls)
+    setattr(module, "_MARKET_READINESS_GATE_AVAILABLE", market_cls is not None)
+
+
+def _patch_strategy_module(module: ModuleType) -> bool:
+    cls = getattr(module, "TradingStrategy", None)
+    if not isinstance(cls, type):
+        return False
+    if getattr(cls, "_nija_v105_wrapped", False):
+        return True
+
+    original_init = cls.__init__
+
+    @wraps(original_init)
+    def _init(self: Any, *args: Any, **kwargs: Any) -> None:
+        _hydrate_strategy_dependencies(module)
+        return original_init(self, *args, **kwargs)
+
+    cls.__init__ = _init  # type: ignore[assignment]
+    setattr(cls, "_nija_v105_wrapped", True)
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_PUBLICATION_V105_PATCHED marker=%s module=%s class_published=true lazy_dependency_hydration=true safety_gates_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_mabm_module(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "_on_platform_ready", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_v105_wrapped", False):
+        return True
+
+    @wraps(original)
+    def _single_flight(self: Any, broker_type: Any) -> Any:
+        if bool(getattr(self, "_nija_v105_platform_ready_inflight", False)):
+            LOGGER.warning(
+                "CAPITAL_PLATFORM_READY_V105_REENTRANT_SUPPRESSED marker=%s broker=%s real_snapshot_preserved=true trading_fail_closed=true",
+                MARKER,
+                getattr(broker_type, "value", str(broker_type)),
+            )
+            return None
+        setattr(self, "_nija_v105_platform_ready_inflight", True)
+        try:
+            return original(self, broker_type)
+        finally:
+            setattr(self, "_nija_v105_platform_ready_inflight", False)
+
+    setattr(_single_flight, "_nija_v105_wrapped", True)
+    cls._on_platform_ready = _single_flight  # type: ignore[assignment]
+    LOGGER.critical(
+        "CAPITAL_PLATFORM_READY_V105_PATCHED marker=%s module=%s single_flight=true recursive_refresh_blocked=true snapshot_fabrication=false",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded_modules() -> None:
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and not _initializing(module):
+            _patch_strategy_module(module)
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and not _initializing(module):
+            _patch_mabm_module(module)
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            _patch_loaded_modules()
+            return True
+
+        current_import = builtins.__import__
+        if not getattr(current_import, _HOOK_FLAG, False):
+            setattr(builtins, _ORIGINAL_ATTR, current_import)
+
+            @wraps(current_import)
+            def _import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+                caller_initializing, caller = _caller_is_initializing(globals)
+                absolute = str(name or "")
+                if caller_initializing and level == 0 and absolute in _DEFERRED_IMPORTS:
+                    LOGGER.warning(
+                        "STARTUP_PUBLICATION_V105_DEFERRED marker=%s caller=%s dependency=%s reason=publish_canonical_class_first fail_closed=true",
+                        MARKER,
+                        caller,
+                        absolute,
+                    )
+                    raise ImportError(f"v105 deferred optional import during TradingStrategy publication: {absolute}")
+
+                result = current_import(name, globals, locals, fromlist, level)
+                _patch_loaded_modules()
+                return result
+
+            setattr(_import, _HOOK_FLAG, True)
+            setattr(_import, _ORIGINAL_ATTR, current_import)
+            builtins.__import__ = _import
+
+        _patch_loaded_modules()
+        os.environ["NIJA_STARTUP_PUBLICATION_BOOTSTRAP_V105_INSTALLED"] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "STARTUP_PUBLICATION_BOOTSTRAP_V105_INSTALLED marker=%s class_first=true lazy_strategy_dependencies=true capital_callback_single_flight=true readiness_bypass=false position_fabrication=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/tests/test_startup_publication_bootstrap_v105.py
+++ b/bot/tests/test_startup_publication_bootstrap_v105.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+import types
+
+
+def _fresh_v105():
+    sys.modules.pop("bot.startup_publication_bootstrap_v105_patch", None)
+    return importlib.import_module("bot.startup_publication_bootstrap_v105_patch")
+
+
+def test_v105_defers_cycle_prone_imports_while_trading_strategy_initializes(monkeypatch):
+    v105 = _fresh_v105()
+    original = builtins.__import__
+    try:
+        assert v105.install() is True
+        fake = types.ModuleType("bot.trading_strategy")
+        fake.__spec__ = types.SimpleNamespace(_initializing=True)
+        monkeypatch.setitem(sys.modules, "bot.trading_strategy", fake)
+        globals_dict = {"__name__": "bot.trading_strategy"}
+        try:
+            builtins.__import__("bot.nija_core_loop", globals_dict, globals_dict, (), 0)
+        except ImportError as exc:
+            assert "v105 deferred optional import" in str(exc)
+        else:
+            raise AssertionError("cycle-prone import was not deferred")
+    finally:
+        builtins.__import__ = original
+
+
+def test_v105_platform_ready_callback_is_single_flight(monkeypatch):
+    v105 = _fresh_v105()
+
+    class Manager:
+        calls = 0
+
+        def _on_platform_ready(self, broker_type):
+            type(self).calls += 1
+            if type(self).calls == 1:
+                self._on_platform_ready(broker_type)
+            return "ok"
+
+    fake = types.ModuleType("bot.multi_account_broker_manager")
+    fake.MultiAccountBrokerManager = Manager
+    fake.__spec__ = types.SimpleNamespace(_initializing=False)
+    monkeypatch.setitem(sys.modules, "bot.multi_account_broker_manager", fake)
+
+    assert v105._patch_mabm_module(fake) is True
+    manager = Manager()
+    assert manager._on_platform_ready("kraken") == "ok"
+    assert Manager.calls == 1
+
+
+def test_v105_hydrates_strategy_dependencies_after_class_publication(monkeypatch):
+    v105 = _fresh_v105()
+    strategy = types.ModuleType("bot.trading_strategy")
+    strategy.__spec__ = types.SimpleNamespace(_initializing=False)
+
+    class TradingStrategy:
+        def __init__(self):
+            self.seen_apex_available = strategy._APEX_AVAILABLE
+
+    strategy.TradingStrategy = TradingStrategy
+    strategy._APEX_AVAILABLE = False
+
+    apex = types.ModuleType("bot.nija_apex_strategy_v71")
+
+    class Apex:
+        pass
+
+    apex.NIJAApexStrategyV71 = Apex
+    broker = types.ModuleType("bot.broker_manager")
+    for name in ("BrokerType", "KrakenBroker", "CoinbaseBroker", "BaseBroker", "BrokerManager"):
+        setattr(broker, name, type(name, (), {}))
+    mabm = types.ModuleType("bot.multi_account_broker_manager")
+    mabm.MultiAccountBrokerManager = type("MultiAccountBrokerManager", (), {})
+    ibt = types.ModuleType("bot.independent_broker_trader")
+    ibt.IndependentBrokerTrader = type("IndependentBrokerTrader", (), {})
+    core = types.ModuleType("bot.nija_core_loop")
+    core.get_nija_core_loop = lambda **kwargs: object()
+    pipeline = types.ModuleType("bot.pipeline_order_submitter")
+    pipeline.submit_market_order_via_pipeline = lambda *args, **kwargs: None
+    market = types.ModuleType("bot.market_readiness_gate")
+    market.MarketReadinessGate = type("MarketReadinessGate", (), {})
+
+    for name, module in {
+        "bot.trading_strategy": strategy,
+        "bot.nija_apex_strategy_v71": apex,
+        "bot.broker_manager": broker,
+        "bot.multi_account_broker_manager": mabm,
+        "bot.independent_broker_trader": ibt,
+        "bot.nija_core_loop": core,
+        "bot.pipeline_order_submitter": pipeline,
+        "bot.market_readiness_gate": market,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    assert v105._patch_strategy_module(strategy) is True
+    instance = strategy.TradingStrategy()
+    assert instance.seen_apex_available is True
+    assert strategy.NIJAApexStrategyV71 is Apex


### PR DESCRIPTION
## What changed

- adds v105 startup convergence guard
- publishes the canonical `TradingStrategy` class before cycle-prone optional dependencies are hydrated
- lazily hydrates APEX, core-loop, broker, MABM, independent-trader, pipeline, and market-readiness dependencies before the first strategy instance initializes
- makes `MultiAccountBrokerManager._on_platform_ready()` single-flight so a successful capital refresh cannot recursively trigger another capital refresh through platform-state synchronization
- wires v105 into the existing early v98 installer before v104/v100/v102/v103
- adds regression tests for import deferral, post-publication dependency hydration, and recursive platform-ready suppression

## Why

Production deployment `047f901513e4f01927b6b6f3b2d76df2806fb5c8` shows capital and broker readiness converging, but `TradingStrategy` remains unavailable while `bot.trading_strategy` is initializing, leaving `strategy_ready=false`, `core_registered=false`, and execution fail closed. The same runtime also logs `BootstrapContract ... maximum recursion depth exceeded` immediately after a valid three-broker CapitalAuthority snapshot. The capital path synchronizes platform connection state and can re-enter `_on_platform_ready()` -> `refresh_capital_authority()` recursively.

## Safety

This change does not fabricate broker connectivity, balances, positions, position-sync readiness, strategy readiness, authority, nonce state, bootstrap readiness, execution readiness, or kill-switch state. All existing production gates remain fail closed. The capital callback guard only suppresses a re-entrant callback while the original callback is already executing; future independent callbacks remain allowed.

## Expected production evidence

After deployment, expect `CANONICAL_STRATEGY_PUBLICATION_V105_PATCHED`, then canonical strategy publication/core startup without the repeated class-unavailable loop. Capital refreshes should no longer end in `RecursionError` through the platform-ready callback. Full live activation must still wait for real position-sync, supervised core registration, strategy, authority, nonce, bootstrap, risk, and execution proofs.