### PR TITLE
Fix runtime release identity v139

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -55,4 +55,5 @@ jobs:
             tests/test_activation_stop_capital_freshness_v135.py \
             tests/test_activation_publication_convergence_v136.py \
             tests/test_capital_publication_deadline_v137.py \
-            tests/test_final_execution_state_router_convergence_v138.py
+            tests/test_final_execution_state_router_convergence_v138.py \
+            tests/test_runtime_release_identity_v139.py

--- a/bot/runtime_release_identity_guard_patch.py
+++ b/bot/runtime_release_identity_guard_patch.py
@@ -1,0 +1,113 @@
+"""Keep runtime release identity owned by the canonical manifest.
+
+Older convergence modules may register their required flags with the runtime
+manifest, but they must never rewrite the manifest's active release identity.
+Production v138 exposed that v136 still assigned ``manifest.RELEASE_ID`` during
+every audit, causing a v138 deployment to report itself as v136.
+
+This guard is deliberately observational/control-plane only. It does not alter
+trading state, readiness, capital freshness, kill-switch state, writer/nonce
+authority, risk, sizing, or execution gates.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_release_identity_guard")
+MARKER = "20260817-runtime-release-identity-guard-v1"
+_FLAG = "NIJA_RUNTIME_RELEASE_IDENTITY_GUARD_INSTALLED"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _declared_release(manifest: Any) -> str:
+    value = str(getattr(manifest, "DECLARED_RELEASE_ID", "") or "").strip()
+    if value:
+        return value
+    return str(getattr(manifest, "RELEASE_ID", "") or "").strip()
+
+
+def _patch_v136_manifest_registration() -> bool:
+    """Make v136 register only its flag, never own the parent release ID."""
+    from bot import activation_publication_convergence_v136_patch as v136
+    from bot import runtime_release_manifest_patch as manifest
+
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+
+    def register_v136_without_release_override() -> bool:
+        current_required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(current_required, dict):
+            return False
+        current_required["activation_publication_convergence_v136"] = (
+            "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+        )
+        return True
+
+    register_v136_without_release_override._nija_release_identity_guard = True  # type: ignore[attr-defined]
+    v136._patch_release_manifest = register_v136_without_release_override
+    return True
+
+
+def _restore_manifest_identity() -> bool:
+    from bot import runtime_release_manifest_patch as manifest
+
+    declared = _declared_release(manifest)
+    if not declared:
+        return False
+    previous = str(getattr(manifest, "RELEASE_ID", "") or "").strip()
+    manifest.RELEASE_ID = declared
+    if previous and previous != declared:
+        LOGGER.critical(
+            "RUNTIME_RELEASE_IDENTITY_DRIFT_REPAIRED marker=%s previous=%s declared=%s",
+            MARKER,
+            previous,
+            declared,
+        )
+    return True
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        try:
+            ok = _patch_v136_manifest_registration() and _restore_manifest_identity()
+        except Exception as exc:
+            LOGGER.critical(
+                "RUNTIME_RELEASE_IDENTITY_GUARD_INSTALL_FAILED marker=%s err=%s:%s fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+        os.environ[_FLAG] = "1"
+        _INSTALLED = True
+    LOGGER.critical(
+        "RUNTIME_RELEASE_IDENTITY_GUARD_INSTALLED marker=%s canonical_manifest_owner=true "
+        "legacy_release_override=false readiness_unchanged=true kill_switch_unchanged=true "
+        "nonce_unchanged=true risk_gates_unchanged=true execution_authority_unchanged=true",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_declared_release",
+    "_patch_v136_manifest_registration",
+    "_restore_manifest_identity",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -11,6 +11,9 @@ from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
 RELEASE_ID = "20260817-runtime-convergence-v138"
+# Immutable owner used by the v139 release-identity guard. Older convergence
+# installers may register flags, but may not downgrade this manifest identity.
+DECLARED_RELEASE_ID = RELEASE_ID
 _INSTALLED = False
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
@@ -59,6 +62,10 @@ _INSTALLERS = (
     # makes publication expiry authoritative at read time. It also reasserts
     # the v78 dependency for long-running processes.
     ("bot.activation_stop_capital_freshness_v135_patch", "install_import_hook"),
+    # v139 must run before v136: v136 historically wrote its own RELEASE_ID into
+    # the parent manifest. The guard rewires that registration to be flag-only
+    # and restores the canonical manifest identity before v136 is invoked.
+    ("bot.runtime_release_identity_guard_patch", "install_import_hook"),
     # v136 makes the activation snapshot bridge observational only. Current
     # v134 proof plus the non-expired v135 publication are required before cycle
     # snapshot augmentation, and TradingStateMachine.commit_activation remains
@@ -104,6 +111,7 @@ _REQUIRED_FLAGS = {
     "capital_refresh_live_continuity_v78": "NIJA_CAPITAL_REFRESH_LIVE_CONTINUITY_V78_INSTALLED",
     "readiness_proof_convergence_v134": "NIJA_READINESS_PROOF_CONVERGENCE_V134_INSTALLED",
     "activation_stop_capital_freshness_v135": "NIJA_ACTIVATION_STOP_CAPITAL_FRESHNESS_V135_INSTALLED",
+    "runtime_release_identity_v139": "NIJA_RUNTIME_RELEASE_IDENTITY_GUARD_INSTALLED",
     "activation_publication_convergence_v136": "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED",
     "capital_publication_deadline_v137": "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED",
     "final_execution_state_router_v138": "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY",
@@ -236,21 +244,25 @@ def _audit() -> tuple[bool, dict[str, str]]:
 
 def _publish(ready: bool, details: dict[str, str]) -> None:
     previous = os.environ.get("NIJA_RUNTIME_RELEASE_READY", "")
-    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+    # Re-anchor the mutable compatibility name before publishing. This is a
+    # second line of defense if an older module was reloaded between audits.
+    global RELEASE_ID
+    RELEASE_ID = DECLARED_RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = DECLARED_RELEASE_ID
     os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
     logger.critical(
         "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
-        RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
+        DECLARED_RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
     )
     if not ready:
         logger.critical(
             "RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed",
-            RELEASE_ID,
+            DECLARED_RELEASE_ID,
         )
     elif previous == "0":
         logger.critical(
             "RUNTIME_RELEASE_CONVERGENCE_RECOVERED release=%s action=broker_order_gates_may_follow_normal_authority_checks",
-            RELEASE_ID,
+            DECLARED_RELEASE_ID,
         )
 
 
@@ -264,7 +276,7 @@ def _watchdog() -> None:
                 last_signature = signature
                 _publish(ready, details)
         except Exception as exc:
-            logger.critical("RUNTIME_RELEASE_AUDIT_FAILED release=%s error=%s", RELEASE_ID, exc)
+            logger.critical("RUNTIME_RELEASE_AUDIT_FAILED release=%s error=%s", DECLARED_RELEASE_ID, exc)
         time.sleep(max(10.0, float(os.environ.get("NIJA_RUNTIME_RELEASE_AUDIT_INTERVAL_S", "30") or 30)))
 
 
@@ -276,11 +288,11 @@ def install_import_hook() -> None:
         if not _INSTALLED:
             _INSTALLED = True
             threading.Thread(target=_watchdog, name="RuntimeReleaseManifest", daemon=True).start()
-    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", RELEASE_ID)
+    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", DECLARED_RELEASE_ID)
 
 
 __all__ = [
-    "RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
+    "RELEASE_ID", "DECLARED_RELEASE_ID", "install_import_hook", "_audit", "_deployment_sha",
     "_expected_scan_wrapper_release", "_scan_release_compatible", "_bounded_acyclic_scan",
     "_readiness_contract_consistent", "_runtime_limits_consistent",
 ]

--- a/tests/test_runtime_release_identity_v139.py
+++ b/tests/test_runtime_release_identity_v139.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+
+from bot import activation_publication_convergence_v136_patch as v136
+from bot import runtime_release_identity_guard_patch as v139
+from bot import runtime_release_manifest_patch as manifest
+
+
+def test_v139_restores_declared_manifest_identity_after_legacy_downgrade(monkeypatch) -> None:
+    declared = manifest.DECLARED_RELEASE_ID
+    assert declared == "20260817-runtime-convergence-v138"
+
+    monkeypatch.setattr(manifest, "RELEASE_ID", v136.RELEASE_ID)
+    assert manifest.RELEASE_ID == "20260817-runtime-convergence-v136"
+
+    assert v139.install_import_hook() is True
+    assert manifest.RELEASE_ID == declared
+    assert os.environ["NIJA_RUNTIME_RELEASE_IDENTITY_GUARD_INSTALLED"] == "1"
+
+
+def test_v139_makes_v136_manifest_registration_flag_only(monkeypatch) -> None:
+    declared = manifest.DECLARED_RELEASE_ID
+    monkeypatch.setattr(manifest, "RELEASE_ID", declared)
+
+    assert v139.install_import_hook() is True
+    assert v136._patch_release_manifest() is True
+
+    assert manifest.RELEASE_ID == declared
+    assert manifest._REQUIRED_FLAGS["activation_publication_convergence_v136"] == (
+        "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED"
+    )
+
+
+def test_manifest_wires_v139_before_v136_and_requires_guard() -> None:
+    guard = ("bot.runtime_release_identity_guard_patch", "install_import_hook")
+    legacy = ("bot.activation_publication_convergence_v136_patch", "install_import_hook")
+
+    assert guard in manifest._INSTALLERS
+    assert legacy in manifest._INSTALLERS
+    assert manifest._INSTALLERS.index(guard) < manifest._INSTALLERS.index(legacy)
+    assert manifest._REQUIRED_FLAGS["runtime_release_identity_v139"] == (
+        "NIJA_RUNTIME_RELEASE_IDENTITY_GUARD_INSTALLED"
+    )
+
+
+def test_v139_does_not_mutate_trading_safety_authority(monkeypatch) -> None:
+    sentinels = {
+        "NIJA_KILL_SWITCH": "true",
+        "NIJA_NONCE_READY": "0",
+        "NIJA_RUNTIME_NONCE_READY": "0",
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY": "0",
+        "NIJA_PRE_DISPATCH_RISK_SIZING_READY": "1",
+    }
+    for key, value in sentinels.items():
+        monkeypatch.setenv(key, value)
+
+    assert v139.install_import_hook() is True
+
+    for key, value in sentinels.items():
+        assert os.environ[key] == value


### PR DESCRIPTION
## Summary
- prevent the legacy v136 activation-publication installer from downgrading the parent runtime manifest `RELEASE_ID`
- add a v139 release-identity guard that rewires v136 manifest registration to flag-only behavior and restores the canonical manifest identity
- run the guard before v136 on every runtime release audit
- make manifest publication re-anchor to the immutable declared release identity before logging/exporting `NIJA_RUNTIME_RELEASE_ID`
- add focused regressions and include them in the runtime convergence smoke job

## Production evidence addressed
The 2026-08-17 23:50 deployment reports `deployment_sha=d816213a1a094c8fb8c141466ba40f7be1138e73`, includes the v137 and v138 installers as ready, but logs `NIJA_RUNTIME_RELEASE_MANIFEST release=20260817-runtime-convergence-v136`. At that exact SHA the checked-in manifest declares v138. Source inspection shows v136 `_patch_release_manifest()` mutates `manifest.RELEASE_ID = RELEASE_ID` during every audit, explaining the downgrade.

## Safety
- no readiness proof is synthesized
- no kill switch is cleared
- no writer/nonce authority is granted
- no risk, sizing, capital-freshness, or execution gate is relaxed
- no activation state transition is changed
- release identity remains a control-plane/provenance concern only
