### PR TITLE
Fix canonical core startup handoff v124

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -33,6 +33,7 @@ _FAST_PATH_INSTALLERS = (
     ("bot.zero_signal_streak_cap_repair_v51_patch", "ZERO_SIGNAL_STREAK_CAP_V51"),
     ("bot.heartbeat_authority_single_source_patch", "HEARTBEAT_AUTHORITY_SINGLE_SOURCE"),
     ("bot.precore_authority_heartbeat_v63_patch", "PRECORE_AUTHORITY_HEARTBEAT_V63"),
+    ("bot.canonical_self_healing_handoff_v124_patch", "CANONICAL_SELF_HEALING_HANDOFF_V124"),
     ("bot.activation_convergence_v17_patch", "ACTIVATION_CONVERGENCE_V17"),
     ("bot.activation_convergence_v17_importlib_bridge", "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE"),
     ("bot.okx_patch_churn_guard_patch", "OKX_PATCH_CHURN_GUARD"),

--- a/bot/canonical_self_healing_handoff_v124_patch.py
+++ b/bot/canonical_self_healing_handoff_v124_patch.py
@@ -1,0 +1,300 @@
+"""Converge canonical startup into core registration without bypassing safety gates.
+
+Production release v123 proved writer authority, broker connectivity, balance
+hydration, capital, risk, nonce, and position synchronization while bot_main was
+still blocked in the legacy SelfHealingStartup compatibility phase.  Canonical
+broker prebootstrap already establishes and verifies those prerequisites before
+bot_main reaches Step 1, so repeating the legacy recovery sequence can delay core
+registration indefinitely while the BootstrapFSM remains LOCK_ACQUIRED.
+
+v124 replaces only that redundant canonical Step-1 wait.  The fast handoff is
+allowed when all proof-backed prerequisites are currently true:
+
+* canonical fast-path production launch is active;
+* exact distributed writer authority verifies successfully;
+* the canonical broker manager contract is initialized;
+* at least one connected platform broker exists;
+* broker_connected, balance_hydrated, capital_ready, risk_ready, nonce_ready,
+  and position_sync_ready are all true; and
+* no process-exit/shutdown request is active.
+
+If any proof is absent, the original SelfHealingStartup path runs unchanged.  The
+patch never marks strategy/execution/bootstrap readiness, never fabricates nonce
+or broker state, never grants execution authority, and keeps trading fail-closed
+until the existing post-core activation convergence completes.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.canonical_self_healing_handoff_v124")
+MARKER = "20260816-canonical-self-healing-handoff-v124"
+RELEASE_ID = "20260816-runtime-convergence-v124"
+_FLAG = "NIJA_CANONICAL_SELF_HEALING_HANDOFF_V124_INSTALLED"
+_PATCH_ATTR = "_nija_canonical_self_healing_handoff_v124"
+_WIRING_GUARD_ATTR = "_nija_v124_idempotent_install_guard"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_REQUIRED_READINESS = (
+    "broker_connected",
+    "balance_hydrated",
+    "capital_ready",
+    "risk_ready",
+    "nonce_ready",
+    "position_sync_ready",
+)
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _canonical_fast_path() -> bool:
+    if not (
+        _truthy(os.environ.get("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH"))
+        and _truthy(os.environ.get("NIJA_DEFER_RUNTIME_SITE_HOOKS"))
+        and str(os.environ.get("NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY", "")) == "1"
+    ):
+        return False
+    try:
+        from bot.runtime_mode import resolve_runtime_mode
+
+        return bool(resolve_runtime_mode().is_live)
+    except Exception:
+        return False
+
+
+def _shutdown_requested(module: ModuleType | None = None) -> bool:
+    if _truthy(os.environ.get("NIJA_PROCESS_EXIT_REQUESTED")):
+        return True
+    module = module or sys.modules.get("bot.bot_main") or sys.modules.get("bot_main")
+    shutdown = getattr(module, "_shutdown_event", None) if isinstance(module, ModuleType) else None
+    return bool(
+        shutdown is not None
+        and callable(getattr(shutdown, "is_set", None))
+        and shutdown.is_set()
+    )
+
+
+def _connected_broker(manager: Any) -> tuple[Any | None, str]:
+    brokers = getattr(manager, "platform_brokers", None)
+    if callable(brokers):
+        brokers = brokers()
+    if brokers is None:
+        brokers = getattr(manager, "_platform_brokers", {})
+    try:
+        items = list(dict(brokers or {}).items())
+    except Exception:
+        items = []
+
+    # Prefer Kraken when healthy because it is the funded primary account in
+    # the canonical production path, but any already-connected platform broker
+    # remains a valid recovery/fallback surface.
+    healthy: list[tuple[int, str, Any]] = []
+    for key, broker in items:
+        if broker is None or not bool(getattr(broker, "connected", False)):
+            continue
+        name = str(getattr(key, "value", None) or key or type(broker).__name__).lower()
+        priority = 0 if "kraken" in name or "kraken" in type(broker).__name__.lower() else 1
+        healthy.append((priority, name, broker))
+    if not healthy:
+        return None, ""
+    healthy.sort(key=lambda row: (row[0], row[1]))
+    _, name, broker = healthy[0]
+    return broker, name
+
+
+def _fast_handoff_proof(module: ModuleType | None = None) -> tuple[bool, Any | None, str, str]:
+    if not _canonical_fast_path():
+        return False, None, "", "canonical_fast_live_path_inactive"
+    if _shutdown_requested(module):
+        return False, None, "", "shutdown_requested"
+
+    try:
+        from bot.execution_authority_context import assert_distributed_writer_authority
+
+        assert_distributed_writer_authority()
+    except Exception as exc:
+        return False, None, "", f"writer_authority:{type(exc).__name__}:{exc}"
+
+    try:
+        from bot import canonical_broker_prebootstrap_v22 as prebootstrap
+
+        manager = prebootstrap._canonical_manager()
+        writer_ok, writer_reason = prebootstrap._writer_handoff_proof()
+        if not writer_ok:
+            return False, None, "", f"writer_handoff:{writer_reason}"
+        contract_ok, contract_reason = prebootstrap._manager_contract(manager)
+        if not contract_ok:
+            return False, None, "", f"manager_contract:{contract_reason}"
+        registered, connected, names = prebootstrap._platform_counts(manager)
+        if connected < 1:
+            return False, None, "", f"connected_broker_missing:registered={registered}:names={names}"
+    except Exception as exc:
+        return False, None, "", f"prebootstrap:{type(exc).__name__}:{exc}"
+
+    try:
+        from bot.readiness_table import snapshot
+
+        readiness = dict(snapshot() or {})
+    except Exception as exc:
+        return False, None, "", f"readiness_snapshot:{type(exc).__name__}:{exc}"
+
+    missing = [key for key in _REQUIRED_READINESS if not bool(readiness.get(key, False))]
+    if missing:
+        return False, None, "", "readiness_false:" + ",".join(missing)
+
+    broker, broker_name = _connected_broker(manager)
+    if broker is None:
+        return False, None, "", "connected_broker_selection_failed"
+
+    return True, broker, broker_name, (
+        "proofs_ready:writer,manager,broker,balance,capital,risk,nonce,position_sync"
+    )
+
+
+def _patch_bot_main(module: ModuleType | None = None) -> bool:
+    module = module or sys.modules.get("bot.bot_main") or sys.modules.get("bot_main")
+    if not isinstance(module, ModuleType):
+        try:
+            import bot.bot_main as module  # type: ignore[no-redef]
+        except Exception:
+            return False
+
+    current = getattr(module, "_run_self_healing_startup", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def run_self_healing_startup_v124(*args: Any, **kwargs: Any):
+        ok, broker, broker_name, detail = _fast_handoff_proof(module)
+        if ok:
+            # Explicitly preserve fail-closed execution truth.  Step 2/3 and the
+            # existing post-core convergence own all later readiness/authority.
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "false"
+            LOGGER.critical(
+                "CANONICAL_SELF_HEALING_FAST_HANDOFF_V124_READY marker=%s broker=%s detail=%s legacy_recovery_skipped=true core_registration_next=true execution_authority_granted=false safety_gates_unchanged=true",
+                MARKER,
+                broker_name,
+                detail,
+            )
+            return True, broker, broker_name
+
+        LOGGER.warning(
+            "CANONICAL_SELF_HEALING_FAST_HANDOFF_V124_FALLBACK marker=%s detail=%s action=run_original_self_healing execution_authority_granted=false",
+            MARKER,
+            detail,
+        )
+        return current(*args, **kwargs)
+
+    setattr(run_self_healing_startup_v124, _PATCH_ATTR, True)
+    setattr(run_self_healing_startup_v124, "__wrapped__", current)
+    module._run_self_healing_startup = run_self_healing_startup_v124
+    return True
+
+
+def _method_wiring_ready(cls: type) -> bool:
+    getattribute = getattr(cls, "__getattribute__", None)
+    run_cycle = getattr(cls, "run_cycle", None)
+    init = getattr(cls, "__init__", None)
+    get_ok = bool(getattr(getattribute, "_nija_apex_backref_getattribute_20260709ah", False))
+    run_ok = not callable(run_cycle) or bool(getattr(run_cycle, "_nija_apex_wiring_wrapped_20260709ah", False))
+    init_ok = not callable(init) or bool(getattr(init, "_nija_apex_wiring_wrapped_20260709ah", False))
+    return get_ok and run_ok and init_ok
+
+
+def _patch_wiring_reinstall_churn() -> bool:
+    """Suppress no-op TradingStrategy reinstall churn while preserving reload repair."""
+    try:
+        from bot import trading_strategy_apex_wiring_patch as wiring
+    except Exception:
+        return False
+
+    current = getattr(wiring, "_install_on_module", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _WIRING_GUARD_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def install_on_module_v124(module: ModuleType) -> bool:
+        cls = getattr(module, "TradingStrategy", None)
+        if isinstance(cls, type) and _method_wiring_ready(cls):
+            return True
+        return bool(current(module))
+
+    setattr(install_on_module_v124, _WIRING_GUARD_ATTR, True)
+    setattr(install_on_module_v124, "__wrapped__", current)
+    wiring._install_on_module = install_on_module_v124
+    LOGGER.critical(
+        "TRADING_STRATEGY_APEX_WIRING_V124_CHURN_GUARD_INSTALLED marker=%s reload_repair_preserved=true no_op_repatch_suppressed=true",
+        MARKER,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        import bot.runtime_release_manifest_patch as manifest
+    except Exception:
+        return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["canonical_self_healing_handoff_v124"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+        bot_main_ok = _patch_bot_main()
+        wiring_ok = _patch_wiring_reinstall_churn()
+        manifest_ok = _patch_release_manifest()
+        if not (bot_main_ok and wiring_ok and manifest_ok):
+            os.environ.pop(_FLAG, None)
+            _INSTALLED = False
+            LOGGER.critical(
+                "CANONICAL_SELF_HEALING_HANDOFF_V124_INSTALL_FAILED marker=%s bot_main=%s wiring=%s manifest=%s trading_fail_closed=true",
+                MARKER,
+                bot_main_ok,
+                wiring_ok,
+                manifest_ok,
+            )
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "CANONICAL_SELF_HEALING_HANDOFF_V124_INSTALLED marker=%s release=%s proof_backed_fast_handoff=true fallback_preserved=true execution_gates_unchanged=true",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_fast_handoff_proof",
+    "_patch_bot_main",
+    "_patch_wiring_reinstall_churn",
+]

--- a/bot/canonical_self_healing_handoff_v124_patch.py
+++ b/bot/canonical_self_healing_handoff_v124_patch.py
@@ -2,25 +2,28 @@
 
 Production release v123 proved writer authority, broker connectivity, balance
 hydration, capital, risk, nonce, and position synchronization while bot_main was
-still blocked in the legacy SelfHealingStartup compatibility phase.  Canonical
-broker prebootstrap already establishes and verifies those prerequisites before
-bot_main reaches Step 1, so repeating the legacy recovery sequence can delay core
-registration indefinitely while the BootstrapFSM remains LOCK_ACQUIRED.
+still blocked in the legacy SelfHealingStartup compatibility phase. Canonical
+broker prebootstrap already establishes and verifies the prerequisites needed to
+continue into core creation before bot_main reaches Step 1, so repeating the
+legacy recovery sequence can delay core registration indefinitely while the
+BootstrapFSM remains LOCK_ACQUIRED.
 
-v124 replaces only that redundant canonical Step-1 wait.  The fast handoff is
-allowed when all proof-backed prerequisites are currently true:
+v124 replaces only that redundant canonical Step-1 wait. The fast handoff is
+allowed when all proof-backed pre-core prerequisites are currently true:
 
 * canonical fast-path production launch is active;
 * exact distributed writer authority verifies successfully;
 * the canonical broker manager contract is initialized;
 * at least one connected platform broker exists;
-* broker_connected, balance_hydrated, capital_ready, risk_ready, nonce_ready,
-  and position_sync_ready are all true; and
+* broker_connected, balance_hydrated, capital_ready, risk_ready, and nonce_ready
+  are all true; and
 * no process-exit/shutdown request is active.
 
-If any proof is absent, the original SelfHealingStartup path runs unchanged.  The
-patch never marks strategy/execution/bootstrap readiness, never fabricates nonce
-or broker state, never grants execution authority, and keeps trading fail-closed
+Position synchronization, strategy readiness, execution readiness, bootstrap
+finalization, and dispatch authority remain owned by their existing downstream
+activation gates after the real core thread is registered. If any pre-core proof
+is absent, the original SelfHealingStartup path runs unchanged. The patch never
+fabricates readiness or grants execution authority and keeps trading fail-closed
 until the existing post-core activation convergence completes.
 """
 from __future__ import annotations
@@ -48,7 +51,6 @@ _REQUIRED_READINESS = (
     "capital_ready",
     "risk_ready",
     "nonce_ready",
-    "position_sync_ready",
 )
 
 
@@ -94,9 +96,8 @@ def _connected_broker(manager: Any) -> tuple[Any | None, str]:
     except Exception:
         items = []
 
-    # Prefer Kraken when healthy because it is the funded primary account in
-    # the canonical production path, but any already-connected platform broker
-    # remains a valid recovery/fallback surface.
+    # Prefer Kraken when healthy because it is the canonical funded primary;
+    # any already-connected platform broker remains a valid fallback surface.
     healthy: list[tuple[int, str, Any]] = []
     for key, broker in items:
         if broker is None or not bool(getattr(broker, "connected", False)):
@@ -155,9 +156,7 @@ def _fast_handoff_proof(module: ModuleType | None = None) -> tuple[bool, Any | N
     if broker is None:
         return False, None, "", "connected_broker_selection_failed"
 
-    return True, broker, broker_name, (
-        "proofs_ready:writer,manager,broker,balance,capital,risk,nonce,position_sync"
-    )
+    return True, broker, broker_name, "proofs_ready:writer,manager,broker,balance,capital,risk,nonce"
 
 
 def _patch_bot_main(module: ModuleType | None = None) -> bool:
@@ -178,7 +177,7 @@ def _patch_bot_main(module: ModuleType | None = None) -> bool:
     def run_self_healing_startup_v124(*args: Any, **kwargs: Any):
         ok, broker, broker_name, detail = _fast_handoff_proof(module)
         if ok:
-            # Explicitly preserve fail-closed execution truth.  Step 2/3 and the
+            # Explicitly preserve fail-closed execution truth. Step 2/3 and the
             # existing post-core convergence own all later readiness/authority.
             os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
             os.environ["NIJA_EXECUTION_ACTIVE"] = "false"

--- a/bot/test_canonical_self_healing_handoff_v124.py
+++ b/bot/test_canonical_self_healing_handoff_v124.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import types
+import unittest
+from unittest.mock import patch
+
+from bot import canonical_self_healing_handoff_v124_patch as v124
+
+
+class _Broker:
+    def __init__(self, connected: bool = True) -> None:
+        self.connected = connected
+
+
+class CanonicalSelfHealingHandoffV124Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_authority = os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY")
+        self._old_active = os.environ.get("NIJA_EXECUTION_ACTIVE")
+
+    def tearDown(self) -> None:
+        if self._old_authority is None:
+            os.environ.pop("NIJA_RUNTIME_EXECUTION_AUTHORITY", None)
+        else:
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = self._old_authority
+        if self._old_active is None:
+            os.environ.pop("NIJA_EXECUTION_ACTIVE", None)
+        else:
+            os.environ["NIJA_EXECUTION_ACTIVE"] = self._old_active
+
+    def _module_with_original(self):
+        module = types.ModuleType("bot.bot_main_test_v124")
+        calls = []
+
+        def original():
+            calls.append("original")
+            return False, None, "legacy"
+
+        module._run_self_healing_startup = original
+        return module, calls
+
+    def test_fast_handoff_skips_legacy_and_stays_fail_closed(self) -> None:
+        module, calls = self._module_with_original()
+        broker = _Broker()
+        self.assertTrue(v124._patch_bot_main(module))
+        with patch.object(
+            v124,
+            "_fast_handoff_proof",
+            return_value=(True, broker, "kraken", "proofs_ready"),
+        ):
+            os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"
+            os.environ["NIJA_EXECUTION_ACTIVE"] = "true"
+            result = module._run_self_healing_startup()
+
+        self.assertEqual((True, broker, "kraken"), result)
+        self.assertEqual([], calls)
+        self.assertEqual("0", os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"])
+        self.assertEqual("false", os.environ["NIJA_EXECUTION_ACTIVE"])
+
+    def test_failed_proof_runs_original_self_healing(self) -> None:
+        module, calls = self._module_with_original()
+        self.assertTrue(v124._patch_bot_main(module))
+        with patch.object(
+            v124,
+            "_fast_handoff_proof",
+            return_value=(False, None, "", "readiness_false:nonce_ready"),
+        ):
+            result = module._run_self_healing_startup()
+
+        self.assertEqual((False, None, "legacy"), result)
+        self.assertEqual(["original"], calls)
+
+    def test_patch_bot_main_is_idempotent(self) -> None:
+        module, _ = self._module_with_original()
+        self.assertTrue(v124._patch_bot_main(module))
+        first = module._run_self_healing_startup
+        self.assertTrue(v124._patch_bot_main(module))
+        self.assertIs(first, module._run_self_healing_startup)
+
+    def test_connected_broker_prefers_kraken(self) -> None:
+        manager = types.SimpleNamespace(
+            platform_brokers={
+                "coinbase": _Broker(),
+                "kraken": _Broker(),
+            }
+        )
+        broker, name = v124._connected_broker(manager)
+        self.assertIs(broker, manager.platform_brokers["kraken"])
+        self.assertEqual("kraken", name)
+
+    def test_position_sync_not_a_pre_core_handoff_requirement(self) -> None:
+        self.assertNotIn("position_sync_ready", v124._REQUIRED_READINESS)
+        self.assertIn("nonce_ready", v124._REQUIRED_READINESS)
+        self.assertIn("risk_ready", v124._REQUIRED_READINESS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Adds a proof-backed canonical v124 startup handoff that skips the redundant legacy `SelfHealingStartup` wait only when writer authority, canonical broker manager, connected broker, balance, capital, risk, and nonce proofs are already true.
- Keeps execution fail-closed during the handoff; strategy, position-sync, bootstrap, execution, and dispatch gates remain downstream and unchanged.
- Falls back to the original self-healing path whenever any required pre-core proof is missing.
- Adds an idempotency guard for repeated TradingStrategy APEX wiring reinstalls to stop the observed no-op ~200 ms repatch churn while retaining repair after a real module/class replacement.
- Installs v124 on the canonical fast path and attests it in the runtime release manifest.
- Adds focused regression tests for fast handoff, fallback, fail-closed authority, idempotency, broker preference, and ensuring position sync is not moved ahead of core registration.

## Root cause

Production v123 held a healthy writer lease and showed broker/balance/capital/risk/nonce readiness, but `bot_main` remained in `LOCK_ACQUIRED` with `core_thread_registered=False`. Canonical broker prebootstrap had already established the pre-core prerequisites, then `bot_main` repeated the legacy `SelfHealingStartup.run()` compatibility phase before advancing the FSM and creating the core thread. That redundant phase prevented the canonical core-registration handoff.

## Safety

No readiness bit is fabricated. No nonce, risk, kill-switch, strategy, execution, position-sync, or dispatch gate is bypassed. `NIJA_RUNTIME_EXECUTION_AUTHORITY=0` and `NIJA_EXECUTION_ACTIVE=false` are explicitly preserved until the existing post-core activation convergence grants authority normally.