### PR TITLE
Dispatch platform position sync before capital readiness

### DIFF
--- a/bot/platform_position_sync_v108_patch.py
+++ b/bot/platform_position_sync_v108_patch.py
@@ -1,0 +1,270 @@
+"""Dispatch authoritative platform position sync independently of capital readiness.
+
+Production deployment 32c124c showed a circular startup dependency:
+CapitalAuthority published a fresh three-broker live snapshot, while canonical
+readiness remained false because every platform broker still had
+``_startup_position_sync_adopted == False``.  The historical runtime repair only
+started reconciliation after ``refresh_capital_authority()`` returned ready with
+positive capital, so position sync could wait behind a readiness path that was
+itself blocked by position sync.
+
+v108 breaks that liveness cycle without weakening safety:
+* connected platform brokers are discovered before each capital refresh;
+* each unsynchronized broker gets one daemon reconciliation worker at a time;
+* workers call the existing ``startup_position_sync._adopt_broker_positions``
+  path, which is already bounded by v95 and fail-closed by v98;
+* empty snapshots count only when the broker actually returned an authoritative
+  empty result through that existing path;
+* canonical v96 position-sync readiness is republished after every attempt;
+* no balance, connectivity, capital, position, writer, nonce, strategy,
+  bootstrap, risk, kill-switch, or execution readiness is synthesized.
+
+This module deliberately does not add another ``builtins.__import__`` wrapper.
+A short-lived monitor patches MABM once it is loaded, then exits.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.platform_position_sync_v108")
+MARKER = "20260816-platform-position-sync-v108"
+_PATCH_ATTR = "_nija_platform_position_sync_v108"
+_LOCK = threading.RLock()
+_ACTIVE: set[tuple[int, int]] = set()
+_INSTALLED = False
+_MONITOR_STARTED = False
+
+
+def _broker_name(broker_type: Any) -> str:
+    return str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+
+
+def _connected_unsynced_platform_brokers(manager: Any) -> list[tuple[str, Any]]:
+    found: list[tuple[str, Any]] = []
+    try:
+        platform = getattr(manager, "platform_brokers", {}) or {}
+        if callable(platform):
+            platform = platform()
+        for broker_type, broker in dict(platform or {}).items():
+            if broker is None or not bool(getattr(broker, "connected", False)):
+                continue
+            if bool(getattr(broker, "_startup_position_sync_adopted", False)):
+                continue
+            found.append((_broker_name(broker_type), broker))
+    except Exception as exc:
+        LOGGER.warning(
+            "PLATFORM_POSITION_SYNC_V108_DISCOVERY_FAILED marker=%s error=%s:%s fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+    return found
+
+
+def _publish_readiness(manager: Any, source: str) -> None:
+    try:
+        try:
+            from bot.position_sync_dispatch_authority_v96_patch import publish_position_sync_readiness
+        except ImportError:
+            from position_sync_dispatch_authority_v96_patch import publish_position_sync_readiness  # type: ignore[import]
+        publish_position_sync_readiness(manager, source=source)
+    except Exception as exc:
+        LOGGER.warning(
+            "PLATFORM_POSITION_SYNC_V108_READINESS_PUBLISH_FAILED marker=%s source=%s error=%s:%s fail_closed=true",
+            MARKER,
+            source,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def _worker(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
+    try:
+        try:
+            from bot import startup_position_sync as sync_module
+        except ImportError:
+            import startup_position_sync as sync_module  # type: ignore[import]
+
+        get_eps = getattr(sync_module, "_get_entry_price_store", None)
+        eps = get_eps() if callable(get_eps) else None
+        adopt = getattr(sync_module, "_adopt_broker_positions", None)
+        if not callable(adopt):
+            raise RuntimeError("startup position-sync adopter unavailable")
+
+        LOGGER.critical(
+            "PLATFORM_POSITION_SYNC_V108_START marker=%s broker=%s trigger=%s authoritative_fetch=true synthetic_empty_snapshot=false",
+            MARKER,
+            broker_name,
+            trigger,
+        )
+        adopt(broker, f"platform:{broker_name}", eps)
+        synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
+        LOGGER.critical(
+            "PLATFORM_POSITION_SYNC_V108_COMPLETE marker=%s broker=%s trigger=%s synced=%s fetch_ok=%s error=%s",
+            MARKER,
+            broker_name,
+            trigger,
+            str(synced).lower(),
+            getattr(broker, "_startup_position_sync_fetch_ok", None),
+            getattr(broker, "_startup_position_sync_error", None),
+        )
+    except BaseException as exc:
+        try:
+            setattr(broker, "_startup_position_sync_adopted", False)
+            setattr(broker, "_startup_position_sync_fetch_ok", False)
+            setattr(broker, "_startup_position_sync_error", f"{type(exc).__name__}:{exc}")
+        except Exception:
+            pass
+        LOGGER.warning(
+            "PLATFORM_POSITION_SYNC_V108_FAILED marker=%s broker=%s trigger=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            broker_name,
+            trigger,
+            type(exc).__name__,
+            exc,
+        )
+    finally:
+        _publish_readiness(manager, source=f"v108:{trigger}:{broker_name}")
+        with _LOCK:
+            _ACTIVE.discard(key)
+
+
+def dispatch_platform_position_sync(manager: Any, *, trigger: str) -> int:
+    """Start at most one authoritative reconciliation worker per platform broker."""
+    started = 0
+    for broker_name, broker in _connected_unsynced_platform_brokers(manager):
+        key = (id(manager), id(broker))
+        with _LOCK:
+            if key in _ACTIVE:
+                continue
+            _ACTIVE.add(key)
+        try:
+            thread = threading.Thread(
+                target=_worker,
+                args=(manager, broker_name, broker, key, trigger),
+                name=f"platform-position-sync-v108-{broker_name}",
+                daemon=True,
+            )
+            thread.start()
+            started += 1
+        except BaseException:
+            with _LOCK:
+                _ACTIVE.discard(key)
+            raise
+    if started:
+        LOGGER.info(
+            "PLATFORM_POSITION_SYNC_V108_DISPATCH marker=%s trigger=%s workers_started=%d capital_ready_required=false",
+            MARKER,
+            trigger,
+            started,
+        )
+    return started
+
+
+def _patch_mabm(module: ModuleType) -> bool:
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def refresh_capital_authority_v108(self: Any, *args: Any, **kwargs: Any):
+        trigger = str(kwargs.get("trigger", args[0] if args else "refresh_capital_authority"))
+        try:
+            dispatch_platform_position_sync(self, trigger=trigger)
+        except Exception as exc:
+            LOGGER.warning(
+                "PLATFORM_POSITION_SYNC_V108_DISPATCH_FAILED marker=%s trigger=%s error=%s:%s capital_refresh_continues=true trading_fail_closed=true",
+                MARKER,
+                trigger,
+                type(exc).__name__,
+                exc,
+            )
+        return current(self, *args, **kwargs)
+
+    setattr(refresh_capital_authority_v108, _PATCH_ATTR, True)
+    setattr(refresh_capital_authority_v108, "__wrapped__", current)
+    cls.refresh_capital_authority = refresh_capital_authority_v108  # type: ignore[assignment]
+    LOGGER.critical(
+        "PLATFORM_POSITION_SYNC_V108_MABM_PATCHED marker=%s module=%s dispatch_before_capital_refresh=true capital_ready_dependency=false safety_gates_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_loaded() -> bool:
+    patched = False
+    seen: set[int] = set()
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        patched = _patch_mabm(module) or patched
+    return patched
+
+
+def _patch_monitor() -> None:
+    deadline = time.monotonic() + 90.0
+    while time.monotonic() < deadline:
+        try:
+            if _patch_loaded():
+                return
+        except Exception:
+            pass
+        time.sleep(0.05)
+    LOGGER.critical(
+        "PLATFORM_POSITION_SYNC_V108_PATCH_TIMEOUT marker=%s mabm_unavailable=true trading_fail_closed=true",
+        MARKER,
+    )
+
+
+def install() -> bool:
+    global _INSTALLED, _MONITOR_STARTED
+    with _LOCK:
+        if _INSTALLED:
+            _patch_loaded()
+            return True
+        patched = _patch_loaded()
+        if not patched and not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_patch_monitor,
+                name="platform-position-sync-v108-patch-monitor",
+                daemon=True,
+            ).start()
+        os.environ["NIJA_PLATFORM_POSITION_SYNC_V108_INSTALLED"] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "PLATFORM_POSITION_SYNC_V108_INSTALLED marker=%s direct_platform_dispatch=true capital_ready_dependency=false single_flight=true import_hook=false synthetic_empty_snapshot=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    # Compatibility with the canonical installer naming convention. No import
+    # hook is installed; install() uses direct patching plus a bounded monitor.
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "dispatch_platform_position_sync",
+    "_connected_unsynced_platform_brokers",
+    "_patch_mabm",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -14,9 +14,11 @@ published before cycle-prone optional dependencies are hydrated. v106 guards
 the shared MultiAccountBrokerManager capital-refresh choke point against
 same-thread recursive startup callbacks while preserving only already-published
 authoritative capital truth. v107 serializes Kraken nonce rebuild recovery and
-adds import-hook reentry hardening. v104 remains as the narrow legacy import-cycle
-guard. v100/v102 retain bounded fail-closed class recovery, and v103 retains
-the runtime reconciliation single-flight guard.
+adds import-hook reentry hardening. v108 dispatches connected platform broker
+position snapshots independently of capital readiness while preserving the
+existing bounded/fail-closed v95/v98 position-sync contract. v104 remains as the
+narrow legacy import-cycle guard. v100/v102 retain bounded fail-closed class
+recovery, and v103 retains the runtime reconciliation single-flight guard.
 """
 from __future__ import annotations
 
