### PR TITLE
Bound canonical strategy startup handoff

### DIFF
--- a/bot/canonical_strategy_startup_bound_v124_patch.py
+++ b/bot/canonical_strategy_startup_bound_v124_patch.py
@@ -1,0 +1,248 @@
+"""Bound canonical strategy publication work before the core thread starts.
+
+Production release v123 reached broker/capital/nonce/position readiness but
+remained in BootstrapState.THREADS_STARTING for many minutes with
+strategy_ready=false.  The canonical bot_main path publishes TradingStrategy
+synchronously before start_trading_engine().  Two helpers on that path could
+block indefinitely:
+
+* TradingStrategy._discover_broker_symbols called broker market-catalog methods
+  directly with no timeout.
+* trading_strategy_apex_wiring_patch._bounded_hydrate_strategy_wiring performed
+  an unbounded synchronous hydration attempt before its timed worker.
+
+v124 makes both operations actually bounded.  It does not fabricate strategy,
+execution, broker, capital, nonce, position, writer, risk, kill-switch, or
+bootstrap readiness and it adds no import hook.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.canonical_strategy_startup_bound_v124")
+MARKER = "20260816-canonical-strategy-startup-bound-v124"
+RELEASE_ID = "20260816-runtime-convergence-v124"
+_FLAG = "NIJA_CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED"
+_DISCOVERY_PATCH_ATTR = "_nija_canonical_strategy_startup_bound_v124"
+_WIRING_PATCH_ATTR = "_nija_canonical_strategy_wiring_bound_v124"
+_INSTALLED = False
+_LOCK = threading.RLock()
+
+
+def _float_env(name: str, default: float, minimum: float = 0.1, maximum: float = 60.0) -> float:
+    try:
+        value = float(os.environ.get(name, default) or default)
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _symbol_timeout_s() -> float:
+    return _float_env("NIJA_SYMBOL_DISCOVERY_TIMEOUT_S", 8.0, 0.1, 30.0)
+
+
+def _wiring_timeout_s() -> float:
+    return _float_env("NIJA_TRADING_STRATEGY_WIRING_TIMEOUT_S", 20.0, 0.1, 60.0)
+
+
+def _patch_symbol_discovery(strategy_module: ModuleType) -> bool:
+    cls = getattr(strategy_module, "TradingStrategy", None)
+    call_with_timeout = getattr(strategy_module, "call_with_timeout", None)
+    if not isinstance(cls, type) or not callable(call_with_timeout):
+        return False
+
+    current = getattr(cls, "_discover_broker_symbols", None)
+    if not callable(current):
+        return False
+    if getattr(current, _DISCOVERY_PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def _discover_broker_symbols_v124(self: Any, broker: Any):
+        broker_name = "unknown"
+        try:
+            broker_name = str(self._broker_key_from_obj(broker) or "unknown")
+        except Exception:
+            broker_name = type(broker).__name__.replace("Broker", "").lower() or "unknown"
+
+        timeout_s = _symbol_timeout_s()
+        for method_name in ("get_available_markets", "get_all_products"):
+            method = getattr(broker, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                products, error = call_with_timeout(method, timeout_seconds=timeout_s)
+            except BaseException as exc:
+                products, error = None, exc
+
+            if error is not None:
+                LOGGER.warning(
+                    "CANONICAL_STRATEGY_V124_SYMBOL_DISCOVERY_FAILED marker=%s broker=%s method=%s timeout_s=%.2f error=%s:%s fallback=true trading_fail_closed_unchanged=true",
+                    MARKER,
+                    broker_name,
+                    method_name,
+                    timeout_s,
+                    type(error).__name__,
+                    error,
+                )
+                continue
+            if isinstance(products, list):
+                try:
+                    discovered = self._dedupe_symbols(products)
+                except Exception:
+                    discovered = [str(item).strip() for item in products if str(item).strip()]
+                if discovered:
+                    return discovered
+        return []
+
+    setattr(_discover_broker_symbols_v124, _DISCOVERY_PATCH_ATTR, True)
+    setattr(_discover_broker_symbols_v124, "__wrapped__", current)
+    setattr(cls, "_discover_broker_symbols", _discover_broker_symbols_v124)
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_V124_SYMBOL_DISCOVERY_PATCHED marker=%s timeout_s=%.2f read_only=true fallback_preserved=true",
+        MARKER,
+        _symbol_timeout_s(),
+    )
+    return True
+
+
+def _patch_wiring_bound(wiring_module: ModuleType) -> bool:
+    current = getattr(wiring_module, "_bounded_hydrate_strategy_wiring", None)
+    hydrate = getattr(wiring_module, "_hydrate_strategy_wiring", None)
+    needs = getattr(wiring_module, "_needs_hydration", None)
+    if not callable(current) or not callable(hydrate) or not callable(needs):
+        return False
+    if getattr(current, _WIRING_PATCH_ATTR, False):
+        return True
+
+    def _bounded_hydrate_v124(strategy: Any, broker: Any = None, reason: str = "runtime") -> bool:
+        if not needs(strategy):
+            return True
+
+        timeout_s = _wiring_timeout_s()
+        result_q: "queue.Queue[tuple[str, Any]]" = queue.Queue(maxsize=1)
+
+        def _runner() -> None:
+            try:
+                result_q.put(("result", hydrate(strategy, broker=broker, reason=f"{reason}:v124")))
+            except BaseException as exc:
+                try:
+                    result_q.put(("error", exc))
+                except Exception:
+                    pass
+
+        worker = threading.Thread(
+            target=_runner,
+            name="canonical-strategy-wiring-v124",
+            daemon=True,
+        )
+        worker.start()
+        try:
+            kind, payload = result_q.get(timeout=timeout_s)
+        except queue.Empty:
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_V124_WIRING_TIMEOUT marker=%s reason=%s timeout_s=%.2f worker_alive=%s strategy_ready=false execution_authority_unchanged=true",
+                MARKER,
+                reason,
+                timeout_s,
+                worker.is_alive(),
+            )
+            return not bool(needs(strategy))
+
+        if kind == "error":
+            LOGGER.warning(
+                "CANONICAL_STRATEGY_V124_WIRING_ERROR marker=%s reason=%s error=%s:%s",
+                MARKER,
+                reason,
+                type(payload).__name__,
+                payload,
+            )
+            return False
+        return bool(payload) and not bool(needs(strategy))
+
+    setattr(_bounded_hydrate_v124, _WIRING_PATCH_ATTR, True)
+    setattr(_bounded_hydrate_v124, "__wrapped__", current)
+    setattr(wiring_module, "_bounded_hydrate_strategy_wiring", _bounded_hydrate_v124)
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_V124_WIRING_BOUND_PATCHED marker=%s timeout_s=%.2f synchronous_unbounded_attempt=false import_hook_added=false",
+        MARKER,
+        _wiring_timeout_s(),
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
+        "runtime_release_manifest_patch"
+    )
+    if not isinstance(manifest, ModuleType):
+        try:
+            import bot.runtime_release_manifest_patch as manifest  # type: ignore[no-redef]
+        except Exception:
+            return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["canonical_strategy_startup_bound_v124"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+        try:
+            from bot import trading_strategy as strategy_module
+            from bot import trading_strategy_apex_wiring_patch as wiring_module
+        except Exception as exc:
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_V124_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+        if not _patch_symbol_discovery(strategy_module):
+            return False
+        if not _patch_wiring_bound(wiring_module):
+            return False
+
+        os.environ[_FLAG] = "1"
+        if not _patch_release_manifest():
+            os.environ.pop(_FLAG, None)
+            return False
+        _INSTALLED = True
+        LOGGER.critical(
+            "CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED marker=%s symbol_timeout_s=%.2f wiring_timeout_s=%.2f strategy_readiness_synthetic=false execution_readiness_synthetic=false broker_io_read_only=true import_hook_added=false safety_gates_unchanged=true",
+            MARKER,
+            _symbol_timeout_s(),
+            _wiring_timeout_s(),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    """Compatibility installer name; v124 deliberately adds no import hook."""
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_symbol_timeout_s",
+    "_wiring_timeout_s",
+    "_patch_symbol_discovery",
+    "_patch_wiring_bound",
+]

--- a/bot/canonical_strategy_startup_bound_v124_patch.py
+++ b/bot/canonical_strategy_startup_bound_v124_patch.py
@@ -2,18 +2,19 @@
 
 Production release v123 reached broker/capital/nonce/position readiness but
 remained in BootstrapState.THREADS_STARTING for many minutes with
-strategy_ready=false.  The canonical bot_main path publishes TradingStrategy
-synchronously before start_trading_engine().  Two helpers on that path could
-block indefinitely:
+strategy_ready=false. The canonical bot_main path publishes TradingStrategy
+synchronously before start_trading_engine(). Several operations on that path
+could block indefinitely.
 
-* TradingStrategy._discover_broker_symbols called broker market-catalog methods
-  directly with no timeout.
-* trading_strategy_apex_wiring_patch._bounded_hydrate_strategy_wiring performed
-  an unbounded synchronous hydration attempt before its timed worker.
+v124 adds three conservative bounds:
 
-v124 makes both operations actually bounded.  It does not fabricate strategy,
-execution, broker, capital, nonce, position, writer, risk, kill-switch, or
-bootstrap readiness and it adds no import hook.
+* broker market-catalog reads used by TradingStrategy._populate_symbols;
+* APEX/CoreLoop wiring hydration (removing its unbounded synchronous first try);
+* the complete publish_canonical_strategy handoff, with late publication
+  suppressed after its deadline.
+
+No strategy, execution, broker, capital, nonce, position, writer, risk,
+kill-switch, or bootstrap readiness is fabricated. No import hook is added.
 """
 from __future__ import annotations
 
