### PR TITLE
Fix startup router convergence v138

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -49,9 +49,10 @@ jobs:
       - name: Run import smoke test
         run: python -m pytest -q tests/imports_smoke_test.py
 
-      - name: Run capital convergence regression tests
+      - name: Run runtime convergence regression tests
         run: |
           python -m pytest -q \
             tests/test_activation_stop_capital_freshness_v135.py \
             tests/test_activation_publication_convergence_v136.py \
-            tests/test_capital_publication_deadline_v137.py
+            tests/test_capital_publication_deadline_v137.py \
+            tests/test_final_execution_state_router_convergence_v138.py

--- a/bot/final_execution_state_router_convergence_patch.py
+++ b/bot/final_execution_state_router_convergence_patch.py
@@ -6,14 +6,15 @@ order and does not bypass risk, sizing, cash, position, or broker controls.
 v138 hardening
 --------------
 The convergence watchdog must report *current convergence*, not merely whether
-it changed something on the current call.  Earlier versions returned ``False``
+it changed something on the current call. Earlier versions returned ``False``
 for already-wrapped execution/startup targets, which meant the 200 ms watchdog
 could never reach its terminal ready state after the first successful patch.
 The startup probe also looked only for module-level functions even though the
 canonical implementation lives on :class:`StartupCoordinator`.
 
