### PR TITLE
Require canonical position sync in preactivation

### DIFF
--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -1,29 +1,11 @@
-"""Tune startup position-fetch timeout without weakening position-sync safety.
+"""Tune startup position synchronization without weakening activation safety.
 
-Production logs on 2026-08-15 showed authoritative Kraken position snapshots
-crossing the v95 five-second default. v95 correctly failed closed, but the
-short default caused repeated timeout/invalidation during otherwise healthy
-broker startup.
-
-v98 changes only the *default* timeout to 12 seconds. An explicit
-NIJA_POSITION_FETCH_TIMEOUT_S value remains authoritative. v99 is installed
-from the same canonical slot so platform readiness is isolated from slow user
-position snapshots while each user execution path remains fail closed. v105 is
-installed before strategy recovery so the canonical TradingStrategy class is
-published before cycle-prone optional dependencies are hydrated. v106 guards
-the shared MultiAccountBrokerManager capital-refresh choke point against
-same-thread recursive startup callbacks while preserving only already-published
-authoritative capital truth. v107 serializes Kraken nonce rebuild recovery and
-adds import-hook reentry hardening. v108 dispatches connected platform broker
-position snapshots independently of capital readiness while preserving the
-existing bounded/fail-closed v95/v98 position-sync contract. v116 closes the
-activation/writer/readiness convergence races, v117 adds bounded stale
-position-fetch generations plus supervised-pending THREADS_STARTING liveness
-without granting execution authority, and v118 repairs the terminal writer-loss
-SEAK halt signature mismatch while preserving fail-closed shutdown semantics.
-v104 remains as the narrow legacy import-cycle guard. v100/v102 retain bounded
-fail-closed class recovery, and v103 retains the runtime reconciliation
-single-flight guard.
+v98 raises the default broker-position fetch timeout to 12 seconds while
+preserving an explicit ``NIJA_POSITION_FETCH_TIMEOUT_S`` override.  Later
+repairs are installed from this canonical slot in dependency order.  v119 adds
+canonical position-sync observation to preactivation truth and expands release
+attestation so v98/v116/v117/v118/v119 must all be present before the runtime
+release manifest can report complete.
 """
 from __future__ import annotations
 
@@ -72,6 +54,7 @@ def install() -> bool:
         ("runtime_convergence_v116_patch", "V116"),
         ("position_fetch_generation_v117_patch", "V117"),
         ("terminal_writer_loss_seak_v118_patch", "V118"),
+        ("preactivation_position_sync_v119_patch", "V119"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -91,7 +74,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/preactivation_position_sync_v119_patch.py
+++ b/bot/preactivation_position_sync_v119_patch.py
@@ -1,0 +1,261 @@
+"""Canonical position-sync preactivation truth and release attestation v119.
+
+Production deployment 2b43a7d2 showed the canonical readiness table with
+``position_sync_ready=False`` while v61's PREACTIVATION_READINESS truth-sync
+pending lists omitted that key.  The omission is diagnostic and semantic:
+``NIJA_PREACTIVATION_READINESS_V16_READY`` can otherwise describe only the
+legacy nine proof keys instead of the complete canonical readiness table.
+
+v119 fixes that without making v61 a second publisher of position-sync truth:
+
+* v61/v16 continue to own and update only their existing legacy readiness keys;
+* ``position_sync_ready`` is observed from ``readiness_table`` and is never
+  marked or revoked by this patch;
+* preactivation remains false while that canonical key is missing or false;
+* the v61 activation-prerequisite boundary independently observes the same key;
+* the runtime release manifest explicitly attests v98, v116, v117, v118, and
+  v119 so a release cannot report complete while those repairs are absent;
+* no new ``builtins.__import__`` hook is installed.
+
+No readiness, position, writer, nonce, capital, risk, or execution permission is
+fabricated by this patch.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.preactivation_position_sync_v119")
+MARKER = "20260816-preactivation-position-sync-v119"
+RELEASE_ID = "20260816-runtime-convergence-v119"
+_PATCH_ATTR = "_nija_preactivation_position_sync_v119"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _module(*names: str) -> ModuleType | None:
+    for name in names:
+        mod = sys.modules.get(name)
+        if isinstance(mod, ModuleType):
+            return mod
+    for name in names:
+        try:
+            mod = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(mod, ModuleType):
+            return mod
+    return None
+
+
+def _readiness_table_module() -> ModuleType | None:
+    return _module("bot.readiness_table", "readiness_table")
+
+
+def _position_sync_truth() -> tuple[bool, str, dict[str, Any]]:
+    table = _readiness_table_module()
+    if table is None:
+        return False, "readiness_table_unavailable", {}
+    try:
+        snapshot = dict(table.snapshot() or {})
+    except Exception as exc:
+        return False, f"readiness_snapshot_failed:{type(exc).__name__}:{exc}", {}
+    if "position_sync_ready" not in snapshot:
+        return False, "position_sync_ready_missing", snapshot
+    return bool(snapshot.get("position_sync_ready", False)), "canonical_readiness_table", snapshot
+
+
+def _patch_truth_sync(v61: ModuleType, v16: ModuleType) -> bool:
+    current = getattr(v16, "_mark_proven_readiness", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    legacy_keys = tuple(getattr(v61, "_KEYS", ()) or ())
+    if not legacy_keys:
+        return False
+    state_value = getattr(v61, "_state_value", None)
+    if not callable(state_value):
+        return False
+
+    @wraps(current)
+    def mark_proven_readiness_v119(proofs: dict[str, bool]) -> tuple[bool, list[str]]:
+        table = _readiness_table_module()
+        if table is None:
+            os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] = "0"
+            return False, ["readiness_table_unavailable", "position_sync_ready"]
+
+        try:
+            before = dict(table.snapshot() or {})
+        except Exception as exc:
+            os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] = "0"
+            return False, [f"readiness_snapshot_failed:{type(exc).__name__}:{exc}", "position_sync_ready"]
+
+        trading_state = str(state_value() or "UNAVAILABLE")
+        prelive = trading_state != "LIVE_ACTIVE"
+        for key in legacy_keys:
+            if bool(proofs.get(key, False)):
+                table.mark_ready(key)
+            elif prelive:
+                table.revoke_ready(key, reason="v119_current_proof_false")
+
+        try:
+            after = dict(table.snapshot() or {})
+        except Exception as exc:
+            os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] = "0"
+            return False, [f"readiness_snapshot_failed:{type(exc).__name__}:{exc}", "position_sync_ready"]
+
+        current_pending = [key for key in legacy_keys if not bool(proofs.get(key, False))]
+        table_pending = [key for key in legacy_keys if not bool(after.get(key, False))]
+        position_ready = bool(after.get("position_sync_ready", False))
+        position_source = "canonical_readiness_table" if "position_sync_ready" in after else "missing"
+        if not position_ready:
+            table_pending.append("position_sync_ready")
+
+        pending: list[str] = []
+        for key in (*current_pending, *table_pending):
+            if key not in pending:
+                pending.append(key)
+        ready = not pending
+
+        os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] = "1" if ready else "0"
+        if prelive:
+            authority = bool(proofs.get("authority_ready", False))
+            nonce = bool(proofs.get("nonce_ready", False))
+            os.environ["NIJA_AUTHORITY_READY"] = "1" if authority else "0"
+            os.environ["NIJA_NONCE_READY"] = "1" if nonce else "0"
+            os.environ["NIJA_RUNTIME_NONCE_READY"] = "1" if nonce else "0"
+
+        LOGGER.critical(
+            "PREACTIVATION_READINESS_V119_TRUTH_SYNC marker=%s state=%s prelive=%s before=%s after=%s current_pending=%s table_pending=%s pending=%s position_sync_ready=%s position_source=%s canonical_position_publisher_preserved=true",
+            MARKER,
+            trading_state,
+            str(prelive).lower(),
+            before,
+            after,
+            current_pending,
+            table_pending,
+            pending,
+            position_ready,
+            position_source,
+        )
+        if ready:
+            LOGGER.critical(
+                "PREACTIVATION_READY marker=%s authority_ready=%s nonce_ready=%s position_sync_ready=true writer_authority=confirmed blockers_cleared=true current_proofs=true",
+                MARKER,
+                bool(proofs.get("authority_ready", False)),
+                bool(proofs.get("nonce_ready", False)),
+            )
+        return ready, pending
+
+    setattr(mark_proven_readiness_v119, _PATCH_ATTR, True)
+    setattr(mark_proven_readiness_v119, "__wrapped__", current)
+    v16._mark_proven_readiness = mark_proven_readiness_v119
+    return True
+
+
+def _patch_activation_prerequisites(v61: ModuleType) -> bool:
+    current = getattr(v61, "_activation_prerequisites", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def activation_prerequisites_v119() -> tuple[bool, list[str], dict[str, Any]]:
+        ready, blockers, details = current()
+        position_ready, position_source, snapshot = _position_sync_truth()
+        final_details = dict(details or {})
+        final_details["position_sync_readiness"] = {
+            "ready": position_ready,
+            "source": position_source,
+            "table_value": snapshot.get("position_sync_ready") if snapshot else None,
+        }
+        final_blockers = list(blockers or [])
+        if not position_ready and "position_sync_ready" not in final_blockers:
+            final_blockers.append("position_sync_ready")
+        if final_blockers:
+            return False, final_blockers, final_details
+        return bool(ready), final_blockers, final_details
+
+    setattr(activation_prerequisites_v119, _PATCH_ATTR, True)
+    setattr(activation_prerequisites_v119, "__wrapped__", current)
+    v61._activation_prerequisites = activation_prerequisites_v119
+    return True
+
+
+def _patch_release_manifest(manifest: ModuleType) -> bool:
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required.update(
+        {
+            "position_sync_timeout_v98": "NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED",
+            "runtime_convergence_v116": "NIJA_RUNTIME_CONVERGENCE_V116_INSTALLED",
+            "position_fetch_generation_v117": "NIJA_POSITION_FETCH_GENERATION_V117_INSTALLED",
+            "terminal_writer_loss_seak_v118": "NIJA_TERMINAL_WRITER_LOSS_SEAK_V118_INSTALLED",
+            "preactivation_position_sync_v119": "NIJA_PREACTIVATION_POSITION_SYNC_V119_INSTALLED",
+        }
+    )
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED:
+            return True
+
+        v61 = _module("bot.final_production_activation_repair_v61_patch", "final_production_activation_repair_v61_patch")
+        if v61 is None:
+            return False
+        v61_install = getattr(v61, "install", None)
+        if callable(v61_install) and v61_install() is False:
+            return False
+
+        v16 = _module("preactivation_readiness_convergence_v16_patch", "bot.preactivation_readiness_convergence_v16_patch")
+        manifest = _module("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch")
+        if v16 is None or manifest is None:
+            return False
+
+        truth_ok = _patch_truth_sync(v61, v16)
+        activation_ok = _patch_activation_prerequisites(v61)
+        if not (truth_ok and activation_ok):
+            return False
+
+        os.environ["NIJA_PREACTIVATION_POSITION_SYNC_V119_INSTALLED"] = "1"
+        manifest_ok = _patch_release_manifest(manifest)
+        if not manifest_ok:
+            os.environ.pop("NIJA_PREACTIVATION_POSITION_SYNC_V119_INSTALLED", None)
+            return False
+
+        _INSTALLED = True
+        LOGGER.critical(
+            "PREACTIVATION_POSITION_SYNC_V119_INSTALLED marker=%s canonical_position_publisher_preserved=true position_sync_required_for_preactivation=true release_attestation=v98,v116,v117,v118,v119 import_hook_added=false safety_gates_unchanged=true",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    """Compatibility installer name; v119 deliberately installs no import hook."""
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_patch_truth_sync",
+    "_patch_activation_prerequisites",
+    "_patch_release_manifest",
+]

--- a/bot/tests/test_preactivation_position_sync_v119.py
+++ b/bot/tests/test_preactivation_position_sync_v119.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+import types
+
+from bot import preactivation_position_sync_v119_patch as v119
+
+
+class FakeTable:
+    def __init__(self) -> None:
+        self.values = {
+            "broker_connected": True,
+            "balance_hydrated": True,
+            "authority_ready": True,
+            "capital_ready": True,
+            "risk_ready": True,
+            "strategy_ready": True,
+            "execution_ready": True,
+            "nonce_ready": True,
+            "bootstrap_ready": True,
+            "position_sync_ready": False,
+        }
+
+    def snapshot(self):
+        return dict(self.values)
+
+    def mark_ready(self, key):
+        self.values[key] = True
+
+    def revoke_ready(self, key, reason=""):
+        self.values[key] = False
+
+
+def test_truth_sync_observes_position_sync_without_publishing_it(monkeypatch):
+    table = FakeTable()
+    v61 = types.SimpleNamespace(
+        _KEYS=(
+            "broker_connected",
+            "balance_hydrated",
+            "authority_ready",
+            "capital_ready",
+            "risk_ready",
+            "strategy_ready",
+            "execution_ready",
+            "nonce_ready",
+            "bootstrap_ready",
+        ),
+        _state_value=lambda: "LIVE_PENDING_CONFIRMATION",
+    )
+    v16 = types.SimpleNamespace(_mark_proven_readiness=lambda proofs: (True, []))
+    monkeypatch.setattr(v119, "_readiness_table_module", lambda: table)
+
+    assert v119._patch_truth_sync(v61, v16) is True
+    proofs = {key: True for key in v61._KEYS}
+    ready, pending = v16._mark_proven_readiness(proofs)
+
+    assert ready is False
+    assert pending == ["position_sync_ready"]
+    assert table.values["position_sync_ready"] is False
+    assert os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] == "0"
+
+
+def test_activation_prerequisites_require_canonical_position_sync(monkeypatch):
+    v61 = types.SimpleNamespace(
+        _activation_prerequisites=lambda: (True, [], {"legacy": "ready"})
+    )
+    monkeypatch.setattr(
+        v119,
+        "_position_sync_truth",
+        lambda: (False, "canonical_readiness_table", {"position_sync_ready": False}),
+    )
+
+    assert v119._patch_activation_prerequisites(v61) is True
+    ready, blockers, details = v61._activation_prerequisites()
+
+    assert ready is False
+    assert blockers == ["position_sync_ready"]
+    assert details["position_sync_readiness"]["ready"] is False
+
+
+def test_release_manifest_attests_modern_convergence_flags(monkeypatch):
+    manifest = types.SimpleNamespace(_REQUIRED_FLAGS={}, RELEASE_ID="old")
+
+    assert v119._patch_release_manifest(manifest) is True
+    assert manifest.RELEASE_ID == v119.RELEASE_ID
+    assert manifest._REQUIRED_FLAGS["position_sync_timeout_v98"] == "NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["runtime_convergence_v116"] == "NIJA_RUNTIME_CONVERGENCE_V116_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["position_fetch_generation_v117"] == "NIJA_POSITION_FETCH_GENERATION_V117_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["terminal_writer_loss_seak_v118"] == "NIJA_TERMINAL_WRITER_LOSS_SEAK_V118_INSTALLED"
+    assert manifest._REQUIRED_FLAGS["preactivation_position_sync_v119"] == "NIJA_PREACTIVATION_POSITION_SYNC_V119_INSTALLED"
+
+
+def test_v119_installs_no_builtins_import_hook():
+    import inspect
+
+    source = inspect.getsource(v119.install_import_hook)
+    assert "builtins.__import__" not in source


