### PR TITLE
Retry transient Coinbase position sync failures

### DIFF
--- a/bot/platform_position_sync_v108_patch.py
+++ b/bot/platform_position_sync_v108_patch.py
@@ -13,6 +13,9 @@ v108 breaks that liveness cycle without weakening safety:
 * each unsynchronized broker gets one daemon reconciliation worker at a time;
 * workers call the existing ``startup_position_sync._adopt_broker_positions``
   path, which is already bounded by v95 and fail-closed by v98;
+* transient fetch failures receive a short bounded retry window in the same
+  single-flight worker, so a brief upstream 5xx does not require an unrelated
+  capital refresh before position readiness can recover;
 * empty snapshots count only when the broker actually returned an authoritative
   empty result through that existing path;
 * canonical v96 position-sync readiness is republished after every attempt;
@@ -85,6 +88,28 @@ def _publish_readiness(manager: Any, source: str) -> None:
         )
 
 
+def _retry_policy() -> tuple[int, float, float]:
+    """Return bounded position-sync retry policy.
+
+    The defaults keep retry ownership inside one v108 single-flight worker for
+    roughly seven seconds after the initial attempt (1s + 2s + 4s). Explicit
+    environment values remain authoritative. Invalid values fall back safely.
+    """
+    try:
+        attempts = int(os.getenv("NIJA_PLATFORM_POSITION_SYNC_MAX_ATTEMPTS", "4"))
+    except (TypeError, ValueError):
+        attempts = 4
+    try:
+        base_delay = float(os.getenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_BASE_S", "1.0"))
+    except (TypeError, ValueError):
+        base_delay = 1.0
+    try:
+        max_delay = float(os.getenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_MAX_S", "4.0"))
+    except (TypeError, ValueError):
+        max_delay = 4.0
+    return max(1, min(attempts, 8)), max(0.1, base_delay), max(0.1, max_delay)
+
+
 def _worker(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
     try:
         try:
@@ -98,23 +123,59 @@ def _worker(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], t
         if not callable(adopt):
             raise RuntimeError("startup position-sync adopter unavailable")
 
+        max_attempts, base_delay_s, max_delay_s = _retry_policy()
         LOGGER.critical(
-            "PLATFORM_POSITION_SYNC_V108_START marker=%s broker=%s trigger=%s authoritative_fetch=true synthetic_empty_snapshot=false",
+            "PLATFORM_POSITION_SYNC_V108_START marker=%s broker=%s trigger=%s authoritative_fetch=true synthetic_empty_snapshot=false max_attempts=%d",
             MARKER,
             broker_name,
             trigger,
+            max_attempts,
         )
-        adopt(broker, f"platform:{broker_name}", eps)
-        synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
-        LOGGER.critical(
-            "PLATFORM_POSITION_SYNC_V108_COMPLETE marker=%s broker=%s trigger=%s synced=%s fetch_ok=%s error=%s",
-            MARKER,
-            broker_name,
-            trigger,
-            str(synced).lower(),
-            getattr(broker, "_startup_position_sync_fetch_ok", None),
-            getattr(broker, "_startup_position_sync_error", None),
-        )
+
+        for attempt in range(1, max_attempts + 1):
+            adopt(broker, f"platform:{broker_name}", eps)
+            synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None)
+            error = getattr(broker, "_startup_position_sync_error", None)
+            _publish_readiness(manager, source=f"v108:{trigger}:{broker_name}:attempt_{attempt}")
+
+            if synced:
+                LOGGER.critical(
+                    "PLATFORM_POSITION_SYNC_V108_COMPLETE marker=%s broker=%s trigger=%s attempt=%d synced=true fetch_ok=%s error=%s",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    attempt,
+                    fetch_ok,
+                    error,
+                )
+                break
+
+            if attempt >= max_attempts:
+                LOGGER.warning(
+                    "PLATFORM_POSITION_SYNC_V108_RETRIES_EXHAUSTED marker=%s broker=%s trigger=%s attempts=%d synced=false fetch_ok=%s error=%s trading_fail_closed=true",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    max_attempts,
+                    fetch_ok,
+                    error,
+                )
+                break
+
+            delay_s = min(max_delay_s, base_delay_s * (2 ** (attempt - 1)))
+            LOGGER.warning(
+                "PLATFORM_POSITION_SYNC_V108_RETRY marker=%s broker=%s trigger=%s attempt=%d next_attempt=%d delay_s=%.2f synced=false fetch_ok=%s error=%s trading_fail_closed=true",
+                MARKER,
+                broker_name,
+                trigger,
+                attempt,
+                attempt + 1,
+                delay_s,
+                fetch_ok,
+                error,
+            )
+            time.sleep(delay_s)
     except BaseException as exc:
         try:
             setattr(broker, "_startup_position_sync_adopted", False)
@@ -131,7 +192,7 @@ def _worker(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], t
             exc,
         )
     finally:
-        _publish_readiness(manager, source=f"v108:{trigger}:{broker_name}")
+        _publish_readiness(manager, source=f"v108:{trigger}:{broker_name}:final")
         with _LOCK:
             _ACTIVE.discard(key)
 
@@ -248,7 +309,7 @@ def install() -> bool:
         os.environ["NIJA_PLATFORM_POSITION_SYNC_V108_INSTALLED"] = "1"
         _INSTALLED = True
         LOGGER.critical(
-            "PLATFORM_POSITION_SYNC_V108_INSTALLED marker=%s direct_platform_dispatch=true capital_ready_dependency=false single_flight=true import_hook=false synthetic_empty_snapshot=false",
+            "PLATFORM_POSITION_SYNC_V108_INSTALLED marker=%s direct_platform_dispatch=true capital_ready_dependency=false single_flight=true bounded_retry=true import_hook=false synthetic_empty_snapshot=false",
             MARKER,
         )
         return True
@@ -266,5 +327,6 @@ __all__ = [
     "install_import_hook",
     "dispatch_platform_position_sync",
     "_connected_unsynced_platform_brokers",
+    "_retry_policy",
     "_patch_mabm",
 ]

--- a/bot/tests/test_platform_position_sync_v108.py
+++ b/bot/tests/test_platform_position_sync_v108.py
@@ -72,6 +72,18 @@ def test_dispatch_is_single_flight_per_broker(monkeypatch):
     assert calls == [("kraken", "first")]
 
 
+def test_retry_policy_defaults_and_bounds(monkeypatch):
+    monkeypatch.delenv("NIJA_PLATFORM_POSITION_SYNC_MAX_ATTEMPTS", raising=False)
+    monkeypatch.delenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_BASE_S", raising=False)
+    monkeypatch.delenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_MAX_S", raising=False)
+    assert v108._retry_policy() == (4, 1.0, 4.0)
+
+    monkeypatch.setenv("NIJA_PLATFORM_POSITION_SYNC_MAX_ATTEMPTS", "999")
+    monkeypatch.setenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_BASE_S", "0")
+    monkeypatch.setenv("NIJA_PLATFORM_POSITION_SYNC_RETRY_MAX_S", "0")
+    assert v108._retry_policy() == (8, 0.1, 0.1)
+
+
 def test_worker_retries_unsynced_fetch_and_recovers(monkeypatch):
     broker = FakeBroker(connected=True)
     manager = FakeManager(broker)
@@ -136,6 +148,7 @@ def test_worker_preserves_fail_closed_state_on_error(monkeypatch):
 
     import bot
     monkeypatch.setattr(bot, "startup_position_sync", FakeSyncModule, raising=False)
+    monkeypatch.setattr(v108, "_retry_policy", lambda: (1, 0.1, 0.1))
     monkeypatch.setattr(v108, "_publish_readiness", lambda *args, **kwargs: None)
     with v108._LOCK:
         v108._ACTIVE.add(key)
@@ -145,6 +158,43 @@ def test_worker_preserves_fail_closed_state_on_error(monkeypatch):
     assert broker._startup_position_sync_adopted is False
     assert broker._startup_position_sync_fetch_ok is False
     assert "TimeoutError" in str(broker._startup_position_sync_error)
+    with v108._LOCK:
+        assert key not in v108._ACTIVE
+
+
+def test_worker_exhausts_retries_without_granting_readiness(monkeypatch):
+    broker = FakeBroker(connected=True)
+    manager = FakeManager(broker)
+    key = (id(manager), id(broker))
+    calls = []
+
+    class FakeSyncModule:
+        @staticmethod
+        def _get_entry_price_store():
+            return None
+
+        @staticmethod
+        def _adopt_broker_positions(broker_arg, broker_name, eps):
+            calls.append(broker_name)
+            broker_arg._startup_position_sync_adopted = False
+            broker_arg._startup_position_sync_fetch_ok = False
+            broker_arg._startup_position_sync_error = "HTTPError:502 Bad Gateway"
+            return 0
+
+    import bot
+    monkeypatch.setattr(bot, "startup_position_sync", FakeSyncModule, raising=False)
+    monkeypatch.setattr(v108, "_retry_policy", lambda: (3, 0.1, 0.1))
+    monkeypatch.setattr(v108.time, "sleep", lambda delay: None)
+    monkeypatch.setattr(v108, "_publish_readiness", lambda *args, **kwargs: None)
+    with v108._LOCK:
+        v108._ACTIVE.add(key)
+
+    v108._worker(manager, "coinbase", broker, key, "test")
+
+    assert calls == ["platform:coinbase"] * 3
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert "502" in str(broker._startup_position_sync_error)
     with v108._LOCK:
         assert key not in v108._ACTIVE
 

--- a/bot/tests/test_platform_position_sync_v108.py
+++ b/bot/tests/test_platform_position_sync_v108.py
@@ -29,17 +29,13 @@ class FakeManager:
 def test_connected_unsynced_platform_broker_discovered_before_capital_ready():
     broker = FakeBroker(connected=True)
     manager = FakeManager(broker)
-
-    found = v108._connected_unsynced_platform_brokers(manager)
-
-    assert found == [("kraken", broker)]
+    assert v108._connected_unsynced_platform_brokers(manager) == [("kraken", broker)]
 
 
 def test_synced_broker_is_not_redispatched():
     broker = FakeBroker(connected=True)
     broker._startup_position_sync_adopted = True
     manager = FakeManager(broker)
-
     assert v108._connected_unsynced_platform_brokers(manager) == []
 
 
@@ -74,6 +70,54 @@ def test_dispatch_is_single_flight_per_broker(monkeypatch):
         time.sleep(0.01)
 
     assert calls == [("kraken", "first")]
+
+
+def test_worker_retries_unsynced_fetch_and_recovers(monkeypatch):
+    broker = FakeBroker(connected=True)
+    manager = FakeManager(broker)
+    key = (id(manager), id(broker))
+    calls = []
+    sleeps = []
+    readiness = []
+
+    class FakeSyncModule:
+        @staticmethod
+        def _get_entry_price_store():
+            return None
+
+        @staticmethod
+        def _adopt_broker_positions(broker_arg, broker_name, eps):
+            calls.append(broker_name)
+            if len(calls) < 3:
+                broker_arg._startup_position_sync_adopted = False
+                broker_arg._startup_position_sync_fetch_ok = False
+                broker_arg._startup_position_sync_error = "HTTPError:502"
+                return 0
+            broker_arg._startup_position_sync_adopted = True
+            broker_arg._startup_position_sync_fetch_ok = True
+            broker_arg._startup_position_sync_error = None
+            return 0
+
+    import bot
+    monkeypatch.setattr(bot, "startup_position_sync", FakeSyncModule, raising=False)
+    monkeypatch.setattr(v108, "_retry_policy", lambda: (4, 1.0, 4.0))
+    monkeypatch.setattr(v108.time, "sleep", lambda delay: sleeps.append(delay))
+    monkeypatch.setattr(v108, "_publish_readiness", lambda manager_arg, source: readiness.append(source))
+    with v108._LOCK:
+        v108._ACTIVE.add(key)
+
+    v108._worker(manager, "coinbase", broker, key, "test")
+
+    assert len(calls) == 3
+    assert sleeps == [1.0, 2.0]
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_fetch_ok is True
+    assert any(source.endswith("attempt_1") for source in readiness)
+    assert any(source.endswith("attempt_2") for source in readiness)
+    assert any(source.endswith("attempt_3") for source in readiness)
+    assert readiness[-1].endswith(":final")
+    with v108._LOCK:
+        assert key not in v108._ACTIVE
 
 
 def test_worker_preserves_fail_closed_state_on_error(monkeypatch):


### PR DESCRIPTION
## Summary
- keep platform position sync fail-closed on every unsuccessful authoritative fetch
- retry unsynchronized platform position reconciliation in the existing v108 single-flight worker with bounded exponential backoff
- republish canonical position-sync readiness after every attempt and at worker exit
- add regression coverage for transient 502-style failure followed by successful recovery

## Why
The latest production run reaches `RUNNING_SUPERVISED`, `authority_ready=True`, and `nonce_ready=True`. The remaining blocker is `position_sync_ready=False` after Coinbase returns a transient HTTP 502. Previously v108 ended the worker after that unsuccessful authoritative fetch, leaving recovery dependent on a later unrelated capital refresh. This change keeps all gates closed while retrying the same authoritative sync path for a short bounded window.

## Safety
No positions, balances, connectivity, writer authority, nonce state, risk readiness, execution readiness, or bootstrap readiness are synthesized. Empty snapshots remain valid only when returned authoritatively by the existing startup sync path.