-v138 makes every patch probe idempotent, patches the canonical class method,
-and publishes ``NIJA_FINAL_EXECUTION_STATE_ROUTER_READY=1`` only when execution,
+v138 makes every patch probe idempotent, verifies the canonical
+``StartupCoordinator.build_snapshot`` owner without changing its behavior, and
+publishes ``NIJA_FINAL_EXECUTION_STATE_ROUTER_READY=1`` only when execution,
 startup, and OKX router convergence are all currently true.
 """
 from __future__ import annotations
@@ -21,10 +22,8 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-import sys
 import threading
 import time
-from dataclasses import is_dataclass, replace
 from functools import wraps
 from types import ModuleType
 from typing import Any
@@ -142,87 +141,85 @@ def _runtime_live() -> bool:
 
 
 def _repair_startup_result(result: Any, method_name: str) -> Any:
-    """Preserve monotonic public LIVE state only when runtime authority is already live."""
-    if not _runtime_live():
+    """Legacy module-level compatibility repair; canonical snapshots are untouched."""
+    if not _runtime_live() or not isinstance(result, dict):
         return result
 
-    if isinstance(result, dict):
-        state = str(result.get("trading_state", result.get("state", ""))).upper()
-        if state in {"", "UNKNOWN", "PENDING", "STARTING", "LIVE_PENDING_CONFIRMATION"}:
-            result["trading_state"] = "LIVE_ACTIVE"
-            result["state"] = "LIVE_ACTIVE"
-            result["state_repair_reason"] = "monotonic_live_runtime_evidence"
-            logger.critical(
-                "STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s",
-                _MARKER, method_name, state,
-            )
-        os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
-        return result
-
-    # StartupCoordinator.build_snapshot returns a frozen dataclass.  Preserve
-    # the historical monotonic repair on its public trading_state field only;
-    # do not mutate runtime_authority_state, readiness, nonce, or dispatch.
-    if is_dataclass(result) and hasattr(result, "trading_state"):
-        state = str(getattr(result, "trading_state", "") or "").upper()
-        if state in {"", "UNKNOWN", "PENDING", "STARTING", "LIVE_PENDING_CONFIRMATION"}:
-            try:
-                result = replace(result, trading_state="LIVE_ACTIVE")
-                logger.critical(
-                    "STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s dataclass=true",
-                    _MARKER, method_name, state,
-                )
-            except Exception:
-                logger.exception(
-                    "STARTUP_STATE_MONOTONIC_LIVE_REPAIR_FAILED marker=%s method=%s previous=%s",
-                    _MARKER, method_name, state,
-                )
-        os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
+    state = str(result.get("trading_state", result.get("state", ""))).upper()
+    if state in {"", "UNKNOWN", "PENDING", "STARTING", "LIVE_PENDING_CONFIRMATION"}:
+        result["trading_state"] = "LIVE_ACTIVE"
+        result["state"] = "LIVE_ACTIVE"
+        result["state_repair_reason"] = "monotonic_live_runtime_evidence"
+        logger.critical(
+            "STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s legacy_module_level=true",
+            _MARKER, method_name, state,
+        )
+    os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
     return result
 
 
-def _patch_startup_state() -> bool:
-    """Patch canonical startup snapshot owners and return current convergence."""
-    converged = False
-    seen_owners: set[int] = set()
-    seen_methods: set[tuple[int, str]] = set()
+def _mark_canonical_startup_owner(module: ModuleType) -> bool:
+    """Verify canonical StartupCoordinator ownership without wrapping it."""
+    cls = getattr(module, "StartupCoordinator", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "build_snapshot", None)
+    if not callable(current):
+        return False
+    if not getattr(current, "_nija_startup_router_converged_v138", False):
+        try:
+            current._nija_startup_router_converged_v138 = True  # type: ignore[attr-defined]
+        except Exception:
+            logger.exception(
+                "STARTUP_ROUTER_CANONICAL_OWNER_MARK_FAILED marker=%s module=%s",
+                _MARKER, module.__name__,
+            )
+            return False
+        logger.critical(
+            "STARTUP_ROUTER_CANONICAL_OWNER_CONVERGED marker=%s release=%s module=%s owner=StartupCoordinator.build_snapshot behavior_unchanged=true",
+            _MARKER, _RELEASE, module.__name__,
+        )
+    return True
 
+
+def _patch_legacy_startup_functions(module: ModuleType) -> bool:
+    """Retain historical compatibility wrappers only for module-level helpers."""
+    converged = False
+    for method_name in ("reconcile", "_reconcile", "build_snapshot", "_build_snapshot"):
+        current = getattr(module, method_name, None)
+        if not callable(current):
+            continue
+        if getattr(current, "_nija_live_monotonic_v1", False):
+            converged = True
+            continue
+
+        @wraps(current)
+        def wrapper(*args: Any, __current=current, __name=method_name, **kwargs: Any):
+            return _repair_startup_result(__current(*args, **kwargs), __name)
+
+        wrapper._nija_live_monotonic_v1 = True  # type: ignore[attr-defined]
+        wrapper.__wrapped__ = current  # type: ignore[attr-defined]
+        setattr(module, method_name, wrapper)
+        converged = True
+    return converged
+
+
+def _patch_startup_state() -> bool:
+    """Return True when canonical startup ownership is currently converged."""
+    canonical = False
+    legacy = False
+    seen_modules: set[int] = set()
     for name in ("bot.startup_coordinator", "startup_coordinator"):
         try:
             module = importlib.import_module(name)
         except Exception:
             continue
-
-        owners: list[Any] = [module]
-        coordinator_cls = getattr(module, "StartupCoordinator", None)
-        if isinstance(coordinator_cls, type):
-            owners.append(coordinator_cls)
-
-        for owner in owners:
-            if id(owner) in seen_owners:
-                continue
-            seen_owners.add(id(owner))
-            for method_name in ("reconcile", "_reconcile", "build_snapshot", "_build_snapshot"):
-                key = (id(owner), method_name)
-                if key in seen_methods:
-                    continue
-                seen_methods.add(key)
-                current = getattr(owner, method_name, None)
-                if not callable(current):
-                    continue
-                if getattr(current, "_nija_live_monotonic_v1", False):
-                    converged = True
-                    continue
-
-                @wraps(current)
-                def wrapper(*args: Any, __current=current, __name=method_name, **kwargs: Any):
-                    return _repair_startup_result(__current(*args, **kwargs), __name)
-
-                wrapper._nija_live_monotonic_v1 = True  # type: ignore[attr-defined]
-                wrapper.__wrapped__ = current  # type: ignore[attr-defined]
-                setattr(owner, method_name, wrapper)
-                converged = True
-
-    return converged
+        if id(module) in seen_modules:
+            continue
+        seen_modules.add(id(module))
+        canonical = _mark_canonical_startup_owner(module) or canonical
+        legacy = _patch_legacy_startup_functions(module) or legacy
+    return canonical or legacy
 
 
 def _patch_okx_router_identity() -> bool:

--- a/bot/final_execution_state_router_convergence_patch.py
+++ b/bot/final_execution_state_router_convergence_patch.py
@@ -2,6 +2,19 @@
 
 This patch is fail-closed. It does not convert a rejected order into an accepted
 order and does not bypass risk, sizing, cash, position, or broker controls.
+
+v138 hardening
+--------------
+The convergence watchdog must report *current convergence*, not merely whether
+it changed something on the current call.  Earlier versions returned ``False``
+for already-wrapped execution/startup targets, which meant the 200 ms watchdog
+could never reach its terminal ready state after the first successful patch.
+The startup probe also looked only for module-level functions even though the
+canonical implementation lives on :class:`StartupCoordinator`.
+
+v138 makes every patch probe idempotent, patches the canonical class method,
+and publishes ``NIJA_FINAL_EXECUTION_STATE_ROUTER_READY=1`` only when execution,
+startup, and OKX router convergence are all currently true.
 """
 from __future__ import annotations
 
