### PR TITLE
Guard capital refresh against recursive startup reentry

### DIFF
--- a/bot/capital_refresh_reentrancy_v106_patch.py
+++ b/bot/capital_refresh_reentrancy_v106_patch.py
@@ -1,0 +1,200 @@
+"""Prevent same-thread recursive capital refresh during startup.
+
+Production logs on 2026-08-16 show CapitalAuthority refresh succeeding and then
+startup callbacks re-entering MultiAccountBrokerManager.refresh_capital_authority()
+until RecursionError.  v105 guarded one callback (_on_platform_ready), but the
+same refresh method is also reached from BootstrapContract, runtime convergence,
+Kraken recovery, and self-healing startup paths.
+
+v106 installs the guard at the shared refresh choke point.  A same-thread
+recursive call never starts another refresh.  It may report only capital state
+that was already authoritatively published by CapitalAuthority; otherwise it
+returns a conservative pending/not-ready result.  It never fabricates balances,
+connectivity, readiness, execution authority, nonce state, positions, or writer
+ownership, and it does not weaken any activation/risk/kill-switch gate.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Dict
+
+LOGGER = logging.getLogger("nija.capital_refresh_reentrancy_v106")
+MARKER = "20260816-capital-refresh-reentrancy-v106"
+_LOCK = threading.RLock()
+_LOCAL = threading.local()
+_INSTALLED = False
+
+
+def _authoritative_snapshot(module: ModuleType, manager: Any) -> Dict[str, float]:
+    """Return only already-published CapitalAuthority truth.
+
+    The helper intentionally does not call broker balance APIs and does not
+    invoke refresh.  If the exact authoritative shape cannot be proven, return
+    pending/not-ready so downstream startup remains fail closed.
+    """
+    ca = None
+    getter = getattr(module, "get_capital_authority", None)
+    if callable(getter):
+        try:
+            ca = getter()
+        except Exception:
+            ca = None
+
+    ready = False
+    total = 0.0
+    valid = 0.0
+    kraken = 0.0
+
+    if ca is not None:
+        for attr in ("is_hydrated", "hydrated", "_hydrated"):
+            value = getattr(ca, attr, None)
+            try:
+                ready = bool(value() if callable(value) else value)
+            except Exception:
+                ready = False
+            if ready:
+                break
+
+        for attr in ("total_capital", "real_capital", "total", "_total_capital", "_real_capital"):
+            value = getattr(ca, attr, None)
+            try:
+                value = value() if callable(value) else value
+                if value is not None:
+                    total = float(value)
+                    if total > 0.0:
+                        break
+            except Exception:
+                continue
+
+        snapshot = getattr(ca, "snapshot", None) or getattr(ca, "_snapshot", None)
+        try:
+            if snapshot is not None:
+                if total <= 0.0:
+                    for attr in ("total_capital", "real_capital", "total_usd", "total"):
+                        value = getattr(snapshot, attr, None)
+                        if value is not None:
+                            total = float(value)
+                            if total > 0.0:
+                                break
+                balances = getattr(snapshot, "broker_balances", None)
+                if isinstance(balances, dict):
+                    valid = float(sum(1 for v in balances.values() if float(v or 0.0) > 0.0))
+                    kraken = float(balances.get("kraken", 0.0) or 0.0)
+        except Exception:
+            pass
+
+    if total <= 0.0:
+        ready = False
+
+    return {
+        "ready": 1.0 if ready else 0.0,
+        "total_capital": max(0.0, total),
+        "valid_brokers": max(0.0, valid),
+        "kraken_capital": max(0.0, kraken),
+        "pending": 0.0 if ready else 1.0,
+        "reentrant": 1.0,
+    }
+
+
+def _patch_module(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+
+    original = getattr(cls, "refresh_capital_authority", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_v106_wrapped", False):
+        return True
+
+    @wraps(original)
+    def _guarded(self: Any, trigger: str = "manual", *args: Any, **kwargs: Any) -> Any:
+        depth = int(getattr(_LOCAL, "capital_refresh_depth", 0) or 0)
+        if depth > 0:
+            snapshot = _authoritative_snapshot(module, self)
+            LOGGER.warning(
+                "CAPITAL_REFRESH_V106_REENTRANT_SUPPRESSED marker=%s trigger=%s depth=%d authoritative_ready=%s total=%.2f valid_brokers=%d trading_fail_closed=%s",
+                MARKER,
+                trigger,
+                depth,
+                bool(snapshot.get("ready", 0.0)),
+                float(snapshot.get("total_capital", 0.0)),
+                int(snapshot.get("valid_brokers", 0.0)),
+                str(not bool(snapshot.get("ready", 0.0))).lower(),
+            )
+            return snapshot
+
+        _LOCAL.capital_refresh_depth = depth + 1
+        try:
+            return original(self, trigger, *args, **kwargs)
+        finally:
+            _LOCAL.capital_refresh_depth = depth
+
+    setattr(_guarded, "_nija_v106_wrapped", True)
+    setattr(_guarded, "_nija_v106_original", original)
+    cls.refresh_capital_authority = _guarded  # type: ignore[assignment]
+    LOGGER.critical(
+        "CAPITAL_REFRESH_REENTRANCY_V106_PATCHED marker=%s module=%s method=MultiAccountBrokerManager.refresh_capital_authority same_thread_recursive_refresh_blocked=true authoritative_snapshot_only=true safety_gates_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen = set()
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        patched = _patch_module(module) or patched
+    return patched
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            _patch_loaded()
+            return True
+
+        _patch_loaded()
+
+        # If MABM is not loaded yet, add a narrow import hook so the exact class
+        # method is patched immediately after its module finishes importing.
+        import builtins
+        current_import = builtins.__import__
+        if not getattr(current_import, "_nija_v106_import_hook", False):
+            @wraps(current_import)
+            def _import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+                result = current_import(name, globals, locals, fromlist, level)
+                if name in {"bot.multi_account_broker_manager", "multi_account_broker_manager"} or _patch_loaded():
+                    _patch_loaded()
+                return result
+
+            setattr(_import, "_nija_v106_import_hook", True)
+            setattr(_import, "_nija_v106_original", current_import)
+            builtins.__import__ = _import
+
+        os.environ["NIJA_CAPITAL_REFRESH_REENTRANCY_V106_INSTALLED"] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "CAPITAL_REFRESH_REENTRANCY_V106_INSTALLED marker=%s shared_refresh_choke_guard=true authoritative_snapshot_only=true readiness_bypass=false execution_bypass=false position_fabrication=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -10,10 +10,12 @@ NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
 from the same canonical slot so platform readiness is isolated from slow user
 position snapshots while each user execution path remains fail closed. v105 is
 installed before strategy recovery so the canonical TradingStrategy class is
-published before cycle-prone optional dependencies are hydrated and the
-platform-ready capital callback is single-flight. v104 remains as the narrow
-legacy import-cycle guard. v100/v102 retain bounded fail-closed class recovery,
-and v103 retains the runtime reconciliation single-flight guard.
+published before cycle-prone optional dependencies are hydrated. v106 guards
+the shared MultiAccountBrokerManager capital-refresh choke point against
+same-thread recursive startup callbacks while preserving only already-published
+authoritative capital truth. v104 remains as the narrow legacy import-cycle
+guard. v100/v102 retain bounded fail-closed class recovery, and v103 retains
+the runtime reconciliation single-flight guard.
 """
 from __future__ import annotations
 