@@ -32,11 +33,15 @@ RELEASE_ID = "20260816-runtime-convergence-v124"
 _FLAG = "NIJA_CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED"
 _DISCOVERY_PATCH_ATTR = "_nija_canonical_strategy_startup_bound_v124"
 _WIRING_PATCH_ATTR = "_nija_canonical_strategy_wiring_bound_v124"
+_PUBLICATION_PATCH_ATTR = "_nija_canonical_strategy_publication_bound_v124"
+_PUBLISH_GUARD_ATTR = "_nija_canonical_strategy_publish_guard_v124"
 _INSTALLED = False
 _LOCK = threading.RLock()
+_CANCELLED_PUBLICATION_THREADS: set[int] = set()
+_CANCEL_LOCK = threading.RLock()
 
 
-def _float_env(name: str, default: float, minimum: float = 0.1, maximum: float = 60.0) -> float:
+def _float_env(name: str, default: float, minimum: float = 0.1, maximum: float = 90.0) -> float:
     try:
         value = float(os.environ.get(name, default) or default)
     except (TypeError, ValueError):
@@ -50,6 +55,10 @@ def _symbol_timeout_s() -> float:
 
 def _wiring_timeout_s() -> float:
     return _float_env("NIJA_TRADING_STRATEGY_WIRING_TIMEOUT_S", 20.0, 0.1, 60.0)