@@ -11,14 +24,17 @@ import os
 import sys
 import threading
 import time
+from dataclasses import is_dataclass, replace
 from functools import wraps
 from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.final_execution_state_router_convergence")
 _MARKER = "20260719-final-execution-state-router-v1"
+_RELEASE = "20260817-startup-router-convergence-v138"
 _LOCK = threading.RLock()
 _INSTALLED = False
+_WATCHDOG_STARTED = False
 
 
 def _reason_from(value: Any) -> str:
@@ -53,9 +69,12 @@ def _deep_reason(owner: Any) -> str:
 
 
 def _patch_execute_action_class(cls: type) -> bool:
+    """Patch one execution owner and return whether it is converged now."""
     current = getattr(cls, "execute_action", None)
-    if not callable(current) or getattr(current, "_nija_terminal_reason_v1", False):
+    if not callable(current):
         return False
+    if getattr(current, "_nija_terminal_reason_v1", False):
+        return True
 
     @wraps(current)
     def execute_action(self: Any, *args: Any, **kwargs: Any):
@@ -90,13 +109,15 @@ def _patch_execute_action_class(cls: type) -> bool:
 
 
 def _patch_execution_modules() -> bool:
-    patched = False
+    """Return True when at least one canonical execution target is converged."""
+    converged = False
     names = (
         "bot.nija_apex_strategy_v71", "nija_apex_strategy_v71",
         "bot.trading_strategy", "trading_strategy",
         "bot.execution_engine", "execution_engine",
         "bot.core_loop", "core_loop",
     )
+    seen_classes: set[int] = set()
     for name in names:
         try:
             module = importlib.import_module(name)
@@ -104,9 +125,12 @@ def _patch_execution_modules() -> bool:
             continue
         for attr in dir(module):
             obj = getattr(module, attr, None)
-            if isinstance(obj, type):
-                patched = _patch_execute_action_class(obj) or patched
-    return patched
+            if not isinstance(obj, type) or id(obj) in seen_classes:
+                continue
+            seen_classes.add(id(obj))
+            if callable(getattr(obj, "execute_action", None)):
+                converged = _patch_execute_action_class(obj) or converged
+    return converged
 
 
 def _runtime_live() -> bool:
@@ -117,37 +141,88 @@ def _runtime_live() -> bool:
     return heartbeat and authority and not kill and lifecycle
 
 
+def _repair_startup_result(result: Any, method_name: str) -> Any:
+    """Preserve monotonic public LIVE state only when runtime authority is already live."""
+    if not _runtime_live():
+        return result
+
+    if isinstance(result, dict):
+        state = str(result.get("trading_state", result.get("state", ""))).upper()
+        if state in {"", "UNKNOWN", "PENDING", "STARTING", "LIVE_PENDING_CONFIRMATION"}:
+            result["trading_state"] = "LIVE_ACTIVE"
+            result["state"] = "LIVE_ACTIVE"
+            result["state_repair_reason"] = "monotonic_live_runtime_evidence"
+            logger.critical(
+                "STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s",
+                _MARKER, method_name, state,
+            )
+        os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
+        return result
+
+    # StartupCoordinator.build_snapshot returns a frozen dataclass.  Preserve
+    # the historical monotonic repair on its public trading_state field only;
+    # do not mutate runtime_authority_state, readiness, nonce, or dispatch.
+    if is_dataclass(result) and hasattr(result, "trading_state"):
+        state = str(getattr(result, "trading_state", "") or "").upper()
+        if state in {"", "UNKNOWN", "PENDING", "STARTING", "LIVE_PENDING_CONFIRMATION"}:
+            try:
+                result = replace(result, trading_state="LIVE_ACTIVE")
+                logger.critical(
+                    "STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s dataclass=true",
+                    _MARKER, method_name, state,
+                )
+            except Exception:
+                logger.exception(
+                    "STARTUP_STATE_MONOTONIC_LIVE_REPAIR_FAILED marker=%s method=%s previous=%s",
+                    _MARKER, method_name, state,
+                )
+        os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
+    return result
+
+
 def _patch_startup_state() -> bool:
-    patched = False
+    """Patch canonical startup snapshot owners and return current convergence."""
+    converged = False
+    seen_owners: set[int] = set()
+    seen_methods: set[tuple[int, str]] = set()
+
     for name in ("bot.startup_coordinator", "startup_coordinator"):
         try:
             module = importlib.import_module(name)
         except Exception:
             continue
