### PR TITLE
Install canonical import shield on fast path

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -157,7 +157,30 @@ def _install_guards(
     return ready
 
 
+def _install_canonical_import_shield_v123() -> bool:
+    try:
+        module = _canonical_fast_import("bot.canonical_import_shield_v123_patch")
+        installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+        if not callable(installer) or installer() is False:
+            raise RuntimeError("canonical import shield v123 installer unavailable or returned false")
+        logger.critical(
+            "CANONICAL_IMPORT_SHIELD_V123_EARLY_READY source=bot_entrypoint before_fast_guard_bundle=true"
+        )
+        return True
+    except Exception as exc:
+        logger.critical(
+            "CANONICAL_IMPORT_SHIELD_V123_EARLY_FAILED source=bot_entrypoint err=%s trading_fail_closed=true",
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
 if _canonical_fast_path_enabled():
+    if not _install_canonical_import_shield_v123():
+        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+        raise RuntimeError("canonical import shield failed; trading remains fail closed")
     if not _install_guards(
         _FAST_PATH_INSTALLERS,
         mode="canonical_fast",
@@ -167,7 +190,7 @@ if _canonical_fast_path_enabled():
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
         raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
     logger.critical(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred handoff=bot.bot_main",
+        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred import_shield_v123=true handoff=bot.bot_main",
         _FAST_PATH_MARKER,
     )
 else:

--- a/bot/canonical_import_shield_v123_patch.py
+++ b/bot/canonical_import_shield_v123_patch.py
@@ -1,0 +1,153 @@
+"""Keep the canonical fast path behind NIJA's process-wide import compactor.
+
+Production release v121 showed a very deep compatibility ``__import__`` wrapper
+chain while sklearn/joblib was imported during a live runtime.  The repository
+already ships ``import_hook_recursion_shield_patch`` to compact that chain, but
+canonical production sets ``NIJA_DEFER_RUNTIME_SITE_HOOKS=1`` and therefore
+skips the .pth installer that normally activates the shield.  The canonical
+``bot.py`` fast path also did not install it explicitly.
+
+v123 closes that lifecycle gap without removing historical safety wrappers:
+
+* the existing compactor is installed before any canonical fast-path guard;
+* the compactor's existing short-lived monitor remains intact;
+* a lightweight daemon keeps re-compacting late wrapper replacements for the
+  lifetime of the process after the historical 600-second monitor expires;
+* the runtime release manifest eventually requires and attests v123;
+* no writer, nonce, broker, capital, risk, position, kill-switch, strategy, or
+  execution readiness is synthesized or bypassed.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.canonical_import_shield_v123")
+MARKER = "20260816-canonical-import-shield-v123"
+RELEASE_ID = "20260816-runtime-convergence-v123"
+_FLAG = "NIJA_CANONICAL_IMPORT_SHIELD_V123_INSTALLED"
+_MONITOR_ATTR = "_NIJA_CANONICAL_IMPORT_SHIELD_V123_MONITOR_STARTED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _load_shield() -> Any:
+    import import_hook_recursion_shield_patch as shield
+
+    return shield
+
+
+def _shield_active() -> bool:
+    current = builtins.__import__
+    return bool(getattr(current, "_nija_import_chain_compactor", None))
+
+
+def _patch_release_manifest_if_loaded() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
+        "runtime_release_manifest_patch"
+    )
+    if not isinstance(manifest, ModuleType):
+        return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["canonical_import_shield_v123"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def _lifetime_monitor(shield: Any) -> None:
+    manifest_patched = False
+    last_error_log = 0.0
+    while True:
+        try:
+            compactor = getattr(shield, "compact_import_chain", None)
+            if callable(compactor):
+                compactor()
+            if not manifest_patched:
+                manifest_patched = _patch_release_manifest_if_loaded()
+        except BaseException as exc:
+            now = time.monotonic()
+            if now - last_error_log >= 60.0:
+                LOGGER.warning(
+                    "CANONICAL_IMPORT_SHIELD_V123_MONITOR_ERROR marker=%s error=%s:%s fail_closed_gates_unchanged=true",
+                    MARKER,
+                    type(exc).__name__,
+                    exc,
+                )
+                last_error_log = now
+        time.sleep(0.5)
+
+
+def _start_lifetime_monitor(shield: Any) -> bool:
+    if bool(getattr(builtins, _MONITOR_ATTR, False)):
+        return True
+    setattr(builtins, _MONITOR_ATTR, True)
+    try:
+        thread = threading.Thread(
+            target=_lifetime_monitor,
+            args=(shield,),
+            name="canonical-import-shield-v123",
+            daemon=True,
+        )
+        thread.start()
+    except BaseException:
+        setattr(builtins, _MONITOR_ATTR, False)
+        raise
+    return bool(thread.is_alive())
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        try:
+            shield = _load_shield()
+            installer = getattr(shield, "install_import_hook", None) or getattr(shield, "install", None)
+            if not callable(installer):
+                raise RuntimeError("import recursion shield installer unavailable")
+            installer()
+            if not _shield_active():
+                raise RuntimeError("process-wide compact import guard not active")
+            if not _start_lifetime_monitor(shield):
+                raise RuntimeError("lifetime import compactor monitor did not start")
+
+            os.environ[_FLAG] = "1"
+            _patch_release_manifest_if_loaded()
+            _INSTALLED = True
+            LOGGER.critical(
+                "CANONICAL_IMPORT_SHIELD_V123_INSTALLED marker=%s compact_guard_active=true lifetime_monitor=true historical_wrappers_preserved=true nested_import_recursion_bounded=true safety_gates_unchanged=true",
+                MARKER,
+            )
+            return True
+        except BaseException as exc:
+            os.environ.pop(_FLAG, None)
+            _INSTALLED = False
+            LOGGER.critical(
+                "CANONICAL_IMPORT_SHIELD_V123_INSTALL_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_shield_active",
+    "_patch_release_manifest_if_loaded",
+    "_start_lifetime_monitor",
+]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -5,8 +5,9 @@ preserving an explicit ``NIJA_POSITION_FETCH_TIMEOUT_S`` override. Later repairs
 are installed from this canonical slot in dependency order. v119 adds canonical
 position-sync observation to preactivation truth. v120 preserves canonical
 TradingLoop liveness while exact-writer supervised activation remains pending.
-v121 bounds read-only Kraken HTTP calls, and v122 requires that timeout layer to
-be installed before v108 may dispatch a Kraken platform reconciliation worker.
+v121 bounds read-only Kraken HTTP calls, v122 requires that timeout layer before
+v108 may dispatch a Kraken platform reconciliation worker, and v123 keeps the
+canonical fast path behind the process-wide import-chain compactor.
 """
 from __future__ import annotations
 
@@ -62,6 +63,7 @@ def install() -> bool:
         ("terminal_writer_loss_seak_v118_patch", "V118"),
         ("preactivation_position_sync_v119_patch", "V119"),
         ("core_supervised_pending_v120_patch", "V120"),
+        ("canonical_import_shield_v123_patch", "V123"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -81,7 +83,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true kraken_read_timeout_v121=true kraken_position_sync_prereq_v122=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true core_supervised_pending_v120=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true kraken_read_timeout_v121=true kraken_position_sync_prereq_v122=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true core_supervised_pending_v120=true canonical_import_shield_v123=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_canonical_import_shield_v123.py
+++ b/bot/tests/test_canonical_import_shield_v123.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from types import ModuleType
+
+from bot import canonical_import_shield_v123_patch as v123
+
+
+def test_shield_active_detects_process_compactor(monkeypatch):
+    original = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        return original(name, globals, locals, fromlist, level)
+
+    setattr(fake_import, "_nija_import_chain_compactor", "test")
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert v123._shield_active() is True
+
+
+def test_release_manifest_attests_v123(monkeypatch):
+    import sys
+
+    fake = ModuleType("bot.runtime_release_manifest_patch")
+    fake._REQUIRED_FLAGS = {}
+    fake.RELEASE_ID = "old"
+    monkeypatch.setitem(sys.modules, "bot.runtime_release_manifest_patch", fake)
+
+    assert v123._patch_release_manifest_if_loaded() is True
+    assert fake._REQUIRED_FLAGS["canonical_import_shield_v123"] == (
+        "NIJA_CANONICAL_IMPORT_SHIELD_V123_INSTALLED"
+    )
+    assert fake.RELEASE_ID == "20260816-runtime-convergence-v123"
+
+
+def test_canonical_entrypoint_installs_v123_before_fast_guard_bundle():
+    source = Path("bot/bot.py").read_text(encoding="utf-8")
+    call = source.index("if not _install_canonical_import_shield_v123():")
+    bundle = source.index("if not _install_guards(\n        _FAST_PATH_INSTALLERS", call)
+    assert call < bundle
+
+
+def test_v98_attests_v123_in_canonical_convergence_chain():
+    source = Path("bot/position_sync_timeout_v98_patch.py").read_text(encoding="utf-8")
+    assert '("canonical_import_shield_v123_patch", "V123")' in source
+    assert "canonical_import_shield_v123=true" in source

--- a/bot/tests/test_canonical_writer_first_v59.py
+++ b/bot/tests/test_canonical_writer_first_v59.py
@@ -78,7 +78,7 @@ def test_writer_first_requires_exact_distributed_runtime(monkeypatch) -> None:
             return bot_main
         raise AssertionError(f"unexpected import: {name}")
 
-    monkeypatch.setattr(launcher.importlib, "import_module", _import)
+    monkeypatch.setattr(launcher, "_canonical_import", _import)
 
     try:
         launcher._bootstrap_writer_first()

--- a/bot/tests/test_startup_handoff_all_fixes.py
+++ b/bot/tests/test_startup_handoff_all_fixes.py
@@ -181,17 +181,12 @@ def test_canonical_fast_path_remains_fail_closed_for_required_guard_failure() ->
     env["NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY"] = "1"
 
     script = """
-import importlib
+import sys
 import types
 
-_original = importlib.import_module
-
-def _patched(name, package=None):
-    if name == "bot.writer_generation_state_gate_v50_patch":
-        return types.SimpleNamespace(install_import_hook=lambda: False)
-    return _original(name, package)
-
-importlib.import_module = _patched
+failed_guard = types.ModuleType("bot.writer_generation_state_gate_v50_patch")
+failed_guard.install_import_hook = lambda: False
+sys.modules["bot.writer_generation_state_gate_v50_patch"] = failed_guard
 
 try:
     import bot.bot  # noqa: F401


### PR DESCRIPTION
## What changed
- install the existing process-wide import recursion shield before any canonical fast-path guard bundle runs
- keep a lightweight lifetime compaction monitor active after the historical 600-second shield monitor expires
- attest v123 in the runtime release manifest through the canonical v98 convergence chain
- add regression tests for early installation and release attestation

## Root cause
Production on the canonical fast path showed a very deep `builtins.__import__` wrapper chain during a later sklearn/joblib import. The repository already had `import_hook_recursion_shield_patch`, but the canonical deployment sets `NIJA_DEFER_RUNTIME_SITE_HOOKS=1`, which skips the `.pth` installer, and `bot.py` did not explicitly install the shield. The existing shield monitor also stops after 600 seconds, allowing later wrapper replacements to accumulate again.

## Safety
- historical safety wrappers remain installed
- no writer, nonce, broker, capital, risk, position, kill-switch, strategy, or execution readiness is synthesized or bypassed
- canonical startup fails closed if the import shield cannot be installed
- non-canonical legacy startup behavior is unchanged
