### PR TITLE
Recover persisted heartbeat stops without weakening kill-switch safety

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -56,4 +56,5 @@ jobs:
             tests/test_activation_publication_convergence_v136.py \
             tests/test_capital_publication_deadline_v137.py \
             tests/test_final_execution_state_router_convergence_v138.py \
-            tests/test_runtime_release_identity_v139.py
+            tests/test_runtime_release_identity_v139.py \
+            tests/test_runtime_killswitch_authority_liveness.py

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -1,8 +1,8 @@
 """Keep StartupCoordinator kill-switch truth aligned with the canonical KillSwitch.
 
-The canonical kill switch is the safety authority.  This patch mirrors its
+The canonical kill switch is the safety authority. This patch mirrors its
 active/inactive state into StartupCoordinator without clearing the stop,
-changing risk gates, or forcing a coordinator lifecycle state.  A state change
+changing risk gates, or forcing a coordinator lifecycle state. A state change
 invalidates any prior activation commit and advances the global epoch so a
 fresh activation proof is required after deactivation.
 """
@@ -116,6 +116,26 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
     return True
 
 
+def _install_authority_liveness() -> bool:
+    """Chain the narrow heartbeat-stop liveness repair fail-closed."""
+    try:
+        from bot import runtime_killswitch_authority_liveness_patch as liveness
+
+        installer = getattr(liveness, "install_import_hook", None) or getattr(
+            liveness, "install", None
+        )
+        if not callable(installer):
+            return False
+        return bool(installer())
+    except Exception as exc:
+        logger.exception(
+            "KILL_SWITCH_AUTHORITY_LIVENESS_CHAIN_FAILED marker=%s error=%s",
+            _MARKER,
+            exc,
+        )
+        return False
+
+
 def install_import_hook() -> None:
     """Install synchronization and immediately reconcile preexisting state."""
     with _LOCK:
@@ -133,11 +153,14 @@ def install_import_hook() -> None:
         active = bool(instance.is_active())
         if not _publish_coordinator_truth(active, "install_reconcile"):
             raise RuntimeError("startup_coordinator_sync_failed")
+        if not _install_authority_liveness():
+            raise RuntimeError("runtime_killswitch_authority_liveness_not_ready")
 
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_INSTALLED"] = "1"
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_READY"] = "1"
         logger.critical(
-            "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false risk_gates_unchanged=true",
+            "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
+            "risk_gates_unchanged=true authority_liveness_chained=true",
             _MARKER,
             str(active).lower(),
         )
@@ -152,4 +175,5 @@ __all__ = [
     "install_import_hook",
     "_patch_kill_switch_class",
     "_publish_coordinator_truth",
+    "_install_authority_liveness",
 ]

--- a/bot/runtime_killswitch_authority_liveness_patch.py
+++ b/bot/runtime_killswitch_authority_liveness_patch.py
@@ -1,17 +1,25 @@
-"""Preserve heartbeat kill-switch causality and canonical writer ownership.
+"""Preserve heartbeat kill-switch causality and recover only retired heartbeat stops.
 
-This runtime patch is deliberately non-authoritative: it never activates or
-clears the kill switch, never grants execution authority, never resumes SEAK,
-and never releases the canonical writer lease.  It only:
+This runtime patch is deliberately non-authoritative: it never creates a kill
+switch stop, never grants execution authority, never forces LIVE_ACTIVE, and
+never releases the canonical writer lease.
 
-* preserves AUTOMATIC provenance when an existing caller materializes a
-  heartbeat-owned emergency stop through ``KillSwitch.activate`` without an
-  explicit source; and
-* replaces the legacy v58 canonical-path stalled-writer diagnostic with a
-  throttled owner/phase diagnostic while keeping destructive release disabled.
+It closes two production convergence defects:
 
-The v132 durability worker periodically reasserts these wrappers so later
-compatibility churn cannot silently restore the old behavior.
+* legacy heartbeat-owned emergency stops could be persisted with the default
+  ``MANUAL`` source, preventing the v132 restart recovery from recognizing the
+  retired pre-v129 ``AUTHORITY_HEARTBEAT_EXPIRED/core_thread_dead`` race; and
+* v130 required SEAK to be clear before clearing that persisted heartbeat stop,
+  while the heartbeat-owned SEAK recovery required the kill switch to be clear
+  first. This circular dependency could leave an otherwise healthy runtime in
+  EMERGENCY_STOP indefinitely.
+
+Recovery remains narrow and fail closed. The latest kill-switch record must be
+restart persistence, the causal reason must be the exact retired heartbeat/core
+failure signature, the current writer lease/core/readiness/bootstrap proofs must
+all be healthy, and any SEAK halt must itself be heartbeat-owned. Recovery
+returns the trading FSM to OFF and resumes only that heartbeat-owned SEAK halt;
+normal activation gates must reconverge before any dispatch can occur.
 """
 from __future__ import annotations
 
@@ -24,24 +32,30 @@ from functools import wraps
 from typing import Any
 
 LOGGER = logging.getLogger("nija.runtime_killswitch_authority_liveness")
-MARKER = "20260817-runtime-killswitch-authority-liveness-v1"
-_FLAG = "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_READY"
+MARKER = "20260817-runtime-killswitch-authority-liveness-v140"
+_FLAG = "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"
 _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
-_KILL_PATCH_ATTR = "_nija_heartbeat_killswitch_provenance_v1"
-_HEARTBEAT_PATCH_ATTR = "_nija_heartbeat_owned_stop_provenance_v1"
-_WRITER_PATCH_ATTR = "_nija_canonical_writer_release_diagnostic_v1"
+_KILL_PATCH_ATTR = "_nija_heartbeat_killswitch_provenance_v140"
+_HEARTBEAT_PATCH_ATTR = "_nija_heartbeat_owned_stop_provenance_v140"
+_WRITER_PATCH_ATTR = "_nija_canonical_writer_release_diagnostic_v140"
+_V132_PATCH_ATTR = "_nija_heartbeat_persisted_stop_recovery_v140"
 _OWNED_STOP_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"
 _OWNED_REASON_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP_REASON"
 _LAST_WRITER_DIAGNOSTIC: dict[str, float] = {}
 _ANNOUNCED = False
 
 
+def _truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
 def _truthy_env(name: str) -> bool:
-    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+    return _truthy(os.environ.get(name, ""))
 
 
 def _heartbeat_failure_reason(reason: object) -> bool:
+    """Match only the retired authority-heartbeat/core-death stop signature."""
     text = str(reason or "").strip().upper()
     if not text:
         return False
@@ -50,23 +64,305 @@ def _heartbeat_failure_reason(reason: object) -> bool:
     return heartbeat and dead_core
 
 
-def _normalized_activation_source(reason: object, source: object) -> str:
-    """Return AUTOMATIC only for a runtime-proven heartbeat-owned stop.
+def _explicit_manual_reason(reason: object) -> bool:
+    text = str(reason or "").strip().lower()
+    return any(token in text for token in ("operator", "manual", "ui stop", "cli stop"))
 
