### PR TITLE
Fix protected-stop authority and capital freshness liveness (v135)

### DIFF
--- a/bot/activation_stop_capital_freshness_v135_patch.py
+++ b/bot/activation_stop_capital_freshness_v135_patch.py
@@ -1,0 +1,378 @@
+"""Protected-stop authority and capital freshness convergence v135.
+
+Production v134 proved that current capital/readiness proof convergence is
+working, but two remaining contradictions can still make runtime truth oscillate:
+
+* ``trading_state_machine._is_authority_ready`` may bootstrap
+  ``authority_ready=True`` from writer proof alone while the kill switch is
+  active.  v16/v133 correctly revoke that same proof because protected stops are
+  part of authority readiness.
+* ``CapitalAuthority.get_snapshot_publication_status`` returns the publication
+  object captured at publish time.  Once its expiry passes, callers can observe
+  ``is_fresh=False`` together with ``publication.stale=False``.
+
+This patch makes those readers agree without clearing a kill switch, extending
+capital freshness, granting nonce/execution authority, or forcing LIVE_ACTIVE.
+It also makes the existing v78 freshness-bounded refresh patch a hard runtime
+release dependency so slow venue reads cannot monopolize a refresh past the
+canonical capital TTL.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from functools import wraps
+from types import ModuleType
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.activation_stop_capital_freshness_v135")
+MARKER = "20260817-activation-stop-capital-freshness-v135"
+RELEASE_ID = "20260817-runtime-convergence-v135"
+_FLAG = "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED"
+_LOCK = threading.RLock()
+_MONITOR_STARTED = False
+_LAST_BLOCK_SIGNATURE = ""
+
+
+def _kill_switch_state(tsm: ModuleType) -> tuple[Optional[bool], str]:
+    """Return the current kill-switch state, failing closed on probe errors."""
+    probe = getattr(tsm, "_kill_switch_is_active", None)
+    if callable(probe):
+        try:
+            active, detail = probe()
+            if active is None:
+                return None, str(detail or "kill_switch_state_unknown")
+            return bool(active), str(detail or "")
+        except Exception as exc:
+            return None, f"kill_switch_probe_failed:{type(exc).__name__}:{exc}"
+    try:
+        try:
+            module = importlib.import_module("bot.kill_switch")
+        except Exception:
+            module = importlib.import_module("kill_switch")
+        return bool(module.get_kill_switch().is_active()), ""
+    except Exception as exc:
+        return None, f"kill_switch_probe_failed:{type(exc).__name__}:{exc}"
+
+
+def _revoke_authority(reason: str) -> None:
+    """Publish fail-closed authority truth without touching nonce readiness."""
+    os.environ["NIJA_AUTHORITY_READY"] = "0"
+    try:
+        try:
+            table = importlib.import_module("bot.readiness_table")
+        except Exception:
+            table = importlib.import_module("readiness_table")
+        revoke = getattr(table, "revoke_ready", None)
+        if callable(revoke):
+            revoke("authority_ready", reason=reason)
+    except Exception as exc:
+        LOGGER.warning(
+            "AUTHORITY_V135_REVOKE_PUBLISH_FAILED marker=%s reason=%s err=%s:%s",
+            MARKER,
+            reason,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def _log_authority_block(reason: str, detail: str) -> None:
+    global _LAST_BLOCK_SIGNATURE
+    signature = f"{reason}:{detail}"
+    with _LOCK:
+        if signature == _LAST_BLOCK_SIGNATURE:
+            return
+        _LAST_BLOCK_SIGNATURE = signature
+    LOGGER.critical(
+        "AUTHORITY_V135_PROTECTED_STOP_BLOCK marker=%s reason=%s detail=%s "
+        "writer_nonce_unchanged=true execution_authority_unchanged=true kill_switch_unchanged=true",
+        MARKER,
+        reason,
+        detail or "none",
+    )
+
+
+def _patch_tsm_authority(tsm: ModuleType) -> bool:
+    """Prevent writer-only bootstrap from contradicting an active/unknown stop."""
+    current = getattr(tsm, "_is_authority_ready", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_v135_kill_switch_scoped", False):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def authority_ready_v135() -> bool:
+        active, detail = _kill_switch_state(tsm)
+        if active is not False:
+            reason = (
+                "v135_kill_switch_active"
+                if active is True
+                else "v135_kill_switch_state_unknown"
+            )
+            _revoke_authority(reason)
+            _log_authority_block(reason, detail)
+            return False
+        return bool(original())
+
+    setattr(authority_ready_v135, "_nija_v135_kill_switch_scoped", True)
+    setattr(authority_ready_v135, "_nija_v135_original", original)
+    tsm._is_authority_ready = authority_ready_v135
+    LOGGER.critical(
+        "AUTHORITY_V135_TSM_PATCHED marker=%s module=%s "
+        "protected_stop_blocks_bootstrap=true fail_closed_unknown=true",
+        MARKER,
+        getattr(tsm, "__name__", "unknown"),
+    )
+    return True
+
+
+def _ensure_aware_utc(value: Any) -> Any:
+    if value is None or not isinstance(value, datetime):
+        return value
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _status_with_runtime_expiry(
+    status: Any,
+    status_type: Any,
+    *,
+    now: Optional[datetime] = None,
+) -> Any:
+    """Return *status* with stale=True once its immutable expiry has passed."""
+    if status is None or bool(getattr(status, "stale", True)):
+        return status
+    expiry = _ensure_aware_utc(getattr(status, "expiry", None))
+    if not isinstance(expiry, datetime):
+        return status
+    current = _ensure_aware_utc(now or datetime.now(timezone.utc))
+    if current < expiry:
+        return status
+
+    accepted = bool(getattr(status, "accepted", False))
+    prior_reason = str(getattr(status, "reason", "") or "").strip()
+    reason = "expired_after_publish" if accepted else prior_reason or "publication_expired"
+    try:
+        return status_type(
+            accepted=accepted,
+            stale=True,
+            reason=reason,
+            timestamp=getattr(status, "timestamp", None),
+            expiry=getattr(status, "expiry", None),
+        )
+    except Exception:
+        return status
+
+
+def _status_dict(status: Any) -> dict[str, Any]:
+    def _iso(value: Any) -> Any:
+        return value.isoformat() if isinstance(value, datetime) else value
+
+    return {
+        "accepted": bool(getattr(status, "accepted", False)),
+        "stale": bool(getattr(status, "stale", True)),
+        "reason": str(getattr(status, "reason", "") or ""),
+        "timestamp": _iso(getattr(status, "timestamp", None)),
+        "expiry": _iso(getattr(status, "expiry", None)),
+    }
+
+
+def _patch_capital_publication_status(module: ModuleType) -> bool:
+    """Make publication status and diagnostics honor elapsed expiry at read time."""
+    cls = getattr(module, "CapitalAuthority", None)
+    status_type = getattr(module, "SnapshotPublicationStatus", None)
+    if not isinstance(cls, type) or status_type is None:
+        return False
+
+    current_status = getattr(cls, "get_snapshot_publication_status", None)
+    if not callable(current_status):
+        return False
+    if not getattr(current_status, "_nija_v135_runtime_expiry", False):
+        original_status = current_status
+
+        @wraps(original_status)
+        def get_status_v135(self: Any) -> Any:
+            status = original_status(self)
+            return _status_with_runtime_expiry(status, status_type)
+
+        setattr(get_status_v135, "_nija_v135_runtime_expiry", True)
+        setattr(get_status_v135, "_nija_v135_original", original_status)
+        cls.get_snapshot_publication_status = get_status_v135
+
+    current_snapshot = getattr(cls, "get_snapshot", None)
+    if callable(current_snapshot) and not getattr(
+        current_snapshot, "_nija_v135_runtime_expiry", False
+    ):
+        original_snapshot = current_snapshot
+
+        @wraps(original_snapshot)
+        def get_snapshot_v135(self: Any) -> dict[str, Any]:
+            result = dict(original_snapshot(self))
+            try:
+                status = self.get_snapshot_publication_status()
+                # Keep the existing diagnostics key synchronized with the
+                # canonical getter.  Do not alter capital values or freshness.
+                if "snapshot_publication" in result:
+                    result["snapshot_publication"] = _status_dict(status)
+            except Exception:
+                pass
+            return result
+
+        setattr(get_snapshot_v135, "_nija_v135_runtime_expiry", True)
+        setattr(get_snapshot_v135, "_nija_v135_original", original_snapshot)
+        cls.get_snapshot = get_snapshot_v135
+
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_EXPIRY_V135_CONVERGED marker=%s module=%s "
+        "runtime_expiry_authoritative=true freshness_extended=false",
+        MARKER,
+        getattr(module, "__name__", "unknown"),
+    )
+    return True
+
+
+def _install_v78() -> bool:
+    """Install the existing freshness-bounded capital refresh continuity patch."""
+    try:
+        module = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
+        if not callable(installer) or not bool(installer()):
+            return False
+        return os.environ.get("NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED") == "1"
+    except Exception as exc:
+        LOGGER.critical(
+            "CAPITAL_REFRESH_V78_REQUIRED_INSTALL_FAILED marker=%s err=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["capital_refresh_live_continuity_v78"] = (
+            "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"
+        )
+        required["activation_stop_capital_freshness_v135"] = _FLAG
+        manifest.RELEASE_ID = RELEASE_ID
+        return True
+    except Exception:
+        return False
+
+
+def _patch_loaded_targets() -> tuple[bool, bool]:
+    authority_ok = False
+    capital_ok = False
+    seen_tsm: set[int] = set()
+    for name in ("bot.trading_state_machine", "trading_state_machine"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen_tsm:
+            seen_tsm.add(id(module))
+            authority_ok = _patch_tsm_authority(module) or authority_ok
+    if not authority_ok:
+        try:
+            authority_ok = _patch_tsm_authority(importlib.import_module("bot.trading_state_machine"))
+        except Exception:
+            authority_ok = False
+
+    seen_ca: set[int] = set()
+    for name in ("bot.capital_authority", "capital_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen_ca:
+            seen_ca.add(id(module))
+            capital_ok = _patch_capital_publication_status(module) or capital_ok
+    if not capital_ok:
+        try:
+            capital_ok = _patch_capital_publication_status(importlib.import_module("bot.capital_authority"))
+        except Exception:
+            capital_ok = False
+    return authority_ok, capital_ok
+
+
+def _monitor() -> None:
+    while True:
+        try:
+            authority_ok, capital_ok = _patch_loaded_targets()
+            if not authority_ok or not capital_ok:
+                LOGGER.warning(
+                    "V135_OWNER_REASSERT_PENDING marker=%s authority=%s capital=%s fail_closed=true",
+                    MARKER,
+                    authority_ok,
+                    capital_ok,
+                )
+        except Exception as exc:
+            LOGGER.warning(
+                "V135_OWNER_REASSERT_ERROR marker=%s err=%s:%s fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(5.0)
+
+
+def install() -> bool:
+    global _MONITOR_STARTED
+    with _LOCK:
+        v78_ok = _install_v78()
+        authority_ok, capital_ok = _patch_loaded_targets()
+        manifest_ok = _patch_release_manifest()
+        ok = bool(v78_ok and authority_ok and capital_ok and manifest_ok)
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            LOGGER.critical(
+                "ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALL_FAILED marker=%s "
+                "v78=%s authority=%s capital=%s manifest=%s trading_fail_closed=true",
+                MARKER,
+                v78_ok,
+                authority_ok,
+                capital_ok,
+                manifest_ok,
+            )
+            return False
+        os.environ[_FLAG] = "1"
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_monitor,
+                name="ActivationStopCapitalFreshnessV135",
+                daemon=True,
+            ).start()
+        LOGGER.critical(
+            "ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED marker=%s release=%s "
+            "v78_required=true protected_stop_authority=true publication_expiry_dynamic=true "
+            "kill_switch_unchanged=true nonce_unchanged=true execution_authority_unchanged=true "
+            "force_live=false",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_kill_switch_state",
+    "_patch_tsm_authority",
+    "_status_with_runtime_expiry",
+    "_patch_capital_publication_status",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,7 +10,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260817-runtime-convergence-v134"
+RELEASE_ID = "20260817-runtime-convergence-v135"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -47,10 +47,18 @@ _INSTALLERS = (
     ("bot.kraken_exit_only_recovery_phase_guard_patch", "install_import_hook"),
     ("bot.kraken_profit_realization_guard_patch", "install_import_hook"),
     ("bot.coinbase_pem_quarantine_patch", "install_import_hook"),
+    # v78 bounds synchronous balance-fetch waits inside the canonical 90-second
+    # capital freshness contract. It is safe and idempotent, and does not extend
+    # stale fallback age or broker timeouts.
+    ("bot.capital_refresh_live_continuity_v78_patch", "install_import_hook"),
     # Must run after v133 and the activation/readiness modules it converges.
     # The installer is idempotent and reasserts ownership if older convergence
     # layers replay later in a long-running process.
     ("bot.readiness_proof_convergence_v134_patch", "install_import_hook"),
+    # v135 prevents writer-only authority bootstrap under a protected stop and
+    # makes publication expiry authoritative at read time. It also reasserts
+    # the v78 dependency for long-running processes.
+    ("bot.activation_stop_capital_freshness_v135_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -79,7 +87,9 @@ _REQUIRED_FLAGS = {
     "kraken_synthetic_equity_scrub": "NIJA_KRAKEN_SYNTHETIC_EQUITY_SCRUB_INSTALLED",
     "kraken_exit_only_recovery_guard": "NIJA_KRAKEN_EXIT_ONLY_RECOVERY_PHASE_GUARD_INSTALLED",
     "profit_realization_guard": "NIJA_KRAKEN_PROFIT_REALIZATION_GUARD_INSTALLED",
+    "capital_refresh_live_continuity_v78": "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED",
     "readiness_proof_convergence_v134": "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED",
+    "activation_stop_capital_freshness_v135": "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED",
 }
 
 

--- a/tests/test_activation_stop_capital_freshness_v135.py
+++ b/tests/test_activation_stop_capital_freshness_v135.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from bot import activation_stop_capital_freshness_v135_patch as v135
+
+
+@dataclass(frozen=True)
+class FakeStatus:
+    accepted: bool
+    stale: bool
+    reason: str
+    timestamp: datetime | None
+    expiry: datetime | None
+
+
+def test_publication_status_turns_stale_after_immutable_expiry() -> None:
+    now = datetime(2026, 8, 17, 19, 27, 30, tzinfo=timezone.utc)
+    status = FakeStatus(
+        accepted=True,
+        stale=False,
+        reason="accepted",
+        timestamp=now - timedelta(minutes=6),
+        expiry=now - timedelta(minutes=4),
+    )
+
+    converged = v135._status_with_runtime_expiry(status, FakeStatus, now=now)
+
+    assert converged.accepted is True
+    assert converged.stale is True
+    assert converged.reason == "expired_after_publish"
+    assert converged.timestamp == status.timestamp
+    assert converged.expiry == status.expiry
+
+
+def test_publication_status_remains_fresh_before_expiry() -> None:
+    now = datetime(2026, 8, 17, 19, 20, 0, tzinfo=timezone.utc)
+    status = FakeStatus(
+        accepted=True,
+        stale=False,
+        reason="accepted",
+        timestamp=now - timedelta(seconds=10),
+        expiry=now + timedelta(seconds=80),
+    )
+
+    assert v135._status_with_runtime_expiry(status, FakeStatus, now=now) is status
+
+
+def test_publication_status_does_not_unstale_rejected_snapshot() -> None:
+    now = datetime(2026, 8, 17, 19, 20, 0, tzinfo=timezone.utc)
+    status = FakeStatus(
+        accepted=False,
+        stale=True,
+        reason="snapshot_not_newer",
+        timestamp=now - timedelta(seconds=20),
+        expiry=now + timedelta(seconds=70),
+    )
+
+    assert v135._status_with_runtime_expiry(status, FakeStatus, now=now) is status
+
+
+def _fake_tsm(active, original_result: bool = True) -> tuple[types.ModuleType, list[str], list[str]]:
+    module = types.ModuleType("bot.trading_state_machine")
+    original_calls: list[str] = []
+    revocations: list[str] = []
+
+    def original() -> bool:
+        original_calls.append("called")
+        return original_result
+
+    module._is_authority_ready = original
+    module._kill_switch_is_active = lambda: (active, "test_stop")
+    return module, original_calls, revocations
+
+
+def test_active_kill_switch_blocks_writer_only_authority_bootstrap(monkeypatch) -> None:
+    tsm, original_calls, revocations = _fake_tsm(True)
+    monkeypatch.setattr(v135, "_revoke_authority", revocations.append)
+
+    assert v135._patch_tsm_authority(tsm)
+    assert tsm._is_authority_ready() is False
+    assert original_calls == []
+    assert revocations == ["v135_kill_switch_active"]
+
+
+def test_unknown_kill_switch_state_fails_closed(monkeypatch) -> None:
+    tsm, original_calls, revocations = _fake_tsm(None)
+    monkeypatch.setattr(v135, "_revoke_authority", revocations.append)
+
+    assert v135._patch_tsm_authority(tsm)
+    assert tsm._is_authority_ready() is False
+    assert original_calls == []
+    assert revocations == ["v135_kill_switch_state_unknown"]
+
+
+def test_clear_kill_switch_delegates_to_existing_authority_proof(monkeypatch) -> None:
+    tsm, original_calls, revocations = _fake_tsm(False, original_result=True)
+    monkeypatch.setattr(v135, "_revoke_authority", revocations.append)
+
+    assert v135._patch_tsm_authority(tsm)
+    assert tsm._is_authority_ready() is True
+    assert original_calls == ["called"]
+    assert revocations == []
+
+
+def test_protected_stop_patch_does_not_mutate_nonce_or_execution_env(monkeypatch) -> None:
+    tsm, _, revocations = _fake_tsm(True)
+    monkeypatch.setattr(v135, "_revoke_authority", revocations.append)
+    monkeypatch.setenv("NIJA_NONCE_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_NONCE_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+
+    assert v135._patch_tsm_authority(tsm)
+    assert tsm._is_authority_ready() is False
+    assert os.environ["NIJA_NONCE_READY"] == "1"
+    assert os.environ["NIJA_RUNTIME_NONCE_READY"] == "1"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+
+
+def test_v78_is_required_and_installed_fail_closed(monkeypatch) -> None:
+    fake = types.ModuleType("bot.capital_refresh_live_continuity_v78_patch")
+
+    def install_import_hook() -> bool:
+        os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] = "1"
+        return True
+
+    fake.install_import_hook = install_import_hook
+    monkeypatch.setitem(sys.modules, "bot.capital_refresh_live_continuity_v78_patch", fake)
+    monkeypatch.delenv("NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED", raising=False)
+
+    assert v135._install_v78() is True
+    assert os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] == "1"
+
+
+def test_release_manifest_statically_wires_v78_and_v135() -> None:
+    from bot import runtime_release_manifest_patch as manifest
+
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v135"
+    assert (
+        "bot.capital_refresh_live_continuity_v78_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+    assert (
+        "bot.activation_stop_capital_freshness_v135_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+    assert manifest._REQUIRED_FLAGS["capital_refresh_live_continuity_v78"] == (
+        "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["activation_stop_capital_freshness_v135"] == (
+        "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED"
+    )


### PR DESCRIPTION
## Summary

Production v134 is deployed and its current-proof convergence is working, but the latest runtime evidence exposed two remaining truth/liveness contradictions plus one release-chain gap.

### Fixes

- Prevent `TradingStateMachine`'s writer-only authority bootstrap from publishing `authority_ready=True` while the kill switch is active or its state cannot be verified.
- Preserve nonce/writer state while revoking only the contradictory authority readiness publication; no kill-switch clearing or execution grant is introduced.
- Make `CapitalAuthority.get_snapshot_publication_status()` re-evaluate immutable publication expiry at read time so an expired accepted snapshot reports `stale=True` instead of remaining frozen at its publish-time `stale=False` value.
- Keep `get_snapshot()` diagnostics synchronized with the canonical dynamic publication status.
- Make the existing v78 freshness-bounded capital refresh continuity patch an explicit runtime-release installer and required flag. This keeps synchronous broker waits inside the canonical capital freshness window without extending stale fallback or broker timeouts.
- Advance the runtime manifest to `20260817-runtime-convergence-v135` and require the v135 installed flag.
- Reassert v135 ownership during long-running patch churn.

## Safety

This patch does **not** clear manual/UI/CLI/file-system protected kill switches, force `LIVE_ACTIVE`, change SEAK, grant nonce or execution authority, broaden capital TTLs, treat stale data as fresh, or promote user-account connectivity into platform readiness. Existing v133 fail-closed revocation remains authoritative.

## Regression coverage

Adds tests for:

- active kill switch blocks writer-only authority bootstrap;
- unknown kill-switch state fails closed;
- clear kill switch delegates to existing writer/nonce authority proof;
- nonce and runtime execution envs are not mutated by the protected-stop patch;
- accepted publication becomes stale once its immutable expiry passes;
- fresh and already-stale publication states retain correct semantics;
- v78 install requirement succeeds only with its installed flag;
- v78 and v135 are statically wired into the release manifest.

## Validation

Branch is three commits ahead of `main` at `9d8adc2e0b4060460f45a44a59f8420470b5054c`, changing only the v135 patch, release-manifest wiring, and focused regression tests. Repository CI is the executable validation path.