### PR DESCRIPTION
## What changed

- add v119 preactivation position-sync truth repair
- keep `position_sync_ready` single-source: v119 observes the canonical readiness table and never publishes that key
- keep preactivation false whenever canonical `position_sync_ready` is false or missing
- add the same canonical position-sync blocker to the v61 activation-prerequisite boundary
- expand runtime release attestation in-process to require v98, v116, v117, v118, and v119
- install v119 from the existing canonical v98 convergence chain
- add focused regression coverage

## Root cause

Production deployment `2b43a7d2...` showed `readiness_table.position_sync_ready=False`, while `PREACTIVATION_READINESS_V61_TRUTH_SYNC` omitted that key from `current_pending`, `table_pending`, and `pending`. v61/v16 still reason over a legacy nine-key proof tuple, even though position-sync readiness was added later as a canonical dispatch gate. The runtime release manifest also still used its historical release ID and did not attest the modern v116-v118 convergence repairs.

## Safety

v119 does not mark or revoke `position_sync_ready`; the existing position-sync dispatch authority remains its canonical publisher. It only observes that truth and refuses preactivation/activation while it is false. No writer, nonce, capital, risk, position, readiness, or execution authority is fabricated. v119 deliberately adds no new `builtins.__import__` hook.

## Validation

Focused tests cover canonical position-sync observation, activation blocking, modern release attestation flags, and the no-new-import-hook invariant.