### PR TITLE
Preserve supervised core liveness and bound Kraken reads

### DIFF
--- a/bot/core_supervised_pending_v120_patch.py
+++ b/bot/core_supervised_pending_v120_patch.py
@@ -2,10 +2,10 @@
 
 Production deployment 2b43a7d2 proved position-sync and bootstrap convergence,
 but the canonical TradingLoop still exited after its bounded
-``TRADING_ENGINE_READY`` wait expired.  That return was then correctly treated
+``TRADING_ENGINE_READY`` wait expired. That return was then correctly treated
 by writer authority as terminal ``core_thread_dead`` and the process restarted.
 
-v120 preserves the existing bounded wait and every execution gate.  It wraps
+v120 preserves the existing bounded wait and every execution gate. It wraps
 ``run_trading_loop`` so that a return is retried only when all of these are true:
 
 * the canonical Redis process-writer proof is still exact and current;
@@ -15,9 +15,9 @@ v120 preserves the existing bounded wait and every execution gate.  It wraps
 * TRADING_ENGINE_READY remains unset (the observed startup-pending return path).
 
 No broker I/O, scan, order, readiness, nonce, capital, position, or execution
-authority is fabricated.  Structural failures still terminate the core thread.
+authority is fabricated. Structural failures still terminate the core thread.
 The patch adds no new global import hook; future nija_core_loop imports are
