### PR TITLE
Fix activation publication convergence v136

### DIFF
--- a/bot/activation_publication_convergence_v136_patch.py
+++ b/bot/activation_publication_convergence_v136_patch.py
@@ -1,0 +1,369 @@
+"""Converge snapshot bridging and activation on one current publication proof.
+
+Production v135 exposed a remaining activation livelock: the legacy activation
+snapshot bridge could convert a stale CapitalAuthority observation back to
+freshness from historical readiness/handoff flags, then attempt a secondary
+LIVE transition after the canonical coordinator had rejected readiness.
+
+v136 makes the bridge observational only:
+
+* bridge acceptance requires the current v134 capital proof AND a non-expired
+  CapitalAuthority publication;
+* historical first-snapshot/readiness latches never turn stale capital fresh;
+* cycle-capital augmentation remains available for a genuinely current snapshot;
+* TradingStateMachine.commit_activation() remains the only activation commit
+  authority; the bridge never calls _force_live_active_transition();
+* kill-switch, writer, nonce, risk, execution, and freshness gates are unchanged.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.activation_publication_convergence_v136")
+MARKER = "20260817-activation-publication-convergence-v136"
+RELEASE_ID = "20260817-runtime-convergence-v136"
+_FLAG = "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_LAST_BLOCK_SIGNATURE = ""
+
+
+def _import_first(*names: str) -> Any:
+    last: BaseException | None = None
+    for name in names:
+        try:
+            return importlib.import_module(name)
+        except Exception as exc:
+            last = exc
+    if last is not None:
+        raise last
+    raise ImportError("no module names supplied")
+
+
+def _number(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value if value not in (None, "") else default)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _integer(value: Any, default: int = 0) -> int:
+    try:
+        return int(float(value if value not in (None, "") else default))
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _publication_current(authority: Any) -> tuple[bool, dict[str, Any]]:
+    """Return whether CapitalAuthority's latest publication is current.
+
+    Runtime expiry is checked here even when v135's reader wrapper is not yet
+    installed, so import ordering cannot temporarily resurrect an expired
+    publication.  Missing/invalid publication state fails closed.
+    """
+    getter = getattr(authority, "get_snapshot_publication_status", None)
+    if not callable(getter):
+        return False, {"reason": "publication_status_unavailable", "stale": True}
+    try:
+        status = getter()
+    except Exception as exc:
+        return False, {
+            "reason": f"publication_status_error:{type(exc).__name__}:{exc}",
+            "stale": True,
+        }
+    if status is None:
+        return False, {"reason": "publication_status_missing", "stale": True}
+
+    stale = bool(getattr(status, "stale", True))
+    accepted = bool(getattr(status, "accepted", False))
+    reason = str(getattr(status, "reason", "") or "")
+    expiry = getattr(status, "expiry", None)
+    if isinstance(expiry, datetime):
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        else:
+            expiry = expiry.astimezone(timezone.utc)
+        if datetime.now(timezone.utc) >= expiry:
+            stale = True
+            reason = "expired_after_publish"
+
+    return (not stale), {
+        "accepted": accepted,
+        "stale": stale,
+        "reason": reason or ("ok" if not stale else "publication_stale"),
+        "timestamp": getattr(status, "timestamp", None),
+        "expiry": expiry,
+    }
+
+
+def _current_capital_meta() -> tuple[bool, dict[str, Any]]:
+    """Build bridge metadata exclusively from current canonical proof.
+
+    v134 owns capital-proof semantics.  v136 adds the immutable publication
+    expiry as a second, fail-closed condition so a fresh-looking handoff/latch
+    cannot outrun the authoritative publication lifetime.
+    """
+    try:
+        v134 = _import_first(
+            "bot.readiness_proof_convergence_v134_patch",
+            "readiness_proof_convergence_v134_patch",
+        )
+        proof_reader = getattr(v134, "_current_capital_proof", None)
+        proof_acceptor = getattr(v134, "_current_capital_accepted", None)
+        if not callable(proof_reader) or not callable(proof_acceptor):
+            raise RuntimeError("v134_current_capital_proof_unavailable")
+        proof = proof_reader()
+        if not isinstance(proof, dict):
+            raise RuntimeError("v134_current_capital_proof_invalid")
+
+        proof_accepted = bool(proof_acceptor(proof))
+        hydrated = bool(proof.get("hydrated", False))
+        proof_stale = bool(proof.get("stale", True))
+        real = max(0.0, _number(proof.get("real", 0.0)))
+        registered = max(0, _integer(proof.get("registered", 0)))
+        source = str(proof.get("source", "v134_current_capital") or "v134_current_capital")
+
+        ca_module = _import_first("bot.capital_authority", "capital_authority")
+        authority = ca_module.get_capital_authority()
+        publication_ok, publication = _publication_current(authority)
+
+        brokers_ready = False
+        try:
+            bridge = _import_first(
+                "bot.activation_snapshot_bridge_patch",
+                "activation_snapshot_bridge_patch",
+            )
+            checker = getattr(bridge, "_mabm_brokers_ready", None)
+            if callable(checker):
+                brokers_ready = bool(checker())
+        except Exception:
+            brokers_ready = False
+
+        accepted = bool(proof_accepted and publication_ok)
+        stale = bool(proof_stale or not publication_ok)
+        meta = {
+            "ca_available": True,
+            # Compatibility telemetry only: this mirrors CURRENT acceptance and
+            # is never sourced from CapitalAuthority.first_snap_accepted.
+            "accepted_latch": accepted,
+            "hydrated": hydrated,
+            "stale": stale,
+            "real_capital": real,
+            "valid_brokers": registered,
+            "brokers_ready": brokers_ready,
+            "conditions_met": accepted,
+            "current_proof": True,
+            "proof_accepted": proof_accepted,
+            "publication_current": publication_ok,
+            "publication": publication,
+            "source": source,
+        }
+        return accepted, meta
+    except Exception as exc:
+        return False, {
+            "ca_available": False,
+            "accepted_latch": False,
+            "hydrated": False,
+            "stale": True,
+            "real_capital": 0.0,
+            "valid_brokers": 0,
+            "brokers_ready": False,
+            "conditions_met": False,
+            "current_proof": True,
+            "proof_accepted": False,
+            "publication_current": False,
+            "reason": f"current_publication_proof_error:{type(exc).__name__}:{exc}",
+            "source": "v136_fail_closed",
+        }
+
+
+def _log_block(meta: dict[str, Any]) -> None:
+    global _LAST_BLOCK_SIGNATURE
+    signature = ":".join(
+        (
+            str(bool(meta.get("proof_accepted", False))).lower(),
+            str(bool(meta.get("publication_current", False))).lower(),
+            str(bool(meta.get("stale", True))).lower(),
+            str(meta.get("source", "unknown")),
+        )
+    )
+    with _LOCK:
+        if signature == _LAST_BLOCK_SIGNATURE:
+            return
+        _LAST_BLOCK_SIGNATURE = signature
+    LOGGER.critical(
+        "ACTIVATION_PUBLICATION_V136_BLOCK marker=%s proof_accepted=%s "
+        "publication_current=%s stale=%s source=%s canonical_commit_only=true "
+        "force_fallback=false trading_fail_closed=true",
+        MARKER,
+        bool(meta.get("proof_accepted", False)),
+        bool(meta.get("publication_current", False)),
+        bool(meta.get("stale", True)),
+        meta.get("source", "unknown"),
+    )
+
+
+def _unwrap_legacy_bridge_commit(current: Any) -> Any:
+    """Remove only the legacy activation-snapshot bridge wrapper.
+
+    Other wrappers below it remain intact.  v136 itself carries the bridge
+    ownership marker so the legacy bridge autowire worker will not re-wrap it.
+    """
+    candidate = current
+    if (
+        callable(candidate)
+        and getattr(candidate, "_nija_activation_snapshot_bridge_wrapped", False)
+        and not getattr(candidate, "_nija_activation_publication_v136", False)
+    ):
+        wrapped = getattr(candidate, "__wrapped__", None)
+        if callable(wrapped):
+            candidate = wrapped
+    return candidate
+
+
+def _patch_trading_state_machine_class(cls: type) -> bool:
+    current = getattr(cls, "commit_activation", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_activation_publication_v136", False):
+        return True
+
+    canonical_commit = _unwrap_legacy_bridge_commit(current)
+    if not callable(canonical_commit):
+        return False
+
+    @wraps(canonical_commit)
+    def commit_activation_v136(self: Any, cycle_capital: Any = None) -> bool:
+        accepted, meta = _current_capital_meta()
+        bridged_capital = cycle_capital
+        if accepted:
+            try:
+                bridge = _import_first(
+                    "bot.activation_snapshot_bridge_patch",
+                    "activation_snapshot_bridge_patch",
+                )
+                sync_first = getattr(bridge, "_sync_first_snapshot_flag", None)
+                augment = getattr(bridge, "_augment_cycle_capital", None)
+                if callable(sync_first):
+                    sync_first(self, meta)
+                if callable(augment):
+                    bridged_capital = augment(cycle_capital, meta)
+            except Exception as exc:
+                LOGGER.warning(
+                    "ACTIVATION_PUBLICATION_V136_AUGMENT_FAILED marker=%s err=%s:%s "
+                    "canonical_snapshot_unchanged=true trading_fail_closed=true",
+                    MARKER,
+                    type(exc).__name__,
+                    exc,
+                )
+                bridged_capital = cycle_capital
+        else:
+            _log_block(meta)
+
+        # Exactly one activation authority.  Do not perform any fallback or
+        # state mutation after this result; canonical commit_activation owns it.
+        return bool(canonical_commit(self, cycle_capital=bridged_capital))
+
+    setattr(commit_activation_v136, "_nija_activation_publication_v136", True)
+    # Deliberately retain the legacy bridge marker so its autowire worker treats
+    # this stricter owner as already patched instead of wrapping it again.
+    setattr(commit_activation_v136, "_nija_activation_snapshot_bridge_wrapped", True)
+    setattr(commit_activation_v136, "_nija_v136_original", canonical_commit)
+    cls.commit_activation = commit_activation_v136
+    LOGGER.critical(
+        "ACTIVATION_PUBLICATION_V136_TSM_CONVERGED marker=%s class=%s "
+        "canonical_commit_only=true secondary_force_transition_removed=true",
+        MARKER,
+        cls.__name__,
+    )
+    return True
+
+
+def _patch_bridge_owner() -> bool:
+    bridge = _import_first(
+        "bot.activation_snapshot_bridge_patch",
+        "activation_snapshot_bridge_patch",
+    )
+    tsm = _import_first("bot.trading_state_machine", "trading_state_machine")
+    cls = getattr(tsm, "TradingStateMachine", None)
+    if not isinstance(cls, type):
+        return False
+
+    # Direct-scan bridge calls this module global dynamically, so replacing the
+    # reader also converges that path without removing useful scan augmentation.
+    bridge._capital_snapshot_meta = _current_capital_meta
+    bridge._patch_trading_state_machine_class = _patch_trading_state_machine_class
+    return _patch_trading_state_machine_class(cls)
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = _import_first(
+            "bot.runtime_release_manifest_patch",
+            "runtime_release_manifest_patch",
+        )
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["activation_publication_convergence_v136"] = _FLAG
+        manifest.RELEASE_ID = RELEASE_ID
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        try:
+            bridge_ok = _patch_bridge_owner()
+            manifest_ok = _patch_release_manifest()
+            ok = bool(bridge_ok and manifest_ok)
+        except Exception as exc:
+            LOGGER.critical(
+                "ACTIVATION_PUBLICATION_V136_INSTALL_FAILED marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED marker=%s release=%s "
+            "current_v134_proof_required=true publication_expiry_required=true "
+            "historical_latch_freshness=false canonical_commit_only=true "
+            "kill_switch_unchanged=true nonce_unchanged=true risk_gates_unchanged=true "
+            "execution_authority_unchanged=true force_live=false",
+            MARKER,
+            RELEASE_ID,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_publication_current",
+    "_current_capital_meta",
+    "_unwrap_legacy_bridge_commit",
+    "_patch_trading_state_machine_class",
+    "_patch_bridge_owner",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,7 +10,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260817-runtime-convergence-v135"
+RELEASE_ID = "20260817-runtime-convergence-v136"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -59,6 +59,11 @@ _INSTALLERS = (
     # makes publication expiry authoritative at read time. It also reasserts
     # the v78 dependency for long-running processes.
     ("bot.activation_stop_capital_freshness_v135_patch", "install_import_hook"),
+    # v136 makes the activation snapshot bridge observational only. Current
+    # v134 proof plus the non-expired v135 publication are required before cycle
+    # snapshot augmentation, and TradingStateMachine.commit_activation remains
+    # the sole transition authority.
+    ("bot.activation_publication_convergence_v136_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -90,6 +95,7 @@ _REQUIRED_FLAGS = {
     "capital_refresh_live_continuity_v78": "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED",
     "readiness_proof_convergence_v134": "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED",
     "activation_stop_capital_freshness_v135": "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED",
+    "activation_publication_convergence_v136": "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED",
 }
 
 

--- a/tests/test_activation_publication_convergence_v136.py
+++ b/tests/test_activation_publication_convergence_v136.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import os
+import types
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from functools import wraps
+
+from bot import activation_publication_convergence_v136_patch as v136
+
+
+@dataclass(frozen=True)
+class FakeStatus:
+    accepted: bool
+    stale: bool
+    reason: str
+    timestamp: datetime | None
+    expiry: datetime | None
+
+
+class FakeAuthority:
+    def __init__(self, status: FakeStatus) -> None:
+        self._status = status
+
+    def get_snapshot_publication_status(self) -> FakeStatus:
+        return self._status
+
+
+def test_publication_current_rejects_elapsed_expiry_even_before_v135_wrapper() -> None:
+    now = datetime.now(timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(minutes=3),
+            expiry=now - timedelta(seconds=1),
+        )
+    )
+
+    current, meta = v136._publication_current(authority)
+
+    assert current is False
+    assert meta["stale"] is True
+    assert meta["reason"] == "expired_after_publish"
+
+
+def _install_current_meta_fakes(
+    monkeypatch,
+    *,
+    proof: dict[str, object],
+    publication: FakeStatus,
+) -> None:
+    fake_v134 = types.ModuleType("bot.readiness_proof_convergence_v134_patch")
+    fake_v134._current_capital_proof = lambda: dict(proof)
+    fake_v134._current_capital_accepted = lambda value: bool(
+        value.get("hydrated")
+        and not value.get("stale")
+        and float(value.get("real", 0.0) or 0.0) > 0.0
+        and int(value.get("registered", 0) or 0) > 0
+    )
+
+    fake_ca = types.ModuleType("bot.capital_authority")
+    fake_ca.get_capital_authority = lambda: FakeAuthority(publication)
+
+    fake_bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    fake_bridge._mabm_brokers_ready = lambda: True
+
+    def fake_import_first(*names: str):
+        if any("readiness_proof_convergence_v134_patch" in name for name in names):
+            return fake_v134
+        if any(name.endswith("capital_authority") for name in names):
+            return fake_ca
+        if any("activation_snapshot_bridge_patch" in name for name in names):
+            return fake_bridge
+        raise ImportError(names)
+
+    monkeypatch.setattr(v136, "_import_first", fake_import_first)
+
+
+def test_historical_handoff_flags_cannot_turn_stale_current_proof_fresh(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    monkeypatch.setenv("NIJA_CAPITAL_READINESS_HANDOFF_V34", "1")
+    monkeypatch.setenv("NIJA_CAPITAL_READINESS_HANDOFF_V34_READY", "1")
+    monkeypatch.setenv("CAPITAL_SYSTEM_READY", "1")
+    monkeypatch.setenv("NIJA_CAPITAL_READY", "1")
+    _install_current_meta_fakes(
+        monkeypatch,
+        proof={
+            "hydrated": True,
+            "stale": True,
+            "real": 468.02,
+            "registered": 3,
+            "source": "capital_authority",
+        },
+        publication=FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=10),
+            expiry=now + timedelta(seconds=80),
+        ),
+    )
+
+    accepted, meta = v136._current_capital_meta()
+
+    assert accepted is False
+    assert meta["proof_accepted"] is False
+    assert meta["stale"] is True
+    assert meta["accepted_latch"] is False
+
+
+def test_expired_publication_blocks_even_when_v134_proof_looks_fresh(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    _install_current_meta_fakes(
+        monkeypatch,
+        proof={
+            "hydrated": True,
+            "stale": False,
+            "real": 468.02,
+            "registered": 3,
+            "source": "capital_authority",
+        },
+        publication=FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(minutes=2),
+            expiry=now - timedelta(seconds=1),
+        ),
+    )
+
+    accepted, meta = v136._current_capital_meta()
+
+    assert accepted is False
+    assert meta["proof_accepted"] is True
+    assert meta["publication_current"] is False
+    assert meta["stale"] is True
+
+
+def test_fresh_current_proof_and_publication_can_augment_cycle_snapshot(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    _install_current_meta_fakes(
+        monkeypatch,
+        proof={
+            "hydrated": True,
+            "stale": False,
+            "real": 468.02,
+            "registered": 3,
+            "source": "capital_authority",
+        },
+        publication=FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=10),
+            expiry=now + timedelta(seconds=80),
+        ),
+    )
+
+    accepted, meta = v136._current_capital_meta()
+
+    assert accepted is True
+    assert meta["publication_current"] is True
+    assert meta["stale"] is False
+    assert meta["real_capital"] == 468.02
+    assert meta["valid_brokers"] == 3
+    assert meta["conditions_met"] is True
+
+
+def test_v136_removes_secondary_bridge_activation_fallback(monkeypatch) -> None:
+    canonical_calls: list[dict[str, object]] = []
+    legacy_calls: list[str] = []
+    force_calls: list[str] = []
+
+    def canonical_commit(self, cycle_capital=None) -> bool:
+        canonical_calls.append(dict(cycle_capital or {}))
+        return False
+
+    @wraps(canonical_commit)
+    def legacy_bridge_commit(self, cycle_capital=None) -> bool:
+        legacy_calls.append("legacy_wrapper_called")
+        result = canonical_commit(self, cycle_capital=cycle_capital)
+        if not result:
+            force_calls.append("legacy_force_fallback")
+        return result
+
+    legacy_bridge_commit._nija_activation_snapshot_bridge_wrapped = True
+
+    class FakeTradingStateMachine:
+        commit_activation = legacy_bridge_commit
+
+    fake_bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    fake_bridge._sync_first_snapshot_flag = lambda self, meta: None
+    fake_bridge._augment_cycle_capital = lambda cycle, meta: {
+        **dict(cycle or {}),
+        "snapshot_source": "capital_authority",
+        "ca_not_stale": True,
+    }
+
+    monkeypatch.setattr(
+        v136,
+        "_current_capital_meta",
+        lambda: (
+            True,
+            {
+                "proof_accepted": True,
+                "publication_current": True,
+                "stale": False,
+                "real_capital": 468.02,
+                "valid_brokers": 3,
+            },
+        ),
+    )
+    monkeypatch.setattr(v136, "_import_first", lambda *names: fake_bridge)
+
+    assert v136._patch_trading_state_machine_class(FakeTradingStateMachine)
+    machine = FakeTradingStateMachine()
+    assert machine.commit_activation({"initial": True}) is False
+
+    assert len(canonical_calls) == 1
+    assert canonical_calls[0]["snapshot_source"] == "capital_authority"
+    assert canonical_calls[0]["ca_not_stale"] is True
+    assert legacy_calls == []
+    assert force_calls == []
+    assert getattr(
+        FakeTradingStateMachine.commit_activation,
+        "_nija_activation_snapshot_bridge_wrapped",
+        False,
+    ) is True
+    assert getattr(
+        FakeTradingStateMachine.commit_activation,
+        "_nija_activation_publication_v136",
+        False,
+    ) is True
+
+
+def test_v136_does_not_mutate_execution_or_nonce_authority_when_blocked(monkeypatch) -> None:
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_NONCE_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_NONCE_READY", "1")
+
+    monkeypatch.setattr(
+        v136,
+        "_current_capital_meta",
+        lambda: (
+            False,
+            {
+                "proof_accepted": False,
+                "publication_current": False,
+                "stale": True,
+                "source": "capital_authority",
+            },
+        ),
+    )
+
+    canonical_calls: list[int] = []
+
+    class FakeTradingStateMachine:
+        def commit_activation(self, cycle_capital=None) -> bool:
+            canonical_calls.append(1)
+            return False
+
+    assert v136._patch_trading_state_machine_class(FakeTradingStateMachine)
+    assert FakeTradingStateMachine().commit_activation({}) is False
+    assert canonical_calls == [1]
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_NONCE_READY"] == "1"
+    assert os.environ["NIJA_RUNTIME_NONCE_READY"] == "1"
+
+
+def test_release_manifest_statically_wires_v136() -> None:
+    from bot import runtime_release_manifest_patch as manifest
+
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v136"
+    assert (
+        "bot.activation_publication_convergence_v136_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+    assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
+        "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+    )

--- a/tests/test_activation_stop_capital_freshness_v135.py
+++ b/tests/test_activation_stop_capital_freshness_v135.py
@@ -136,10 +136,10 @@ def test_v78_is_required_and_installed_fail_closed(monkeypatch) -> None:
     assert os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] == "1"
 
 
-def test_release_manifest_statically_wires_v78_and_v135() -> None:
+def test_release_manifest_statically_wires_v78_v135_and_successor_v136() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v135"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v136"
     assert (
         "bot.capital_refresh_live_continuity_v78_patch",
         "install_import_hook",
@@ -148,9 +148,16 @@ def test_release_manifest_statically_wires_v78_and_v135() -> None:
         "bot.activation_stop_capital_freshness_v135_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.activation_publication_convergence_v136_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["capital_refresh_live_continuity_v78"] == (
         "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"
     )
     assert manifest._REQUIRED_FLAGS["activation_stop_capital_freshness_v135"] == (
         "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
+        "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
     )


### PR DESCRIPTION
## Summary
- make activation snapshot bridging consume the current v134 capital proof plus a non-expired CapitalAuthority publication
- prevent historical readiness/handoff latches from converting stale capital back to fresh
- remove the bridge's secondary force-transition fallback so `TradingStateMachine.commit_activation()` remains the sole LIVE commit authority
- wire release `20260817-runtime-convergence-v136` into the runtime manifest
- add regressions for stale handoff resurrection, publication expiry, single-authority activation, and nonce/execution safety preservation

## Safety
- no kill-switch changes
- no nonce/writer authority changes
- no execution/risk gate bypasses
- no force-live path
- stale or missing publication remains fail-closed

## Production symptom addressed
`LIVE_PENDING_CONFIRMATION` livelock where `ACTIVATION_SNAPSHOT_BRIDGE_COMMIT` claimed concrete gates passed while canonical readiness simultaneously rejected `readiness.complete` / `capital.not_stale`.