-        for method_name in ("reconcile", "_reconcile", "build_snapshot", "_build_snapshot"):
-            current = getattr(module, method_name, None)
-            if not callable(current) or getattr(current, "_nija_live_monotonic_v1", False):
+
+        owners: list[Any] = [module]
+        coordinator_cls = getattr(module, "StartupCoordinator", None)
+        if isinstance(coordinator_cls, type):
+            owners.append(coordinator_cls)
+
+        for owner in owners:
+            if id(owner) in seen_owners:
                 continue
+            seen_owners.add(id(owner))
+            for method_name in ("reconcile", "_reconcile", "build_snapshot", "_build_snapshot"):
+                key = (id(owner), method_name)
+                if key in seen_methods:
+                    continue
+                seen_methods.add(key)
+                current = getattr(owner, method_name, None)
+                if not callable(current):
+                    continue
+                if getattr(current, "_nija_live_monotonic_v1", False):
+                    converged = True
+                    continue
 
-            @wraps(current)
-            def wrapper(*args: Any, __current=current, __name=method_name, **kwargs: Any):
-                result = __current(*args, **kwargs)
-                if _runtime_live():
-                    if isinstance(result, dict):
-                        state = str(result.get("trading_state", result.get("state", ""))).upper()
-                        if state in {"", "UNKNOWN", "PENDING", "STARTING"}:
-                            result["trading_state"] = "LIVE_ACTIVE"
-                            result["state"] = "LIVE_ACTIVE"
-                            result["state_repair_reason"] = "monotonic_live_runtime_evidence"
-                            logger.critical("STARTUP_STATE_MONOTONIC_LIVE_REPAIRED marker=%s method=%s previous=%s", _MARKER, __name, state)
-                    os.environ["NIJA_TRADING_STATE"] = "LIVE_ACTIVE"
-                return result
+                @wraps(current)
+                def wrapper(*args: Any, __current=current, __name=method_name, **kwargs: Any):
+                    return _repair_startup_result(__current(*args, **kwargs), __name)
 
-            wrapper._nija_live_monotonic_v1 = True  # type: ignore[attr-defined]
-            wrapper.__wrapped__ = current  # type: ignore[attr-defined]
-            setattr(module, method_name, wrapper)
-            patched = True
-    return patched
+                wrapper._nija_live_monotonic_v1 = True  # type: ignore[attr-defined]
+                wrapper.__wrapped__ = current  # type: ignore[attr-defined]
+                setattr(owner, method_name, wrapper)
+                converged = True
+
+    return converged
 
 
 def _patch_okx_router_identity() -> bool:
@@ -178,41 +253,91 @@ def _patch_okx_router_identity() -> bool:
             patcher(router)
         patched = bool(getattr(bridge, "_ROUTER_PATCHED", False)) or patched
     if patched:
+        was_ready = os.environ.get("NIJA_OKX_ROUTER_PATCHED") == "1"
         os.environ["NIJA_OKX_ROUTER_PATCHED"] = "1"
-        logger.critical("OKX_ROUTER_MODULE_IDENTITY_CONVERGED marker=%s bridges=%s routers=%s", _MARKER, [m.__name__ for m in bridges], [m.__name__ for m in routers])
+        if not was_ready:
+            logger.critical(
+                "OKX_ROUTER_MODULE_IDENTITY_CONVERGED marker=%s bridges=%s routers=%s",
+                _MARKER, [m.__name__ for m in bridges], [m.__name__ for m in routers],
+            )
     else:
-        logger.error("OKX_ROUTER_MODULE_IDENTITY_PENDING marker=%s bridges=%s routers=%s", _MARKER, [m.__name__ for m in bridges], [m.__name__ for m in routers])
+        logger.error(
+            "OKX_ROUTER_MODULE_IDENTITY_PENDING marker=%s bridges=%s routers=%s",
+            _MARKER, [m.__name__ for m in bridges], [m.__name__ for m in routers],
+        )
     return patched
 
 
+def _converge_once() -> tuple[bool, dict[str, bool]]:
+    execution = _patch_execution_modules()
+    startup = _patch_startup_state()
+    okx = _patch_okx_router_identity()
+    ready = bool(execution and startup and okx)
+    state = {"execution": execution, "startup": startup, "okx": okx}
+    os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"] = "1" if ready else "PENDING"
+    return ready, state
+
+
 def _watchdog() -> None:
-    for _ in range(600):
-        try:
-            execution = _patch_execution_modules()
-            startup = _patch_startup_state()
-            okx = _patch_okx_router_identity()
-            if execution and startup and okx:
-                logger.critical("FINAL_EXECUTION_STATE_ROUTER_READY marker=%s execution=true startup=true okx=true", _MARKER)
-                return
-        except Exception:
-            logger.exception("FINAL_EXECUTION_STATE_ROUTER_RETRY marker=%s", _MARKER)
-        time.sleep(0.2)
-    logger.error("FINAL_EXECUTION_STATE_ROUTER_WATCHDOG_EXHAUSTED marker=%s", _MARKER)
+    global _WATCHDOG_STARTED
+    try:
+        for _ in range(600):
+            try:
+                ready, state = _converge_once()
+                if ready:
+                    logger.critical(
+                        "FINAL_EXECUTION_STATE_ROUTER_READY marker=%s release=%s execution=true startup=true okx=true",
+                        _MARKER, _RELEASE,
+                    )
+                    return
+            except Exception:
+                logger.exception("FINAL_EXECUTION_STATE_ROUTER_RETRY marker=%s", _MARKER)
+            time.sleep(0.2)
+        os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"] = "0"
+        logger.error("FINAL_EXECUTION_STATE_ROUTER_WATCHDOG_EXHAUSTED marker=%s", _MARKER)
+    finally:
+        with _LOCK:
+            _WATCHDOG_STARTED = False
+
+
+def _ensure_watchdog() -> None:
+    global _WATCHDOG_STARTED
+    with _LOCK:
+        if _WATCHDOG_STARTED:
+            return
+        _WATCHDOG_STARTED = True
+        threading.Thread(target=_watchdog, name="FinalExecutionStateRouter", daemon=True).start()
 
 
 def install() -> bool:
     global _INSTALLED
     with _LOCK:
-        if _INSTALLED:
-            return True
-        _patch_execution_modules()
-        _patch_startup_state()
-        _patch_okx_router_identity()
-        threading.Thread(target=_watchdog, name="FinalExecutionStateRouter", daemon=True).start()
-        os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_INSTALLED"] = "1"
-        _INSTALLED = True
-        logger.critical("FINAL_EXECUTION_STATE_ROUTER_INSTALLED marker=%s", _MARKER)
+        ready, state = _converge_once()
+        if not ready:
+            _ensure_watchdog()
+        if not _INSTALLED:
+            os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_INSTALLED"] = "1"
+            _INSTALLED = True
+            logger.critical(
+                "FINAL_EXECUTION_STATE_ROUTER_INSTALLED marker=%s release=%s immediate=%s state=%s fail_closed=true",
+                _MARKER, _RELEASE, str(ready).lower(), state,
+            )
+        elif ready:
+            logger.critical(
+                "FINAL_EXECUTION_STATE_ROUTER_RECONVERGED marker=%s release=%s state=%s",
+                _MARKER, _RELEASE, state,
+            )
         return True
 
 