-patched through the already-installed v54 lifecycle hook.
+patched by extending the already-installed v54 lifecycle dispatch function.
 """
 from __future__ import annotations
 
@@ -34,6 +34,7 @@ LOGGER = logging.getLogger("nija.core_supervised_pending_v120")
 MARKER = "20260816-core-supervised-pending-v120"
 RELEASE_ID = "20260816-runtime-convergence-v120"
 _PATCH_ATTR = "_nija_core_supervised_pending_v120"
+_V54_DISPATCH_ATTR = "_nija_core_supervised_pending_v120_dispatch"
 _LOCK = threading.RLock()
 _INSTALLED = False
 
@@ -168,6 +169,34 @@ def _patch_core_loop(module: ModuleType) -> bool:
     return True
 
 
+def _patch_v54_dispatch() -> bool:
+    try:
+        from bot import writer_runtime_lifecycle_supervisor_v54_patch as v54
+    except Exception:
+        return False
+
+    current = getattr(v54, "_patch_core_loop", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V54_DISPATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def patch_core_loop_v120(module: ModuleType) -> bool:
+        if not current(module):
+            return False
+        return _patch_core_loop(module)
+
+    setattr(patch_core_loop_v120, _V54_DISPATCH_ATTR, True)
+    setattr(patch_core_loop_v120, "__wrapped__", current)
+    v54._patch_core_loop = patch_core_loop_v120
+    LOGGER.critical(
+        "CORE_SUPERVISED_PENDING_V120_V54_DISPATCH_PATCHED marker=%s existing_import_hook_reused=true new_import_hook=false",
+        MARKER,
+    )
+    return True
+
+
 def _patch_release_manifest() -> bool:
     manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
         "runtime_release_manifest_patch"
@@ -188,6 +217,9 @@ def _patch_release_manifest() -> bool:
 def install() -> bool:
     global _INSTALLED
     with _LOCK:
+        if not _patch_v54_dispatch():
+            return False
+
         module = _loaded_core()
         patch_ok = True if module is None else _patch_core_loop(module)
         if not patch_ok:
@@ -200,7 +232,7 @@ def install() -> bool:
 
         _INSTALLED = True
         LOGGER.critical(
-            "CORE_SUPERVISED_PENDING_V120_INSTALLED marker=%s import_hook_added=false start_gate_timeout_still_bounded=true core_liveness_preserved=true execution_fail_closed=true initial_patch_ready=%s",
+            "CORE_SUPERVISED_PENDING_V120_INSTALLED marker=%s import_hook_added=false v54_dispatch_reused=true start_gate_timeout_still_bounded=true core_liveness_preserved=true execution_fail_closed=true initial_patch_ready=%s",
             MARKER,
             patch_ok,
         )
@@ -218,5 +250,6 @@ __all__ = [
     "install",
     "install_import_hook",
     "_patch_core_loop",
+    "_patch_v54_dispatch",
     "_supervised_pending_return_allowed",
 ]

--- a/bot/core_supervised_pending_v120_patch.py
+++ b/bot/core_supervised_pending_v120_patch.py
@@ -1,0 +1,222 @@
+"""Keep the canonical TradingLoop alive while execution authority converges.
+
+Production deployment 2b43a7d2 proved position-sync and bootstrap convergence,
+but the canonical TradingLoop still exited after its bounded
+``TRADING_ENGINE_READY`` wait expired.  That return was then correctly treated
+by writer authority as terminal ``core_thread_dead`` and the process restarted.
+
+v120 preserves the existing bounded wait and every execution gate.  It wraps
+``run_trading_loop`` so that a return is retried only when all of these are true:
+
+* the canonical Redis process-writer proof is still exact and current;
+* BootstrapFSM is THREADS_STARTING or RUNNING_SUPERVISED;
+* process shutdown/exit has not been requested;
+* runtime execution authority is still explicitly zero; and
+* TRADING_ENGINE_READY remains unset (the observed startup-pending return path).
+
+No broker I/O, scan, order, readiness, nonce, capital, position, or execution
+authority is fabricated.  Structural failures still terminate the core thread.
+The patch adds no new global import hook; future nija_core_loop imports are
+patched through the already-installed v54 lifecycle hook.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.core_supervised_pending_v120")
+MARKER = "20260816-core-supervised-pending-v120"
+RELEASE_ID = "20260816-runtime-convergence-v120"
+_PATCH_ATTR = "_nija_core_supervised_pending_v120"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _loaded_core() -> ModuleType | None:
+    for name in ("bot.nija_core_loop", "nija_core_loop"):
+        mod = sys.modules.get(name)
+        if isinstance(mod, ModuleType):
+            return mod
+    return None
+
+
+def _shutdown_requested() -> bool:
+    if str(os.environ.get("NIJA_PROCESS_EXIT_REQUESTED", "") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
+    mod = sys.modules.get("bot.bot_main") or sys.modules.get("bot_main")
+    shutdown = getattr(mod, "_shutdown_event", None) if isinstance(mod, ModuleType) else None
+    return bool(
+        shutdown is not None
+        and callable(getattr(shutdown, "is_set", None))
+        and shutdown.is_set()
+    )
+
+
+def _bootstrap_state() -> str:
+    try:
+        from bot.bootstrap_state_machine import get_bootstrap_fsm
+
+        fsm = get_bootstrap_fsm()
+        state = getattr(fsm, "state", getattr(fsm, "current_state", ""))
+        return str(getattr(state, "value", state) or "").strip().upper()
+    except Exception:
+        return "UNAVAILABLE"
+
+
+def _writer_proof() -> tuple[bool, str, int]:
+    try:
+        from bot.writer_runtime_lifecycle_supervisor_v54_patch import _writer_proof as prove
+
+        return prove()
+    except Exception as exc:
+        return False, f"writer_proof_unavailable:{type(exc).__name__}:{exc}", 0
+
+
+def _supervised_pending_return_allowed(module: ModuleType) -> tuple[bool, str, int, str]:
+    if _shutdown_requested():
+        return False, "shutdown_requested", 0, _bootstrap_state()
+
+    ready_event = getattr(module, "TRADING_ENGINE_READY", None)
+    if ready_event is None or not callable(getattr(ready_event, "is_set", None)):
+        return False, "trading_engine_ready_event_missing", 0, _bootstrap_state()
+    if ready_event.is_set():
+        return False, "trading_engine_ready_already_set", 0, _bootstrap_state()
+
+    if str(os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0") or "0").strip() == "1":
+        return False, "runtime_execution_authority_granted", 0, _bootstrap_state()
+
+    state = _bootstrap_state()
+    if state not in {"THREADS_STARTING", "RUNNING_SUPERVISED"}:
+        return False, f"bootstrap_state:{state}", 0, state
+
+    ok, reason, generation = _writer_proof()
+    if not ok:
+        return False, reason, generation, state
+    return True, "supervised_activation_pending", generation, state
+
+
+def _retry_delay_s() -> float:
+    try:
+        return max(
+            0.1,
+            min(
+                10.0,
+                float(os.environ.get("NIJA_CORE_SUPERVISED_PENDING_RETRY_S", "2") or 2.0),
+            ),
+        )
+    except (TypeError, ValueError):
+        return 2.0
+
+
+def _patch_core_loop(module: ModuleType) -> bool:
+    current = getattr(module, "run_trading_loop", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def run_trading_loop_v120(strategy: Any, *args: Any, **kwargs: Any) -> None:
+        reentries = 0
+        while True:
+            current(strategy, *args, **kwargs)
+            allowed, reason, generation, state = _supervised_pending_return_allowed(module)
+            if not allowed:
+                if reentries:
+                    LOGGER.critical(
+                        "CORE_SUPERVISED_PENDING_V120_EXIT marker=%s reentries=%d reason=%s bootstrap=%s generation=%s structural_exit=true",
+                        MARKER,
+                        reentries,
+                        reason,
+                        state,
+                        generation,
+                    )
+                return
+
+            reentries += 1
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            LOGGER.critical(
+                "CORE_SUPERVISED_PENDING_V120_REENTER marker=%s reentries=%d reason=%s bootstrap=%s generation=%s trading_engine_ready=false broker_io=false execution_fail_closed=true",
+                MARKER,
+                reentries,
+                reason,
+                state,
+                generation,
+            )
+            time.sleep(_retry_delay_s())
+
+    setattr(run_trading_loop_v120, _PATCH_ATTR, True)
+    setattr(run_trading_loop_v120, "__wrapped__", current)
+    module.run_trading_loop = run_trading_loop_v120
+    LOGGER.critical(
+        "CORE_SUPERVISED_PENDING_V120_PATCHED marker=%s module=%s bounded_wait_preserved=true execution_authority_unchanged=true",
+        MARKER,
+        module.__name__,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
+        "runtime_release_manifest_patch"
+    )
+    if not isinstance(manifest, ModuleType):
+        try:
+            import bot.runtime_release_manifest_patch as manifest  # type: ignore[no-redef]
+        except Exception:
+            return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["core_supervised_pending_v120"] = "NIJA_CORE_SUPERVISED_PENDING_V120_INSTALLED"
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        module = _loaded_core()
+        patch_ok = True if module is None else _patch_core_loop(module)
+        if not patch_ok:
+            return False
+
+        os.environ["NIJA_CORE_SUPERVISED_PENDING_V120_INSTALLED"] = "1"
+        if not _patch_release_manifest():
+            os.environ.pop("NIJA_CORE_SUPERVISED_PENDING_V120_INSTALLED", None)
+            return False
+
+        _INSTALLED = True
+        LOGGER.critical(
+            "CORE_SUPERVISED_PENDING_V120_INSTALLED marker=%s import_hook_added=false start_gate_timeout_still_bounded=true core_liveness_preserved=true execution_fail_closed=true initial_patch_ready=%s",
+            MARKER,
+            patch_ok,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    """Compatibility installer name; v120 deliberately installs no import hook."""
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_patch_core_loop",
+    "_supervised_pending_return_allowed",
+]

--- a/bot/kraken_read_timeout_v121_patch.py
+++ b/bot/kraken_read_timeout_v121_patch.py
@@ -1,0 +1,229 @@
+"""Bound read-only Kraken HTTP calls and reuse the existing v117 import hook.
+
+Production generation logs showed repeated v117 Kraken position generations
+reaching the 12-second caller timeout.  NIJA's Kraken private-call wrapper held
+the global Kraken API lock while calling ``krakenex.API.query_private`` without
+supplying the timeout parameter supported by krakenex.  A single stalled Balance
+request could therefore retain that lock while later position generations piled
+up behind it.
+
+v121 sets a bounded timeout only for read-only Kraken REST calls.  Mutating
+methods (AddOrder/Cancel/Edit/etc.) preserve their existing timeout semantics so
+an ambiguous client timeout cannot trigger an automatic duplicate mutation.
+Public reads are also bounded.  v117 remains the outer fail-closed position
+snapshot authority and synthetic empty snapshots remain forbidden.
+
+No new builtins/importlib hook is installed.  Future broker_manager imports are
+patched by extending v117's already-installed broker-manager dispatch hook.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.kraken_read_timeout_v121")
+MARKER = "20260816-kraken-read-timeout-v121"
+RELEASE_ID = "20260816-runtime-convergence-v121"
+_PATCH_ATTR = "_nija_kraken_read_timeout_v121"
+_API_ATTR = "_nija_kraken_read_timeout_v121_api"
+_V117_DISPATCH_ATTR = "_nija_kraken_read_timeout_v121_dispatch"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+_MUTATING = {
+    "AddOrder",
+    "AddOrderBatch",
+    "CancelOrder",
+    "CancelOrderBatch",
+    "CancelAll",
+    "CancelAllOrdersAfter",
+    "EditOrder",
+}
+
+
+def _env_timeout(name: str, default: float, *, maximum: float = 30.0) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        value = default
+    return max(1.0, min(maximum, value))
+
+
+def _private_read_timeout_s() -> float:
+    return _env_timeout("NIJA_KRAKEN_PRIVATE_READ_TIMEOUT_S", 8.0)
+
+
+def _public_read_timeout_s() -> float:
+    return _env_timeout("NIJA_KRAKEN_PUBLIC_READ_TIMEOUT_S", 6.0)
+
+
+def _wrap_api(api: Any) -> bool:
+    if api is None:
+        return True
+    if bool(getattr(api, _API_ATTR, False)):
+        return True
+
+    original_private = getattr(api, "query_private", None)
+    original_public = getattr(api, "query_public", None)
+    if not callable(original_private):
+        return False
+
+    @wraps(original_private)
+    def query_private(method: str, data: Any = None, timeout: Any = None):
+        selected = timeout
+        read_only = str(method or "") not in _MUTATING
+        if selected is None and read_only:
+            selected = _private_read_timeout_s()
+        if selected is not None and read_only:
+            LOGGER.debug(
+                "KRAKEN_READ_TIMEOUT_V121_PRIVATE method=%s timeout_s=%.2f read_only=true",
+                method,
+                float(selected),
+            )
+        return original_private(method, data, timeout=selected)
+
+    api.query_private = query_private
+
+    if callable(original_public):
+        @wraps(original_public)
+        def query_public(method: str, data: Any = None, timeout: Any = None):
+            selected = timeout if timeout is not None else _public_read_timeout_s()
+            return original_public(method, data, timeout=selected)
+
+        api.query_public = query_public
+
+    setattr(api, _API_ATTR, True)
+    LOGGER.critical(
+        "KRAKEN_READ_TIMEOUT_V121_API_PATCHED marker=%s private_read_timeout_s=%.2f public_read_timeout_s=%.2f mutating_timeout_semantics_unchanged=true",
+        MARKER,
+        _private_read_timeout_s(),
+        _public_read_timeout_s(),
+    )
+    return True
+
+
+def _patch_broker_manager(module: ModuleType | None = None) -> bool:
+    module = module or sys.modules.get("bot.broker_manager") or sys.modules.get("broker_manager")
+    if not isinstance(module, ModuleType):
+        return True
+
+    cls = getattr(module, "KrakenBroker", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "_kraken_private_call", None)
+    if not callable(current):
+        return False
+    if not getattr(current, _PATCH_ATTR, False):
+        @wraps(current)
+        def kraken_private_call_v121(self: Any, *args: Any, **kwargs: Any):
+            _wrap_api(getattr(self, "api", None))
+            return current(self, *args, **kwargs)
+
+        setattr(kraken_private_call_v121, _PATCH_ATTR, True)
+        setattr(kraken_private_call_v121, "__wrapped__", current)
+        cls._kraken_private_call = kraken_private_call_v121
+
+    iterator = getattr(cls, "_iter_live", None)
+    if callable(iterator):
+        try:
+            for broker in list(iterator() or []):
+                _wrap_api(getattr(broker, "api", None))
+        except Exception:
+            LOGGER.debug("KRAKEN_READ_TIMEOUT_V121 live-instance patch skipped", exc_info=True)
+
+    LOGGER.critical(
+        "KRAKEN_READ_TIMEOUT_V121_BROKER_PATCHED marker=%s broker_class=KrakenBroker private_read_timeout_s=%.2f public_read_timeout_s=%.2f global_lock_preserved=true synthetic_empty_snapshot=false",
+        MARKER,
+        _private_read_timeout_s(),
+        _public_read_timeout_s(),
+    )
+    return True
+
+
+def _patch_v117_dispatch() -> bool:
+    try:
+        from bot import position_fetch_generation_v117_patch as v117
+    except Exception:
+        return False
+
+    current = getattr(v117, "_patch_broker_manager", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V117_DISPATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def patch_broker_manager_v121() -> bool:
+        if not current():
+            return False
+        module = sys.modules.get("bot.broker_manager") or sys.modules.get("broker_manager")
+        return _patch_broker_manager(module if isinstance(module, ModuleType) else None)
+
+    setattr(patch_broker_manager_v121, _V117_DISPATCH_ATTR, True)
+    setattr(patch_broker_manager_v121, "__wrapped__", current)
+    v117._patch_broker_manager = patch_broker_manager_v121
+    LOGGER.critical(
+        "KRAKEN_READ_TIMEOUT_V121_V117_DISPATCH_PATCHED marker=%s existing_import_hook_reused=true new_import_hook=false",
+        MARKER,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
+        "runtime_release_manifest_patch"
+    )
+    if not isinstance(manifest, ModuleType):
+        try:
+            import bot.runtime_release_manifest_patch as manifest  # type: ignore[no-redef]
+        except Exception:
+            return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["kraken_read_timeout_v121"] = "NIJA_KRAKEN_READ_TIMEOUT_V121_INSTALLED"
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if not _patch_v117_dispatch():
+            return False
+        if not _patch_broker_manager():
+            return False
+        os.environ["NIJA_KRAKEN_READ_TIMEOUT_V121_INSTALLED"] = "1"
+        if not _patch_release_manifest():
+            os.environ.pop("NIJA_KRAKEN_READ_TIMEOUT_V121_INSTALLED", None)
+            return False
+        _INSTALLED = True
+        LOGGER.critical(
+            "KRAKEN_READ_TIMEOUT_V121_INSTALLED marker=%s private_read_timeout_s=%.2f public_read_timeout_s=%.2f mutating_calls_unchanged=true import_hook_added=false execution_gates_unchanged=true",
+            MARKER,
+            _private_read_timeout_s(),
+            _public_read_timeout_s(),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    """Compatibility installer name; v121 deliberately adds no import hook."""
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_wrap_api",
+    "_patch_broker_manager",
+    "_patch_v117_dispatch",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -1,11 +1,12 @@
 """Tune startup position synchronization without weakening activation safety.
 
 v98 raises the default broker-position fetch timeout to 12 seconds while
-preserving an explicit ``NIJA_POSITION_FETCH_TIMEOUT_S`` override.  Later
-repairs are installed from this canonical slot in dependency order.  v119 adds
-canonical position-sync observation to preactivation truth and expands release
-attestation so v98/v116/v117/v118/v119 must all be present before the runtime
-release manifest can report complete.
+preserving an explicit ``NIJA_POSITION_FETCH_TIMEOUT_S`` override. Later repairs
+are installed from this canonical slot in dependency order. v119 adds canonical
+position-sync observation to preactivation truth. v120 preserves canonical
+TradingLoop liveness while exact-writer supervised activation remains pending,
+and v121 bounds read-only Kraken HTTP calls so a stalled Balance/Ticker request
+cannot retain the shared Kraken API lock indefinitely.
 """
 from __future__ import annotations
 
@@ -55,6 +56,8 @@ def install() -> bool:
         ("position_fetch_generation_v117_patch", "V117"),
         ("terminal_writer_loss_seak_v118_patch", "V118"),
         ("preactivation_position_sync_v119_patch", "V119"),
+        ("core_supervised_pending_v120_patch", "V120"),
+        ("kraken_read_timeout_v121_patch", "V121"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -74,7 +77,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true core_supervised_pending_v120=true kraken_read_timeout_v121=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_core_supervised_pending_v120.py
+++ b/bot/tests/test_core_supervised_pending_v120.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import threading
+import types
+
+from bot import core_supervised_pending_v120_patch as v120
+
+
+def test_supervised_pending_return_requires_exact_writer(monkeypatch):
+    ready = threading.Event()
+    fake_core = types.SimpleNamespace(TRADING_ENGINE_READY=ready)
+
+    monkeypatch.delenv("NIJA_PROCESS_EXIT_REQUESTED", raising=False)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setattr(v120, "_shutdown_requested", lambda: False)
+    monkeypatch.setattr(v120, "_bootstrap_state", lambda: "RUNNING_SUPERVISED")
+    monkeypatch.setattr(v120, "_writer_proof", lambda: (True, "exact_redis_process_writer", 42))
+
+    allowed, reason, generation, state = v120._supervised_pending_return_allowed(fake_core)
+    assert allowed is True
+    assert reason == "supervised_activation_pending"
+    assert generation == 42
+    assert state == "RUNNING_SUPERVISED"
+
+
+def test_supervised_pending_return_rejects_writer_loss(monkeypatch):
+    ready = threading.Event()
+    fake_core = types.SimpleNamespace(TRADING_ENGINE_READY=ready)
+
+    monkeypatch.setattr(v120, "_shutdown_requested", lambda: False)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setattr(v120, "_bootstrap_state", lambda: "RUNNING_SUPERVISED")
+    monkeypatch.setattr(v120, "_writer_proof", lambda: (False, "writer_lock_missing", 0))
+
+    allowed, reason, generation, state = v120._supervised_pending_return_allowed(fake_core)
+    assert allowed is False
+    assert reason == "writer_lock_missing"
+    assert generation == 0
+    assert state == "RUNNING_SUPERVISED"
+
+
+def test_core_wrapper_keeps_execution_fail_closed_on_supervised_reentry(monkeypatch):
+    calls = []
+    fake_core = types.SimpleNamespace(__name__="bot.nija_core_loop")
+
+    def raw(strategy):
+        calls.append(strategy)
+
+    fake_core.run_trading_loop = raw
+    states = iter([
+        (True, "supervised_activation_pending", 7, "RUNNING_SUPERVISED"),
+        (False, "shutdown_requested", 0, "RUNNING_SUPERVISED"),
+    ])
+    monkeypatch.setattr(v120, "_supervised_pending_return_allowed", lambda module: next(states))
+    monkeypatch.setattr(v120.time, "sleep", lambda seconds: None)
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_EXECUTION_ACTIVE", "true")
+
+    assert v120._patch_core_loop(fake_core) is True
+    fake_core.run_trading_loop("strategy")
+
+    assert calls == ["strategy", "strategy"]
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EXECUTION_ACTIVE"] == "false"

--- a/bot/tests/test_kraken_read_timeout_v121.py
+++ b/bot/tests/test_kraken_read_timeout_v121.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import types
+
+from bot import kraken_read_timeout_v121_patch as v121
+
+
+class FakeAPI:
+    def __init__(self):
+        self.private_calls = []
+        self.public_calls = []
+
+    def query_private(self, method, data=None, timeout=None):
+        self.private_calls.append((method, data, timeout))
+        return {"error": [], "result": {}}
+
+    def query_public(self, method, data=None, timeout=None):
+        self.public_calls.append((method, data, timeout))
+        return {"error": [], "result": {}}
+
+
+def test_read_only_private_call_gets_bounded_timeout(monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_PRIVATE_READ_TIMEOUT_S", "7")
+    api = FakeAPI()
+    assert v121._wrap_api(api) is True
+
+    api.query_private("Balance", {})
+    assert api.private_calls[-1] == ("Balance", {}, 7.0)
+
+
+def test_mutating_private_call_preserves_existing_timeout_semantics(monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_PRIVATE_READ_TIMEOUT_S", "7")
+    api = FakeAPI()
+    assert v121._wrap_api(api) is True
+
+    api.query_private("AddOrder", {"pair": "XBTUSD"})
+    assert api.private_calls[-1] == ("AddOrder", {"pair": "XBTUSD"}, None)
+
+
+def test_explicit_private_timeout_is_preserved(monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_PRIVATE_READ_TIMEOUT_S", "7")
+    api = FakeAPI()
+    assert v121._wrap_api(api) is True
+
+    api.query_private("Balance", {}, timeout=3)
+    assert api.private_calls[-1] == ("Balance", {}, 3)
+
+
+def test_public_call_gets_bounded_timeout(monkeypatch):
+    monkeypatch.setenv("NIJA_KRAKEN_PUBLIC_READ_TIMEOUT_S", "5")
+    api = FakeAPI()
+    assert v121._wrap_api(api) is True
+
+    api.query_public("Ticker", {"pair": "XBTUSD"})
+    assert api.public_calls[-1] == ("Ticker", {"pair": "XBTUSD"}, 5.0)
+
+
+def test_broker_manager_patch_wraps_live_api_without_fabricating_positions():
+    api = FakeAPI()
+
+    class KrakenBroker:
+        @classmethod
+        def _iter_live(cls):
+            return []
+
+        def _kraken_private_call(self, method, params=None, category=None):
+            return self.api.query_private(method, params)
+
+    fake_module = types.ModuleType("bot.broker_manager")
+    fake_module.KrakenBroker = KrakenBroker
+
+    assert v121._patch_broker_manager(fake_module) is True
+    broker = KrakenBroker()
+    broker.api = api
+    result = broker._kraken_private_call("Balance")
+
+    assert result == {"error": [], "result": {}}
+    assert api.private_calls[-1][2] == v121._private_read_timeout_s()


### PR DESCRIPTION
## What changed

- add v120 to keep the canonical `TradingLoop` alive when it returns only because execution authority is still intentionally pending under an exact Redis writer and supervised bootstrap
- preserve fail-closed execution authority during v120 re-entry; no broker I/O or scans are enabled by the patch
- reuse v54's existing import dispatch rather than adding another global import hook
- add v121 to apply supported `krakenex` HTTP timeouts to read-only private calls and public calls
- preserve existing timeout semantics for mutating Kraken calls to avoid ambiguous duplicate mutations
- reuse v117's existing broker-manager dispatch rather than adding another import hook
- install v120/v121 from the canonical v98 convergence chain
- add focused regression tests for supervised-pending liveness and Kraken read timeout behavior

## Root cause

Production logs showed two independent liveness problems after earlier convergence repairs:

1. `run_trading_loop()` has a bounded `TRADING_ENGINE_READY` wait. When execution authority remains intentionally fail-closed during supervised convergence, the worker can return after that timeout. Writer authority then correctly classifies the canonical `TradingLoop` as dead and terminates the process.
2. Kraken `get_positions()` calls `_kraken_private_call('Balance')`, which holds the shared Kraken API lock around `krakenex.API.query_private()` without passing the timeout parameter supported by krakenex. One stalled read can therefore hold the lock while later v117 generations time out behind it.

## Safety

- no synthetic position snapshots
- no readiness fabrication
- no nonce, writer, capital, risk, or execution bypass
- mutating Kraken calls keep their existing timeout semantics
- structural writer loss, shutdown intent, or unsupervised bootstrap still terminate normally
- no additional `builtins.__import__` hook is added by v120 or v121