+
+
+def _publication_timeout_s() -> float:
+    return _float_env("NIJA_CANONICAL_STRATEGY_PUBLICATION_TIMEOUT_S", 45.0, 1.0, 90.0)
 
 
 def _patch_symbol_discovery(strategy_module: ModuleType) -> bool:
@@ -178,6 +187,99 @@ def _patch_wiring_bound(wiring_module: ModuleType) -> bool:
     return True
 
 
+def _patch_publication_bound(publication_module: ModuleType) -> bool:
+    current_publish = getattr(publication_module, "_publish", None)
+    current_entry = getattr(publication_module, "publish_canonical_strategy", None)
+    if not callable(current_publish) or not callable(current_entry):
+        return False
+    if getattr(current_entry, _PUBLICATION_PATCH_ATTR, False):
+        return True
+
+    if not getattr(current_publish, _PUBLISH_GUARD_ATTR, False):
+        @wraps(current_publish)
+        def _guarded_publish_v124(strategy: Any) -> None:
+            ident = threading.get_ident()
+            with _CANCEL_LOCK:
+                cancelled = ident in _CANCELLED_PUBLICATION_THREADS
+            if cancelled:
+                LOGGER.critical(
+                    "CANONICAL_STRATEGY_V124_LATE_PUBLICATION_SUPPRESSED marker=%s thread_ident=%s strategy_ready=false execution_ready=false trading_fail_closed=true",
+                    MARKER,
+                    ident,
+                )
+                return None
+            return current_publish(strategy)
+
+        setattr(_guarded_publish_v124, _PUBLISH_GUARD_ATTR, True)
+        setattr(_guarded_publish_v124, "__wrapped__", current_publish)
+        setattr(publication_module, "_publish", _guarded_publish_v124)
+
+    @wraps(current_entry)
+    def _bounded_publish_canonical_strategy_v124(*args: Any, **kwargs: Any):
+        timeout_s = _publication_timeout_s()
+        result_q: "queue.Queue[tuple[str, Any, int]]" = queue.Queue(maxsize=1)
+        started = threading.Event()
+        worker_ident = [0]
+
+        def _runner() -> None:
+            ident = threading.get_ident()
+            worker_ident[0] = ident
+            started.set()
+            try:
+                result_q.put(("result", current_entry(*args, **kwargs), ident))
+            except BaseException as exc:
+                try:
+                    result_q.put(("error", exc, ident))
+                except Exception:
+                    pass
+            finally:
+                with _CANCEL_LOCK:
+                    _CANCELLED_PUBLICATION_THREADS.discard(ident)
+
+        worker = threading.Thread(
+            target=_runner,
+            name="canonical-strategy-publication-v124",
+            daemon=True,
+        )
+        worker.start()
+        started.wait(timeout=min(1.0, timeout_s))
+        try:
+            kind, payload, ident = result_q.get(timeout=timeout_s)
+        except queue.Empty:
+            ident = worker_ident[0]
+            if ident:
+                with _CANCEL_LOCK:
+                    _CANCELLED_PUBLICATION_THREADS.add(ident)
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_V124_PUBLICATION_TIMEOUT marker=%s timeout_s=%.2f worker_alive=%s strategy_ready=false execution_ready=false runtime_execution_authority_unchanged=true trading_fail_closed=true",
+                MARKER,
+                timeout_s,
+                worker.is_alive(),
+            )
+            return None, "publication_timeout_v124"
+
+        if kind == "error":
+            LOGGER.critical(
+                "CANONICAL_STRATEGY_V124_PUBLICATION_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(payload).__name__,
+                payload,
+                exc_info=(type(payload), payload, payload.__traceback__),
+            )
+            return None, f"publication_error_v124:{type(payload).__name__}"
+        return payload
+
+    setattr(_bounded_publish_canonical_strategy_v124, _PUBLICATION_PATCH_ATTR, True)
+    setattr(_bounded_publish_canonical_strategy_v124, "__wrapped__", current_entry)
+    setattr(publication_module, "publish_canonical_strategy", _bounded_publish_canonical_strategy_v124)
+    LOGGER.critical(
+        "CANONICAL_STRATEGY_V124_PUBLICATION_BOUND_PATCHED marker=%s timeout_s=%.2f late_publication_suppressed=true fail_closed=true",
+        MARKER,
+        _publication_timeout_s(),
+    )
+    return True
+
+
 def _patch_release_manifest() -> bool:
     manifest = sys.modules.get("bot.runtime_release_manifest_patch") or sys.modules.get(
         "runtime_release_manifest_patch"
@@ -203,6 +305,7 @@ def install() -> bool:
         try:
             from bot import trading_strategy as strategy_module
             from bot import trading_strategy_apex_wiring_patch as wiring_module
+            from bot import strategy_publication_patch as publication_module
         except Exception as exc:
             LOGGER.critical(
                 "CANONICAL_STRATEGY_V124_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
@@ -216,6 +319,8 @@ def install() -> bool:
             return False
         if not _patch_wiring_bound(wiring_module):
             return False
+        if not _patch_publication_bound(publication_module):
+            return False
 
         os.environ[_FLAG] = "1"
         if not _patch_release_manifest():
@@ -223,10 +328,11 @@ def install() -> bool:
             return False
         _INSTALLED = True
         LOGGER.critical(
-            "CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED marker=%s symbol_timeout_s=%.2f wiring_timeout_s=%.2f strategy_readiness_synthetic=false execution_readiness_synthetic=false broker_io_read_only=true import_hook_added=false safety_gates_unchanged=true",
+            "CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED marker=%s symbol_timeout_s=%.2f wiring_timeout_s=%.2f publication_timeout_s=%.2f late_publication_suppressed=true strategy_readiness_synthetic=false execution_readiness_synthetic=false broker_io_read_only=true import_hook_added=false safety_gates_unchanged=true",
             MARKER,
             _symbol_timeout_s(),
             _wiring_timeout_s(),
+            _publication_timeout_s(),
         )
         return True
 
@@ -243,6 +349,8 @@ __all__ = [
     "install_import_hook",
     "_symbol_timeout_s",
     "_wiring_timeout_s",
+    "_publication_timeout_s",
     "_patch_symbol_discovery",
     "_patch_wiring_bound",
+    "_patch_publication_bound",
 ]

--- a/bot/position_sync_timeout_v98_patch.py
+++ b/bot/position_sync_timeout_v98_patch.py
@@ -6,8 +6,9 @@ are installed from this canonical slot in dependency order. v119 adds canonical
 position-sync observation to preactivation truth. v120 preserves canonical
 TradingLoop liveness while exact-writer supervised activation remains pending.
 v121 bounds read-only Kraken HTTP calls, v122 requires that timeout layer before
-v108 may dispatch a Kraken platform reconciliation worker, and v123 keeps the
-canonical fast path behind the process-wide import-chain compactor.
+v108 may dispatch a Kraken platform reconciliation worker, v123 keeps the
+canonical fast path behind the process-wide import-chain compactor, and v124
+bounds synchronous canonical strategy publication work before core startup.
 """
 from __future__ import annotations
 
@@ -64,6 +65,9 @@ def install() -> bool:
         ("preactivation_position_sync_v119_patch", "V119"),
         ("core_supervised_pending_v120_patch", "V120"),
         ("canonical_import_shield_v123_patch", "V123"),
+        # v124 must be installed before the canonical strategy import-cycle and
+        # recovery layers can trigger synchronous TradingStrategy construction.
+        ("canonical_strategy_startup_bound_v124_patch", "V124"),
         ("startup_strategy_import_cycle_v104_patch", "V104"),
         ("canonical_strategy_class_recovery_v100_patch", "V100"),
         ("canonical_strategy_class_recovery_v102_patch", "V102"),
@@ -83,7 +87,7 @@ def install() -> bool:
     os.environ["NIJA_POSITION_SYNC_TIMEOUT_V98_INSTALLED"] = "1"
     _INSTALLED = True
     LOGGER.critical(
-        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true kraken_read_timeout_v121=true kraken_position_sync_prereq_v122=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true core_supervised_pending_v120=true canonical_import_shield_v123=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
+        "POSITION_SYNC_TIMEOUT_V98_INSTALLED marker=%s default_timeout_s=%.1f explicit_env_override_preserved=true account_isolation_v99=true startup_publication_bootstrap_v105=true capital_refresh_reentrancy_v106=true startup_hook_nonce_v107=true kraken_read_timeout_v121=true kraken_position_sync_prereq_v122=true platform_position_sync_v108=true runtime_convergence_v116=true position_fetch_generation_v117=true terminal_writer_loss_seak_v118=true preactivation_position_sync_v119=true core_supervised_pending_v120=true canonical_import_shield_v123=true canonical_strategy_startup_bound_v124=true strategy_import_cycle_v104=true strategy_class_recovery_v100=true passive_strategy_recovery_v102=true startup_convergence_v103=true safety_gates_unchanged=true",
         MARKER,
         _DEFAULT_TIMEOUT_S,
     )

--- a/bot/tests/test_canonical_strategy_startup_bound_v124.py
+++ b/bot/tests/test_canonical_strategy_startup_bound_v124.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import queue
 import threading
 import time
@@ -78,7 +77,6 @@ def test_wiring_hydration_removes_unbounded_first_attempt(monkeypatch):
         return True
 
     def old_bounded(_strategy, broker=None, reason="runtime"):
-        # Models the old implementation's misleading synchronous first call.
         return hydrate(_strategy, broker=broker, reason=reason)
 
     wiring_module._needs_hydration = needs
@@ -93,6 +91,38 @@ def test_wiring_hydration_removes_unbounded_first_attempt(monkeypatch):
 
     assert elapsed < 0.3
     assert ready is False
+
+
+def test_complete_publication_is_bounded_and_late_publish_is_suppressed(monkeypatch):
+    publication_module = ModuleType("fake_publication")
+    published = []
+
+    def publish(strategy):
+        published.append(strategy)
+
+    def publish_canonical_strategy(*args, **kwargs):
+        time.sleep(1.2)
+        publication_module._publish(object())
+        return object(), "late"
+
+    publication_module._publish = publish
+    publication_module.publish_canonical_strategy = publish_canonical_strategy
+    # The production clamp has a 1s minimum. Make the original operation exceed it.
+    monkeypatch.setenv("NIJA_CANONICAL_STRATEGY_PUBLICATION_TIMEOUT_S", "1")
+
+    assert v124._patch_publication_bound(publication_module)
+    started = time.monotonic()
+    strategy, detail = publication_module.publish_canonical_strategy()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.15
+    assert strategy is None
+    assert detail == "publication_timeout_v124"
+
+    # Let the original worker reach its attempted publish. The guard must keep
+    # a post-deadline strategy from becoming visible/readiness-producing.
+    time.sleep(0.35)
+    assert published == []
 
 
 def test_release_manifest_attests_v124(monkeypatch):

--- a/bot/tests/test_canonical_strategy_startup_bound_v124.py
+++ b/bot/tests/test_canonical_strategy_startup_bound_v124.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from types import ModuleType
+
+import bot.canonical_strategy_startup_bound_v124_patch as v124
+
+
+def _call_with_timeout(fn, *args, timeout_seconds=1.0, **kwargs):
+    q = queue.Queue(maxsize=1)
+
+    def runner():
+        try:
+            q.put(("result", fn(*args, **kwargs)))
+        except BaseException as exc:
+            q.put(("error", exc))
+
+    threading.Thread(target=runner, daemon=True).start()
+    try:
+        kind, payload = q.get(timeout=timeout_seconds)
+    except queue.Empty:
+        return None, TimeoutError("timed out")
+    if kind == "error":
+        return None, payload
+    return payload, None
+
+
+def test_symbol_discovery_is_time_bounded(monkeypatch):
+    strategy_module = ModuleType("fake_trading_strategy")
+
+    class TradingStrategy:
+        @staticmethod
+        def _broker_key_from_obj(_broker):
+            return "kraken"
+
+        @staticmethod
+        def _dedupe_symbols(products):
+            return list(dict.fromkeys(products))
+
+        def _discover_broker_symbols(self, broker):
+            return broker.get_available_markets()
+
+    class BlockingBroker:
+        def get_available_markets(self):
+            time.sleep(0.5)
+            return ["BTC-USD"]
+
+        def get_all_products(self):
+            time.sleep(0.5)
+            return ["ETH-USD"]
+
+    strategy_module.TradingStrategy = TradingStrategy
+    strategy_module.call_with_timeout = _call_with_timeout
+    monkeypatch.setenv("NIJA_SYMBOL_DISCOVERY_TIMEOUT_S", "0.1")
+
+    assert v124._patch_symbol_discovery(strategy_module)
+    started = time.monotonic()
+    result = TradingStrategy()._discover_broker_symbols(BlockingBroker())
+    elapsed = time.monotonic() - started
+
+    # Both catalog probes are bounded at 0.1s rather than inheriting their
+    # 0.5s blocking duration. No symbols are fabricated after timeout.
+    assert elapsed < 0.35
+    assert result == []
+
+
+def test_wiring_hydration_removes_unbounded_first_attempt(monkeypatch):
+    wiring_module = ModuleType("fake_wiring")
+
+    def needs(_strategy):
+        return True
+
+    def hydrate(_strategy, broker=None, reason="runtime"):
+        time.sleep(0.5)
+        return True
+
+    def old_bounded(_strategy, broker=None, reason="runtime"):
+        # Models the old implementation's misleading synchronous first call.
+        return hydrate(_strategy, broker=broker, reason=reason)
+
+    wiring_module._needs_hydration = needs
+    wiring_module._hydrate_strategy_wiring = hydrate
+    wiring_module._bounded_hydrate_strategy_wiring = old_bounded
+    monkeypatch.setenv("NIJA_TRADING_STRATEGY_WIRING_TIMEOUT_S", "0.1")
+
+    assert v124._patch_wiring_bound(wiring_module)
+    started = time.monotonic()
+    ready = wiring_module._bounded_hydrate_strategy_wiring(object(), reason="test")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.3
+    assert ready is False
+
+
+def test_release_manifest_attests_v124(monkeypatch):
+    manifest = ModuleType("bot.runtime_release_manifest_patch")
+    manifest._REQUIRED_FLAGS = {}
+    manifest.RELEASE_ID = "old"
+    monkeypatch.setitem(__import__("sys").modules, "bot.runtime_release_manifest_patch", manifest)
+
+    assert v124._patch_release_manifest()
+    assert manifest._REQUIRED_FLAGS["canonical_strategy_startup_bound_v124"] == (
+        "NIJA_CANONICAL_STRATEGY_STARTUP_BOUND_V124_INSTALLED"
+    )
+    assert manifest.RELEASE_ID == "20260816-runtime-convergence-v124"
+
+
+def test_v98_orders_v124_before_strategy_recovery():
+    source = open("bot/position_sync_timeout_v98_patch.py", encoding="utf-8").read()
+    assert source.index("canonical_strategy_startup_bound_v124_patch") < source.index(
+        "startup_strategy_import_cycle_v104_patch"
+    )
+    assert "canonical_strategy_startup_bound_v124=true" in source


### PR DESCRIPTION
v124 runtime convergence follow-up. Current production v123 logs confirm fail-closed writer/activation behavior, but expose two concrete runtime issues to address before merge: repeated trading-strategy apex rewiring/log storms and transient duplicate module identity for nija_apex_strategy_v71. CI failures are being debugged and will be fixed without weakening writer, risk, nonce, capital, position-sync, kill-switch, or execution gates.