### PR TITLE
Fix readiness proof convergence and stale capital acceptance (v134)

### DIFF
--- a/bot/readiness_proof_convergence_v134_patch.py
+++ b/bot/readiness_proof_convergence_v134_patch.py
@@ -1,0 +1,329 @@
+"""Converge activation/readiness consumers on one current capital proof.
+
+v134 repairs two contradictory readiness paths exposed by production v133:
+
+* ``CapitalAuthority`` declares a 90-second canonical freshness TTL, but its
+  no-argument ``is_stale()`` method still defaulted to 60 seconds.  Consumers
+  using ``is_fresh()``/snapshot publication therefore disagreed with v16/v60
+  consumers using ``is_stale()``.
+* the activation monitor and v60 observational gate could treat historical
+  readiness latches/cached balances as current capital proof after the current
+  snapshot had become stale.
+
+Safety contract:
+- retain v133's fail-closed readiness revocation and LIVE_ACTIVE -> OFF path;
+- never fabricate capital, broker registration, or snapshot freshness;
+- never clear kill switch or SEAK and never grant writer/nonce authority;
+- never force LIVE_ACTIVE;
+- keep the existing short-lived v34 handoff only through v16's TTL-validated
+  proof collector; sticky env/latch state is not accepted independently.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from typing import Any
+
+LOGGER = logging.getLogger("nija.readiness_proof_convergence_v134")
+MARKER = "20260817-readiness-proof-convergence-v134"
+RELEASE_ID = "20260817-runtime-convergence-v134"
+_FLAG = "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _import_first(*names: str) -> Any:
+    last: BaseException | None = None
+    for name in names:
+        try:
+            return importlib.import_module(name)
+        except Exception as exc:  # pragma: no cover - diagnostic fallback
+            last = exc
+    if last is not None:
+        raise last
+    raise ImportError("no module names supplied")
+
+
+def _canonical_ttl_s() -> float:
+    """Return the CapitalAuthority lifecycle TTL used by publication/is_fresh."""
+    ca = _import_first("bot.capital_authority", "capital_authority")
+    try:
+        ttl = float(getattr(ca, "_DEFAULT_FRESHNESS_TTL_S", 90.0) or 90.0)
+    except (TypeError, ValueError, OverflowError):
+        ttl = 90.0
+    return max(1.0, ttl)
+
+
+def _patch_capital_authority_staleness_default() -> bool:
+    """Make no-argument is_stale() use the authority's canonical TTL.
+
+    Explicit TTL callers retain their exact requested threshold.  This changes
+    only the inconsistent legacy default and makes ``is_stale()`` agree with
+    ``is_fresh()`` and snapshot-publication expiry.
+    """
+    ca = _import_first("bot.capital_authority", "capital_authority")
+    cls = getattr(ca, "CapitalAuthority", None)
+    current = getattr(cls, "is_stale", None) if cls is not None else None
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_v134_canonical_ttl", False):
+        return True
+
+    original = current
+    canonical_ttl = _canonical_ttl_s()
+
+    def is_stale_v134(self: Any, ttl_s: float | None = None) -> bool:
+        effective = canonical_ttl if ttl_s is None else float(ttl_s)
+        return bool(original(self, ttl_s=effective))
+
+    is_stale_v134._nija_v134_canonical_ttl = True  # type: ignore[attr-defined]
+    is_stale_v134.__wrapped__ = original  # type: ignore[attr-defined]
+    cls.is_stale = is_stale_v134
+    LOGGER.critical(
+        "CAPITAL_STALENESS_DEFAULT_V134_CONVERGED marker=%s canonical_ttl_s=%.1f "
+        "explicit_ttl_preserved=true",
+        MARKER,
+        canonical_ttl,
+    )
+    return True
+
+
+def _current_capital_proof() -> dict[str, Any]:
+    """Read v16's current capital proof, including only its TTL-validated handoff."""
+    v16 = _import_first(
+        "preactivation_readiness_convergence_v16_patch",
+        "bot.preactivation_readiness_convergence_v16_patch",
+    )
+    reader = getattr(v16, "_capital_snapshot", None)
+    if not callable(reader):
+        raise RuntimeError("v16_capital_snapshot_unavailable")
+    proof = reader()
+    if not isinstance(proof, dict):
+        raise RuntimeError("v16_capital_snapshot_invalid")
+    return dict(proof)
+
+
+def _proof_fields(proof: dict[str, Any]) -> tuple[bool, bool, float, int]:
+    hydrated = bool(proof.get("hydrated", False))
+    stale = bool(proof.get("stale", True))
+    try:
+        real = float(proof.get("real", 0.0) or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        real = 0.0
+    try:
+        registered = int(float(proof.get("registered", 0) or 0))
+    except (TypeError, ValueError, OverflowError):
+        registered = 0
+    return hydrated, stale, real, registered
+
+
+def _current_capital_accepted(proof: dict[str, Any]) -> bool:
+    hydrated, stale, real, registered = _proof_fields(proof)
+    return bool(hydrated and not stale and real > 0.0 and registered > 0)
+
+
+def _patch_activation_monitor() -> bool:
+    """Reject sticky historical snapshot latches and un-aged broker caches."""
+    monitor = _import_first(
+        "bot.activation_pending_commit_monitor_patch",
+        "activation_pending_commit_monitor_patch",
+    )
+    current = getattr(monitor, "_capital_ready_snapshot", None)
+    if callable(current) and getattr(current, "_nija_v134_current_proof", False):
+        return True
+    if not callable(current):
+        return False
+    original = current
+
+    def capital_ready_snapshot_v134() -> tuple[bool, dict[str, Any]]:
+        try:
+            proof = _current_capital_proof()
+            hydrated, stale, real, registered = _proof_fields(proof)
+            accepted = _current_capital_accepted(proof)
+            source = str(proof.get("source", "v16_current_capital") or "v16_current_capital")
+            reason = "ok" if accepted else "current_snapshot_not_accepted"
+            meta = {
+                "hydrated": hydrated,
+                "real_capital": real,
+                "stale": stale,
+                "registered_brokers": registered,
+                # Compatibility field only.  It now reflects current proof and
+                # is never read from CapitalAuthority's historical first latch.
+                "accepted_latch": accepted,
+                "reason": reason,
+                "source": source,
+                "current_proof": True,
+            }
+            LOGGER.info(
+                "ACTIVATION_CAPITAL_PROOF_V134 marker=%s accepted=%s hydrated=%s "
+                "stale=%s real=%.2f registered=%d source=%s sticky_latch_used=false "
+                "unaged_cache_used=false",
+                MARKER,
+                accepted,
+                hydrated,
+                stale,
+                real,
+                registered,
+                source,
+            )
+            return accepted, meta
+        except Exception as exc:
+            LOGGER.critical(
+                "ACTIVATION_CAPITAL_PROOF_V134_FAILED marker=%s err=%s:%s "
+                "accepted=false trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return False, {
+                "hydrated": False,
+                "real_capital": 0.0,
+                "stale": True,
+                "registered_brokers": 0,
+                "accepted_latch": False,
+                "reason": f"current_proof_error:{type(exc).__name__}:{exc}",
+                "source": "v134_fail_closed",
+                "current_proof": True,
+            }
+
+    capital_ready_snapshot_v134._nija_v134_current_proof = True  # type: ignore[attr-defined]
+    capital_ready_snapshot_v134.__wrapped__ = original  # type: ignore[attr-defined]
+    monitor._capital_ready_snapshot = capital_ready_snapshot_v134
+    LOGGER.critical(
+        "ACTIVATION_MONITOR_V134_CONVERGED marker=%s current_v16_proof=true "
+        "sticky_first_snapshot_latch=false unaged_broker_cache_fallback=false",
+        MARKER,
+    )
+    return True
+
+
+def _install_v60_observer() -> bool:
+    """Install the v60 observational gate from the same current proof source."""
+    v60 = _import_first(
+        "bot.final_production_activation_repair_v60_patch",
+        "final_production_activation_repair_v60_patch",
+    )
+    tsm = _import_first("bot.trading_state_machine", "trading_state_machine")
+    current_gate = getattr(tsm, "_capital_readiness_gate", None)
+    if not callable(current_gate):
+        return False
+    original_gate = getattr(current_gate, "__wrapped__", current_gate)
+
+    def observational_gate_v134() -> tuple[bool, str]:
+        try:
+            proof = _current_capital_proof()
+            hydrated, stale, real, registered = _proof_fields(proof)
+            source = str(proof.get("source", "v16_current_capital") or "v16_current_capital")
+        except Exception as exc:
+            return False, f"CA_READY=false: current_proof_error:{type(exc).__name__}:{exc}"
+        LOGGER.info(
+            "CAPITAL_READINESS_OBSERVATIONAL_V134 marker=%s hydrated=%s stale=%s "
+            "real=%.2f registered=%d source=%s private_io=false sticky_handoff=false",
+            MARKER,
+            hydrated,
+            stale,
+            real,
+            registered,
+            source,
+        )
+        if not hydrated:
+            return False, "CA_READY=false: capital_authority_not_hydrated"
+        if stale:
+            return False, "CA_READY=false: capital_authority_stale"
+        if real <= 0.0:
+            return False, "CA_READY=false: real_capital_nonpositive"
+        if registered <= 0:
+            return False, "CA_READY=false: no_registered_capital_broker"
+        return True, "ok"
+
+    observational_gate_v134._nija_v60_observational = True  # type: ignore[attr-defined]
+    observational_gate_v134._nija_v134_current_proof = True  # type: ignore[attr-defined]
+    observational_gate_v134.__wrapped__ = original_gate  # type: ignore[attr-defined]
+
+    def patch_capital_readiness_observer_v134() -> bool:
+        tsm._capital_readiness_gate = observational_gate_v134
+        return True
+
+    patch_capital_readiness_observer_v134._nija_v134_owner = True  # type: ignore[attr-defined]
+    v60._patch_capital_readiness_observer = patch_capital_readiness_observer_v134
+    tsm._capital_readiness_gate = observational_gate_v134
+    LOGGER.critical(
+        "FINAL_ACTIVATION_V60_CAPITAL_GATE_V134_CONVERGED marker=%s "
+        "current_v16_proof=true sticky_handoff=false private_io=false",
+        MARKER,
+    )
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = _import_first("bot.runtime_release_manifest_patch", "runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["readiness_proof_convergence_v134"] = _FLAG
+    manifest.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            # Reassert the two function owners because older convergence layers
+            # can replay their installers during long-running processes.
+            try:
+                return bool(_patch_activation_monitor() and _install_v60_observer())
+            except Exception:
+                return False
+        try:
+            ok = bool(
+                _patch_capital_authority_staleness_default()
+                and _patch_activation_monitor()
+                and _install_v60_observer()
+                and _patch_release_manifest()
+            )
+        except Exception as exc:
+            LOGGER.critical(
+                "READINESS_PROOF_CONVERGENCE_V134_INSTALL_FAILED marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "READINESS_PROOF_CONVERGENCE_V134_INSTALLED marker=%s release=%s "
+            "canonical_stale_ttl=true current_proof_single_source=true "
+            "sticky_latch_acceptance=false unaged_cache_acceptance=false "
+            "kill_switch_unchanged=true seak_unchanged=true nonce_gates_unchanged=true "
+            "risk_gates_unchanged=true force_live=false",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_canonical_ttl_s",
+    "_current_capital_proof",
+    "_current_capital_accepted",
+    "_patch_capital_authority_staleness_default",
+    "_patch_activation_monitor",
+    "_install_v60_observer",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,7 +10,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260716-runtime-convergence-v14"
+RELEASE_ID = "20260817-runtime-convergence-v134"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -47,6 +47,10 @@ _INSTALLERS = (
     ("bot.kraken_exit_only_recovery_phase_guard_patch", "install_import_hook"),
     ("bot.kraken_profit_realization_guard_patch", "install_import_hook"),
     ("bot.coinbase_pem_quarantine_patch", "install_import_hook"),
+    # Must run after v133 and the activation/readiness modules it converges.
+    # The installer is idempotent and reasserts ownership if older convergence
+    # layers replay later in a long-running process.
+    ("bot.readiness_proof_convergence_v134_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -75,6 +79,7 @@ _REQUIRED_FLAGS = {
     "kraken_synthetic_equity_scrub": "NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED",
     "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
     "profit_realization_guard": "NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED",
+    "readiness_proof_convergence_v134": "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED",
 }
 
 

--- a/tests/test_readiness_proof_convergence_v134.py
+++ b/tests/test_readiness_proof_convergence_v134.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from bot import readiness_proof_convergence_v134_patch as v134
+
+
+def test_current_capital_accepted_requires_all_current_facts() -> None:
+    assert v134._current_capital_accepted(
+        {"hydrated": True, "stale": False, "real": 100.0, "registered": 1}
+    )
+    assert not v134._current_capital_accepted(
+        {"hydrated": True, "stale": True, "real": 100.0, "registered": 1}
+    )
+    assert not v134._current_capital_accepted(
+        {"hydrated": True, "stale": False, "real": 0.0, "registered": 1}
+    )
+    assert not v134._current_capital_accepted(
+        {"hydrated": True, "stale": False, "real": 100.0, "registered": 0}
+    )
+
+
+def test_capital_authority_no_arg_staleness_uses_canonical_90s_ttl(monkeypatch) -> None:
+    calls: list[float] = []
+
+    class FakeCapitalAuthority:
+        def is_stale(self, ttl_s: float = 60.0) -> bool:
+            calls.append(float(ttl_s))
+            return ttl_s < 80.0
+
+    fake = types.ModuleType("bot.capital_authority")
+    fake.CapitalAuthority = FakeCapitalAuthority
+    fake._DEFAULT_FRESHNESS_TTL_S = 90.0
+    monkeypatch.setitem(sys.modules, "bot.capital_authority", fake)
+
+    assert v134._patch_capital_authority_staleness_default()
+    authority = FakeCapitalAuthority()
+
+    # No-argument consumers now agree with CapitalAuthority.is_fresh() and
+    # snapshot publication, both of which use the canonical 90-second TTL.
+    assert authority.is_stale() is False
+    assert calls[-1] == 90.0
+
+    # Explicit thresholds remain exact and are not silently broadened.
+    assert authority.is_stale(ttl_s=12.0) is True
+    assert calls[-1] == 12.0
+
+
+def _install_fake_current_proof_modules(monkeypatch, proof: dict[str, object]) -> types.ModuleType:
+    v16 = types.ModuleType("preactivation_readiness_convergence_v16_patch")
+    v16._capital_snapshot = lambda: dict(proof)
+    monkeypatch.setitem(sys.modules, "preactivation_readiness_convergence_v16_patch", v16)
+
+    monitor = types.ModuleType("bot.activation_pending_commit_monitor_patch")
+    monitor._capital_ready_snapshot = lambda: (
+        True,
+        {
+            "reason": "legacy_sticky_acceptance",
+            "accepted_latch": True,
+            "stale": True,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "bot.activation_pending_commit_monitor_patch", monitor)
+    return monitor
+
+
+def test_activation_monitor_rejects_stale_current_proof_even_if_legacy_latch_was_true(monkeypatch) -> None:
+    monitor = _install_fake_current_proof_modules(
+        monkeypatch,
+        {
+            "hydrated": True,
+            "stale": True,
+            "real": 468.25,
+            "registered": 3,
+            "source": "capital_authority",
+        },
+    )
+
+    assert v134._patch_activation_monitor()
+    accepted, meta = monitor._capital_ready_snapshot()
+
+    assert accepted is False
+    assert meta["stale"] is True
+    assert meta["accepted_latch"] is False
+    assert meta["reason"] == "current_snapshot_not_accepted"
+    assert meta["current_proof"] is True
+
+
+def test_activation_monitor_accepts_fresh_funded_registered_current_proof(monkeypatch) -> None:
+    monitor = _install_fake_current_proof_modules(
+        monkeypatch,
+        {
+            "hydrated": True,
+            "stale": False,
+            "real": 468.25,
+            "registered": 3,
+            "source": "capital_authority",
+        },
+    )
+
+    assert v134._patch_activation_monitor()
+    accepted, meta = monitor._capital_ready_snapshot()
+
+    assert accepted is True
+    assert meta["hydrated"] is True
+    assert meta["stale"] is False
+    assert meta["real_capital"] == 468.25
+    assert meta["registered_brokers"] == 3
+    assert meta["accepted_latch"] is True
+    assert meta["current_proof"] is True
+
+
+def test_activation_monitor_fails_closed_when_current_proof_reader_errors(monkeypatch) -> None:
+    v16 = types.ModuleType("preactivation_readiness_convergence_v16_patch")
+
+    def broken_snapshot():
+        raise RuntimeError("boom")
+
+    v16._capital_snapshot = broken_snapshot
+    monkeypatch.setitem(sys.modules, "preactivation_readiness_convergence_v16_patch", v16)
+
+    monitor = types.ModuleType("bot.activation_pending_commit_monitor_patch")
+    monitor._capital_ready_snapshot = lambda: (True, {"accepted_latch": True})
+    monkeypatch.setitem(sys.modules, "bot.activation_pending_commit_monitor_patch", monitor)
+
+    assert v134._patch_activation_monitor()
+    accepted, meta = monitor._capital_ready_snapshot()
+
+    assert accepted is False
+    assert meta["hydrated"] is False
+    assert meta["stale"] is True
+    assert meta["registered_brokers"] == 0
+    assert meta["accepted_latch"] is False
+    assert meta["reason"].startswith("current_proof_error:RuntimeError:boom")


### PR DESCRIPTION
## Summary

Production v133 repeatedly revokes `broker_connected`, `balance_hydrated`, and `capital_ready` while writer/core/nonce/risk readiness remains healthy. This PR converges the activation stack on one current capital proof instead of allowing conflicting freshness and sticky-latch semantics.

### Fixes

- Align no-argument `CapitalAuthority.is_stale()` with the authority's canonical 90-second freshness TTL used by `is_fresh()` and snapshot publication expiry. Explicit caller TTLs remain unchanged.
- Make activation pending commit consume the same current v16 capital proof used by readiness reconstruction.
- Stop treating historical `first_snap_accepted` state as current capital proof.
- Stop treating un-aged cached broker-manager balances as a current activation proof fallback.
- Replace v60's sticky handoff shortcut with the same TTL-validated current proof source.
- Wire v134 into the runtime release manifest and require its installed flag.
- Preserve v133 fail-closed revocation, canonical LIVE_ACTIVE -> OFF behavior, kill switch, SEAK, nonce, risk, broker isolation, and normal activation commit semantics. No force-live path is added.

## Regression coverage

Adds focused tests for fresh/funded/registered current proof acceptance, stale proof rejection despite historical latch state, zero-capital/zero-broker rejection, proof-reader failure, and canonical 90-second no-argument staleness while preserving explicit TTLs.

## Validation

The branch is exactly 3 commits ahead of deployed/main SHA `386b8460320b3d6eb087d86a4817f1dcf27b9d19` with only the v134 patch, release-manifest wiring, and regression tests changed. Preflight/lint and imports smoke test passed on the identical head SHA. The prior draft PR was replaced solely because repository branch policy requires an allowed prefix; this branch uses `fix/*`.

The local execution sandbox cannot resolve `github.com`, so repository CI is the executable validation path.