-    ``KillSwitch.activate`` historically defaults ``source`` to MANUAL.  That
-    default is correct for generic callers, so it is preserved unless the
-    authority-heartbeat callback has already published its owned-stop marker
-    and the activation reason carries the matching heartbeat/core-death proof.
+
+def _normalized_activation_source(reason: object, source: object) -> str:
+    """Preserve AUTOMATIC provenance for a runtime-proven heartbeat-owned stop.
+
+    ``KillSwitch.activate`` defaults ``source`` to MANUAL. That remains the
+    default for generic callers. Reclassification occurs only when the
+    authority-heartbeat callback has already published its owned-stop marker,
+    the callback's recorded reason matches the retired heartbeat/core failure,
+    and the activation was not explicitly described as an operator/manual stop.
     """
 
     normalized = str(source or "MANUAL").strip() or "MANUAL"
     if normalized.upper() != "MANUAL":
         return normalized
+    if _explicit_manual_reason(reason):
+        return normalized
     if not _truthy_env(_OWNED_STOP_ENV):
         return normalized
-    if not _heartbeat_failure_reason(reason):
+    owned_reason = os.environ.get(_OWNED_REASON_ENV, "")
+    if not (_heartbeat_failure_reason(reason) or _heartbeat_failure_reason(owned_reason)):
         return normalized
     return "AUTOMATIC"