-__all__ = ["install"]
+install_import_hook = install
+
+__all__ = [
+    "install",
+    "install_import_hook",
+    "_patch_execute_action_class",
+    "_patch_execution_modules",
+    "_patch_startup_state",
+    "_patch_okx_router_identity",
+    "_converge_once",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,7 +10,7 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260817-runtime-convergence-v137"
+RELEASE_ID = "20260817-runtime-convergence-v138"
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -68,6 +68,11 @@ _INSTALLERS = (
     # publication expiry, coalesces duplicate in-flight refreshes, and clamps
     # legacy-ready results when the publication proof is not current.
     ("bot.capital_publication_deadline_v137_patch", "install_import_hook"),
+    # v138 makes the final execution/startup/router convergence probe idempotent,
+    # targets StartupCoordinator.build_snapshot on the canonical class, and
+    # terminates the 200 ms convergence watchdog once all three components are
+    # already converged. No readiness, nonce, risk, or execution gate is relaxed.
+    ("bot.final_execution_state_router_convergence_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -101,6 +106,7 @@ _REQUIRED_FLAGS = {
     "activation_stop_capital_freshness_v135": "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED",
     "activation_publication_convergence_v136": "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED",
     "capital_publication_deadline_v137": "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED",
+    "final_execution_state_router_v138": "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY",
 }
 
 

--- a/tests/test_activation_publication_convergence_v136.py
+++ b/tests/test_activation_publication_convergence_v136.py
@@ -269,10 +269,10 @@ def test_v136_does_not_mutate_execution_or_nonce_authority_when_blocked(monkeypa
     assert os.environ["NIJA_RUNTIME_NONCE_READY"] == "1"
 
 
-def test_release_manifest_statically_wires_v136_and_successor_v137() -> None:
+def test_release_manifest_statically_wires_v136_and_successors_through_v138() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v138"
     assert (
         "bot.activation_publication_convergence_v136_patch",
         "install_import_hook",
@@ -281,9 +281,16 @@ def test_release_manifest_statically_wires_v136_and_successor_v137() -> None:
         "bot.capital_publication_deadline_v137_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.final_execution_state_router_convergence_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
         "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
     )
     assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
         "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["final_execution_state_router_v138"] == (
+        "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"
     )

--- a/tests/test_activation_stop_capital_freshness_v135.py
+++ b/tests/test_activation_stop_capital_freshness_v135.py
@@ -136,10 +136,10 @@ def test_v78_is_required_and_installed_fail_closed(monkeypatch) -> None:
     assert os.environ["NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"] == "1"
 
 
-def test_release_manifest_statically_wires_v78_v135_and_successors_through_v137() -> None:
+def test_release_manifest_statically_wires_v78_v135_and_successors_through_v138() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v138"
     assert (
         "bot.capital_refresh_live_continuity_v78_patch",
         "install_import_hook",
@@ -156,6 +156,10 @@ def test_release_manifest_statically_wires_v78_v135_and_successors_through_v137(
         "bot.capital_publication_deadline_v137_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.final_execution_state_router_convergence_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["capital_refresh_live_continuity_v78"] == (
         "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED"
     )
@@ -167,4 +171,7 @@ def test_release_manifest_statically_wires_v78_v135_and_successors_through_v137(
     )
     assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
         "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["final_execution_state_router_v138"] == (
+        "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"
     )

--- a/tests/test_capital_publication_deadline_v137.py
+++ b/tests/test_capital_publication_deadline_v137.py
@@ -247,14 +247,21 @@ def test_patch_does_not_change_nonce_risk_or_kill_switch_environment(monkeypatch
     assert os.environ["NIJA_EMERGENCY_STOP"] == "1"
 
 
-def test_release_manifest_statically_wires_v137() -> None:
+def test_release_manifest_statically_wires_v137_and_successor_v138() -> None:
     from bot import runtime_release_manifest_patch as manifest
 
-    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v137"
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v138"
     assert (
         "bot.capital_publication_deadline_v137_patch",
         "install_import_hook",
     ) in manifest._INSTALLERS
+    assert (
+        "bot.final_execution_state_router_convergence_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
     assert manifest._REQUIRED_FLAGS["capital_publication_deadline_v137"] == (
         "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["final_execution_state_router_v138"] == (
+        "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"
     )

--- a/tests/test_final_execution_state_router_convergence_v138.py
+++ b/tests/test_final_execution_state_router_convergence_v138.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import os
+import types
+from dataclasses import dataclass
+
+from bot import final_execution_state_router_convergence_patch as v138
+
+
+def test_execute_action_patch_is_idempotently_converged() -> None:
+    def execute_action(self, *args, **kwargs):
+        return True
+
+    execute_action._nija_terminal_reason_v1 = True
+
+    class FakeExecutionOwner:
+        pass
+
+    FakeExecutionOwner.execute_action = execute_action
+
+    assert v138._patch_execute_action_class(FakeExecutionOwner) is True
+    assert getattr(FakeExecutionOwner.execute_action, "_nija_terminal_reason_v1", False) is True
+
+
+def test_startup_patch_targets_canonical_coordinator_class_and_is_idempotent(monkeypatch) -> None:
+    fake_module = types.ModuleType("bot.startup_coordinator")
+
+    class FakeStartupCoordinator:
+        def build_snapshot(self, *, trading_state: str, activation_intent: bool):
+            return {
+                "trading_state": trading_state,
+                "activation_intent": activation_intent,
+            }
+
+    fake_module.StartupCoordinator = FakeStartupCoordinator
+
+    def fake_import(name: str):
+        if name in {"bot.startup_coordinator", "startup_coordinator"}:
+            return fake_module
+        raise ImportError(name)
+
+    monkeypatch.setattr(v138.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v138, "_runtime_live", lambda: False)
+
+    assert v138._patch_startup_state() is True
+    assert getattr(FakeStartupCoordinator.build_snapshot, "_nija_live_monotonic_v1", False) is True
+    assert v138._patch_startup_state() is True
+
+    result = FakeStartupCoordinator().build_snapshot(
+        trading_state="LIVE_PENDING_CONFIRMATION",
+        activation_intent=True,
+    )
+    assert result["trading_state"] == "LIVE_PENDING_CONFIRMATION"
+    assert result["activation_intent"] is True
+
+
+@dataclass(frozen=True)
+class FakeSnapshot:
+    trading_state: str
+    runtime_authority_state: str
+    nonce_ready: bool
+    dispatch_health_ready: bool
+
+
+def test_live_monotonic_repair_only_changes_public_trading_state(monkeypatch) -> None:
+    monkeypatch.setattr(v138, "_runtime_live", lambda: True)
+    monkeypatch.setenv("NIJA_NONCE_READY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+
+    original = FakeSnapshot(
+        trading_state="LIVE_PENDING_CONFIRMATION",
+        runtime_authority_state="EXECUTING",
+        nonce_ready=False,
+        dispatch_health_ready=False,
+    )
+
+    repaired = v138._repair_startup_result(original, "build_snapshot")
+
+    assert repaired.trading_state == "LIVE_ACTIVE"
+    assert repaired.runtime_authority_state == "EXECUTING"
+    assert repaired.nonce_ready is False
+    assert repaired.dispatch_health_ready is False
+    assert os.environ["NIJA_NONCE_READY"] == "0"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "1"
+
+
+def test_non_live_runtime_never_promotes_pending_state(monkeypatch) -> None:
+    monkeypatch.setattr(v138, "_runtime_live", lambda: False)
+    original = {
+        "trading_state": "LIVE_PENDING_CONFIRMATION",
+        "nonce_ready": False,
+        "dispatch_health_ready": False,
+    }
+
+    repaired = v138._repair_startup_result(original, "build_snapshot")
+
+    assert repaired is original
+    assert repaired["trading_state"] == "LIVE_PENDING_CONFIRMATION"
+    assert repaired["nonce_ready"] is False
+    assert repaired["dispatch_health_ready"] is False
+
+
+def test_converge_once_reports_current_convergence_and_publishes_ready(monkeypatch) -> None:
+    monkeypatch.setattr(v138, "_patch_execution_modules", lambda: True)
+    monkeypatch.setattr(v138, "_patch_startup_state", lambda: True)
+    monkeypatch.setattr(v138, "_patch_okx_router_identity", lambda: True)
+    monkeypatch.delenv("NIJA_FINAL_EXECUTION_STATE_ROUTER_READY", raising=False)
+
+    ready, state = v138._converge_once()
+
+    assert ready is True
+    assert state == {"execution": True, "startup": True, "okx": True}
+    assert os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"] == "1"
+
+
+def test_converge_once_stays_pending_when_any_component_is_not_converged(monkeypatch) -> None:
+    monkeypatch.setattr(v138, "_patch_execution_modules", lambda: True)
+    monkeypatch.setattr(v138, "_patch_startup_state", lambda: False)
+    monkeypatch.setattr(v138, "_patch_okx_router_identity", lambda: True)
+
+    ready, state = v138._converge_once()
+
+    assert ready is False
+    assert state["startup"] is False
+    assert os.environ["NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"] == "PENDING"
+
+
+def test_release_manifest_statically_wires_v138() -> None:
+    from bot import runtime_release_manifest_patch as manifest
+
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v138"
+    assert (
+        "bot.final_execution_state_router_convergence_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+    assert manifest._REQUIRED_FLAGS["final_execution_state_router_v138"] == (
+        "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY"
+    )

--- a/tests/test_final_execution_state_router_convergence_v138.py
+++ b/tests/test_final_execution_state_router_convergence_v138.py
@@ -22,7 +22,7 @@ def test_execute_action_patch_is_idempotently_converged() -> None:
     assert getattr(FakeExecutionOwner.execute_action, "_nija_terminal_reason_v1", False) is True
 
 
-def test_startup_patch_targets_canonical_coordinator_class_and_is_idempotent(monkeypatch) -> None:
+def test_startup_patch_targets_canonical_coordinator_without_wrapping_behavior(monkeypatch) -> None:
     fake_module = types.ModuleType("bot.startup_coordinator")
 
     class FakeStartupCoordinator:
@@ -33,6 +33,7 @@ def test_startup_patch_targets_canonical_coordinator_class_and_is_idempotent(mon
             }
 
     fake_module.StartupCoordinator = FakeStartupCoordinator
+    original = FakeStartupCoordinator.build_snapshot
 
     def fake_import(name: str):
         if name in {"bot.startup_coordinator", "startup_coordinator"}:
@@ -40,11 +41,12 @@ def test_startup_patch_targets_canonical_coordinator_class_and_is_idempotent(mon
         raise ImportError(name)
 
     monkeypatch.setattr(v138.importlib, "import_module", fake_import)
-    monkeypatch.setattr(v138, "_runtime_live", lambda: False)
 
     assert v138._patch_startup_state() is True
-    assert getattr(FakeStartupCoordinator.build_snapshot, "_nija_live_monotonic_v1", False) is True
+    assert FakeStartupCoordinator.build_snapshot is original
+    assert getattr(original, "_nija_startup_router_converged_v138", False) is True
     assert v138._patch_startup_state() is True
+    assert FakeStartupCoordinator.build_snapshot is original
 
     result = FakeStartupCoordinator().build_snapshot(
         trading_state="LIVE_PENDING_CONFIRMATION",
@@ -62,10 +64,11 @@ class FakeSnapshot:
     dispatch_health_ready: bool
 
 
-def test_live_monotonic_repair_only_changes_public_trading_state(monkeypatch) -> None:
+def test_canonical_snapshot_object_is_never_rewritten_even_when_runtime_live(monkeypatch) -> None:
     monkeypatch.setattr(v138, "_runtime_live", lambda: True)
     monkeypatch.setenv("NIJA_NONCE_READY", "0")
     monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.delenv("NIJA_TRADING_STATE", raising=False)
 
     original = FakeSnapshot(
         trading_state="LIVE_PENDING_CONFIRMATION",
@@ -76,15 +79,17 @@ def test_live_monotonic_repair_only_changes_public_trading_state(monkeypatch) ->
 
     repaired = v138._repair_startup_result(original, "build_snapshot")
 
-    assert repaired.trading_state == "LIVE_ACTIVE"
+    assert repaired is original
+    assert repaired.trading_state == "LIVE_PENDING_CONFIRMATION"
     assert repaired.runtime_authority_state == "EXECUTING"
     assert repaired.nonce_ready is False
     assert repaired.dispatch_health_ready is False
     assert os.environ["NIJA_NONCE_READY"] == "0"
     assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "1"
+    assert "NIJA_TRADING_STATE" not in os.environ
 
 
-def test_non_live_runtime_never_promotes_pending_state(monkeypatch) -> None:
+def test_non_live_runtime_never_promotes_pending_legacy_state(monkeypatch) -> None:
     monkeypatch.setattr(v138, "_runtime_live", lambda: False)
     original = {
         "trading_state": "LIVE_PENDING_CONFIRMATION",
@@ -98,6 +103,21 @@ def test_non_live_runtime_never_promotes_pending_state(monkeypatch) -> None:
     assert repaired["trading_state"] == "LIVE_PENDING_CONFIRMATION"
     assert repaired["nonce_ready"] is False
     assert repaired["dispatch_health_ready"] is False
+
+
+def test_legacy_module_level_dict_repair_requires_already_live_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(v138, "_runtime_live", lambda: True)
+    original = {
+        "trading_state": "LIVE_PENDING_CONFIRMATION",
+        "nonce_ready": True,
+    }
+
+    repaired = v138._repair_startup_result(original, "legacy_build_snapshot")
+
+    assert repaired is original
+    assert repaired["trading_state"] == "LIVE_ACTIVE"
+    assert repaired["nonce_ready"] is True
+    assert os.environ["NIJA_TRADING_STATE"] == "LIVE_ACTIVE"
 
 
 def test_converge_once_reports_current_convergence_and_publishes_ready(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- make `final_execution_state_router_convergence_patch` report current convergence instead of only whether a wrapper changed on the current call
- verify canonical `StartupCoordinator.build_snapshot` ownership on the class without wrapping or changing its behavior
- make already-patched execution/startup targets return converged so the 200 ms watchdog can terminate normally
- publish `NIJA_FINAL_EXECUTION_STATE_ROUTER_READY=1` only when execution, startup, and OKX convergence are all current
- suppress repeated OKX convergence CRITICAL spam after readiness is already published
- advance runtime release to `20260817-runtime-convergence-v138`
- add focused regressions and run them in the imports-smoke workflow

## Production evidence addressed
The provided 22:16:19–22:16:21 logs show `LIVE_PENDING_CONFIRMATION` with current readiness proofs still false during early startup, while `OKX_ROUTER_MODULE_IDENTITY_CONVERGED` and `CANONICAL_CORE_V125_IMPORT ... startup_coordinator` repeat roughly every 200 ms. v133 correctly remains fail-closed because the state is not LIVE_ACTIVE.

The repeated router/startup churn is a separate convergence defect: the prior helper returned false for already-wrapped targets and searched only module-level startup functions, while the canonical implementation is `StartupCoordinator.build_snapshot`. Therefore the watchdog could keep retrying for its full 600 iterations even after successful patching.

## Safety
- does not mark broker, balance, authority, capital, strategy, execution, nonce, bootstrap, or position-sync readiness true
- does not force LIVE_ACTIVE
- canonical `StartupCoordinator.build_snapshot` behavior is unchanged
- does not clear kill switch or SEAK
- does not alter nonce/writer authority
- does not bypass risk, sizing, cash, execution, or capital freshness gates
- legacy module-level monotonic state repair remains conditional on already-live runtime evidence only