@@ -61,6 +63,7 @@ def install() -> bool:
         ("startup_publication_bootstrap_v105_patch", "V105"),
         ("capital_refresh_reentrancy_v106_patch", "V106"),
         ("startup_hook_nonce_v107_patch", "V107"),
+        ("platform_position_sync_v108_patch", "V108"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -80,7 +83,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_platform_position_sync_v108.py
+++ b/bot/tests/test_platform_position_sync_v108.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+import bot.platform_position_sync_v108_patch as v108
+
+
+class BrokerType:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class FakeBroker:
+    def __init__(self, *, connected: bool = True):
+        self.connected = connected
+        self._startup_position_sync_adopted = False
+        self._startup_position_sync_fetch_ok = None
+        self._startup_position_sync_error = None
+        self.position_tracker = SimpleNamespace()
+
+
+class FakeManager:
+    def __init__(self, broker: FakeBroker):
+        self.platform_brokers = {BrokerType("kraken"): broker}
+
+
+def test_connected_unsynced_platform_broker_discovered_before_capital_ready():
+    broker = FakeBroker(connected=True)
+    manager = FakeManager(broker)
+
+    found = v108._connected_unsynced_platform_brokers(manager)
+
+    assert found == [("kraken", broker)]
+
+
+def test_synced_broker_is_not_redispatched():
+    broker = FakeBroker(connected=True)
+    broker._startup_position_sync_adopted = True
+    manager = FakeManager(broker)
+
+    assert v108._connected_unsynced_platform_brokers(manager) == []
+
+
+def test_dispatch_is_single_flight_per_broker(monkeypatch):
+    broker = FakeBroker(connected=True)
+    manager = FakeManager(broker)
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def fake_worker(manager_arg, broker_name, broker_arg, key, trigger):
+        calls.append((broker_name, trigger))
+        entered.set()
+        release.wait(timeout=1.0)
+        with v108._LOCK:
+            v108._ACTIVE.discard(key)
+
+    monkeypatch.setattr(v108, "_worker", fake_worker)
+    with v108._LOCK:
+        v108._ACTIVE.clear()
+
+    assert v108.dispatch_platform_position_sync(manager, trigger="first") == 1
+    assert entered.wait(timeout=1.0)
+    assert v108.dispatch_platform_position_sync(manager, trigger="second") == 0
+    release.set()
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        with v108._LOCK:
+            if not v108._ACTIVE:
+                break
+        time.sleep(0.01)
+
+    assert calls == [("kraken", "first")]
+
+
+def test_worker_preserves_fail_closed_state_on_error(monkeypatch):
+    broker = FakeBroker(connected=True)
+    manager = FakeManager(broker)
+    key = (id(manager), id(broker))
+
+    class FakeSyncModule:
+        @staticmethod
+        def _get_entry_price_store():
+            return None
+
+        @staticmethod
+        def _adopt_broker_positions(*args, **kwargs):
+            raise TimeoutError("position snapshot timed out")
+
+    import bot
+    monkeypatch.setattr(bot, "startup_position_sync", FakeSyncModule, raising=False)
+    monkeypatch.setattr(v108, "_publish_readiness", lambda *args, **kwargs: None)
+    with v108._LOCK:
+        v108._ACTIVE.add(key)
+
+    v108._worker(manager, "kraken", broker, key, "test")
+
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert "TimeoutError" in str(broker._startup_position_sync_error)
+    with v108._LOCK:
+        assert key not in v108._ACTIVE
+
+
+def test_patch_dispatches_before_original_capital_refresh(monkeypatch):
+    order = []
+
+    class Manager:
+        def refresh_capital_authority(self, trigger="manual"):
+            order.append(("refresh", trigger))
+            return {"ready": False, "total_capital": 0.0}
+
+    module = SimpleNamespace(__name__="bot.multi_account_broker_manager", MultiAccountBrokerManager=Manager)
+    monkeypatch.setattr(
+        v108,
+        "dispatch_platform_position_sync",
+        lambda manager, trigger: order.append(("dispatch", trigger)) or 1,
+    )
+
+    assert v108._patch_mabm(module) is True
+    result = Manager().refresh_capital_authority(trigger="bootstrap_contract:1")
+
+    assert result == {"ready": False, "total_capital": 0.0}
+    assert order == [
+        ("dispatch", "bootstrap_contract:1"),
+        ("refresh", "bootstrap_contract:1"),
+    ]


### PR DESCRIPTION
## What changed
- Add v108 platform position-sync dispatch that starts from connected platform-broker visibility rather than waiting for `capital_ready`.
- Keep reconciliation on the existing `startup_position_sync._adopt_broker_positions` path, so v95's bounded `get_positions()` timeout and v98's fail-closed stale-success revocation remain authoritative.
- Run at most one daemon reconciliation worker per manager/broker pair.
- Republish canonical v96 `position_sync_ready` truth after every attempt.
- Avoid adding another `builtins.__import__` wrapper; v108 uses direct patching plus a bounded short-lived module monitor.
- Wire v108 into the canonical v98 startup installer after v107.
- Add focused regression tests for pre-capital dispatch, single-flight behavior, fail-closed timeout handling, and dispatch ordering before capital refresh.

## Root cause
Production deployment `32c124c28701aea83e0d8e5b76f0c5bf9364157c` successfully published a fresh three-broker CapitalAuthority/CSM snapshot (`$395.29`, `live_exchange`), but canonical readiness still had `position_sync_ready=false` for Kraken/Coinbase/OKX. The existing runtime position-sync repair only starts reconciliation after `refresh_capital_authority()` returns `ready=True` with positive capital. During startup, canonical readiness/prebootstrap can remain blocked while position sync is false, creating a circular liveness dependency: position sync waits for capital-ready while the startup path waits for position sync/readiness convergence.

## Safety
No broker connectivity, balance, capital, position, strategy, writer, nonce, bootstrap, risk, kill-switch, or execution readiness is synthesized. A legitimate empty position snapshot counts only if the broker really returned an authoritative empty result through the existing startup sync implementation. Timeouts/errors remain fail closed and keep `_startup_position_sync_adopted=false`.

## Expected production evidence
After deployment, expect `PLATFORM_POSITION_SYNC_V108_START` for connected platform brokers before capital readiness, then `PLATFORM_POSITION_SYNC_V108_COMPLETE ... synced=true` only after real snapshots complete. `POSITION_SYNC_V96_READINESS` should become true only after every currently connected platform broker has authoritative sync proof. Full live activation must still wait for all existing canonical gates.