### PR TITLE
Fix capital publication deadline liveness v137

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -48,3 +48,10 @@ jobs:
 
       - name: Run import smoke test
         run: python -m pytest -q tests/imports_smoke_test.py
+
+      - name: Run capital convergence regression tests
+        run: |
+          python -m pytest -q \
+            tests/test_activation_stop_capital_freshness_v135.py \
+            tests/test_activation_publication_convergence_v136.py \
+            tests/test_capital_publication_deadline_v137.py

--- a/bot/capital_publication_deadline_v137_patch.py
+++ b/bot/capital_publication_deadline_v137_patch.py
@@ -1,0 +1,557 @@
+"""Pre-expiry capital publication refresh convergence v137.
+
+Production v135/v136 showed a remaining liveness gap: the immutable
+CapitalAuthority publication could reach its 90-second expiry before the runtime
+watchdog started a replacement refresh.  v133 then correctly revoked live
+execution.  A second issue allowed concurrent/failed coordinator refreshes to
+fall through the MABM legacy path, which could update legacy capital timestamps
+without renewing the immutable publication proof.
+
+v137 keeps the strict expiry contract and fixes scheduling/consumer behavior:
+
+* schedule a canonical coordinator refresh while the current publication is
+  still valid, with headroom derived from the bounded v78 fetch budget plus the
+  watchdog cadence;
+* use only the existing CapitalRefreshCoordinator as the proactive writer;
+* coalesce MABM refresh calls while that coordinator is already in flight rather
+  than letting a duplicate call fall through to legacy CapitalAuthority writes;
+* clamp any MABM refresh result to not-ready when the immutable publication is
+  rejected, missing, or expired;
+* never extend publication expiry, synthesize freshness, force activation,
+  alter nonce/writer ownership, clear a kill switch, or bypass risk gates.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.capital_publication_deadline_v137")
+MARKER = "20260817-capital-publication-deadline-v137"
+RELEASE_ID = "20260817-runtime-convergence-v137"
+_FLAG = "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
+_PATCH_ATTR = "_nija_capital_publication_deadline_v137"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _capital_authority_module() -> ModuleType:
+    for name in ("bot.capital_authority", "capital_authority"):
+        try:
+            return importlib.import_module(name)
+        except ImportError:
+            continue
+    raise ImportError("capital_authority unavailable")
+
+
+def _authority() -> Any:
+    module = _capital_authority_module()
+    getter = getattr(module, "get_capital_authority", None)
+    if not callable(getter):
+        raise RuntimeError("get_capital_authority unavailable")
+    return getter()
+
+
+def _freshness_ttl_seconds() -> float:
+    try:
+        module = _capital_authority_module()
+        canonical = float(getattr(module, "_DEFAULT_FRESHNESS_TTL_S", 90.0) or 90.0)
+    except Exception:
+        canonical = 90.0
+    try:
+        configured = float(os.environ.get("NIJA_CAPITAL_FRESHNESS_TTL_S", canonical) or canonical)
+    except (TypeError, ValueError):
+        configured = canonical
+    # Never broaden the canonical authority TTL from this convergence layer.
+    return max(10.0, min(canonical, configured))
+
+
+def _fetch_budget_seconds() -> float:
+    try:
+        module = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        getter = getattr(module, "fetch_budget_seconds", None)
+        if callable(getter):
+            return max(5.0, float(getter()))
+    except Exception:
+        pass
+    return 50.0
+
+
+def _refresh_headroom_seconds(manager: Any) -> float:
+    """Return how early a refresh must start before immutable publication expiry."""
+    ttl_s = _freshness_ttl_seconds()
+    try:
+        cadence_s = max(1.0, float(getattr(manager, "capital_watchdog_interval_s", 10.0) or 10.0))
+    except (TypeError, ValueError):
+        cadence_s = 10.0
+    default = _fetch_budget_seconds() + max(5.0, cadence_s)
+    raw = str(os.environ.get("NIJA_CAPITAL_PUBLICATION_REFRESH_HEADROOM_S", "") or "").strip()
+    if raw:
+        try:
+            requested = float(raw)
+        except (TypeError, ValueError):
+            requested = default
+    else:
+        requested = default
+    # Preserve at least five seconds of immutable-validity margin.  This only
+    # moves refresh earlier; it never changes the publication's expiry itself.
+    ceiling = max(5.0, ttl_s - 5.0)
+    return max(5.0, min(requested, ceiling))
+
+
+def _publication_meta(authority: Any, *, now: datetime | None = None) -> tuple[bool, dict[str, Any]]:
+    current_time = _utc(now) or datetime.now(timezone.utc)
+    getter = getattr(authority, "get_snapshot_publication_status", None)
+    if not callable(getter):
+        return False, {
+            "accepted": False,
+            "stale": True,
+            "reason": "publication_status_unavailable",
+            "remaining_s": 0.0,
+        }
+    try:
+        status = getter()
+    except Exception as exc:
+        return False, {
+            "accepted": False,
+            "stale": True,
+            "reason": f"publication_status_error:{type(exc).__name__}:{exc}",
+            "remaining_s": 0.0,
+        }
+    if status is None:
+        return False, {
+            "accepted": False,
+            "stale": True,
+            "reason": "publication_status_missing",
+            "remaining_s": 0.0,
+        }
+
+    accepted = bool(getattr(status, "accepted", False))
+    stale = bool(getattr(status, "stale", True))
+    reason = str(getattr(status, "reason", "unknown") or "unknown")
+    timestamp = _utc(getattr(status, "timestamp", None))
+    expiry = _utc(getattr(status, "expiry", None))
+    remaining_s = 0.0
+    if expiry is None:
+        stale = True
+        reason = "publication_expiry_missing"
+    else:
+        remaining_s = (expiry - current_time).total_seconds()
+        if remaining_s <= 0.0:
+            stale = True
+            reason = "expired_after_publish"
+
+    current = bool(accepted and not stale and expiry is not None and remaining_s > 0.0)
+    return current, {
+        "accepted": accepted,
+        "stale": stale,
+        "reason": reason,
+        "timestamp": timestamp,
+        "expiry": expiry,
+        "remaining_s": max(0.0, remaining_s),
+    }
+
+
+def _publication_refresh_due(
+    authority: Any,
+    manager: Any,
+    *,
+    now: datetime | None = None,
+) -> tuple[bool, dict[str, Any]]:
+    current, meta = _publication_meta(authority, now=now)
+    headroom_s = _refresh_headroom_seconds(manager)
+    meta = dict(meta)
+    meta["headroom_s"] = headroom_s
+    if not current:
+        meta["due_reason"] = f"publication_not_current:{meta.get('reason', 'unknown')}"
+        return True, meta
+    if float(meta.get("remaining_s", 0.0) or 0.0) <= headroom_s:
+        meta["due_reason"] = "pre_expiry_headroom"
+        return True, meta
+    meta["due_reason"] = "not_due"
+    return False, meta
+
+
+def _typed_snapshot(authority: Any) -> Any:
+    getter = getattr(authority, "get_typed_snapshot", None)
+    if callable(getter):
+        try:
+            snapshot = getter()
+            if snapshot is not None:
+                return snapshot
+        except Exception:
+            pass
+    return getattr(authority, "_last_typed_snapshot", None)
+
+
+def _read_only_result(authority: Any, *, coalesced: bool) -> dict[str, float]:
+    current, meta = _publication_meta(authority)
+    snapshot = _typed_snapshot(authority) if current else None
+    if snapshot is None:
+        return {
+            "ready": 0.0,
+            "total_capital": 0.0,
+            "valid_brokers": 0.0,
+            "kraken_capital": 0.0,
+            "pending": 1.0,
+            "publication_current": 0.0,
+            "coalesced": 1.0 if coalesced else 0.0,
+        }
+    balances = dict(getattr(snapshot, "broker_balances", {}) or {})
+    total = max(0.0, float(getattr(snapshot, "real_capital", 0.0) or 0.0))
+    valid = max(0, int(getattr(snapshot, "broker_count", 0) or 0))
+    return {
+        "ready": 1.0 if total > 0.0 and valid > 0 else 0.0,
+        "total_capital": total,
+        "valid_brokers": float(valid),
+        "kraken_capital": max(0.0, float(balances.get("kraken", 0.0) or 0.0)),
+        "publication_current": 1.0,
+        "publication_remaining_s": float(meta.get("remaining_s", 0.0) or 0.0),
+        "coalesced": 1.0 if coalesced else 0.0,
+    }
+
+
+def _coordinator_in_flight(manager: Any) -> bool:
+    coordinator = getattr(manager, "_capital_coordinator", None)
+    return bool(coordinator is not None and getattr(coordinator, "_in_flight", False))
+
+
+def _has_payload(broker: Any) -> bool:
+    if getattr(broker, "_last_known_balance", None) is not None:
+        return True
+    for name in ("has_balance_payload_for_capital", "has_balance_payload"):
+        probe = getattr(broker, name, None)
+        if callable(probe):
+            try:
+                if bool(probe()):
+                    return True
+            except Exception:
+                continue
+    return False
+
+
+def _runtime_broker_map(manager: Any) -> dict[str, Any]:
+    brokers: dict[str, Any] = {}
+    for broker_type, broker in list(getattr(manager, "_platform_brokers", {}).items()):
+        if broker is None or not _has_payload(broker):
+            continue
+        key = str(getattr(broker_type, "value", broker_type) or "").strip().lower()
+        if key:
+            brokers[key] = broker
+
+    if _truthy(os.environ.get("NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY", "false")):
+        for user_id, user_brokers in list(getattr(manager, "user_brokers", {}).items()):
+            for broker_type, broker in list((user_brokers or {}).items()):
+                if broker is None or not bool(getattr(broker, "connected", False)):
+                    continue
+                key = f"{user_id}_{getattr(broker_type, 'value', broker_type)}".strip().lower()
+                brokers[key] = broker
+    return brokers
+
+
+def _runtime_schedule_enabled(manager: Any) -> bool:
+    registration = getattr(manager, "_broker_registration_complete", None)
+    if registration is not None and callable(getattr(registration, "is_set", None)):
+        if not registration.is_set():
+            return False
+    if bool(getattr(manager, "_startup_lock_released", False)):
+        return True
+    try:
+        module = _capital_authority_module()
+        getter = getattr(module, "get_startup_lock", None)
+        if callable(getter):
+            return bool(getter().is_set())
+    except Exception:
+        pass
+    return False
+
+
+def _execute_deadline_refresh(manager: Any, *, trigger: str = "publication_deadline_v137") -> bool:
+    coordinator = getattr(manager, "_capital_coordinator", None)
+    if coordinator is None or _coordinator_in_flight(manager):
+        return False
+    broker_map = _runtime_broker_map(manager)
+    if not broker_map:
+        LOGGER.warning(
+            "CAPITAL_PUBLICATION_DEADLINE_V137_SKIPPED marker=%s reason=no_eligible_brokers",
+            MARKER,
+        )
+        return False
+
+    snapshot = coordinator.execute_refresh(
+        broker_map=broker_map,
+        trigger=trigger,
+        open_exposure_usd=0.0,
+    )
+    authority = _authority()
+    current, meta = _publication_meta(authority)
+    if snapshot is None or not current:
+        LOGGER.warning(
+            "CAPITAL_PUBLICATION_DEADLINE_V137_REFRESH_INCOMPLETE marker=%s "
+            "snapshot=%s publication_current=%s reason=%s remaining_s=%.1f",
+            MARKER,
+            snapshot is not None,
+            current,
+            meta.get("reason", "unknown"),
+            float(meta.get("remaining_s", 0.0) or 0.0),
+        )
+        return False
+
+    real = max(0.0, float(getattr(snapshot, "real_capital", 0.0) or 0.0))
+    valid = max(0, int(getattr(snapshot, "broker_count", 0) or 0))
+    state_lock = getattr(manager, "_capital_state_lock", None)
+    try:
+        if state_lock is not None:
+            with state_lock:
+                manager._capital_ready = bool(real > 0.0 and valid > 0)
+                manager._capital_last_refresh_ts = time.time()
+                if valid > 0:
+                    manager._capital_last_valid_brokers = valid
+        sync = getattr(manager, "_sync_platform_connection_states", None)
+        if callable(sync):
+            sync(broker_map)
+    except Exception as exc:
+        LOGGER.debug("v137 manager mirror update failed after canonical publish: %s", exc)
+
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_DEADLINE_V137_REFRESHED marker=%s trigger=%s "
+        "real=%.2f brokers=%d remaining_s=%.1f canonical_coordinator_only=true",
+        MARKER,
+        trigger,
+        real,
+        valid,
+        float(meta.get("remaining_s", 0.0) or 0.0),
+    )
+    return True
+
+
+def _start_deadline_monitor(manager: Any) -> bool:
+    with _LOCK:
+        if bool(getattr(manager, "_nija_capital_publication_deadline_v137_started", False)):
+            return True
+        setattr(manager, "_nija_capital_publication_deadline_v137_started", True)
+
+    stop_event = getattr(manager, "_capital_watchdog_stop", None)
+    if stop_event is None or not callable(getattr(stop_event, "wait", None)):
+        stop_event = threading.Event()
+
+    def _monitor() -> None:
+        last_reason = ""
+        while True:
+            try:
+                interval_s = max(
+                    1.0,
+                    min(10.0, float(getattr(manager, "capital_watchdog_interval_s", 10.0) or 10.0)),
+                )
+            except (TypeError, ValueError):
+                interval_s = 10.0
+            if stop_event.wait(interval_s):
+                return
+            try:
+                if not _runtime_schedule_enabled(manager):
+                    continue
+                authority = _authority()
+                due, meta = _publication_refresh_due(authority, manager)
+                if not due:
+                    continue
+                reason = str(meta.get("due_reason", "unknown"))
+                if reason != last_reason:
+                    last_reason = reason
+                    LOGGER.info(
+                        "CAPITAL_PUBLICATION_DEADLINE_V137_DUE marker=%s reason=%s "
+                        "remaining_s=%.1f headroom_s=%.1f coordinator_in_flight=%s",
+                        MARKER,
+                        reason,
+                        float(meta.get("remaining_s", 0.0) or 0.0),
+                        float(meta.get("headroom_s", 0.0) or 0.0),
+                        _coordinator_in_flight(manager),
+                    )
+                if _coordinator_in_flight(manager):
+                    continue
+                _execute_deadline_refresh(manager)
+            except Exception as exc:
+                LOGGER.warning(
+                    "CAPITAL_PUBLICATION_DEADLINE_V137_MONITOR_ERROR marker=%s err=%s:%s",
+                    MARKER,
+                    type(exc).__name__,
+                    exc,
+                )
+
+    threading.Thread(
+        target=_monitor,
+        name="capital-publication-deadline-v137",
+        daemon=True,
+    ).start()
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_DEADLINE_V137_MONITOR_STARTED marker=%s ttl_s=%.1f "
+        "fetch_budget_s=%.1f headroom_s=%.1f immutable_expiry_unchanged=true",
+        MARKER,
+        _freshness_ttl_seconds(),
+        _fetch_budget_seconds(),
+        _refresh_headroom_seconds(manager),
+    )
+    return True
+
+
+def _patch_manager_class(cls: type) -> bool:
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def refresh_capital_authority_v137(self: Any, *args: Any, **kwargs: Any) -> Any:
+        trigger = str(kwargs.get("trigger", args[0] if args else "manual") or "manual")
+        coordinator = getattr(self, "_capital_coordinator", None)
+
+        # A duplicate call while the canonical writer is active must be read-only.
+        # The legacy method's snapshot=None branch can otherwise call
+        # CapitalAuthority.refresh()/update(), touching legacy timestamps without
+        # renewing the immutable publication proof.
+        if coordinator is not None and _coordinator_in_flight(self):
+            try:
+                result = _read_only_result(_authority(), coalesced=True)
+            except Exception:
+                result = {
+                    "ready": 0.0,
+                    "total_capital": 0.0,
+                    "valid_brokers": 0.0,
+                    "pending": 1.0,
+                    "publication_current": 0.0,
+                    "coalesced": 1.0,
+                }
+            LOGGER.info(
+                "CAPITAL_PUBLICATION_DEADLINE_V137_COALESCED marker=%s trigger=%s "
+                "canonical_writer_in_flight=true legacy_fallback_skipped=true ready=%s",
+                MARKER,
+                trigger,
+                bool(result.get("ready", 0.0)),
+            )
+            return result
+
+        result = current(self, *args, **kwargs)
+        if not isinstance(result, dict):
+            return result
+
+        try:
+            publication_current, meta = _publication_meta(_authority())
+        except Exception as exc:
+            publication_current = False
+            meta = {"reason": f"publication_check_error:{type(exc).__name__}:{exc}", "remaining_s": 0.0}
+
+        converged = dict(result)
+        converged["publication_current"] = 1.0 if publication_current else 0.0
+        converged["publication_remaining_s"] = float(meta.get("remaining_s", 0.0) or 0.0)
+        if publication_current:
+            return converged
+
+        # Immutable publication proof is authoritative.  Never report runtime
+        # capital ready solely because a legacy refresh/update returned a value.
+        converged["ready"] = 0.0
+        converged["publication_fail_closed"] = 1.0
+        state_lock = getattr(self, "_capital_state_lock", None)
+        try:
+            if state_lock is not None:
+                with state_lock:
+                    self._capital_ready = False
+        except Exception:
+            pass
+        LOGGER.critical(
+            "CAPITAL_PUBLICATION_DEADLINE_V137_RESULT_CLAMPED marker=%s trigger=%s "
+            "reason=%s legacy_timestamp_not_authoritative=true trading_fail_closed=true",
+            MARKER,
+            trigger,
+            meta.get("reason", "unknown"),
+        )
+        return converged
+
+    setattr(refresh_capital_authority_v137, _PATCH_ATTR, True)
+    setattr(refresh_capital_authority_v137, "_nija_v137_original", current)
+    cls.refresh_capital_authority = refresh_capital_authority_v137
+
+    original_start = getattr(cls, "_start_capital_watchdog", None)
+    if callable(original_start) and not getattr(original_start, _PATCH_ATTR, False):
+        @wraps(original_start)
+        def start_watchdog_v137(self: Any, *args: Any, **kwargs: Any) -> Any:
+            result = original_start(self, *args, **kwargs)
+            _start_deadline_monitor(self)
+            return result
+
+        setattr(start_watchdog_v137, _PATCH_ATTR, True)
+        cls._start_capital_watchdog = start_watchdog_v137
+
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_DEADLINE_V137_MABM_CONVERGED marker=%s class=%s "
+        "inflight_coalesced=true immutable_publication_authoritative=true",
+        MARKER,
+        cls.__name__,
+    )
+    return True
+
+
+def _install_manager_patch() -> bool:
+    module = importlib.import_module("bot.multi_account_broker_manager")
+    cls = getattr(module, "MultiAccountBrokerManager", None)
+    if not isinstance(cls, type):
+        return False
+    patched = _patch_manager_class(cls)
+    manager = getattr(module, "_manager", None)
+    if manager is not None:
+        _start_deadline_monitor(manager)
+    return patched
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        ok = _install_manager_patch()
+        if not ok:
+            raise RuntimeError("v137 could not patch MultiAccountBrokerManager")
+        _INSTALLED = True
+        os.environ[_FLAG] = "1"
+    LOGGER.critical(
+        "CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED marker=%s release=%s "
+        "pre_expiry_refresh=true canonical_coordinator_only=true "
+        "publication_expiry_extended=false force_live=false risk_gates_unchanged=true "
+        "nonce_gates_unchanged=true kill_switch_unchanged=true",
+        MARKER,
+        RELEASE_ID,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "_publication_meta",
+    "_publication_refresh_due",
+    "_refresh_headroom_seconds",
+    "_runtime_broker_map",
+    "_execute_deadline_refresh",
+    "_patch_manager_class",
+    "install",
+    "install_import_hook",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,7 +10,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260817-runtime-convergence-v136"
+RELEASE_ID = "20260817-runtime-convergence-v137"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -64,6 +64,10 @@ _INSTALLERS = (
     # snapshot augmentation, and TradingStateMachine.commit_activation remains
     # the sole transition authority.
     ("bot.activation_publication_convergence_v136_patch", "install_import_hook"),
+    # v137 schedules a canonical coordinator refresh before immutable capital
+    # publication expiry, coalesces duplicate in-flight refreshes, and clamps
+    # legacy-ready results when the publication proof is not current.
+    ("bot.capital_publication_deadline_v137_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -96,6 +100,7 @@ _REQUIRED_FLAGS = {
     "readiness_proof_convergence_v134": "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED",
     "activation_stop_capital_freshness_v135": "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED",
     "activation_publication_convergence_v136": "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED",
+    "capital_publication_deadline_v137": "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED",
 }
 
 

--- a/tests/test_activation_publication_convergence_v136.py
+++ b/tests/test_activation_publication_convergence_v136.py
@@ -269,14 +269,21 @@ def test_v136_does_not_mutate_execution_or_nonce_authority_when_blocked(monkeypa
     assert os.environ["NIJA_RUNTIME_NONCE_READY"] == "1"
 
 
-def test_release_manifest_statically_wires_v136() -> None:
+def test_release_manifest_statically_wires_v136_and_successor_v137() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v136"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
     assert (
         "bot.activation_publication_convergence_v136_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.capital_publication_deadline_v137_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
         "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
+        "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
     )

--- a/tests/test_activation_stop_capital_freshness_v135.py
+++ b/tests/test_activation_stop_capital_freshness_v135.py
@@ -136,10 +136,10 @@ def test_v78_is_required_and_installed_fail_closed(monkeypatch) -> None:
     assert os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] == "1"
 
 
-def test_release_manifest_statically_wires_v78_v135_and_successor_v136() -> None:
+def test_release_manifest_statically_wires_v78_v135_and_successors_through_v137() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v136"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
     assert (
         "bot.capital_refresh_live_continuity_v78_patch",
         "install_import_hook",
@@ -152,6 +152,10 @@ def test_release_manifest_statically_wires_v78_v135_and_successor_v136() -> None
         "bot.activation_publication_convergence_v136_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.capital_publication_deadline_v137_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["capital_refresh_live_continuity_v78"] == (
         "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"
     )
@@ -160,4 +164,7 @@ def test_release_manifest_statically_wires_v78_v135_and_successor_v136() -> None
     )
     assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
         "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
+        "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
     )

--- a/tests/test_capital_publication_deadline_v137.py
+++ b/tests/test_capital_publication_deadline_v137.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from bot import capital_publication_deadline_v137_patch as v137
+
+
+@dataclass(frozen=True)
+class FakeStatus:
+    accepted: bool
+    stale: bool
+    reason: str
+    timestamp: datetime | None
+    expiry: datetime | None
+
+
+class FakeAuthority:
+    def __init__(self, status: FakeStatus, snapshot=None) -> None:
+        self.status = status
+        self._last_typed_snapshot = snapshot
+
+    def get_snapshot_publication_status(self) -> FakeStatus:
+        return self.status
+
+    def get_typed_snapshot(self):
+        return self._last_typed_snapshot
+
+
+class FakeCoordinator:
+    def __init__(self, snapshot=None) -> None:
+        self._in_flight = False
+        self.snapshot = snapshot
+        self.calls: list[tuple[dict[str, object], str, float]] = []
+
+    def execute_refresh(self, *, broker_map, trigger, open_exposure_usd):
+        self.calls.append((dict(broker_map), str(trigger), float(open_exposure_usd)))
+        return self.snapshot
+
+
+class FakeLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _manager(coordinator=None):
+    registration = SimpleNamespace(is_set=lambda: True)
+    return SimpleNamespace(
+        capital_watchdog_interval_s=10.0,
+        _capital_coordinator=coordinator,
+        _broker_registration_complete=registration,
+        _startup_lock_released=True,
+        _platform_brokers={},
+        user_brokers={},
+        _capital_state_lock=FakeLock(),
+        _capital_ready=True,
+        _capital_last_refresh_ts=0.0,
+        _capital_last_valid_brokers=0,
+    )
+
+
+def test_refresh_is_due_before_expiry_with_v78_budget_headroom(monkeypatch) -> None:
+    now = datetime(2026, 8, 17, 20, 52, 0, tzinfo=timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=35),
+            expiry=now + timedelta(seconds=55),
+        )
+    )
+    manager = _manager()
+    monkeypatch.setattr(v137, "_freshness_ttl_seconds", lambda: 90.0)
+    monkeypatch.setattr(v137, "_fetch_budget_seconds", lambda: 50.0)
+
+    due, meta = v137._publication_refresh_due(authority, manager, now=now)
+
+    assert due is True
+    assert meta["due_reason"] == "pre_expiry_headroom"
+    assert meta["headroom_s"] == 60.0
+    assert meta["remaining_s"] == 55.0
+
+
+def test_refresh_is_not_due_while_publication_has_safe_headroom(monkeypatch) -> None:
+    now = datetime(2026, 8, 17, 20, 52, 0, tzinfo=timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=10),
+            expiry=now + timedelta(seconds=80),
+        )
+    )
+    manager = _manager()
+    monkeypatch.setattr(v137, "_freshness_ttl_seconds", lambda: 90.0)
+    monkeypatch.setattr(v137, "_fetch_budget_seconds", lambda: 50.0)
+
+    due, meta = v137._publication_refresh_due(authority, manager, now=now)
+
+    assert due is False
+    assert meta["due_reason"] == "not_due"
+    assert meta["remaining_s"] == 80.0
+
+
+def test_elapsed_expiry_is_due_even_if_status_stale_flag_lagged() -> None:
+    now = datetime(2026, 8, 17, 20, 52, 0, tzinfo=timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=91),
+            expiry=now - timedelta(seconds=1),
+        )
+    )
+
+    due, meta = v137._publication_refresh_due(authority, _manager(), now=now)
+
+    assert due is True
+    assert meta["stale"] is True
+    assert meta["reason"] == "expired_after_publish"
+
+
+def test_inflight_mabm_refresh_is_read_only_and_skips_legacy_fallback(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    snapshot = SimpleNamespace(
+        real_capital=468.02,
+        broker_count=3,
+        broker_balances={"kraken": 468.02},
+    )
+    authority = FakeAuthority(
+        FakeStatus(True, False, "accepted", now, now + timedelta(seconds=70)),
+        snapshot=snapshot,
+    )
+    monkeypatch.setattr(v137, "_authority", lambda: authority)
+
+    original_calls: list[str] = []
+
+    class FakeManager:
+        def refresh_capital_authority(self, trigger="manual"):
+            original_calls.append(str(trigger))
+            return {"ready": 1.0, "total_capital": 999.0, "valid_brokers": 99.0}
+
+    coordinator = FakeCoordinator()
+    coordinator._in_flight = True
+    manager = FakeManager()
+    manager._capital_coordinator = coordinator
+
+    assert v137._patch_manager_class(FakeManager)
+    result = manager.refresh_capital_authority(trigger="watchdog")
+
+    assert original_calls == []
+    assert result["ready"] == 1.0
+    assert result["total_capital"] == 468.02
+    assert result["coalesced"] == 1.0
+    assert result["publication_current"] == 1.0
+
+
+def test_mabm_ready_result_is_clamped_when_publication_is_expired(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(True, False, "accepted", now - timedelta(seconds=91), now - timedelta(seconds=1))
+    )
+    monkeypatch.setattr(v137, "_authority", lambda: authority)
+
+    class FakeManager:
+        def __init__(self) -> None:
+            self._capital_coordinator = None
+            self._capital_state_lock = FakeLock()
+            self._capital_ready = True
+
+        def refresh_capital_authority(self, trigger="manual"):
+            return {"ready": 1.0, "total_capital": 468.02, "valid_brokers": 3.0}
+
+    assert v137._patch_manager_class(FakeManager)
+    manager = FakeManager()
+    result = manager.refresh_capital_authority(trigger="watchdog")
+
+    assert result["ready"] == 0.0
+    assert result["publication_current"] == 0.0
+    assert result["publication_fail_closed"] == 1.0
+    assert manager._capital_ready is False
+
+
+def test_deadline_refresh_uses_only_canonical_coordinator(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    snapshot = SimpleNamespace(
+        real_capital=468.02,
+        broker_count=1,
+        broker_balances={"kraken": 468.02},
+    )
+    authority = FakeAuthority(
+        FakeStatus(True, False, "accepted", now, now + timedelta(seconds=90)),
+        snapshot=snapshot,
+    )
+    monkeypatch.setattr(v137, "_authority", lambda: authority)
+
+    broker = SimpleNamespace(_last_known_balance=468.02)
+    broker_type = SimpleNamespace(value="kraken")
+    coordinator = FakeCoordinator(snapshot=snapshot)
+    manager = _manager(coordinator)
+    manager._platform_brokers = {broker_type: broker}
+
+    assert v137._execute_deadline_refresh(manager, trigger="test_v137") is True
+    assert len(coordinator.calls) == 1
+    broker_map, trigger, exposure = coordinator.calls[0]
+    assert broker_map == {"kraken": broker}
+    assert trigger == "test_v137"
+    assert exposure == 0.0
+    assert manager._capital_ready is True
+    assert manager._capital_last_valid_brokers == 1
+
+
+def test_user_capital_remains_excluded_without_explicit_opt_in(monkeypatch) -> None:
+    monkeypatch.setenv("NIJA_AGGREGATE_USER_CAPITAL_IN_AUTHORITY", "false")
+    platform_broker = SimpleNamespace(_last_known_balance=100.0)
+    user_broker = SimpleNamespace(_last_known_balance=50.0, connected=True)
+    manager = _manager()
+    manager._platform_brokers = {SimpleNamespace(value="kraken"): platform_broker}
+    manager.user_brokers = {"tania": {SimpleNamespace(value="kraken"): user_broker}}
+
+    broker_map = v137._runtime_broker_map(manager)
+
+    assert list(broker_map) == ["kraken"]
+    assert user_broker not in broker_map.values()
+
+
+def test_patch_does_not_change_nonce_risk_or_kill_switch_environment(monkeypatch) -> None:
+    monkeypatch.setenv("NIJA_NONCE_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+    monkeypatch.setenv("NIJA_EMERGENCY_STOP", "1")
+
+    now = datetime.now(timezone.utc)
+    authority = FakeAuthority(
+        FakeStatus(True, False, "accepted", now, now + timedelta(seconds=80))
+    )
+    v137._publication_refresh_due(authority, _manager(), now=now)
+
+    assert os.environ["NIJA_NONCE_READY"] == "1"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"
+    assert os.environ["NIJA_EMERGENCY_STOP"] == "1"
+
+
+def test_release_manifest_statically_wires_v137() -> None:
+    from bot import runtime_release_manifest_patch as manifest
+
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
+    assert (
+        "bot.capital_publication_deadline_v137_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+    assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
+        "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
+    )

--- a/tests/test_capital_publication_deadline_v137.py
+++ b/tests/test_capital_publication_deadline_v137.py
@@ -203,10 +203,9 @@ def test_deadline_refresh_uses_only_canonical_coordinator(monkeypatch) -> None:
     monkeypatch.setattr(v137, "_authority", lambda: authority)
 
     broker = SimpleNamespace(_last_known_balance=468.02)
-    broker_type = SimpleNamespace(value="kraken")
     coordinator = FakeCoordinator(snapshot=snapshot)
     manager = _manager(coordinator)
-    manager._platform_brokers = {broker_type: broker}
+    manager._platform_brokers = {"kraken": broker}
 
     assert v137._execute_deadline_refresh(manager, trigger="test_v137") is True
     assert len(coordinator.calls) == 1
@@ -223,8 +222,8 @@ def test_user_capital_remains_excluded_without_explicit_opt_in(monkeypatch) -> N
     platform_broker = SimpleNamespace(_last_known_balance=100.0)
     user_broker = SimpleNamespace(_last_known_balance=50.0, connected=True)
     manager = _manager()
-    manager._platform_brokers = {SimpleNamespace(value="kraken"): platform_broker}
-    manager.user_brokers = {"tania": {SimpleNamespace(value="kraken"): user_broker}}
+    manager._platform_brokers = {"kraken": platform_broker}
+    manager.user_brokers = {"tania": {"kraken": user_broker}}
 
     broker_map = v137._runtime_broker_map(manager)
 


### PR DESCRIPTION
## Summary
- refresh immutable CapitalAuthority publication before the 90-second expiry, using v78 fetch budget plus watchdog cadence as scheduling headroom
- use the existing CapitalRefreshCoordinator as the proactive writer; do not extend freshness or create a second capital writer
- coalesce MABM refresh calls while the coordinator is already in flight so duplicate calls do not fall through to legacy CapitalAuthority refresh/update writes
- clamp MABM readiness to false whenever the immutable publication proof is missing, rejected, or expired
- advance runtime release to `20260817-runtime-convergence-v137`
- add regressions for pre-expiry scheduling, expiry enforcement, in-flight coalescing, canonical refresh, user-capital isolation, and safety-gate preservation

## Production evidence addressed
The provided v135 logs show `LIVE_ACTIVE -> OFF` at 20:52:29 because the canonical capital proof became stale at the 90-second boundary (`real=468.0177`, `registered=3`, `v64_freshness_reason=canonical_stale`). A Kraken balance fetch then begins about one second later. v133 is correctly failing closed; the liveness defect is that refresh begins after publication expiry.

The same logs are from deployment SHA `e880cc7e...` / release v135, not current main. v137 includes v136 and adds the pre-expiry refresh fix.

## Safety
- immutable 90-second publication expiry remains unchanged
- no stale/freshness extension
- no force-live path
- no kill-switch changes
- no nonce/writer authority changes
- no risk or execution gate bypasses
- user capital remains excluded from platform CapitalAuthority unless explicitly opted in