### PR TITLE
Fail closed on post-activation proof loss v133

### DIFF
--- a/bot/post_activation_proof_loss_v133_patch.py
+++ b/bot/post_activation_proof_loss_v133_patch.py
@@ -1,0 +1,231 @@
+"""Fail closed when critical current proofs are lost after LIVE_ACTIVE.
+
+v133 closes the post-activation gap exposed by v132: v132 detected false
+current proofs while LIVE_ACTIVE but intentionally left the readiness table
+sticky after activation.  That allowed the public trading state to remain live
+while broker/balance/capital truth had already fallen false.
+
+Safety contract:
+- never fabricate or copy readiness from coarse/sticky state;
+- never clear kill switch or SEAK;
+- never grant writer, nonce, or execution authority;
+- never force LIVE_ACTIVE;
+- use the canonical TradingStateMachine transition for LIVE_ACTIVE -> OFF so
+  activation commitment, dispatch permission, and execution authority are
+  revoked atomically by the existing state machine;
+- leave recovery/reactivation to the existing canonical activation path after
+  all current proofs become true again.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from typing import Any
+
+LOGGER = logging.getLogger("nija.post_activation_proof_loss_v133")
+MARKER = "20260817-post-activation-proof-loss-v133"
+RELEASE_ID = "20260817-runtime-convergence-v133"
+_FLAG = "NIJA_POST_ACTIVATION_PROOF_LOSS_V133_INSTALLED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+_CRITICAL_KEYS = (
+    "broker_connected",
+    "balance_hydrated",
+    "authority_ready",
+    "capital_ready",
+    "risk_ready",
+    "strategy_ready",
+    "execution_ready",
+    "nonce_ready",
+    "bootstrap_ready",
+)
+
+
+def _state_machine() -> Any:
+    monitor = importlib.import_module("bot.activation_pending_commit_monitor_patch")
+    return monitor._state_machine()
+
+
+def _state_value(sm: Any | None = None) -> str:
+    try:
+        machine = sm if sm is not None else _state_machine()
+        if machine is None:
+            return "UNAVAILABLE"
+        state = machine.get_current_state()
+        return str(getattr(state, "value", state) or "UNAVAILABLE").strip().upper()
+    except Exception:
+        return "UNAVAILABLE"
+
+
+def _revoke_false_readiness(proofs: dict[str, bool]) -> tuple[dict[str, bool], list[str]]:
+    table = importlib.import_module("bot.readiness_table")
+    for key in _CRITICAL_KEYS:
+        if bool(proofs.get(key, False)):
+            table.mark_ready(key)
+        else:
+            table.revoke_ready(key, reason="v133_current_proof_false")
+    after = dict(table.snapshot())
+    pending = [key for key in _CRITICAL_KEYS if not bool(proofs.get(key, False))]
+    os.environ["NIJA_PREACTIVATION_READINESS_V16_READY"] = "1" if not pending else "0"
+    return after, pending
+
+
+def _fail_closed_live_state(sm: Any, pending: list[str]) -> bool:
+    """Route LIVE_ACTIVE -> OFF through the canonical FSM when proofs are lost."""
+    if _state_value(sm) != "LIVE_ACTIVE" or not pending:
+        return False
+
+    reason = "v133 current proof loss: " + ",".join(pending)
+    try:
+        tsm = importlib.import_module("bot.trading_state_machine")
+        trading_state = getattr(tsm, "TradingState")
+        sm.transition_to(trading_state.OFF, reason=reason)
+    except Exception as exc:
+        # Do not invent a secondary state mutation if the canonical transition
+        # fails.  Emit a hard diagnostic; existing dispatch gates still observe
+        # the revoked readiness table and false readiness env.
+        LOGGER.critical(
+            "POST_ACTIVATION_PROOF_LOSS_V133_TRANSITION_FAILED marker=%s pending=%s "
+            "err=%s:%s canonical_state_unchanged=true trading_fail_closed_requested=true",
+            MARKER,
+            pending,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+    LOGGER.critical(
+        "POST_ACTIVATION_PROOF_LOSS_V133_FAIL_CLOSED marker=%s pending=%s "
+        "transition=LIVE_ACTIVE->OFF execution_authority_revoked_by_fsm=true "
+        "dispatch_revoked_by_fsm=true reactivation_requires_canonical_commit=true",
+        MARKER,
+        pending,
+    )
+    return True
+
+
+def _truth_sync_v133(proofs: dict[str, bool]) -> tuple[bool, list[str]]:
+    table = importlib.import_module("bot.readiness_table")
+    before = dict(table.snapshot())
+    sm = _state_machine()
+    state_before = _state_value(sm)
+
+    after, pending = _revoke_false_readiness(proofs)
+    failed_closed = _fail_closed_live_state(sm, pending)
+    state_after = _state_value(sm)
+
+    LOGGER.critical(
+        "PREACTIVATION_READINESS_V133_TRUTH_SYNC marker=%s state_before=%s state_after=%s "
+        "before=%s after=%s pending=%s fail_closed_transition=%s",
+        MARKER,
+        state_before,
+        state_after,
+        before,
+        after,
+        pending,
+        str(failed_closed).lower(),
+    )
+    return (not pending), pending
+
+
+# Keep compatibility ownership markers so v132's durability watchdog does not
+# replace this stricter successor with the older pre-live-only function.
+_truth_sync_v133._nija_v61_truth_sync = True  # type: ignore[attr-defined]
+_truth_sync_v133._nija_v132_truth_sync = True  # type: ignore[attr-defined]
+_truth_sync_v133._nija_v133_truth_sync = True  # type: ignore[attr-defined]
+
+
+def _anchor_owner() -> bool:
+    v16 = importlib.import_module("preactivation_readiness_convergence_v16_patch")
+    v58 = importlib.import_module("bot.final_production_activation_repair_v58_patch")
+    v132 = importlib.import_module("bot.readiness_killswitch_durability_v132_patch")
+
+    # Replace every compatibility export that can be replayed later.
+    v132._durable_truth_sync = _truth_sync_v133
+    v58._incremental_mark_proven_readiness = _truth_sync_v133
+    v16._mark_proven_readiness = _truth_sync_v133
+
+    original_patch = getattr(v58, "_patch_readiness", None)
+    if callable(original_patch) and not getattr(original_patch, "_nija_v133_owner", False):
+        def patch_readiness_v133() -> bool:
+            v132._durable_truth_sync = _truth_sync_v133
+            v58._incremental_mark_proven_readiness = _truth_sync_v133
+            v16._mark_proven_readiness = _truth_sync_v133
+            LOGGER.critical(
+                "READINESS_V133_OWNER_REASSERTED marker=%s source=v58_patch_readiness "
+                "post_activation_fail_closed=true",
+                MARKER,
+            )
+            return True
+        patch_readiness_v133._nija_v133_owner = True  # type: ignore[attr-defined]
+        v58._patch_readiness = patch_readiness_v133
+
+    LOGGER.critical(
+        "READINESS_V133_OWNER_ANCHORED marker=%s v132_export_replaced=true "
+        "v58_export_replaced=true v16_owner=true post_activation_fail_closed=true",
+        MARKER,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["post_activation_proof_loss_v133"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+        try:
+            ok = _anchor_owner() and _patch_release_manifest()
+        except Exception as exc:
+            LOGGER.critical(
+                "POST_ACTIVATION_PROOF_LOSS_V133_INSTALL_FAILED marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "POST_ACTIVATION_PROOF_LOSS_V133_INSTALLED marker=%s release=%s "
+            "post_activation_false_proofs_revoke_readiness=true canonical_off_transition=true "
+            "kill_switch_unchanged=true seak_unchanged=true nonce_gates_unchanged=true "
+            "risk_gates_unchanged=true force_live=false",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_truth_sync_v133",
+    "_revoke_false_readiness",
+    "_fail_closed_live_state",
+    "_anchor_owner",
+]

--- a/bot/readiness_killswitch_durability_v132_patch.py
+++ b/bot/readiness_killswitch_durability_v132_patch.py
@@ -6,6 +6,10 @@ v132 addresses two observed post-startup regressions without weakening safety:
 2) the v130 stale-stop worker is startup-bounded, so a persisted restart-file
    record can re-surface the retired v128 heartbeat stop long after boot.
 
+v133 is chained from this canonical installer to revoke false current proofs and
+fail closed through the canonical TradingStateMachine if proof loss occurs after
+LIVE_ACTIVE.
+
 This patch never clears manual/UI/CLI stops, never clears a direct new heartbeat
 activation, never changes SEAK, nonce, risk, or execution authority, and never
 forces LIVE_ACTIVE.
@@ -85,9 +89,6 @@ def _anchor_readiness_owner() -> bool:
     v16 = importlib.import_module("preactivation_readiness_convergence_v16_patch")
     v58 = importlib.import_module("bot.final_production_activation_repair_v58_patch")
 
-    # Replace the exported v58 callable itself. If any later installer assigns
-    # v16._mark_proven_readiness = v58._incremental_mark_proven_readiness, it
-    # still lands on current-proof truth synchronization rather than sticky True.
     v58._incremental_mark_proven_readiness = _durable_truth_sync
     v16._mark_proven_readiness = _durable_truth_sync
 
@@ -187,6 +188,7 @@ def _durability_worker() -> None:
             if now - last_owner_check >= 5.0:
                 v16 = importlib.import_module("preactivation_readiness_convergence_v16_patch")
                 current = getattr(v16, "_mark_proven_readiness", None)
+                # v133 deliberately advertises v132 ownership compatibility.
                 if not getattr(current, "_nija_v132_truth_sync", False):
                     _anchor_readiness_owner()
                     LOGGER.critical(
@@ -209,15 +211,29 @@ def _patch_release_manifest() -> bool:
     if not isinstance(required, dict):
         return False
     required["readiness_killswitch_durability_v132"] = _FLAG
-    manifest.RELEASE_ID = RELEASE_ID
     return True
+
+
+def _install_v133_post_activation_guard() -> bool:
+    try:
+        from bot import post_activation_proof_loss_v133_patch as v133
+        installer = getattr(v133, "install", None)
+        if not callable(installer):
+            return False
+        return bool(installer())
+    except Exception as exc:
+        LOGGER.critical(
+            "POST_ACTIVATION_PROOF_LOSS_V133_CHAIN_FAILED marker=%s err=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc, exc_info=True,
+        )
+        return False
 
 
 def install() -> bool:
     global _INSTALLED
     with _LOCK:
         if _INSTALLED and os.environ.get(_FLAG) == "1":
-            return True
+            return _install_v133_post_activation_guard()
         try:
             ok = _anchor_readiness_owner() and _patch_release_manifest()
         except Exception as exc:
@@ -236,10 +252,14 @@ def install() -> bool:
             name="ReadinessKillSwitchDurabilityV132",
             daemon=True,
         ).start()
+        if not _install_v133_post_activation_guard():
+            os.environ.pop(_FLAG, None)
+            _INSTALLED = False
+            return False
         LOGGER.critical(
             "READINESS_KILLSWITCH_DURABILITY_V132_INSTALLED marker=%s release=%s "
             "generic_auto_clear=false direct_new_heartbeat_stops_preserved=true manual_stops_preserved=true "
-            "risk_gates_unchanged=true seak_unchanged=true execution_authority_unchanged=true",
+            "risk_gates_unchanged=true seak_unchanged=true execution_authority_unchanged=true v133_chained=true",
             MARKER, RELEASE_ID,
         )
         return True

--- a/bot/test_post_activation_proof_loss_v133.py
+++ b/bot/test_post_activation_proof_loss_v133.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import types
+
+from bot import post_activation_proof_loss_v133_patch as v133
+
+
+class _FakeTable:
+    def __init__(self):
+        self.state = {key: True for key in v133._CRITICAL_KEYS}
+
+    def mark_ready(self, key):
+        self.state[key] = True
+
+    def revoke_ready(self, key, reason=""):
+        self.state[key] = False
+
+    def snapshot(self):
+        return dict(self.state)
+
+
+class _FakeState:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeSM:
+    def __init__(self, value="LIVE_ACTIVE"):
+        self.value = value
+        self.transitions = []
+
+    def get_current_state(self):
+        return _FakeState(self.value)
+
+    def transition_to(self, new_state, reason=""):
+        self.transitions.append((getattr(new_state, "value", str(new_state)), reason))
+        self.value = getattr(new_state, "value", str(new_state))
+        return True
+
+
+def test_revoke_false_readiness_revokes_current_false_proofs(monkeypatch):
+    table = _FakeTable()
+    real_import = v133.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.readiness_table":
+            return table
+        return real_import(name)
+
+    monkeypatch.setattr(v133.importlib, "import_module", fake_import)
+    proofs = {key: True for key in v133._CRITICAL_KEYS}
+    proofs["broker_connected"] = False
+    proofs["balance_hydrated"] = False
+    proofs["capital_ready"] = False
+
+    after, pending = v133._revoke_false_readiness(proofs)
+
+    assert pending == ["broker_connected", "balance_hydrated", "capital_ready"]
+    assert after["broker_connected"] is False
+    assert after["balance_hydrated"] is False
+    assert after["capital_ready"] is False
+    assert after["authority_ready"] is True
+
+
+def test_live_proof_loss_routes_through_canonical_off_transition(monkeypatch):
+    sm = _FakeSM("LIVE_ACTIVE")
+    trading_state = types.SimpleNamespace(OFF=_FakeState("OFF"))
+    real_import = v133.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.trading_state_machine":
+            return types.SimpleNamespace(TradingState=trading_state)
+        return real_import(name)
+
+    monkeypatch.setattr(v133.importlib, "import_module", fake_import)
+
+    changed = v133._fail_closed_live_state(sm, ["capital_ready"])
+
+    assert changed is True
+    assert sm.value == "OFF"
+    assert sm.transitions == [("OFF", "v133 current proof loss: capital_ready")]
+
+
+def test_healthy_live_state_is_not_forced_off(monkeypatch):
+    sm = _FakeSM("LIVE_ACTIVE")
+    changed = v133._fail_closed_live_state(sm, [])
+    assert changed is False
+    assert sm.transitions == []
+
+
+def test_non_live_state_is_not_retransitioned(monkeypatch):
+    sm = _FakeSM("OFF")
+    changed = v133._fail_closed_live_state(sm, ["broker_connected"])
+    assert changed is False
+    assert sm.transitions == []
+
+
+def test_owner_markers_keep_v132_watchdog_from_downgrading_successor():
+    assert getattr(v133._truth_sync_v133, "_nija_v61_truth_sync", False) is True
+    assert getattr(v133._truth_sync_v133, "_nija_v132_truth_sync", False) is True
+    assert getattr(v133._truth_sync_v133, "_nija_v133_truth_sync", False) is True
+
+
+def test_source_contains_no_forced_live_or_safety_clear_bypass():
+    import inspect
+
+    source = inspect.getsource(v133)
+    forbidden = [
+        "force_activate_live(",
+        "force_live_active",
+        "clear_kill_switch",
+        "deactivate_kill_switch",
+        "resume_seak",
+        "clear_seak",
+    ]
+    for token in forbidden:
+        assert token not in source


### PR DESCRIPTION
## What changed
- add v133 post-activation proof-loss guard
- revoke readiness whenever current critical proofs are false, including after LIVE_ACTIVE
- route LIVE_ACTIVE -> OFF through the canonical TradingStateMachine when any critical proof is lost
- chain v133 from the existing v132 canonical installer
- preserve kill switch, SEAK, nonce, risk, and writer authority semantics
- add regression tests for live proof loss, healthy-live preservation, non-live behavior, and ownership compatibility

## Root cause
v132 intentionally revoked false proofs only before LIVE_ACTIVE. Production then showed broker_connected, balance_hydrated, and capital_ready false while the state remained LIVE_ACTIVE and the readiness table stayed green.

## Safety impact
The new guard does not fabricate readiness, clear any safety stop, grant execution authority, or force live trading. It uses the existing canonical OFF transition, which already clears activation commitment and dispatch authority. Recovery requires the normal activation path after proofs recover.

## Validation
Code-level regression tests were added. No GitHub CI statuses are configured on this repository, so no CI pass is claimed.