+
+
+def _causal_activation(status: dict[str, Any]) -> tuple[str, str]:
+    history = list(status.get("recent_history") or [])
+    if not history:
+        return "", ""
+    latest = history[-1] if isinstance(history[-1], dict) else {}
+    latest_reason = str(latest.get("reason") or "")
+    latest_source = str(latest.get("source") or "")
+    if latest_source.strip().upper() == "FILE_SYSTEM" and "Kill switch file detected" in latest_reason:
+        for item in reversed(history[:-1]):
+            if not isinstance(item, dict) or not item.get("source"):
+                continue
+            reason = str(item.get("reason") or "")
+            source = str(item.get("source") or "")
+            if source.strip().upper() == "FILE_SYSTEM" and "Kill switch file detected" in reason:
+                continue
+            return reason, source
+    return latest_reason, latest_source
+
+
+def _eligible_persisted_heartbeat_stop(status: dict[str, Any]) -> tuple[bool, str]:
+    """Accept only restart-persisted retired heartbeat stops.
+
+    MANUAL is accepted solely as a compatibility classification when the reason
+    itself is the exact retired heartbeat/core-death signature. Ordinary
+    MANUAL/UI/CLI/FILE_SYSTEM and unrelated automatic risk stops are preserved.
+    """
+
+    history = list(status.get("recent_history") or [])
+    if not history or not isinstance(history[-1], dict):
+        return False, "history_missing"
+    latest = history[-1]
+    latest_reason = str(latest.get("reason") or "")
+    latest_source = str(latest.get("source") or "").strip().upper()
+    if latest_source != "FILE_SYSTEM" or "Kill switch file detected" not in latest_reason:
+        return False, "latest_not_restart_persistence"
+
+    reason, source = _causal_activation(status)
+    source_u = str(source or "").strip().upper()
+    if not _heartbeat_failure_reason(reason):
+        return False, "causal_reason_not_retired_heartbeat"
+    if source_u in {"UI", "CLI", "FILE_SYSTEM"}:
+        return False, "causal_source_forbidden"
+    if source_u == "MANUAL":
+        if _explicit_manual_reason(reason):
+            return False, "causal_source_forbidden"
+        return True, "legacy_manual_heartbeat_provenance"
+    if source_u not in {"AUTO", "AUTOMATIC", "HEARTBEAT", "AUTHORITY_HEARTBEAT"}:
+        return False, "causal_source_forbidden"
+    return True, "automatic_heartbeat_provenance"
+
+
+def _writer_core_proof() -> tuple[bool, str]:
+    if os.environ.get("NIJA_AUTHORITY_HEARTBEAT_STARTUP_GRACE_V129_INSTALLED") != "1":
+        return False, "v129_not_installed"
+    if not _truthy_env("NIJA_CORE_THREAD_ALIVE"):
+        return False, "core_not_alive_env"
+
+    try:
+        module = importlib.import_module("bot.entrypoint_writer_authority")
+        getter = getattr(module, "get_entrypoint_writer_authority", None)
+        writer = getter() if callable(getter) else None
+        if writer is None:
+            return False, "writer_missing"
+        if not bool(getattr(writer, "acquired", False)) or bool(getattr(writer, "lost", False)):
+            return False, "writer_epoch_not_current"
+        if not bool(getattr(writer, "_core_thread_registered", False)):
+            return False, "core_not_registered"
+        core = getattr(writer, "_core_thread", None)
+        alive = getattr(core, "is_alive", None) if core is not None else None
+        if not callable(alive) or not bool(alive()):
+            return False, "core_thread_not_live"
+        renewal = getattr(writer, "_nija_lease_renewal_health", None)
+        if not callable(renewal):
+            return False, "writer_renewal_health_missing"
+        healthy, reason, age_s, max_age_s = renewal()
+        if not bool(healthy):
+            return False, f"writer_renewal_unhealthy:{reason}:age={age_s}:max={max_age_s}"
+    except Exception as exc:
+        return False, f"writer_probe:{type(exc).__name__}:{exc}"
+    return True, "writer_core_current"
+
+
+def _readiness_proof() -> tuple[bool, str]:
+    try:
+        table = importlib.import_module("bot.readiness_table").snapshot()
+        required = (
+            "broker_connected",
+            "balance_hydrated",
+            "capital_ready",
+            "risk_ready",
+            "strategy_ready",
+            "nonce_ready",
+            "bootstrap_ready",
+            "position_sync_ready",
+        )
+        missing = [name for name in required if not bool(table.get(name, False))]
+        if missing:
+            return False, "readiness:" + ",".join(missing)
+    except Exception as exc:
+        return False, f"readiness_probe:{type(exc).__name__}:{exc}"
+
+    try:
+        bootstrap = importlib.import_module("bot.bootstrap_state_machine")
+        getter = getattr(bootstrap, "get_bootstrap_fsm", None) or getattr(
+            bootstrap, "get_bootstrap_state_machine", None
+        )
+        fsm = getter() if callable(getter) else None
+        state = getattr(fsm, "state", None) if fsm is not None else None
+        state_value = str(getattr(state, "value", state) or "").strip().upper()
+        if state_value != "RUNNING_SUPERVISED":
+            return False, "bootstrap:" + (state_value or "unknown")
+    except Exception as exc:
+        return False, f"bootstrap_probe:{type(exc).__name__}:{exc}"
+    return True, "readiness_current"
+
+
+def _seak_status() -> tuple[Any, bool, str]:
+    try:
+        module = importlib.import_module("bot.single_execution_authority_kernel")
+        getter = getattr(module, "get_seak", None) or getattr(
+            module, "get_single_execution_authority_kernel", None
+        )
+        seak = getter() if callable(getter) else None
+        if seak is None:
+            return None, False, ""
+        halted = bool(getattr(seak, "is_halted", False))
+        reason = str(getattr(seak, "halt_reason", "") or getattr(seak, "_halt_reason", "") or "")
+        if not reason:
+            snapshot = getattr(seak, "snapshot", None)
+            if callable(snapshot):
+                try:
+                    payload = snapshot() or {}
+                    if isinstance(payload, dict):
+                        reason = str(payload.get("halt_reason") or "")
+                except Exception:
+                    pass
+        return seak, halted, reason
+    except Exception as exc:
+        return None, True, f"seak_probe:{type(exc).__name__}:{exc}"
+
+
+def _runtime_recovery_proof() -> tuple[bool, str, Any, bool]:
+    writer_ok, writer_detail = _writer_core_proof()
+    if not writer_ok:
+        return False, writer_detail, None, False
+    readiness_ok, readiness_detail = _readiness_proof()
+    if not readiness_ok:
+        return False, readiness_detail, None, False
+
+    seak, halted, seak_reason = _seak_status()
+    if halted and not _heartbeat_failure_reason(seak_reason):
+        return False, "seak_halt_not_heartbeat_owned:" + (seak_reason or "unknown"), seak, True
+    return True, "ok", seak, halted
+
+
+def _fsm_state_value() -> str:
+    try:
+        module = importlib.import_module("bot.trading_state_machine")
+        getter = getattr(module, "get_state_machine", None)
+        sm = getter() if callable(getter) else None
+        state = sm.get_current_state() if sm is not None else None
+        return str(getattr(state, "value", state) or "UNAVAILABLE").strip().upper()
+    except Exception:
+        return "UNAVAILABLE"
+
+
+def _attempt_persisted_heartbeat_stop_recovery() -> bool:
+    """Recover a restart-persisted retired heartbeat stop to fail-closed OFF."""
+    try:
+        kill_module = importlib.import_module("bot.kill_switch")
+        getter = getattr(kill_module, "get_kill_switch", None)
+        kill_switch = getter() if callable(getter) else None
+        if kill_switch is None:
+            return False
+        status = kill_switch.get_status()
+    except Exception as exc:
+        LOGGER.warning(
+            "HEARTBEAT_PERSISTED_STOP_RECOVERY_DEFERRED marker=%s detail=kill_switch_probe:%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    if not bool(status.get("is_active")):
+        return False
+    eligible, provenance = _eligible_persisted_heartbeat_stop(status)
+    if not eligible:
+        return False
+
+    healthy, detail, seak, seak_halted = _runtime_recovery_proof()
+    if not healthy:
+        LOGGER.warning(
+            "HEARTBEAT_PERSISTED_STOP_RECOVERY_DEFERRED marker=%s provenance=%s detail=%s "
+            "trading_fail_closed=true",
+            MARKER,
+            provenance,
+            detail,
+        )
+        return False
+
+    causal_reason, causal_source = _causal_activation(status)
+    try:
+        kill_switch.deactivate(
+            "verified recovery from retired authority-heartbeat/core-death restart persistence"
+        )
+        if bool(kill_switch.is_active()):
+            LOGGER.critical(
+                "HEARTBEAT_PERSISTED_STOP_RECOVERY_REFUSED marker=%s still_active=true trading_fail_closed=true",
+                MARKER,
+            )
+            return False
+    except Exception as exc:
+        LOGGER.critical(
+            "HEARTBEAT_PERSISTED_STOP_RECOVERY_FAILED marker=%s stage=kill_switch_deactivate "
+            "err=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    # KillSwitch.deactivate() is expected to return the trading FSM to OFF.
+    # Verify that invariant before releasing the independent SEAK halt.
+    fsm_state = _fsm_state_value()
+    if fsm_state != "OFF":
+        LOGGER.critical(
+            "HEARTBEAT_PERSISTED_STOP_RECOVERY_INCOMPLETE marker=%s "
+            "reason=fsm_not_off_after_kill_switch_clear state=%s "
+            "seak_remains_fail_closed=true force_live=false",
+            MARKER,
+            fsm_state,
+        )
+        return False
+
+    # Resume only the SEAK halt already proven to be owned by this same retired
+    # heartbeat stop. Any failure here leaves SEAK halted and execution closed.
+    if seak_halted and seak is not None:
+        resume = getattr(seak, "resume", None)
+        if not callable(resume):
+            LOGGER.critical(
+                "HEARTBEAT_PERSISTED_STOP_RECOVERY_INCOMPLETE marker=%s reason=seak_resume_missing "
+                "trading_fail_closed=true",
+                MARKER,
+            )
+            return False
+        try:
+            resume(caller="runtime_killswitch_authority_liveness_v140")
+        except Exception as exc:
+            LOGGER.critical(
+                "HEARTBEAT_PERSISTED_STOP_RECOVERY_INCOMPLETE marker=%s stage=seak_resume "
+                "err=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+    os.environ.pop(_OWNED_STOP_ENV, None)
+    os.environ.pop(_OWNED_REASON_ENV, None)
+    LOGGER.critical(
+        "HEARTBEAT_PERSISTED_STOP_RECOVERED marker=%s provenance=%s causal_source=%s "
+        "causal_reason=%s writer_core_current=true readiness_current=true "
+        "seak_resumed=%s fsm_target=OFF force_live=false execution_authority_unchanged=true",
+        MARKER,
+        provenance,
+        causal_source or "unknown",
+        causal_reason or "unknown",
+        str(bool(seak_halted)).lower(),
+    )
+    return True
 
 
 def _patch_kill_switch() -> bool:
@@ -88,7 +384,7 @@ def _patch_kill_switch() -> bool:
         source: str = "MANUAL",
     ) -> Any:
         normalized = _normalized_activation_source(reason, source)
-        if normalized != str(source or "MANUAL").strip():
+        if normalized != (str(source or "MANUAL").strip() or "MANUAL"):
             LOGGER.critical(
                 "HEARTBEAT_KILL_SWITCH_SOURCE_NORMALIZED marker=%s "
                 "source_before=%s source_after=%s reason=%s",
@@ -158,9 +454,9 @@ def _patch_stalled_writer_release_guard() -> bool:
         if not canonical:
             return bool(current(snapshot, elapsed_s, timeout_s))
 
-        # v58 intentionally made the canonical Render path diagnostic-only:
+        # v58 intentionally makes the canonical Render path diagnostic-only:
         # bot_main owns shutdown/re-election and this legacy guard must never
-        # compare-and-delete a healthy writer lease behind it.  Preserve that
+        # compare-and-delete the writer lease behind it. Preserve that safety
         # contract, but stop describing a live registered core as "startup".
         if elapsed_s >= timeout_s:
             core_live = bool(v58._canonical_core_registered())
@@ -191,16 +487,57 @@ def _patch_stalled_writer_release_guard() -> bool:
     return True
 
 
+def _reassert_runtime_wrappers() -> bool:
+    try:
+        return bool(
+            _patch_authority_heartbeat_callback()
+            and _patch_kill_switch()
+            and _patch_stalled_writer_release_guard()
+        )
+    except Exception as exc:
+        LOGGER.warning(
+            "RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_REASSERT_FAILED marker=%s err=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+def _patch_v132_durability() -> bool:
+    v132 = importlib.import_module("bot.readiness_killswitch_durability_v132_patch")
+    current = getattr(v132, "_attempt_persisted_stop_recovery", None)
+    if not callable(current):
+        return False
+    if getattr(current, _V132_PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def durable_recovery_v140() -> bool:
+        _reassert_runtime_wrappers()
+        try:
+            kill_module = importlib.import_module("bot.kill_switch")
+            getter = getattr(kill_module, "get_kill_switch", None)
+            kill_switch = getter() if callable(getter) else None
+            status = kill_switch.get_status() if kill_switch is not None else {}
+            eligible, _detail = _eligible_persisted_heartbeat_stop(status)
+        except Exception:
+            eligible = False
+        if eligible:
+            return _attempt_persisted_heartbeat_stop_recovery()
+        return bool(current())
+
+    setattr(durable_recovery_v140, _V132_PATCH_ATTR, True)
+    v132._attempt_persisted_stop_recovery = durable_recovery_v140
+    return True
+
+
 def install() -> bool:
     """Install/reassert all non-authoritative convergence wrappers."""
     global _ANNOUNCED
     with _LOCK:
         try:
-            ok = bool(
-                _patch_authority_heartbeat_callback()
-                and _patch_kill_switch()
-                and _patch_stalled_writer_release_guard()
-            )
+            ok = bool(_reassert_runtime_wrappers() and _patch_v132_durability())
         except Exception as exc:
             os.environ.pop(_FLAG, None)
             LOGGER.critical(
@@ -222,9 +559,27 @@ def install() -> bool:
             _ANNOUNCED = True
             LOGGER.critical(
                 "RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_INSTALLED marker=%s "
-                "heartbeat_source_preserved=true generic_manual_source_unchanged=true "
-                "kill_switch_auto_clear=false writer_release=false execution_authority_unchanged=true",
+                "legacy_manual_heartbeat_compat=true heartbeat_source_preserved=true "
+                "heartbeat_seak_cycle_broken=true generic_manual_stops_preserved=true "
+                "kill_switch_generic_auto_clear=false writer_release=false force_live=false "
+                "execution_authority_unchanged=true",
                 MARKER,
+            )
+
+        # One immediate recovery check covers a stop already present when this
+        # patch is installed. If proofs are not yet healthy the v132 durability
+        # worker retries every five seconds without widening eligibility.
+        try:
+            v132 = importlib.import_module("bot.readiness_killswitch_durability_v132_patch")
+            attempt = getattr(v132, "_attempt_persisted_stop_recovery", None)
+            if callable(attempt):
+                attempt()
+        except Exception as exc:
+            LOGGER.warning(
+                "HEARTBEAT_PERSISTED_STOP_INITIAL_CHECK_FAILED marker=%s err=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
             )
         return True
 
@@ -239,7 +594,10 @@ __all__ = [
     "install_import_hook",
     "_heartbeat_failure_reason",
     "_normalized_activation_source",
-    "_patch_authority_heartbeat_callback",
-    "_patch_kill_switch",
+    "_causal_activation",
+    "_eligible_persisted_heartbeat_stop",
+    "_runtime_recovery_proof",
+    "_attempt_persisted_heartbeat_stop_recovery",
+    "_patch_v132_durability",
     "_patch_stalled_writer_release_guard",
 ]

--- a/bot/runtime_killswitch_authority_liveness_patch.py
+++ b/bot/runtime_killswitch_authority_liveness_patch.py
@@ -1,0 +1,245 @@
+"""Preserve heartbeat kill-switch causality and canonical writer ownership.
+
+This runtime patch is deliberately non-authoritative: it never activates or
+clears the kill switch, never grants execution authority, never resumes SEAK,
+and never releases the canonical writer lease.  It only:
+
+* preserves AUTOMATIC provenance when an existing caller materializes a
+  heartbeat-owned emergency stop through ``KillSwitch.activate`` without an
+  explicit source; and
+* replaces the legacy v58 canonical-path stalled-writer diagnostic with a
+  throttled owner/phase diagnostic while keeping destructive release disabled.
+
+The v132 durability worker periodically reasserts these wrappers so later
+compatibility churn cannot silently restore the old behavior.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_killswitch_authority_liveness")
+MARKER = "20260817-runtime-killswitch-authority-liveness-v1"
+_FLAG = "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_READY"
+_LOCK = threading.RLock()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_KILL_PATCH_ATTR = "_nija_heartbeat_killswitch_provenance_v1"
+_HEARTBEAT_PATCH_ATTR = "_nija_heartbeat_owned_stop_provenance_v1"
+_WRITER_PATCH_ATTR = "_nija_canonical_writer_release_diagnostic_v1"
+_OWNED_STOP_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP"
+_OWNED_REASON_ENV = "NIJA_AUTHORITY_HEARTBEAT_OWNED_STOP_REASON"
+_LAST_WRITER_DIAGNOSTIC: dict[str, float] = {}
+_ANNOUNCED = False
+
+
+def _truthy_env(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in _TRUE
+
+
+def _heartbeat_failure_reason(reason: object) -> bool:
+    text = str(reason or "").strip().upper()
+    if not text:
+        return False
+    heartbeat = "AUTHORITY_HEARTBEAT_EXPIRED" in text or "AUTHORITY HEARTBEAT EXPIRED" in text
+    dead_core = "CORE_THREAD_DEAD" in text or "NIJA_CORE_THREAD_ALIVE" in text
+    return heartbeat and dead_core
+
+
+def _normalized_activation_source(reason: object, source: object) -> str:
+    """Return AUTOMATIC only for a runtime-proven heartbeat-owned stop.
+
+    ``KillSwitch.activate`` historically defaults ``source`` to MANUAL.  That
+    default is correct for generic callers, so it is preserved unless the
+    authority-heartbeat callback has already published its owned-stop marker
+    and the activation reason carries the matching heartbeat/core-death proof.
+    """
+
+    normalized = str(source or "MANUAL").strip() or "MANUAL"
+    if normalized.upper() != "MANUAL":
+        return normalized
+    if not _truthy_env(_OWNED_STOP_ENV):
+        return normalized
+    if not _heartbeat_failure_reason(reason):
+        return normalized
+    return "AUTOMATIC"
+
+
+def _patch_kill_switch() -> bool:
+    module = importlib.import_module("bot.kill_switch")
+    cls = getattr(module, "KillSwitch", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "activate", None)
+    if not callable(current):
+        return False
+    if getattr(current, _KILL_PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def activate_with_heartbeat_provenance(
+        self: Any,
+        reason: str,
+        source: str = "MANUAL",
+    ) -> Any:
+        normalized = _normalized_activation_source(reason, source)
+        if normalized != str(source or "MANUAL").strip():
+            LOGGER.critical(
+                "HEARTBEAT_KILL_SWITCH_SOURCE_NORMALIZED marker=%s "
+                "source_before=%s source_after=%s reason=%s",
+                MARKER,
+                source or "MANUAL",
+                normalized,
+                reason,
+            )
+        return current(self, reason, normalized)
+
+    setattr(activate_with_heartbeat_provenance, _KILL_PATCH_ATTR, True)
+    cls.activate = activate_with_heartbeat_provenance
+    return True
+
+
+def _patch_authority_heartbeat_callback() -> bool:
+    module = importlib.import_module("bot.authority_heartbeat")
+    current = getattr(module, "_default_lockdown_callback", None)
+    if not callable(current):
+        return False
+    if getattr(current, _HEARTBEAT_PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def heartbeat_owned_lockdown(reason: str) -> Any:
+        os.environ[_OWNED_STOP_ENV] = "1"
+        os.environ[_OWNED_REASON_ENV] = str(reason or "unknown")
+        return current(reason)
+
+    setattr(heartbeat_owned_lockdown, _HEARTBEAT_PATCH_ATTR, True)
+    module._default_lockdown_callback = heartbeat_owned_lockdown
+
+    existing = getattr(module, "_monitor_instance", None)
+    if existing is not None:
+        callback = getattr(existing, "_lockdown_callback", None)
+        if callback is current:
+            existing._lockdown_callback = heartbeat_owned_lockdown
+    return True
+
+
+def _writer_diagnostic_interval_s() -> float:
+    try:
+        return max(
+            60.0,
+            float(os.environ.get("NIJA_CANONICAL_WRITER_RELEASE_DIAGNOSTIC_INTERVAL_S", "300") or 300.0),
+        )
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def _patch_stalled_writer_release_guard() -> bool:
+    guard = importlib.import_module("bot.stalled_writer_release_guard_v22")
+    v58 = importlib.import_module("bot.final_production_activation_repair_v58_patch")
+    current = getattr(guard, "_should_release", None)
+    if not callable(current):
+        return False
+    if getattr(current, _WRITER_PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def should_release_with_canonical_owner(
+        snapshot: Any,
+        elapsed_s: float,
+        timeout_s: float,
+    ) -> bool:
+        canonical = bool(v58._canonical_fast_path())
+        if not canonical:
+            return bool(current(snapshot, elapsed_s, timeout_s))
+
+        # v58 intentionally made the canonical Render path diagnostic-only:
+        # bot_main owns shutdown/re-election and this legacy guard must never
+        # compare-and-delete a healthy writer lease behind it.  Preserve that
+        # contract, but stop describing a live registered core as "startup".
+        if elapsed_s >= timeout_s:
+            core_live = bool(v58._canonical_core_registered())
+            phase = "runtime_core_live" if core_live else "startup_handoff"
+            generation = str(getattr(snapshot, "generation", "0") or "0")
+            state = str(getattr(snapshot, "state", "unknown") or "unknown")
+            key = f"{generation}:{phase}:{state}"
+            now = time.monotonic()
+            last = _LAST_WRITER_DIAGNOSTIC.get(key, 0.0)
+            if now - last >= _writer_diagnostic_interval_s():
+                _LAST_WRITER_DIAGNOSTIC[key] = now
+                LOGGER.warning(
+                    "WRITER_RELEASE_SUPPRESSED_BY_CANONICAL_OWNER marker=%s "
+                    "phase=%s elapsed_s=%.1f timeout_s=%.1f state=%s generation=%s "
+                    "writer_release_owner=bot_main core_live=%s destructive_release=false",
+                    MARKER,
+                    phase,
+                    elapsed_s,
+                    timeout_s,
+                    state,
+                    generation,
+                    str(core_live).lower(),
+                )
+        return False
+
+    setattr(should_release_with_canonical_owner, _WRITER_PATCH_ATTR, True)
+    guard._should_release = should_release_with_canonical_owner
+    return True
+
+
+def install() -> bool:
+    """Install/reassert all non-authoritative convergence wrappers."""
+    global _ANNOUNCED
+    with _LOCK:
+        try:
+            ok = bool(
+                _patch_authority_heartbeat_callback()
+                and _patch_kill_switch()
+                and _patch_stalled_writer_release_guard()
+            )
+        except Exception as exc:
+            os.environ.pop(_FLAG, None)
+            LOGGER.critical(
+                "RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_INSTALL_FAILED marker=%s "
+                "err=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            return False
+
+        os.environ[_FLAG] = "1"
+        if not _ANNOUNCED:
+            _ANNOUNCED = True
+            LOGGER.critical(
+                "RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_INSTALLED marker=%s "
+                "heartbeat_source_preserved=true generic_manual_source_unchanged=true "
+                "kill_switch_auto_clear=false writer_release=false execution_authority_unchanged=true",
+                MARKER,
+            )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_heartbeat_failure_reason",
+    "_normalized_activation_source",
+    "_patch_authority_heartbeat_callback",
+    "_patch_kill_switch",
+    "_patch_stalled_writer_release_guard",
+]

--- a/tests/test_runtime_killswitch_authority_liveness.py
+++ b/tests/test_runtime_killswitch_authority_liveness.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import bot.runtime_killswitch_authority_liveness_patch as mod
+
+
+_HEARTBEAT_REASON = (
+    "AUTHORITY_HEARTBEAT_EXPIRED: core_thread_dead - "
+    "NIJA_CORE_THREAD_ALIVE is not set"
+)
+
+
+def _status(source: str, reason: str):
+    return {
+        "is_active": True,
+        "recent_history": [
+            {"source": source, "reason": reason},
+            {"source": "FILE_SYSTEM", "reason": "Kill switch file detected"},
+        ],
+    }
+
+
+def test_heartbeat_signature_is_narrow():
+    assert mod._heartbeat_failure_reason(_HEARTBEAT_REASON)
+    assert not mod._heartbeat_failure_reason("AUTHORITY_HEARTBEAT_EXPIRED: redis timeout")
+    assert not mod._heartbeat_failure_reason("daily loss limit exceeded")
+
+
+def test_legacy_manual_heartbeat_persistence_is_eligible():
+    ok, detail = mod._eligible_persisted_heartbeat_stop(_status("MANUAL", _HEARTBEAT_REASON))
+    assert ok is True
+    assert detail == "legacy_manual_heartbeat_provenance"
+
+
+def test_explicit_operator_manual_stop_is_preserved():
+    reason = "operator manual stop after AUTHORITY_HEARTBEAT_EXPIRED: core_thread_dead"
+    ok, detail = mod._eligible_persisted_heartbeat_stop(_status("MANUAL", reason))
+    assert ok is False
+    assert detail == "causal_source_forbidden"
+
+
+def test_unrelated_automatic_risk_stop_is_preserved():
+    ok, detail = mod._eligible_persisted_heartbeat_stop(
+        _status("AUTOMATIC", "daily loss limit exceeded")
+    )
+    assert ok is False
+    assert detail == "causal_reason_not_retired_heartbeat"
+
+
+def test_unknown_source_is_preserved_even_with_heartbeat_words():
+    ok, detail = mod._eligible_persisted_heartbeat_stop(
+        _status("FAILURE_MODE_MANAGER", _HEARTBEAT_REASON)
+    )
+    assert ok is False
+    assert detail == "causal_source_forbidden"
+
+
+def test_direct_new_heartbeat_stop_is_not_restart_eligible():
+    status = {
+        "is_active": True,
+        "recent_history": [{"source": "AUTOMATIC", "reason": _HEARTBEAT_REASON}],
+    }
+    ok, detail = mod._eligible_persisted_heartbeat_stop(status)
+    assert ok is False
+    assert detail == "latest_not_restart_persistence"
+
+
+def test_source_normalization_requires_owned_heartbeat(monkeypatch):
+    monkeypatch.delenv(mod._OWNED_STOP_ENV, raising=False)
+    monkeypatch.delenv(mod._OWNED_REASON_ENV, raising=False)
+    assert mod._normalized_activation_source("generic system stop", "MANUAL") == "MANUAL"
+
+    monkeypatch.setenv(mod._OWNED_STOP_ENV, "1")
+    monkeypatch.setenv(
+        mod._OWNED_REASON_ENV,
+        "AUTHORITY HEARTBEAT EXPIRED: 3 failures; core_thread_dead",
+    )
+    assert mod._normalized_activation_source("state machine emergency stop", "MANUAL") == "AUTOMATIC"
+    assert mod._normalized_activation_source("operator manual stop", "MANUAL") == "MANUAL"
+    assert mod._normalized_activation_source("state machine emergency stop", "UI") == "UI"
+
+
+def test_recovery_clears_only_verified_latch_and_returns_to_off(monkeypatch):
+    class FakeKillSwitch:
+        def __init__(self):
+            self.active = True
+            self.deactivations = []
+
+        def get_status(self):
+            return _status("MANUAL", _HEARTBEAT_REASON)
+
+        def deactivate(self, reason):
+            self.deactivations.append(reason)
+            self.active = False
+
+        def is_active(self):
+            return self.active
+
+    class FakeSeak:
+        def __init__(self):
+            self.resumed = []
+
+        def resume(self, caller="operator"):
+            self.resumed.append(caller)
+
+    kill = FakeKillSwitch()
+    seak = FakeSeak()
+    kill_module = SimpleNamespace(get_kill_switch=lambda: kill)
+    original_import = mod.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.kill_switch":
+            return kill_module
+        return original_import(name)
+
+    monkeypatch.setattr(mod.importlib, "import_module", fake_import)
+    monkeypatch.setattr(mod, "_runtime_recovery_proof", lambda: (True, "ok", seak, True))
+    monkeypatch.setattr(mod, "_fsm_state_value", lambda: "OFF")
+
+    assert mod._attempt_persisted_heartbeat_stop_recovery() is True
+    assert len(kill.deactivations) == 1
+    assert seak.resumed == ["runtime_killswitch_authority_liveness_v140"]
+
+
+def test_recovery_does_not_resume_seak_until_fsm_is_off(monkeypatch):
+    class FakeKillSwitch:
+        def __init__(self):
+            self.active = True
+
+        def get_status(self):
+            return _status("AUTOMATIC", _HEARTBEAT_REASON)
+
+        def deactivate(self, _reason):
+            self.active = False
+
+        def is_active(self):
+            return self.active
+
+    class FakeSeak:
+        def __init__(self):
+            self.resumed = False
+
+        def resume(self, caller="operator"):
+            self.resumed = True
+
+    kill = FakeKillSwitch()
+    seak = FakeSeak()
+    original_import = mod.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.kill_switch":
+            return SimpleNamespace(get_kill_switch=lambda: kill)
+        return original_import(name)
+
+    monkeypatch.setattr(mod.importlib, "import_module", fake_import)
+    monkeypatch.setattr(mod, "_runtime_recovery_proof", lambda: (True, "ok", seak, True))
+    monkeypatch.setattr(mod, "_fsm_state_value", lambda: "EMERGENCY_STOP")
+
+    assert mod._attempt_persisted_heartbeat_stop_recovery() is False
+    assert seak.resumed is False
+
+
+def test_recovery_keeps_stop_when_runtime_proof_is_not_healthy(monkeypatch):
+    class FakeKillSwitch:
+        def __init__(self):
+            self.deactivated = False
+
+        def get_status(self):
+            return _status("AUTOMATIC", _HEARTBEAT_REASON)
+
+        def deactivate(self, _reason):
+            self.deactivated = True
+
+        def is_active(self):
+            return True
+
+    kill = FakeKillSwitch()
+    original_import = mod.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.kill_switch":
+            return SimpleNamespace(get_kill_switch=lambda: kill)
+        return original_import(name)
+
+    monkeypatch.setattr(mod.importlib, "import_module", fake_import)
+    monkeypatch.setattr(
+        mod,
+        "_runtime_recovery_proof",
+        lambda: (False, "writer_epoch_not_current", None, False),
+    )
+
+    assert mod._attempt_persisted_heartbeat_stop_recovery() is False
+    assert kill.deactivated is False
+
+
+def test_canonical_writer_guard_remains_diagnostic_only(monkeypatch):
+    calls = []
+
+    def original_should_release(snapshot, elapsed_s, timeout_s):
+        calls.append((snapshot, elapsed_s, timeout_s))
+        return True
+
+    guard = SimpleNamespace(_should_release=original_should_release)
+    v58 = SimpleNamespace(
+        _canonical_fast_path=lambda: True,
+        _canonical_core_registered=lambda: True,
+    )
+    original_import = mod.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.stalled_writer_release_guard_v22":
+            return guard
+        if name == "bot.final_production_activation_repair_v58_patch":
+            return v58
+        return original_import(name)
+
+    monkeypatch.setattr(mod.importlib, "import_module", fake_import)
+    assert mod._patch_stalled_writer_release_guard() is True
+    snap = SimpleNamespace(generation="4225", state="OFF")
+    assert guard._should_release(snap, 2530.5, 360.0) is False
+    assert calls == []
+
+
+def test_patch_has_no_live_or_execution_authority_grant():
+    source = inspect.getsource(mod)
+    assert 'NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"' not in source
+    assert "TradingState.LIVE_ACTIVE" not in source
+    assert "force_live=false" in source
+    assert "writer_release=false" in source


### PR DESCRIPTION
## Summary

Fix the remaining production convergence deadlock visible in the 2026-08-18 runtime logs: broker/capital/risk/nonce/bootstrap proofs are healthy, but a restart-persisted authority-heartbeat stop keeps the canonical kill switch active, leaving `authority_ready` and `execution_ready` false.

## Root cause

Two narrow compatibility defects can preserve this retired stop indefinitely:

1. historical heartbeat-owned stops can reach `KillSwitch.activate()` through compatibility paths without an explicit source, so its legacy default records them as `MANUAL`; v132 correctly refuses to auto-clear ordinary manual stops;
2. v130 requires SEAK to be clear before clearing the persisted heartbeat kill switch, while the heartbeat-owned SEAK recovery requires the kill switch to be clear first.

## Changes

- Add `runtime_killswitch_authority_liveness_patch` (v140).
- Preserve `AUTOMATIC` provenance for future heartbeat-owned stop materialization, but only when the heartbeat-owned marker and retired heartbeat/core-death signature are present.
- Recover a legacy `MANUAL` record only when it is immediately followed by restart file persistence and the causal reason is the exact retired `AUTHORITY_HEARTBEAT_EXPIRED` + core-death signature.
- Keep `UI`, `CLI`, explicit operator/manual reasons, file-system stops, unknown sources, and unrelated automatic risk stops protected.
- Require current writer lease/renewal, registered live core, broker/balance/capital/risk/strategy/nonce/bootstrap/position-sync readiness, and `RUNNING_SUPERVISED` before recovery.
- Permit the circular SEAK dependency to resolve only when the SEAK halt itself has the same heartbeat/core-death signature.
- Clear the stale kill-switch latch first, verify the trading FSM is `OFF`, then resume only the heartbeat-owned SEAK halt. No transition to `LIVE_ACTIVE` is performed.
- Keep the canonical writer lease owned by `bot_main`; replace the misleading long-running `...DURING_CANONICAL_STARTUP` condition with a throttled `runtime_core_live`/`startup_handoff` diagnostic while destructive release remains disabled.
- Chain the repair through the existing kill-switch coordinator installer so startup fails closed if the repair cannot install.
- Add targeted regression coverage to the import-smoke runtime convergence job.

## Safety invariants

- no generic kill-switch auto-clear
- no execution-authority grant
- no forced `LIVE_ACTIVE`
- no risk/nonce/capital threshold relaxation
- no canonical writer-lease release
- manual/operator/UI/CLI/unrelated risk stops remain fail-closed
- recovery target is `OFF`; normal activation gates must reconverge before dispatch

## Validation

Local isolated validation completed for the new module: Python compilation succeeds and the focused provenance/eligibility unit subset passes. GitHub Actions is the authoritative full-repository validation because this environment cannot clone the private repo or run `gh`/networked checkout locally.