### PR TITLE
Fix terminal writer loss SEAK halt

### DIFF
--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -17,11 +17,13 @@ authoritative capital truth. v107 serializes Kraken nonce rebuild recovery and
 adds import-hook reentry hardening. v108 dispatches connected platform broker
 position snapshots independently of capital readiness while preserving the
 existing bounded/fail-closed v95/v98 position-sync contract. v116 closes the
-activation/writer/readiness convergence races, and v117 adds bounded stale
+activation/writer/readiness convergence races, v117 adds bounded stale
 position-fetch generations plus supervised-pending THREADS_STARTING liveness
-without granting execution authority. v104 remains as the narrow legacy
-import-cycle guard. v100/v102 retain bounded fail-closed class recovery, and
-v103 retains the runtime reconciliation single-flight guard.
+without granting execution authority, and v118 repairs the terminal writer-loss
+SEAK halt signature mismatch while preserving fail-closed shutdown semantics.
+v104 remains as the narrow legacy import-cycle guard. v100/v102 retain bounded
+fail-closed class recovery, and v103 retains the runtime reconciliation
+single-flight guard.
 """
 from __future__ import annotations
 
@@ -69,6 +71,7 @@ def install() -> bool:
         ("platform_position_sync_v108_patch", "V108"),
         ("runtime_convergence_v116_patch", "V116"),
         ("position_fetch_generation_v117_patch", "V117"),
+        ("terminal_writer_loss_seak_v118_patch", "V118"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -88,7 +91,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/terminal_writer_loss_seak_v118_patch.py
+++ b/bot/terminal_writer_loss_seak_v118_patch.py
@@ -1,0 +1,122 @@
+"""Terminal writer-loss SEAK compatibility repair v118.
+
+Production logs showed terminal_writer_loss_latch passing a ``source`` keyword
+to SingleExecutionAuthorityKernel.emergency_halt(), whose canonical signature
+accepts only ``reason``.  The resulting TypeError did not reopen execution, but
+it prevented the terminal-loss latch from performing its own SEAK halt step.
+
+v118 replaces only that helper.  It preserves the existing terminal-loss
+classification, readiness revocation, global shutdown, and process-exit flow.
+No writer authority, readiness, nonce state, capital, position state, or
+execution permission is fabricated.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.terminal_writer_loss_seak_v118")
+MARKER = "20260816-terminal-writer-loss-seak-v118"
+_LOCK = threading.RLock()
+_IMPORT_LOCAL = threading.local()
+_IMPORT_FLAG = "_NIJA_TERMINAL_WRITER_LOSS_SEAK_V118_IMPORT_HOOK"
+_PATCH_ATTR = "_nija_terminal_writer_loss_seak_v118"
+
+
+def _loaded(*names: str) -> ModuleType | None:
+    for name in names:
+        mod = sys.modules.get(name)
+        if isinstance(mod, ModuleType):
+            return mod
+    return None
+
+
+def _patch_terminal_latch() -> bool:
+    mod = _loaded("bot.terminal_writer_loss_latch", "terminal_writer_loss_latch")
+    if mod is None:
+        return True
+
+    current = getattr(mod, "_halt_seak_on_terminal_loss", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    def halt_seak_compatible(reason: str) -> None:
+        try:
+            try:
+                from bot.single_execution_authority_kernel import get_seak
+            except ImportError:
+                from single_execution_authority_kernel import get_seak  # type: ignore[import]
+            seak = get_seak()
+            if seak is None:
+                return
+            halt = getattr(seak, "emergency_halt", None)
+            if not callable(halt):
+                return
+            halt(f"terminal_writer_loss:{reason}")
+            LOGGER.critical(
+                "TERMINAL_WRITER_LOSS_SEAK_V118_HALTED marker=%s reason=%s source=terminal_writer_loss_latch execution_fail_closed=true",
+                MARKER,
+                reason,
+            )
+        except Exception as exc:
+            LOGGER.critical(
+                "TERMINAL_WRITER_LOSS_SEAK_V118_FAILED marker=%s err=%s execution_fail_closed=true",
+                MARKER,
+                exc,
+                exc_info=True,
+            )
+
+    setattr(halt_seak_compatible, _PATCH_ATTR, True)
+    setattr(halt_seak_compatible, "__wrapped__", current)
+    mod._halt_seak_on_terminal_loss = halt_seak_compatible
+    return True
+
+
+def _patch_loaded() -> bool:
+    return _patch_terminal_latch()
+
+
+def install_import_hook() -> bool:
+    with _LOCK:
+        ready = _patch_loaded()
+        if not getattr(builtins, _IMPORT_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def importing(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if getattr(_IMPORT_LOCAL, "active", False):
+                    return result
+                if "terminal_writer_loss_latch" in str(name or ""):
+                    _IMPORT_LOCAL.active = True
+                    try:
+                        _patch_loaded()
+                    finally:
+                        _IMPORT_LOCAL.active = False
+                return result
+
+            builtins.__import__ = importing
+            setattr(builtins, _IMPORT_FLAG, True)
+
+        os.environ["NIJA_TERMINAL_WRITER_LOSS_SEAK_V118_INSTALLED"] = "1"
+        LOGGER.critical(
+            "TERMINAL_WRITER_LOSS_SEAK_V118_INSTALLED marker=%s emergency_halt_signature_compatible=true safety_gates_unchanged=true initial_patch_ready=%s",
+            MARKER,
+            ready,
+        )
+        return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = ["MARKER", "install", "install_import_hook"]

--- a/bot/tests/test_terminal_writer_loss_seak_v118.py
+++ b/bot/tests/test_terminal_writer_loss_seak_v118.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+
+def test_terminal_writer_loss_halt_uses_canonical_seak_signature(monkeypatch):
+    import bot.terminal_writer_loss_seak_v118_patch as patch
+
+    calls: list[str] = []
+
+    class FakeSEAK:
+        def emergency_halt(self, reason: str = "emergency halt") -> None:
+            calls.append(reason)
+
+    seak_mod = ModuleType("bot.single_execution_authority_kernel")
+    seak_mod.get_seak = lambda: FakeSEAK()
+    monkeypatch.setitem(sys.modules, "bot.single_execution_authority_kernel", seak_mod)
+
+    latch_mod = ModuleType("bot.terminal_writer_loss_latch")
+
+    def old_halt(reason: str) -> None:
+        raise AssertionError(reason)
+
+    latch_mod._halt_seak_on_terminal_loss = old_halt
+    monkeypatch.setitem(sys.modules, "bot.terminal_writer_loss_latch", latch_mod)
+
+    assert patch._patch_terminal_latch() is True
+    latch_mod._halt_seak_on_terminal_loss("core_thread_dead")
+
+    assert calls == ["terminal_writer_loss:core_thread_dead"]
+
+
+def test_terminal_writer_loss_patch_is_idempotent(monkeypatch):
+    import bot.terminal_writer_loss_seak_v118_patch as patch
+
+    latch_mod = ModuleType("bot.terminal_writer_loss_latch")
+    latch_mod._halt_seak_on_terminal_loss = lambda reason: None
+    monkeypatch.setitem(sys.modules, "bot.terminal_writer_loss_latch", latch_mod)
+
+    assert patch._patch_terminal_latch() is True
+    first = latch_mod._halt_seak_on_terminal_loss
+    assert patch._patch_terminal_latch() is True
+    assert latch_mod._halt_seak_on_terminal_loss is first


### PR DESCRIPTION
## What changed

- add v118 compatibility repair for terminal writer-loss SEAK shutdown
- replace the incompatible `emergency_halt(..., source=...)` call path with the canonical single-argument SEAK API
- install v118 through the existing v98 startup convergence chain
- add focused regression coverage for signature compatibility and idempotent patching

## Root cause

Production logs from the old `24eb31c3...` deployment showed a terminal writer-loss shutdown after the canonical `TradingLoop` thread died. The terminal-loss latch correctly revoked readiness and requested exit, but its own SEAK halt step raised `TypeError` because `SingleExecutionAuthorityKernel.emergency_halt()` accepts only `reason` while `terminal_writer_loss_latch` passed an unsupported `source` keyword.

## Safety

This patch does not alter terminal-loss classification, writer authority, readiness, nonce state, capital, position state, or execution permissions. It only restores the intended SEAK emergency-halt call during an already-terminal writer-loss sequence. All shutdown behavior remains fail closed.

## Validation

Focused tests verify the canonical SEAK signature and idempotent patch application.