### PR TITLE
Fix stalled writer capital freshness v141

### DIFF
--- a/.github/workflows/import-smoke.yml
+++ b/.github/workflows/import-smoke.yml
@@ -57,4 +57,5 @@ jobs:
             tests/test_capital_publication_deadline_v137.py \
             tests/test_final_execution_state_router_convergence_v138.py \
             tests/test_runtime_release_identity_v139.py \
-            tests/test_runtime_killswitch_authority_liveness.py
+            tests/test_runtime_killswitch_authority_liveness.py \
+            tests/test_stalled_writer_capital_freshness_v141.py

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -117,16 +117,15 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
 
 
 def _install_authority_liveness() -> bool:
-    """Chain the narrow heartbeat-stop liveness repair fail-closed."""
+    """Chain narrow runtime liveness repairs fail-closed."""
     try:
         from bot import runtime_killswitch_authority_liveness_patch as liveness
 
         installer = getattr(liveness, "install_import_hook", None) or getattr(
             liveness, "install", None
         )
-        if not callable(installer):
+        if not callable(installer) or not bool(installer()):
             return False
-        return bool(installer())
     except Exception as exc:
         logger.exception(
             "KILL_SWITCH_AUTHORITY_LIVENESS_CHAIN_FAILED marker=%s error=%s",
@@ -134,6 +133,24 @@ def _install_authority_liveness() -> bool:
             exc,
         )
         return False
+
+    try:
+        from bot import stalled_writer_capital_freshness_v141_patch as capital_liveness
+
+        installer = getattr(capital_liveness, "install_import_hook", None) or getattr(
+            capital_liveness, "install", None
+        )
+        if not callable(installer) or not bool(installer()):
+            return False
+    except Exception as exc:
+        logger.exception(
+            "STALLED_WRITER_CAPITAL_FRESHNESS_CHAIN_FAILED marker=%s error=%s",
+            _MARKER,
+            exc,
+        )
+        return False
+
+    return True
 
 
 def install_import_hook() -> None:
@@ -154,13 +171,14 @@ def install_import_hook() -> None:
         if not _publish_coordinator_truth(active, "install_reconcile"):
             raise RuntimeError("startup_coordinator_sync_failed")
         if not _install_authority_liveness():
-            raise RuntimeError("runtime_killswitch_authority_liveness_not_ready")
+            raise RuntimeError("runtime_liveness_guards_not_ready")
 
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_INSTALLED"] = "1"
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_READY"] = "1"
         logger.critical(
             "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
-            "risk_gates_unchanged=true authority_liveness_chained=true",
+            "risk_gates_unchanged=true authority_liveness_chained=true "
+            "stalled_writer_capital_freshness_chained=true",
             _MARKER,
             str(active).lower(),
         )