@@ -53,6 +55,17 @@ def _install_v105() -> bool:
     except ImportError:
         import startup_publication_bootstrap_v105_patch as v105  # type: ignore[import]
     installer = getattr(v105, "install_import_hook", None) or getattr(v105, "install", None)
+    if not callable(installer):
+        return False
+    return installer() is not False
+
+
+def _install_v106() -> bool:
+    try:
+        from bot import capital_refresh_reentrancy_v106_patch as v106
+    except ImportError:
+        import capital_refresh_reentrancy_v106_patch as v106  # type: ignore[import]
+    installer = getattr(v106, "install_import_hook", None) or getattr(v106, "install", None)
     if not callable(installer):
         return False
     return installer() is not False
@@ -123,6 +136,12 @@ def install() -> bool:
             MARKER,
         )
         return False
+    if not _install_v106():
+        LOGGER.critical(
+            "POSITION_SYNC_TIMEOUT_V98_V106_INSTALL_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
     if not _install_v104():
         LOGGER.critical(
             "POSITION_SYNC_TIMEOUT_V98_V104_INSTALL_FAILED marker=%s trading_fail_closed=true",
@@ -156,9 +175,10 @@ def install() -> bool:
     LOGGER.critical(
         "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f "
         "explicit_env_override_preserved=true account_isolation_v99=true "
-        "startup_publication_bootstrap_v105=true strategy_import_cycle_v104=true "
-        "strategy_class_recovery_v100=true passive_strategy_recovery_v102=true "
-        "startup_convergence_v103=true safety_gates_unchanged=true",
+        "startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true "
+        "strategy_import_cycle_v104=true strategy_class_recovery_v100=true "
+        "passive_strategy_recovery_v102=true startup_convergence_v103=true "
+        "safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_capital_refresh_reentrancy_v106.py
+++ b/bot/tests/test_capital_refresh_reentrancy_v106.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+from bot import capital_refresh_reentrancy_v106_patch as v106
+
+
+def _make_module(*, hydrated: bool, total: float, balances: dict[str, float] | None = None):
+    module = ModuleType("test_mabm_v106")
+    snapshot = SimpleNamespace(
+        total_capital=total,
+        broker_balances=balances or {},
+    )
+    authority = SimpleNamespace(
+        hydrated=hydrated,
+        total_capital=total,
+        snapshot=snapshot,
+    )
+    module.get_capital_authority = lambda: authority
+
+    class Manager:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.nested = None
+
+        def refresh_capital_authority(self, trigger: str = "manual"):
+            self.calls += 1
+            if trigger == "outer":
+                self.nested = self.refresh_capital_authority("nested")
+            return {
+                "ready": 1.0,
+                "total_capital": total,
+                "valid_brokers": float(len(balances or {})),
+            }
+
+    module.MultiAccountBrokerManager = Manager
+    return module, Manager
+
+
+def test_nested_refresh_is_suppressed_and_reuses_authoritative_snapshot():
+    module, manager_cls = _make_module(
+        hydrated=True,
+        total=466.92,
+        balances={"kraken": 226.84, "coinbase": 95.12, "okx": 144.96},
+    )
+
+    assert v106._patch_module(module) is True
+    manager = manager_cls()
+    outer = manager.refresh_capital_authority("outer")
+
+    assert manager.calls == 1
+    assert outer["ready"] == 1.0
+    assert manager.nested["reentrant"] == 1.0
+    assert manager.nested["ready"] == 1.0
+    assert manager.nested["total_capital"] == 466.92
+    assert manager.nested["valid_brokers"] == 3.0
+    assert manager.nested["kraken_capital"] == 226.84
+
+
+def test_nested_refresh_fails_closed_when_authoritative_snapshot_is_not_ready():
+    module, manager_cls = _make_module(hydrated=False, total=0.0)
+
+    assert v106._patch_module(module) is True
+    manager = manager_cls()
+    manager.refresh_capital_authority("outer")
+
+    assert manager.calls == 1
+    assert manager.nested["reentrant"] == 1.0
+    assert manager.nested["ready"] == 0.0
+    assert manager.nested["pending"] == 1.0
+    assert manager.nested["total_capital"] == 0.0
+
+
+def test_guard_depth_is_released_after_exception():
+    module = ModuleType("test_mabm_v106_exception")
+    module.get_capital_authority = lambda: SimpleNamespace(hydrated=False, total_capital=0.0)
+
+    class Manager:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def refresh_capital_authority(self, trigger: str = "manual"):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("boom")
+            return {"ready": 0.0, "total_capital": 0.0, "valid_brokers": 0.0}
+
+    module.MultiAccountBrokerManager = Manager
+    assert v106._patch_module(module) is True
+
+    manager = Manager()
+    try:
+        manager.refresh_capital_authority("first")
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    result = manager.refresh_capital_authority("second")
+    assert manager.calls == 2
+    assert result["ready"] == 0.0


### PR DESCRIPTION
## What changed
- Add v106 guard around the shared `MultiAccountBrokerManager.refresh_capital_authority()` choke point.
- Suppress only same-thread recursive refresh calls.
- On recursion, return only already-published authoritative CapitalAuthority state; otherwise return pending/not-ready.
- Wire v106 into the canonical v98 startup installer after v105.
- Add regression tests for authoritative reuse, fail-closed unhydrated state, and guard release after exceptions.

## Root cause
Production deployment `47f89b41ae3d3fff66b0d36f3ad580b1bba01498` still showed `RecursionError` from `BootstrapContract`, `runtime_execution_convergence_v32`, Kraken recovery, and self-healing startup even after v105. v105 guarded `_on_platform_ready()`, but capital refresh is invoked through several other callbacks, so the correct single re-entry boundary is the shared refresh method itself.

## Safety
No balance, connectivity, position, strategy, execution, nonce, writer, bootstrap, risk, or kill-switch state is fabricated. Existing activation gates remain authoritative and fail closed when no published capital snapshot is available.

## Validation
Added targeted unit tests under `bot/tests/test_capital_refresh_reentrancy_v106.py`. CI should validate the full repository integration.