### PR TITLE
Fix authority heartbeat startup race v129

### DIFF
--- a/bot/authority_heartbeat_startup_grace_v129_patch.py
+++ b/bot/authority_heartbeat_startup_grace_v129_patch.py
@@ -1,0 +1,168 @@
+"""Prevent pre-core startup from being misclassified as core death.
+
+Production v128 proved that the authority heartbeat starts before canonical core
+registration. During that legitimate window, ``NIJA_CORE_THREAD_ALIVE=0`` was
+counted as ``core_thread_dead`` and three retries permanently halted SEAK even
+though the core later registered and stayed alive.
+
+v129 preserves fail-closed authority semantics. It suppresses only the *core
+liveness flag* while canonical core registration has never been observed, then
+runs the original authority check in full so Redis, fencing, generation, writer
+renewal, and all other authority checks still execute. Once registration has
+been observed, core liveness is enforced permanently for the life of the
+process. No SEAK resume, readiness fabrication, execution grant, or shutdown
+clearing is performed here.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.authority_heartbeat_startup_grace_v129")
+MARKER = "20260816-authority-heartbeat-startup-grace-v129"
+RELEASE_ID = "20260816-runtime-convergence-v129"
+_FLAG = "NIJA_AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129_INSTALLED"
+_PATCH_ATTR = "_nija_authority_heartbeat_startup_grace_v129"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_CORE_REGISTRATION_OBSERVED = False
+
+
+def _canonical_import(name: str) -> ModuleType:
+    existing = sys.modules.get(name)
+    if isinstance(existing, ModuleType):
+        return existing
+    bootstrap = getattr(importlib, "_bootstrap", None)
+    gcd_import = getattr(bootstrap, "_gcd_import", None) if bootstrap is not None else None
+    if not callable(gcd_import):
+        raise RuntimeError("canonical_import_primitive_unavailable")
+    module = gcd_import(name)
+    if not isinstance(module, ModuleType):
+        raise RuntimeError(f"canonical_import_invalid_module:{name}")
+    return module
+
+
+def _writer_singleton() -> Any:
+    module = _canonical_import("bot.entrypoint_writer_authority")
+    getter = getattr(module, "get_entrypoint_writer_authority", None)
+    return getter() if callable(getter) else None
+
+
+def _core_registration_state() -> tuple[bool, bool, str]:
+    """Return (observed_once, registered_now, reason) without mutating runtime state."""
+    global _CORE_REGISTRATION_OBSERVED
+    singleton = _writer_singleton()
+    registered_now = bool(getattr(singleton, "_core_thread_registered", False)) if singleton else False
+    if registered_now:
+        _CORE_REGISTRATION_OBSERVED = True
+    reason = "registered" if registered_now else "startup_not_registered"
+    return _CORE_REGISTRATION_OBSERVED, registered_now, reason
+
+
+def _patch_authority_check() -> bool:
+    heartbeat = _canonical_import("bot.authority_heartbeat")
+    current = getattr(heartbeat, "_check_authority_once", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def _check_authority_once_v129(timeout_s: float):
+        observed_once, registered_now, reason = _core_registration_state()
+        core_raw = os.environ.get("NIJA_CORE_THREAD_ALIVE")
+        core_false = str(core_raw or "").strip().lower() in {"0", "false", "no", "off", "disabled"}
+
+        # Only neutralize the pre-registration core flag. The original check is
+        # still executed in full, so writer lease, fencing, Redis, renewal proof,
+        # and generation checks remain unchanged and fail closed as before.
+        if core_false and not observed_once and not registered_now:
+            os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+            try:
+                ok, err = current(timeout_s)
+            finally:
+                if core_raw is None:
+                    os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)
+                else:
+                    os.environ["NIJA_CORE_THREAD_ALIVE"] = core_raw
+            if ok:
+                LOGGER.warning(
+                    "AUTHORITY_HEARTBEAT_V129_PRECORE_DEFERRED marker=%s reason=%s "
+                    "core_registration_observed=false redis_authority_verified=true "
+                    "failure_counter_unchanged=true execution_authority_unchanged=true",
+                    MARKER,
+                    reason,
+                )
+            return ok, err
+
+        return current(timeout_s)
+
+    setattr(_check_authority_once_v129, _PATCH_ATTR, True)
+    setattr(_check_authority_once_v129, "__wrapped__", current)
+    heartbeat._check_authority_once = _check_authority_once_v129
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = _canonical_import("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["authority_heartbeat_startup_grace_v129"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+        try:
+            check_ok = _patch_authority_check()
+            manifest_ok = _patch_release_manifest()
+        except Exception as exc:
+            LOGGER.critical(
+                "AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129_INSTALL_FAILED marker=%s err=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            check_ok = manifest_ok = False
+
+        if not (check_ok and manifest_ok):
+            os.environ.pop(_FLAG, None)
+            _INSTALLED = False
+            return False
+
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129_INSTALLED marker=%s release=%s "
+            "precore_core_liveness_deferred=true redis_authority_still_verified=true "
+            "post_registration_core_death_fatal=true seak_auto_resume=false "
+            "shutdown_clear=false readiness_synthetic=false execution_authority_unchanged=true",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_core_registration_state",
+]

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -67,6 +67,7 @@ _FAST_PATH_INSTALLERS = (
     ("bot.canonical_strategy_fast_start_v126_patch", "CANONICAL_STRATEGY_FAST_START_V126"),
     ("bot.canonical_publication_direct_v127_patch", "CANONICAL_PUBLICATION_DIRECT_V127"),
     ("bot.seak_nonce_causality_v128_patch", "SEAK_NONCE_CAUSALITY_V128"),
+    ("bot.authority_heartbeat_startup_grace_v129_patch", "AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129"),
 )
 
 _FAST_PATH_COMPAT_OPTIONAL_GUARDS = frozenset(

--- a/bot/test_authority_heartbeat_startup_grace_v129.py
+++ b/bot/test_authority_heartbeat_startup_grace_v129.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import bot.authority_heartbeat_startup_grace_v129_patch as patch
+
+
+def test_v129_installs_after_v128():
+    source = Path(__file__).with_name("bot.py").read_text(encoding="utf-8")
+    v128 = source.index("SEAK_NONCE_CAUSALITY_V128")
+    v129 = source.index("AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129")
+    assert v129 > v128
+
+
+def test_release_and_marker_are_v129():
+    assert patch.MARKER == "20260816-authority-heartbeat-startup-grace-v129"
+    assert patch.RELEASE_ID == "20260816-runtime-convergence-v129"
+
+
+def test_registration_state_latches_after_first_registration():
+    patch._CORE_REGISTRATION_OBSERVED = False
+    with mock.patch.object(
+        patch,
+        "_writer_singleton",
+        side_effect=[
+            SimpleNamespace(_core_thread_registered=False),
+            SimpleNamespace(_core_thread_registered=True),
+            SimpleNamespace(_core_thread_registered=False),
+        ],
+    ):
+        assert patch._core_registration_state() == (
+            False,
+            False,
+            "startup_not_registered",
+        )
+        assert patch._core_registration_state() == (True, True, "registered")
+        observed, registered, reason = patch._core_registration_state()
+        assert observed is True
+        assert registered is False
+        assert reason == "startup_not_registered"
+
+
+def test_v129_does_not_resume_seak_clear_shutdown_or_grant_execution():
+    source = Path(patch.__file__).read_text(encoding="utf-8")
+    assert ".resume(" not in source
+    assert "_halt_event.clear(" not in source
+    assert "shutdown_requested"] = " not in source
+    assert "mark_ready(" not in source
+    assert 'NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"' not in source
+    assert "post_registration_core_death_fatal=true" in source
+    assert "redis_authority_still_verified=true" in source
+
+
+def test_v129_only_neutralizes_core_flag_before_registration():
+    source = Path(patch.__file__).read_text(encoding="utf-8")
+    assert 'os.environ.pop("NIJA_CORE_THREAD_ALIVE", None)' in source
+    assert "not observed_once and not registered_now" in source
+    assert "return current(timeout_s)" in source


### PR DESCRIPTION
## What changed
- add v129 authority-heartbeat startup grace
- treat `NIJA_CORE_THREAD_ALIVE=0` as startup-pending only before canonical core registration has ever been observed
- continue running the original authority check so Redis, fencing, writer renewal, and generation validation remain fail-closed
- permanently re-enable normal core-death enforcement once canonical core registration has been observed
- add regression coverage and install v129 after v128 in the canonical fast-path guard bundle

## Root cause
The authority heartbeat starts before canonical core registration and performs an immediate tick. During normal startup the writer authority reports `startup_not_registered`, but the authority heartbeat classified the same state as `core_thread_dead`, incremented the three-strike failure counter, halted SEAK, and latched shutdown before the core later registered healthy.

## Safety
This change does not resume SEAK, clear a halt, clear shutdown, synthesize readiness, grant execution authority, bypass nonce checks, or weaken genuine post-registration core-death handling.