--- a/bot/stalled_writer_capital_freshness_v141_patch.py
+++ b/bot/stalled_writer_capital_freshness_v141_patch.py
@@ -1,0 +1,182 @@
+"""Make stalled-writer liveness consume canonical capital publication freshness.
+
+The legacy v22 stalled-writer guard predates the immutable publication contract.
+Its local capital probe can turn a stale snapshot back into fresh when a historic
+handoff/first-snapshot latch is present. Production then reports canonical
+``capital_ready=False`` while v22 reports ``capital_ready=True`` and keeps the
+writer lease indefinitely past its release timeout.
+
+v141 makes immutable CapitalAuthority publication status authoritative for this
+liveness guard only. It never changes capital values, extends publication expiry,
+marks readiness, clears a kill switch, grants writer/nonce authority, or alters
+risk/execution gates.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.stalled_writer_capital_freshness_v141")
+MARKER = "20260818-stalled-writer-capital-freshness-v141"
+_FLAG = "NIJA_STALLED_WRITER_CAPITAL_FRESHNESS_V141_INSTALLED"
+_PATCH_ATTR = "_nija_stalled_writer_capital_freshness_v141"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _utc(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _authority() -> Any:
+    for name in ("bot.capital_authority", "capital_authority"):
+        try:
+            module = importlib.import_module(name)
+        except ImportError:
+            continue
+        getter = getattr(module, "get_capital_authority", None)
+        if callable(getter):
+            authority = getter()
+            if authority is not None:
+                return authority
+    raise RuntimeError("capital_authority_unavailable")
+
+
+def _publication_current(authority: Any, *, now: datetime | None = None) -> tuple[bool, str]:
+    getter = getattr(authority, "get_snapshot_publication_status", None)
+    if not callable(getter):
+        return False, "publication_status_unavailable"
+    try:
+        status = getter()
+    except Exception as exc:
+        return False, f"publication_status_error:{type(exc).__name__}:{exc}"
+    if status is None:
+        return False, "publication_status_missing"
+
+    accepted = bool(getattr(status, "accepted", False))
+    stale = bool(getattr(status, "stale", True))
+    reason = str(getattr(status, "reason", "unknown") or "unknown")
+    expiry = _utc(getattr(status, "expiry", None))
+    current_time = _utc(now) or datetime.now(timezone.utc)
+
+    if not accepted:
+        return False, f"not_accepted:{reason}"
+    if stale:
+        return False, f"stale:{reason}"
+    if expiry is None:
+        return False, "publication_expiry_missing"
+    if expiry <= current_time:
+        return False, "expired_after_publish"
+    return True, "current"
+
+
+def _patch_stalled_writer_guard() -> bool:
+    guard = importlib.import_module("bot.stalled_writer_release_guard_v22")
+
+    current_snapshot = getattr(guard, "_capital_snapshot", None)
+    if not callable(current_snapshot):
+        return False
+    if not getattr(current_snapshot, _PATCH_ATTR, False):
+        original_snapshot = current_snapshot
+
+        @wraps(original_snapshot)
+        def capital_snapshot_v141() -> tuple[bool, float, bool, int]:
+            hydrated, capital, legacy_stale, valid_brokers = original_snapshot()
+            try:
+                current, reason = _publication_current(_authority())
+            except Exception as exc:
+                current = False
+                reason = f"publication_probe_failed:{type(exc).__name__}:{exc}"
+
+            stale = not current
+            if stale and bool(hydrated) and float(capital or 0.0) > 0.0 and int(valid_brokers or 0) > 0:
+                LOGGER.warning(
+                    "STALLED_WRITER_CAPITAL_V141_FAIL_CLOSED marker=%s reason=%s "
+                    "legacy_stale=%s hydrated=%s capital=%.8f valid_brokers=%d "
+                    "historical_latch_not_freshness=true",
+                    MARKER,
+                    reason,
+                    bool(legacy_stale),
+                    bool(hydrated),
+                    float(capital or 0.0),
+                    int(valid_brokers or 0),
+                )
+            return bool(hydrated), float(capital or 0.0), bool(stale), int(valid_brokers or 0)
+
+        setattr(capital_snapshot_v141, _PATCH_ATTR, True)
+        setattr(capital_snapshot_v141, "_nija_v141_original", original_snapshot)
+        guard._capital_snapshot = capital_snapshot_v141
+
+    current_ingest = getattr(guard, "_ingest_authority_snapshot_into_csm", None)
+    if callable(current_ingest) and not getattr(current_ingest, _PATCH_ATTR, False):
+        original_ingest = current_ingest
+
+        @wraps(original_ingest)
+        def ingest_current_publication_only(source: str) -> bool:
+            try:
+                current, reason = _publication_current(_authority())
+            except Exception as exc:
+                current = False
+                reason = f"publication_probe_failed:{type(exc).__name__}:{exc}"
+            if not current:
+                LOGGER.warning(
+                    "STALLED_WRITER_CAPITAL_V141_CSM_REPLAY_BLOCKED marker=%s source=%s "
+                    "reason=%s immutable_publication_authoritative=true",
+                    MARKER,
+                    source,
+                    reason,
+                )
+                return False
+            return bool(original_ingest(source))
+
+        setattr(ingest_current_publication_only, _PATCH_ATTR, True)
+        setattr(ingest_current_publication_only, "_nija_v141_original", original_ingest)
+        guard._ingest_authority_snapshot_into_csm = ingest_current_publication_only
+
+    return bool(getattr(guard._capital_snapshot, _PATCH_ATTR, False))
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        ok = _patch_stalled_writer_guard()
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            raise RuntimeError("stalled_writer_guard_not_patchable")
+        os.environ[_FLAG] = "1"
+        first = not _INSTALLED
+        _INSTALLED = True
+
+    if first:
+        LOGGER.critical(
+            "STALLED_WRITER_CAPITAL_FRESHNESS_V141_INSTALLED marker=%s "
+            "immutable_publication_authoritative=true historical_latch_freshness=false "
+            "publication_expiry_extended=false writer_authority_unchanged=true "
+            "kill_switch_unchanged=true nonce_unchanged=true risk_gates_unchanged=true "
+            "execution_authority_unchanged=true",
+            MARKER,
+        )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_authority",
+    "_publication_current",
+    "_patch_stalled_writer_guard",
+]

--- a/tests/test_stalled_writer_capital_freshness_v141.py
+++ b/tests/test_stalled_writer_capital_freshness_v141.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+import types
+from datetime import datetime, timedelta, timezone
+
+from bot import stalled_writer_capital_freshness_v141_patch as v141
+
+
+class FakeStatus:
+    def __init__(self, *, accepted=True, stale=False, reason="accepted", expiry=None):
+        self.accepted = accepted
+        self.stale = stale
+        self.reason = reason
+        self.expiry = expiry
+
+
+class FakeAuthority:
+    def __init__(self, status):
+        self.status = status
+
+    def get_snapshot_publication_status(self):
+        return self.status
+
+
+def _install_fake_modules(monkeypatch, *, status, legacy_stale=False):
+    calls = {"snapshot": 0, "ingest": 0}
+    guard = types.ModuleType("bot.stalled_writer_release_guard_v22")
+
+    def legacy_snapshot():
+        calls["snapshot"] += 1
+        return True, 240.07922401, legacy_stale, 2
+
+    def legacy_ingest(source):
+        calls["ingest"] += 1
+        return source == "unit_test"
+
+    guard._capital_snapshot = legacy_snapshot
+    guard._ingest_authority_snapshot_into_csm = legacy_ingest
+
+    authority = FakeAuthority(status)
+    authority_module = types.ModuleType("bot.capital_authority")
+    authority_module.get_capital_authority = lambda: authority
+
+    real_import = v141.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.stalled_writer_release_guard_v22":
+            return guard
+        if name in {"bot.capital_authority", "capital_authority"}:
+            return authority_module
+        return real_import(name)
+
+    monkeypatch.setattr(v141.importlib, "import_module", fake_import)
+    return guard, calls
+
+
+def test_expired_publication_overrides_sticky_legacy_freshness(monkeypatch):
+    now = datetime.now(timezone.utc)
+    status = FakeStatus(expiry=now - timedelta(seconds=1))
+    guard, calls = _install_fake_modules(monkeypatch, status=status, legacy_stale=False)
+
+    assert v141._patch_stalled_writer_guard() is True
+    hydrated, capital, stale, brokers = guard._capital_snapshot()
+
+    assert calls["snapshot"] == 1
+    assert hydrated is True
+    assert capital == 240.07922401
+    assert brokers == 2
+    assert stale is True
+
+
+def test_current_publication_preserves_fresh_capital(monkeypatch):
+    now = datetime.now(timezone.utc)
+    status = FakeStatus(expiry=now + timedelta(seconds=60))
+    guard, _calls = _install_fake_modules(monkeypatch, status=status, legacy_stale=True)
+
+    assert v141._patch_stalled_writer_guard() is True
+    hydrated, capital, stale, brokers = guard._capital_snapshot()
+
+    assert hydrated is True
+    assert capital == 240.07922401
+    assert brokers == 2
+    assert stale is False
+
+
+def test_missing_publication_status_fails_closed(monkeypatch):
+    authority = types.SimpleNamespace()
+    authority_module = types.ModuleType("bot.capital_authority")
+    authority_module.get_capital_authority = lambda: authority
+    monkeypatch.setattr(v141.importlib, "import_module", lambda name: authority_module)
+
+    current, reason = v141._publication_current(authority)
+
+    assert current is False
+    assert reason == "publication_status_unavailable"
+
+
+def test_expired_publication_blocks_csm_replay(monkeypatch):
+    now = datetime.now(timezone.utc)
+    status = FakeStatus(expiry=now - timedelta(seconds=1))
+    guard, calls = _install_fake_modules(monkeypatch, status=status)
+
+    assert v141._patch_stalled_writer_guard() is True
+    assert guard._ingest_authority_snapshot_into_csm("unit_test") is False
+    assert calls["ingest"] == 0
+
+
+def test_current_publication_allows_existing_csm_replay_path(monkeypatch):
+    now = datetime.now(timezone.utc)
+    status = FakeStatus(expiry=now + timedelta(seconds=60))
+    guard, calls = _install_fake_modules(monkeypatch, status=status)
+
+    assert v141._patch_stalled_writer_guard() is True
+    assert guard._ingest_authority_snapshot_into_csm("unit_test") is True
+    assert calls["ingest"] == 1
+
+
+def test_install_preserves_trading_safety_environment(monkeypatch):
+    now = datetime.now(timezone.utc)
+    status = FakeStatus(expiry=now + timedelta(seconds=60))
+    _guard, _calls = _install_fake_modules(monkeypatch, status=status)
+    monkeypatch.setattr(v141, "_INSTALLED", False)
+
+    sentinels = {
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY": "0",
+        "NIJA_NONCE_READY": "1",
+        "NIJA_EMERGENCY_STOP": "0",
+        "NIJA_PRE_DISPATCH_RISK_SIZING_READY": "1",
+    }
+    for key, value in sentinels.items():
+        monkeypatch.setenv(key, value)
+
+    assert v141.install_import_hook() is True
+    assert os.environ["NIJA_STALLED_WRITER_CAPITAL_FRESHNESS_V141_INSTALLED"] == "1"
+    for key, value in sentinels.items():
+        assert os.environ[key] == value
+
+
+def test_kill_switch_coordinator_chains_v141() -> None:
+    from pathlib import Path
+    from bot import kill_switch_coordinator_sync_patch as sync
+
+    source = Path(sync.__file__).read_text(encoding="utf-8")
+    assert "stalled_writer_capital_freshness_v141_patch" in source
+    assert "runtime_liveness_guards_not_ready" in source


### PR DESCRIPTION
## Summary
- make `stalled_writer_release_guard_v22` consume immutable `CapitalAuthority` publication freshness instead of its historical handoff/first-snapshot latch
- fail closed when publication status is missing, rejected, stale, or past its immutable expiry
- block stale authority snapshots from being replayed into CapitalCSMv2 by the stalled-writer recovery path
- chain v141 through the existing kill-switch/runtime-liveness startup installer so startup fails closed if the guard cannot install
- add focused regressions to the runtime convergence smoke job

## Production evidence addressed
At 2026-08-18 04:10 the canonical v133 readiness truth reports `broker_connected=False`, `balance_hydrated=False`, `capital_ready=False` while the process remains `OFF`. At the same time `STALLED_WRITER_RELEASE_GUARD_V22_WAITING` reports `elapsed_s=3301.5`, `timeout_s=360.0`, `manager_ready=True`, `capital_ready=True`, so the writer lease is not recycled despite canonical capital being unready.

Source inspection shows v22 still contains a pre-v134 compatibility rule that sets `stale=False` whenever a historical v34 handoff or `first_snap_accepted` latch is present. That conflicts with the immutable publication-expiry contract enforced by v133/v135/v137.

## Safety
- no capital value is synthesized
- immutable publication expiry is not extended
- no readiness key is marked true
- no kill switch is cleared
- no writer/nonce authority is granted
- no risk, sizing, or execution gate is relaxed
- no forced activation or `LIVE_ACTIVE` transition
- stale/missing publication remains fail-closed
