### PR TITLE
Fix readiness and kill-switch causality v131

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -69,14 +69,13 @@ _FAST_PATH_INSTALLERS = (
     ("bot.seak_nonce_causality_v128_patch", "SEAK_NONCE_CAUSALITY_V128"),
     ("bot.authority_heartbeat_startup_grace_v129_patch", "AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129"),
     ("bot.kill_switch_stale_heartbeat_recovery_v130_patch", "KILL_SWITCH_STALE_HEARTBEAT_RECOVERY_V130"),
+    ("bot.readiness_killswitch_causality_v131_patch", "READINESS_KILLSWITCH_CAUSALITY_V131"),
 )
 
-_FAST_PATH_COMPAT_OPTIONAL_GUARDS = frozenset(
-    {
-        "WRITER_REELECTION_LOSS_REASON_V46",
-        "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE",
-    }
-)
+_FAST_PATH_COMPAT_OPTIONAL_GUARDS = frozenset({
+    "WRITER_REELECTION_LOSS_REASON_V46",
+    "ACTIVATION_CONVERGENCE_V17_IMPORTLIB_BRIDGE",
+})
 
 _LEGACY_INSTALLERS = (
     *_FAST_PATH_INSTALLERS,
@@ -91,17 +90,11 @@ _LEGACY_INSTALLERS = (
 
 
 def _truthy(name: str) -> bool:
-    return str(os.environ.get(name, "")).strip().lower() in {
-        "1", "true", "yes", "on", "enabled", "y",
-    }
+    return str(os.environ.get(name, "")).strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
 
 
 def _canonical_fast_path_enabled() -> bool:
-    return bool(
-        _truthy("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH")
-        and _truthy("NIJA_DEFER_RUNTIME_SITE_HOOKS")
-        and os.environ.get("NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY") == "1"
-    )
+    return bool(_truthy("NIJA_CANONICAL_ENTRYPOINT_FAST_PATH") and _truthy("NIJA_DEFER_RUNTIME_SITE_HOOKS") and os.environ.get("NIJA_CANONICAL_RUNTIME_LAUNCHER_V26_READY") == "1")
 
 
 def _canonical_fast_import(module_name: str):
@@ -112,22 +105,13 @@ def _canonical_fast_import(module_name: str):
     return gcd_import(module_name)
 
 
-def _install_guards(
-    specs: Iterable[tuple[str, str]],
-    *,
-    mode: str,
-    optional_labels: frozenset[str] | None = None,
-) -> bool:
+def _install_guards(specs: Iterable[tuple[str, str]], *, mode: str, optional_labels: frozenset[str] | None = None) -> bool:
     ready = True
     installed: list[str] = []
     optional_labels = optional_labels or frozenset()
     for module_name, label in specs:
         try:
-            module = (
-                _canonical_fast_import(module_name)
-                if mode == "canonical_fast"
-                else importlib.import_module(module_name)
-            )
+            module = _canonical_fast_import(module_name) if mode == "canonical_fast" else importlib.import_module(module_name)
             installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
             if not callable(installer):
                 raise RuntimeError("installer_missing")
@@ -138,19 +122,11 @@ def _install_guards(
             logger.warning("%s_INSTALL_REQUESTED source=bot_entrypoint mode=%s", label, mode)
         except Exception as exc:
             if label in optional_labels:
-                logger.warning(
-                    "%s_INSTALL_SKIPPED_OPTIONAL source=bot_entrypoint mode=%s err=%s",
-                    label, mode, exc,
-                )
+                logger.warning("%s_INSTALL_SKIPPED_OPTIONAL source=bot_entrypoint mode=%s err=%s", label, mode, exc)
                 continue
             ready = False
-            logger.critical(
-                "%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s", label, mode, exc, exc_info=True,
-            )
-    logger.critical(
-        "BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s installed=%s",
-        _FAST_PATH_MARKER, mode, ready, ",".join(installed) or "none",
-    )
+            logger.critical("%s_INSTALL_FAILED source=bot_entrypoint mode=%s err=%s", label, mode, exc, exc_info=True)
+    logger.critical("BOT_ENTRYPOINT_GUARD_BUNDLE_COMPLETE marker=%s mode=%s ready=%s installed=%s", _FAST_PATH_MARKER, mode, ready, ",".join(installed) or "none")
     return ready
 
 
@@ -160,16 +136,10 @@ def _install_canonical_import_shield_v123() -> bool:
         installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
         if not callable(installer) or installer() is False:
             raise RuntimeError("canonical import shield v123 installer unavailable or returned false")
-        logger.critical(
-            "CANONICAL_IMPORT_SHIELD_V123_EARLY_READY source=bot_entrypoint before_fast_guard_bundle=true"
-        )
+        logger.critical("CANONICAL_IMPORT_SHIELD_V123_EARLY_READY source=bot_entrypoint before_fast_guard_bundle=true")
         return True
     except Exception as exc:
-        logger.critical(
-            "CANONICAL_IMPORT_SHIELD_V123_EARLY_FAILED source=bot_entrypoint err=%s trading_fail_closed=true",
-            exc,
-            exc_info=True,
-        )
+        logger.critical("CANONICAL_IMPORT_SHIELD_V123_EARLY_FAILED source=bot_entrypoint err=%s trading_fail_closed=true", exc, exc_info=True)
         return False
 
 
@@ -178,23 +148,13 @@ if _canonical_fast_path_enabled():
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
         raise RuntimeError("canonical import shield failed; trading remains fail closed")
-    if not _install_guards(
-        _FAST_PATH_INSTALLERS,
-        mode="canonical_fast",
-        optional_labels=_FAST_PATH_COMPAT_OPTIONAL_GUARDS,
-    ):
+    if not _install_guards(_FAST_PATH_INSTALLERS, mode="canonical_fast", optional_labels=_FAST_PATH_COMPAT_OPTIONAL_GUARDS):
         os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
         os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
         raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
-    logger.critical(
-        "CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred import_shield_v123=true handoff=bot.bot_main",
-        _FAST_PATH_MARKER,
-    )
+    logger.critical("CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred import_shield_v123=true handoff=bot.bot_main", _FAST_PATH_MARKER)
 else:
-    logger.warning(
-        "BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false",
-        _FAST_PATH_MARKER,
-    )
+    logger.warning("BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false", _FAST_PATH_MARKER)
     _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")
 
 from bot.bot_main import main

--- a/bot/readiness_killswitch_causality_v131_patch.py
+++ b/bot/readiness_killswitch_causality_v131_patch.py
@@ -1,0 +1,193 @@
+"""Repair v130 kill-switch recovery causality and v58/v61 readiness precedence.
+
+v131 is deliberately narrow:
+- preserve v61 current-proof truth synchronization if v58 is reinstalled later;
+- recover original activation causality when restart file detection appended a
+  FILE_SYSTEM record after an earlier heartbeat-triggered activation;
+- remove the circular requirement that authority/execution readiness already be
+  true while the kill switch itself is intentionally forcing them false.
+
+No generic kill-switch clearing, risk bypass, synthetic readiness, SEAK resume,
+or execution-authority grant is introduced.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.readiness_killswitch_causality_v131")
+MARKER = "20260817-readiness-killswitch-causality-v131"
+RELEASE_ID = "20260817-runtime-convergence-v131"
+_FLAG = "NIJA_READINESS_KILLSWITCH_CAUSALITY_V131_INSTALLED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _patch_v58_precedence() -> bool:
+    from bot import final_production_activation_repair_v58_patch as v58
+
+    current = getattr(v58, "_patch_readiness", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_v131_precedence", False):
+        return True
+
+    @wraps(current)
+    def patch_readiness_v131() -> bool:
+        try:
+            from bot import final_production_activation_repair_v61_patch as v61
+            if os.environ.get("NIJA_FINAL_PRODUCTION_ACTIVATION_V61_INSTALLED") == "1" or bool(
+                getattr(v61, "_INSTALLED", False)
+            ):
+                # Re-assert the newer current-proof synchronizer. v58 must never
+                # replace it with its older monotonic-true publisher.
+                reapply = getattr(v61, "_patch_v16_truth_sync", None)
+                if callable(reapply) and bool(reapply()):
+                    LOGGER.critical(
+                        "READINESS_V131_V61_PRECEDENCE marker=%s v58_reinstall_blocked=true current_proof_sync=true",
+                        MARKER,
+                    )
+                    return True
+        except Exception as exc:
+            LOGGER.warning("READINESS_V131_V61_PRECEDENCE_PROBE_FAILED marker=%s err=%s", MARKER, exc)
+        return bool(current())
+
+    patch_readiness_v131._nija_v131_precedence = True  # type: ignore[attr-defined]
+    v58._patch_readiness = patch_readiness_v131
+    return True
+
+
+def _causal_activation(status: dict[str, Any]) -> tuple[str, str]:
+    history = list(status.get("recent_history") or [])
+    if not history:
+        return "", ""
+
+    latest = history[-1] if isinstance(history[-1], dict) else {}
+    latest_reason = str(latest.get("reason") or "")
+    latest_source = str(latest.get("source") or "")
+
+    # Restart file detection is not a new safety cause; it is persistence of an
+    # already-active stop. Look backward only in that exact case.
+    if latest_source.strip().upper() == "FILE_SYSTEM" and "Kill switch file detected" in latest_reason:
+        for item in reversed(history[:-1]):
+            if not isinstance(item, dict) or not item.get("source"):
+                continue
+            reason = str(item.get("reason") or "")
+            source = str(item.get("source") or "")
+            if source.strip().upper() == "FILE_SYSTEM" and "Kill switch file detected" in reason:
+                continue
+            return reason, source
+    return latest_reason, latest_source
+
+
+def _patch_v130_causality() -> bool:
+    from bot import kill_switch_stale_heartbeat_recovery_v130_patch as v130
+
+    v130._latest_activation = _causal_activation
+
+    def runtime_proofs_healthy_v131() -> tuple[bool, str]:
+        if os.environ.get("NIJA_AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129_INSTALLED") != "1":
+            return False, "v129_not_installed"
+        if str(os.environ.get("NIJA_CORE_THREAD_ALIVE", "")).strip().lower() not in {
+            "1", "true", "yes", "on", "enabled", "y"
+        }:
+            return False, "core_not_alive"
+
+        try:
+            from bot.entrypoint_writer_authority import get_entrypoint_writer_authority
+            writer = get_entrypoint_writer_authority()
+            if writer is None or not bool(getattr(writer, "acquired", False)) or bool(getattr(writer, "lost", False)):
+                return False, "writer_epoch_not_current"
+            if not bool(getattr(writer, "_core_thread_registered", False)):
+                return False, "core_not_registered"
+        except Exception as exc:
+            return False, f"writer_probe:{type(exc).__name__}"
+
+        # authority_ready/execution_ready are intentionally excluded here: an
+        # active kill switch makes those proofs false by design, so requiring
+        # them before clearing the stale kill switch is circular.
+        try:
+            from bot.readiness_table import snapshot
+            table = snapshot()
+            required = (
+                "broker_connected", "balance_hydrated", "capital_ready",
+                "risk_ready", "strategy_ready", "nonce_ready", "bootstrap_ready",
+            )
+            missing = [key for key in required if not bool(table.get(key, False))]
+            if missing:
+                return False, "readiness:" + ",".join(missing)
+        except Exception as exc:
+            return False, f"readiness_probe:{type(exc).__name__}"
+
+        try:
+            from bot.seak_nonce_causality_v128_patch import _seak_halted
+            halted, reason = _seak_halted()
+            if halted:
+                return False, "seak_halted:" + str(reason or "unknown")
+        except Exception as exc:
+            return False, f"seak_probe:{type(exc).__name__}"
+
+        try:
+            from bot.bootstrap_state_machine import get_bootstrap_fsm
+            state = getattr(get_bootstrap_fsm(), "state", None)
+            state_value = str(getattr(state, "value", state) or "")
+            if state_value != "RUNNING_SUPERVISED":
+                return False, "bootstrap:" + (state_value or "unknown")
+        except Exception as exc:
+            return False, f"bootstrap_probe:{type(exc).__name__}"
+
+        return True, "ok"
+
+    v130._runtime_proofs_healthy = runtime_proofs_healthy_v131
+    LOGGER.critical(
+        "KILL_SWITCH_V131_CAUSALITY_PATCHED marker=%s restart_file_record_is_persistence=true "
+        "authority_execution_circularity_removed=true unrelated_stops_preserved=true",
+        MARKER,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    from bot import runtime_release_manifest_patch as manifest
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["readiness_killswitch_causality_v131"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+        try:
+            ok = _patch_v58_precedence() and _patch_v130_causality() and _patch_release_manifest()
+        except Exception as exc:
+            LOGGER.critical(
+                "READINESS_KILLSWITCH_CAUSALITY_V131_INSTALL_FAILED marker=%s err=%s:%s trading_fail_closed=true",
+                MARKER, type(exc).__name__, exc, exc_info=True,
+            )
+            ok = False
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "READINESS_KILLSWITCH_CAUSALITY_V131_INSTALLED marker=%s release=%s "
+            "generic_auto_clear=false risk_gates_unchanged=true readiness_synthetic=false execution_authority_unchanged=true",
+            MARKER, RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "RELEASE_ID", "install", "install_import_hook", "_causal_activation"]

--- a/bot/test_readiness_killswitch_causality_v131.py
+++ b/bot/test_readiness_killswitch_causality_v131.py
@@ -1,0 +1,39 @@
+from bot.readiness_killswitch_causality_v131_patch import _causal_activation
+
+
+def test_restart_file_record_recovers_prior_cause():
+    status = {"recent_history": [
+        {"reason": "AUTHORITY_HEARTBEAT_EXPIRED: core_thread_dead — NIJA_CORE_THREAD_ALIVE is not set", "source": "AUTO"},
+        {"reason": "Kill switch file detected", "source": "FILE_SYSTEM"},
+    ]}
+    reason, source = _causal_activation(status)
+    assert source == "AUTO"
+    assert "AUTHORITY_HEARTBEAT_EXPIRED" in reason
+    assert "core_thread_dead" in reason
+
+
+def test_manual_stop_is_never_reclassified():
+    status = {"recent_history": [
+        {"reason": "operator stop", "source": "MANUAL"},
+    ]}
+    assert _causal_activation(status) == ("operator stop", "MANUAL")
+
+
+def test_explicit_filesystem_stop_is_not_reclassified():
+    status = {"recent_history": [
+        {"reason": "operator created emergency marker", "source": "FILE_SYSTEM"},
+    ]}
+    assert _causal_activation(status) == ("operator created emergency marker", "FILE_SYSTEM")
+
+
+def test_v131_source_preserves_safety_contract():
+    import inspect
+    import bot.readiness_killswitch_causality_v131_patch as patch
+
+    src = inspect.getsource(patch)
+    assert '"authority_ready", "execution_ready"' not in src
+    assert "generic_auto_clear=false" in src
+    assert "risk_gates_unchanged=true" in src
+    assert "readiness_synthetic=false" in src
+    assert "execution_authority_unchanged=true" in src
+    assert "_patch_v16_truth_sync" in src


### PR DESCRIPTION
## What changed
- preserve v61 current-proof readiness synchronization when v58 is reinstalled later
- treat restart `FILE_SYSTEM / Kill switch file detected` records as persistence rather than a new safety cause, so the prior activation cause remains inspectable
- remove the circular v130 requirement that `authority_ready` and `execution_ready` already be true while the active kill switch itself forces those proofs false
- keep writer/core/bootstrap/nonce/SEAK and non-circular readiness proofs mandatory
- preserve manual/UI/CLI/filesystem and unrelated automatic risk stops
- add regression tests for restart causality and safety invariants

## Production evidence
v130 is deployed on `45ebaf9a0...`. Production shows `RUNNING_SUPERVISED`, core alive, `seak_halted=False`, nonce ready, but the kill switch remains active. It also shows a green readiness table while current v16 proofs for broker/balance/authority/capital/execution are false, proving stale readiness publication.

## Safety
No generic auto-clear, risk bypass, synthetic readiness, SEAK resume, forced LIVE_ACTIVE, or execution-authority grant is introduced.