### PR TITLE
Fix capital publication liveness v142

### DIFF
--- a/bot/capital_publication_liveness_v142_patch.py
+++ b/bot/capital_publication_liveness_v142_patch.py
@@ -1,0 +1,843 @@
+"""Bound runtime capital refreshes and keep readiness proofs semantically truthful.
+
+Production 2026-08-18 showed a canonical CapitalRefreshCoordinator remaining
+``_in_flight`` beyond the immutable CapitalAuthority publication expiry. v137
+correctly detected the expired publication but could only coalesce behind the
+stuck coordinator, so v133 correctly failed LIVE_ACTIVE closed to OFF.
+
+v142 repairs liveness without weakening that safety behavior:
+
+* reassert the v35/v36 bounded broker-fetch wrapper plus the v78 freshness
+  budget before every canonical runtime refresh;
+* put a total runtime deadline around the coordinator pipeline after capital
+  bootstrap is terminal, so a stuck downstream stage cannot monopolize the
+  single writer indefinitely;
+* generation-fence abandoned coordinator workers and replace a timed-out
+  canonical coordinator in the manager, allowing one immediate v137 retry;
+* keep CapitalAuthority publication expiry immutable and reject late retired
+  generations without mutating the current publication status;
+* make ``broker_connected`` come from the canonical broker registry and make
+  ``balance_hydrated`` mean hydration only. ``capital_ready`` remains freshness
+  gated, so an expired publication still revokes live execution through v133;
+* register v140/v141/v142 as required runtime-release proofs.
+
+The patch never fabricates capital or connectivity, extends snapshot expiry,
+forces LIVE_ACTIVE, clears a kill switch, grants writer/nonce authority, or
+bypasses risk/execution gates.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import queue
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.capital_publication_liveness_v142")
+MARKER = "20260818-capital-publication-liveness-v142"
+RELEASE_ID = "20260818-runtime-convergence-v142"
+_FLAG = "NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"
+_PATCH_ATTR = "_nija_capital_publication_liveness_v142"
+_LOCK = threading.RLock()
+_ROLLOVER_LOCK = threading.RLock()
+_GENERATION_LOCK = threading.RLock()
+_LOCAL = threading.local()
+_INSTALLED = False
+_NEXT_GENERATION = 0
+_ACTIVE_GENERATION = 0
+_ROLLOVER_OCCURRED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _import_first(*names: str) -> ModuleType:
+    last: BaseException | None = None
+    for name in names:
+        try:
+            return importlib.import_module(name)
+        except Exception as exc:
+            last = exc
+    if last is not None:
+        raise last
+    raise ImportError("no module names supplied")
+
+
+def _capital_flow_module() -> ModuleType:
+    return _import_first("bot.capital_flow_state_machine", "capital_flow_state_machine")
+
+
+def _authority() -> Any:
+    module = _import_first("bot.capital_authority", "capital_authority")
+    getter = getattr(module, "get_capital_authority", None)
+    if not callable(getter):
+        raise RuntimeError("capital_authority_getter_missing")
+    authority = getter()
+    if authority is None:
+        raise RuntimeError("capital_authority_missing")
+    return authority
+
+
+def _canonical_manager() -> Any:
+    module = sys.modules.get("bot.multi_account_broker_manager")
+    if not isinstance(module, ModuleType):
+        try:
+            module = importlib.import_module("bot.multi_account_broker_manager")
+        except Exception:
+            return None
+    getter = getattr(module, "get_broker_manager", None)
+    if callable(getter):
+        try:
+            return getter()
+        except Exception:
+            return None
+    return getattr(module, "_manager", None) or getattr(
+        module, "multi_account_broker_manager", None
+    )
+
+
+def _freshness_ttl_seconds() -> float:
+    try:
+        ca = _import_first("bot.capital_authority", "capital_authority")
+        canonical = float(getattr(ca, "_DEFAULT_FRESHNESS_TTL_S", 90.0) or 90.0)
+    except Exception:
+        canonical = 90.0
+    try:
+        configured = float(os.environ.get("NIJA_CAPITAL_FRESHNESS_TTL_S", canonical) or canonical)
+    except (TypeError, ValueError):
+        configured = canonical
+    return max(10.0, min(canonical, configured))
+
+
+def _fetch_budget_seconds() -> float:
+    try:
+        v78 = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        getter = getattr(v78, "fetch_budget_seconds", None)
+        if callable(getter):
+            return max(5.0, float(getter()))
+    except Exception:
+        pass
+    return max(5.0, _freshness_ttl_seconds() - 30.0)
+
+
+def _runtime_pipeline_deadline_seconds() -> float:
+    """Return a total runtime coordinator deadline strictly inside freshness TTL."""
+    ttl_s = _freshness_ttl_seconds()
+    fetch_budget_s = _fetch_budget_seconds()
+    default = min(ttl_s - 10.0, fetch_budget_s + 5.0)
+    raw = str(os.environ.get("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "") or "").strip()
+    if raw:
+        try:
+            requested = float(raw)
+        except (TypeError, ValueError):
+            requested = default
+    else:
+        requested = default
+    # Never allow this liveness layer to broaden the immutable freshness window.
+    return max(10.0, min(requested, max(10.0, ttl_s - 10.0)))
+
+
+def _next_generation() -> int:
+    global _NEXT_GENERATION, _ACTIVE_GENERATION
+    with _GENERATION_LOCK:
+        _NEXT_GENERATION += 1
+        _ACTIVE_GENERATION = _NEXT_GENERATION
+        return _ACTIVE_GENERATION
+
+
+def _retire_generation(generation: int | None, reason: str) -> int:
+    """Fence a timed-out/abandoned writer generation before replacement work starts."""
+    global _NEXT_GENERATION, _ACTIVE_GENERATION, _ROLLOVER_OCCURRED
+    with _GENERATION_LOCK:
+        candidate = int(generation or 0)
+        if candidate <= 0 or _ACTIVE_GENERATION == candidate:
+            _NEXT_GENERATION = max(_NEXT_GENERATION, candidate) + 1
+            _ACTIVE_GENERATION = _NEXT_GENERATION
+        _ROLLOVER_OCCURRED = True
+        active = _ACTIVE_GENERATION
+    LOGGER.critical(
+        "CAPITAL_COORDINATOR_GENERATION_RETIRED_V142 marker=%s retired=%s active=%d "
+        "reason=%s late_publication_fenced=true",
+        MARKER,
+        candidate or "untagged",
+        active,
+        reason,
+    )
+    return active
+
+
+def _generation_state() -> tuple[int, bool]:
+    with _GENERATION_LOCK:
+        return int(_ACTIVE_GENERATION), bool(_ROLLOVER_OCCURRED)
+
+
+def _chain_contains(callable_obj: Any, *, marker: str, expected_name: str = "") -> bool:
+    seen: set[int] = set()
+    current = callable_obj
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, marker, False)):
+            if not expected_name or str(getattr(current, "__name__", "")) == expected_name:
+                return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
+def _reassert_bounded_fetch_contract() -> tuple[bool, str]:
+    """Prove the actual wrappers are present, not merely their environment flags."""
+    try:
+        flow = _capital_flow_module()
+        v35 = importlib.import_module("bot.capital_refresh_stall_guard_v35")
+        v78 = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        cls = getattr(flow, "CapitalRefreshCoordinator", None)
+        batch_cls = getattr(v35, "_BalanceFetchBatch", None)
+        if not isinstance(cls, type) or not isinstance(batch_cls, type):
+            return False, "classes_missing"
+
+        pipeline = getattr(cls, "_pipeline", None)
+        bounded = _chain_contains(
+            pipeline,
+            marker="_nija_capital_refresh_stall_guard_v36",
+            expected_name="_pipeline_with_bounded_brokers",
+        )
+        if not bounded:
+            # functools.wraps can copy marker attributes to unrelated outer
+            # wrappers. Remove only the copied top-level markers so v35 can
+            # safely wrap the current owner and preserve every inner layer.
+            for attr in (
+                "_nija_capital_refresh_stall_guard_v35",
+                "_nija_capital_refresh_stall_guard_v36",
+            ):
+                try:
+                    if callable(pipeline) and hasattr(pipeline, attr):
+                        delattr(pipeline, attr)
+                except Exception:
+                    pass
+            patcher = getattr(v35, "_patch", None)
+            if not callable(patcher) or not bool(patcher(flow)):
+                return False, "v35_repatch_failed"
+            pipeline = getattr(cls, "_pipeline", None)
+            bounded = _chain_contains(
+                pipeline,
+                marker="_nija_capital_refresh_stall_guard_v36",
+                expected_name="_pipeline_with_bounded_brokers",
+            )
+
+        init_fn = getattr(batch_cls, "__init__", None)
+        v78_marker = str(getattr(v78, "_PATCH_ATTR", "_nija_capital_refresh_live_continuity_v78"))
+        freshness_bounded = _chain_contains(
+            init_fn,
+            marker=v78_marker,
+            expected_name="init_v78",
+        )
+        if not freshness_bounded:
+            try:
+                if callable(init_fn) and hasattr(init_fn, v78_marker):
+                    delattr(init_fn, v78_marker)
+            except Exception:
+                pass
+            patch_guard = getattr(v78, "_patch_guard", None)
+            if not callable(patch_guard) or not bool(patch_guard(v35)):
+                return False, "v78_repatch_failed"
+            init_fn = getattr(batch_cls, "__init__", None)
+            freshness_bounded = _chain_contains(
+                init_fn,
+                marker=v78_marker,
+                expected_name="init_v78",
+            )
+
+        if not (bounded and freshness_bounded):
+            return False, f"wrapper_proof_failed:v35={bounded}:v78={freshness_bounded}"
+        return True, "v35_v36_and_v78_proven"
+    except Exception as exc:
+        return False, f"bounded_fetch_probe:{type(exc).__name__}:{exc}"
+
+
+def _runtime_terminal(coordinator: Any) -> bool:
+    boot = getattr(coordinator, "_boot", None)
+    state = getattr(boot, "state", None) if boot is not None else None
+    value = str(getattr(state, "value", state) or "").strip().upper()
+    return value in {"READY", "RUNNING"}
+
+
+def _emit_snapshot_rejected(coordinator: Any, trigger: str, exc: BaseException) -> None:
+    try:
+        flow = _capital_flow_module()
+        event_cls = getattr(flow, "CapitalEvent")
+        event_type = getattr(flow, "CapitalEventType").SNAPSHOT_REJECTED
+        coordinator._bus.emit(
+            event_cls(
+                event_type=event_type,
+                trigger=trigger,
+                metadata={"error": str(exc), "marker": MARKER},
+            )
+        )
+    except Exception:
+        pass
+
+
+def _flight_age_s(coordinator: Any) -> float:
+    try:
+        started = float(
+            getattr(coordinator, "_nija_v142_flight_started_monotonic", 0.0) or 0.0
+        )
+    except (TypeError, ValueError):
+        started = 0.0
+    return max(0.0, time.monotonic() - started) if started > 0.0 else float("inf")
+
+
+def _rollover_coordinator(
+    manager: Any,
+    *,
+    expected_old: Any = None,
+    reason: str,
+) -> Any:
+    """Swap only the canonical manager's coordinator; the retired worker is fenced."""
+    with _ROLLOVER_LOCK:
+        old = getattr(manager, "_capital_coordinator", None)
+        if old is None:
+            return None
+        if expected_old is not None and old is not expected_old:
+            return old
+
+        generation = int(getattr(old, "_nija_v142_flight_generation", 0) or 0)
+        _retire_generation(generation, reason)
+
+        flow = _capital_flow_module()
+        cls = getattr(flow, "CapitalRefreshCoordinator", None)
+        if not isinstance(cls, type):
+            return None
+        bus = getattr(manager, "_capital_event_bus", None) or getattr(old, "_bus", None)
+        boot = getattr(manager, "_capital_bootstrap_fsm", None) or getattr(old, "_boot", None)
+        runtime = getattr(manager, "_capital_runtime_fsm", None) or getattr(old, "_runtime", None)
+        if bus is None or boot is None or runtime is None:
+            LOGGER.critical(
+                "CAPITAL_COORDINATOR_ROLLOVER_V142_FAILED marker=%s reason=%s "
+                "bus=%s boot=%s runtime=%s trading_fail_closed=true",
+                MARKER,
+                reason,
+                bus is not None,
+                boot is not None,
+                runtime is not None,
+            )
+            return None
+
+        replacement = cls(bus, boot, runtime)
+        try:
+            authority = _authority()
+            if bool(getattr(authority, "is_hydrated", False)):
+                replacement.balance_hydrated = True
+                event = getattr(replacement, "balance_hydrated_event", None)
+                if event is not None and callable(getattr(event, "set", None)):
+                    event.set()
+        except Exception:
+            pass
+
+        # The manager reference is the canonical ownership point. Old work is
+        # allowed to unwind in its daemon thread but can no longer publish once
+        # its generation has been retired.
+        manager._capital_coordinator = replacement
+        LOGGER.critical(
+            "CAPITAL_COORDINATOR_ROLLOVER_V142 marker=%s reason=%s old_id=%s new_id=%s "
+            "old_generation=%s old_age_s=%.1f old_trigger=%s old_thread_alive=%s "
+            "publication_expiry_unchanged=true trading_fail_closed_until_refresh=true",
+            MARKER,
+            reason,
+            hex(id(old)),
+            hex(id(replacement)),
+            generation or "untagged",
+            _flight_age_s(old),
+            str(getattr(old, "_nija_v142_flight_trigger", "unknown") or "unknown"),
+            bool(
+                getattr(
+                    getattr(old, "_nija_v142_flight_thread", None),
+                    "is_alive",
+                    lambda: False,
+                )()
+            ),
+        )
+        return replacement
+
+
+def _patch_coordinator_execute() -> bool:
+    flow = _capital_flow_module()
+    cls = getattr(flow, "CapitalRefreshCoordinator", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "execute_refresh", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+    original = current
+
+    @wraps(original)
+    def execute_refresh_v142(
+        self: Any,
+        broker_map: dict[str, Any],
+        trigger: str = "coordinator",
+        open_exposure_usd: float = 0.0,
+    ) -> Any:
+        bounded_ok, bounded_detail = _reassert_bounded_fetch_contract()
+        if not bounded_ok:
+            LOGGER.critical(
+                "CAPITAL_RUNTIME_BOUND_CONTRACT_V142_FAILED marker=%s trigger=%s detail=%s "
+                "refresh_started=false trading_fail_closed=true",
+                MARKER,
+                trigger,
+                bounded_detail,
+            )
+            return None
+
+        # Bootstrap transitions are thread-owned. Preserve the exact legacy
+        # synchronous path until the capital bootstrap FSM is terminal.
+        if not _runtime_terminal(self):
+            return original(
+                self,
+                broker_map=broker_map,
+                trigger=trigger,
+                open_exposure_usd=open_exposure_usd,
+            )
+
+        with self._lock:
+            if bool(getattr(self, "_in_flight", False)):
+                LOGGER.info(
+                    "CAPITAL_RUNTIME_REFRESH_V142_COALESCED marker=%s trigger=%s "
+                    "owner_trigger=%s age_s=%.1f",
+                    MARKER,
+                    trigger,
+                    str(getattr(self, "_nija_v142_flight_trigger", "unknown") or "unknown"),
+                    _flight_age_s(self),
+                )
+                return None
+            self._in_flight = True
+            generation = _next_generation()
+            self._nija_v142_flight_generation = generation
+            self._nija_v142_flight_started_monotonic = time.monotonic()
+            self._nija_v142_flight_trigger = str(trigger)
+            self._nija_v142_flight_timed_out = False
+
+        result_queue: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=1)
+
+        def _run() -> None:
+            previous_generation = getattr(_LOCAL, "refresh_generation", None)
+            _LOCAL.refresh_generation = generation
+            try:
+                result = self._pipeline(
+                    broker_map=broker_map,
+                    trigger=trigger,
+                    open_exposure_usd=open_exposure_usd,
+                )
+                try:
+                    result_queue.put_nowait(("ok", result))
+                except queue.Full:
+                    pass
+            except BaseException as exc:
+                LOGGER.exception(
+                    "CAPITAL_RUNTIME_PIPELINE_V142_EXCEPTION marker=%s trigger=%s "
+                    "generation=%d error=%s:%s trading_fail_closed=true",
+                    MARKER,
+                    trigger,
+                    generation,
+                    type(exc).__name__,
+                    exc,
+                )
+                _emit_snapshot_rejected(self, trigger, exc)
+                try:
+                    result_queue.put_nowait(("error", None))
+                except queue.Full:
+                    pass
+            finally:
+                if previous_generation is None:
+                    try:
+                        delattr(_LOCAL, "refresh_generation")
+                    except AttributeError:
+                        pass
+                else:
+                    _LOCAL.refresh_generation = previous_generation
+                with self._lock:
+                    if int(getattr(self, "_nija_v142_flight_generation", 0) or 0) == generation:
+                        self._in_flight = False
+                        self._nija_v142_flight_finished_monotonic = time.monotonic()
+
+        worker = threading.Thread(
+            target=_run,
+            name=f"capital-runtime-refresh-v142-g{generation}",
+            daemon=True,
+        )
+        with self._lock:
+            self._nija_v142_flight_thread = worker
+        worker.start()
+
+        deadline_s = _runtime_pipeline_deadline_seconds()
+        try:
+            outcome, result = result_queue.get(timeout=deadline_s)
+            return result if outcome == "ok" else None
+        except queue.Empty:
+            with self._lock:
+                self._nija_v142_flight_timed_out = True
+            _retire_generation(generation, "runtime_pipeline_deadline_exceeded")
+            manager = _canonical_manager()
+            replacement = None
+            if manager is not None and getattr(manager, "_capital_coordinator", None) is self:
+                replacement = _rollover_coordinator(
+                    manager,
+                    expected_old=self,
+                    reason="runtime_pipeline_deadline_exceeded",
+                )
+            LOGGER.critical(
+                "CAPITAL_RUNTIME_PIPELINE_V142_TIMEOUT marker=%s trigger=%s generation=%d "
+                "deadline_s=%.1f age_s=%.1f rollover=%s late_publication_fenced=true "
+                "publication_expiry_extended=false trading_fail_closed=true",
+                MARKER,
+                trigger,
+                generation,
+                deadline_s,
+                _flight_age_s(self),
+                replacement is not None and replacement is not self,
+            )
+            # Do not clear this retired instance's _in_flight flag here. Its
+            # daemon owns that flag until it actually unwinds. The manager has
+            # already moved to a fresh fenced coordinator when rollover succeeds.
+            return None
+
+    setattr(execute_refresh_v142, _PATCH_ATTR, True)
+    setattr(execute_refresh_v142, "_nija_v142_original", original)
+    cls.execute_refresh = execute_refresh_v142
+    return True
+
+
+def _patch_publication_generation_fence() -> bool:
+    ca = _import_first("bot.capital_authority", "capital_authority")
+    cls = getattr(ca, "CapitalAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "publish_snapshot", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+    original = current
+
+    @wraps(original)
+    def publish_snapshot_v142(self: Any, snapshot: Any, writer_id: str) -> bool:
+        generation = getattr(_LOCAL, "refresh_generation", None)
+        active, rolled = _generation_state()
+        authorized = str(writer_id or "") == str(
+            getattr(self, "_AUTHORIZED_WRITER_ID", "mabm_capital_refresh_coordinator")
+        )
+        if authorized:
+            if generation is not None and int(generation) != active:
+                LOGGER.warning(
+                    "CAPITAL_PUBLICATION_V142_RETIRED_GENERATION_REJECTED marker=%s "
+                    "generation=%s active=%s publication_status_unchanged=true",
+                    MARKER,
+                    generation,
+                    active,
+                )
+                return False
+            if generation is None and rolled:
+                # Covers a legacy coordinator that entered before v142 was
+                # installed and only returned after a rollover occurred.
+                LOGGER.warning(
+                    "CAPITAL_PUBLICATION_V142_UNTAGGED_AFTER_ROLLOVER_REJECTED marker=%s "
+                    "active=%s publication_status_unchanged=true",
+                    MARKER,
+                    active,
+                )
+                return False
+        return bool(original(self, snapshot, writer_id))
+
+    setattr(publish_snapshot_v142, _PATCH_ATTR, True)
+    setattr(publish_snapshot_v142, "_nija_v142_original", original)
+    cls.publish_snapshot = publish_snapshot_v142
+    return True
+
+
+def _coordinator_in_flight_v142(manager: Any) -> bool:
+    coordinator = getattr(manager, "_capital_coordinator", None)
+    if coordinator is None:
+        return False
+    if not bool(getattr(coordinator, "_in_flight", False)):
+        return False
+
+    timed_out = bool(getattr(coordinator, "_nija_v142_flight_timed_out", False))
+    thread = getattr(coordinator, "_nija_v142_flight_thread", None)
+    alive_fn = getattr(thread, "is_alive", None) if thread is not None else None
+    thread_alive = bool(alive_fn()) if callable(alive_fn) else False
+    age_s = _flight_age_s(coordinator)
+    limit_s = _runtime_pipeline_deadline_seconds()
+    tracked = bool(getattr(coordinator, "_nija_v142_flight_generation", 0))
+
+    should_roll = bool(timed_out or (tracked and (not thread_alive or age_s > limit_s + 1.0)))
+    if not tracked:
+        # A pre-v142/untracked flight cannot prove the total-runtime bound. Only
+        # replace it once the immutable publication itself is no longer current.
+        try:
+            v137 = importlib.import_module("bot.capital_publication_deadline_v137_patch")
+            current, _meta = v137._publication_meta(_authority())
+        except Exception:
+            current = False
+        should_roll = not current
+
+    if should_roll:
+        replacement = _rollover_coordinator(
+            manager,
+            expected_old=coordinator,
+            reason=(
+                "coordinator_timeout_flag"
+                if timed_out
+                else "coordinator_owner_dead"
+                if tracked and not thread_alive
+                else "coordinator_age_exceeded"
+                if tracked
+                else "untracked_inflight_with_expired_publication"
+            ),
+        )
+        return bool(replacement is coordinator or replacement is None)
+    return True
+
+
+def _patch_v137_liveness() -> bool:
+    v137 = importlib.import_module("bot.capital_publication_deadline_v137_patch")
+    v137._coordinator_in_flight = _coordinator_in_flight_v142
+
+    current = getattr(v137, "_execute_deadline_refresh", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+    original = current
+
+    @wraps(original)
+    def execute_deadline_refresh_v142(
+        manager: Any,
+        *,
+        trigger: str = "publication_deadline_v137",
+    ) -> bool:
+        # Probe liveness before v137 captures its local coordinator reference.
+        if _coordinator_in_flight_v142(manager):
+            return False
+        before = getattr(manager, "_capital_coordinator", None)
+        ok = bool(original(manager, trigger=trigger))
+        if ok:
+            return True
+
+        after = getattr(manager, "_capital_coordinator", None)
+        if after is not None and after is not before:
+            LOGGER.warning(
+                "CAPITAL_PUBLICATION_V142_IMMEDIATE_ROLLOVER_RETRY marker=%s "
+                "trigger=%s old_id=%s new_id=%s",
+                MARKER,
+                trigger,
+                hex(id(before)) if before is not None else "none",
+                hex(id(after)),
+            )
+            if _coordinator_in_flight_v142(manager):
+                return False
+            return bool(original(manager, trigger=f"{trigger}:v142_rollover_retry"))
+        return False
+
+    setattr(execute_deadline_refresh_v142, _PATCH_ATTR, True)
+    setattr(execute_deadline_refresh_v142, "_nija_v142_original", original)
+    v137._execute_deadline_refresh = execute_deadline_refresh_v142
+    return True
+
+
+def _canonical_broker_connectivity() -> tuple[bool, dict[str, Any]]:
+    manager = _canonical_manager()
+    if manager is None:
+        return False, {"reason": "manager_missing", "connected": [], "registered": []}
+
+    platform = getattr(manager, "_platform_brokers", None)
+    if not isinstance(platform, dict) or not platform:
+        return False, {"reason": "platform_registry_empty", "connected": [], "registered": []}
+
+    registered: list[str] = []
+    connected: list[str] = []
+    probe = getattr(manager, "is_platform_connected", None)
+    state_map = getattr(manager, "_platform_state", {})
+    for raw_key, broker in list(platform.items()):
+        if broker is None:
+            continue
+        name = str(getattr(raw_key, "value", raw_key) or "").strip().lower()
+        if not name:
+            continue
+        registered.append(name)
+        direct = bool(getattr(broker, "connected", False))
+        manager_connected = False
+        if callable(probe):
+            try:
+                manager_connected = bool(probe(raw_key))
+            except Exception:
+                manager_connected = False
+        state_connected = False
+        if isinstance(state_map, dict):
+            state = state_map.get(name, state_map.get(raw_key))
+            state_value = str(getattr(state, "value", state) or "").strip().lower()
+            state_connected = state_value == "connected"
+        if direct or manager_connected or state_connected:
+            connected.append(name)
+
+    policy = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "optional") or "optional").strip().lower()
+    if policy == "global_all_required":
+        ready = bool(registered and len(connected) == len(registered))
+    else:
+        ready = bool(connected)
+    return ready, {
+        "reason": "ok" if ready else "canonical_platform_connectivity_not_proven",
+        "policy": policy,
+        "registered": sorted(set(registered)),
+        "connected": sorted(set(connected)),
+    }
+
+
+def _patch_readiness_truth() -> bool:
+    v16 = _import_first(
+        "preactivation_readiness_convergence_v16_patch",
+        "bot.preactivation_readiness_convergence_v16_patch",
+    )
+    current = getattr(v16, "_collect_proofs", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+    original = current
+
+    @wraps(original)
+    def collect_proofs_v142() -> tuple[dict[str, bool], dict[str, Any]]:
+        proofs, details = original()
+        proofs = dict(proofs or {})
+        details = dict(details or {})
+        capital = dict(details.get("capital") or {})
+
+        connectivity, connectivity_meta = _canonical_broker_connectivity()
+        authority_hydrated = bool(capital.get("hydrated", False))
+        capital_stale = bool(capital.get("stale", True))
+
+        # Semantics only: connectivity and hydration are independent facts.
+        # capital_ready remains whatever the existing freshness-gated proof
+        # computed, so stale capital still blocks/terminates live execution.
+        proofs["broker_connected"] = bool(connectivity)
+        proofs["balance_hydrated"] = bool(authority_hydrated)
+        details["v142_readiness_truth"] = {
+            "broker_connected": bool(connectivity),
+            "balance_hydrated": bool(authority_hydrated),
+            "capital_stale": capital_stale,
+            "capital_ready": bool(proofs.get("capital_ready", False)),
+            "connectivity": connectivity_meta,
+            "freshness_does_not_relabel_connectivity": True,
+        }
+        return proofs, details
+
+    setattr(collect_proofs_v142, _PATCH_ATTR, True)
+    setattr(collect_proofs_v142, "_nija_v142_original", original)
+    v16._collect_proofs = collect_proofs_v142
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict) or not isinstance(installers, tuple):
+        return False
+
+    required["runtime_killswitch_authority_liveness_v140"] = (
+        "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"
+    )
+    required["stalled_writer_capital_freshness_v141"] = (
+        "NIJA_STALLED_WRITER_CAPITAL_FRESHNESS_V141_INSTALLED"
+    )
+    required["capital_publication_liveness_v142"] = _FLAG
+
+    own = ("bot.capital_publication_liveness_v142_patch", "install_import_hook")
+    if own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+
+    # v139 protects RELEASE_ID from diverging from DECLARED_RELEASE_ID. Advance
+    # the declaration first, then the compatibility name.
+    manifest.DECLARED_RELEASE_ID = RELEASE_ID
+    manifest.RELEASE_ID = RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+    return True
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        try:
+            bounded_ok, bounded_detail = _reassert_bounded_fetch_contract()
+            ok = bool(
+                bounded_ok
+                and _patch_coordinator_execute()
+                and _patch_publication_generation_fence()
+                and _patch_v137_liveness()
+                and _patch_readiness_truth()
+                and _patch_release_manifest()
+            )
+        except Exception as exc:
+            LOGGER.critical(
+                "CAPITAL_PUBLICATION_LIVENESS_V142_INSTALL_FAILED marker=%s error=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+            bounded_detail = f"install_exception:{type(exc).__name__}:{exc}"
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            os.environ["NIJA_RUNTIME_RELEASE_READY"] = "0"
+            return False
+
+        os.environ[_FLAG] = "1"
+        first = not _INSTALLED
+        _INSTALLED = True
+
+    if first:
+        LOGGER.critical(
+            "CAPITAL_PUBLICATION_LIVENESS_V142_INSTALLED marker=%s release=%s "
+            "bounded_fetch=%s runtime_pipeline_deadline_s=%.1f generation_fence=true "
+            "coordinator_rollover=true v137_immediate_retry=true truthful_connectivity=true "
+            "truthful_hydration=true capital_freshness_gate_unchanged=true "
+            "publication_expiry_extended=false kill_switch_unchanged=true nonce_unchanged=true "
+            "risk_gates_unchanged=true execution_gates_unchanged=true force_live=false",
+            MARKER,
+            RELEASE_ID,
+            bounded_detail,
+            _runtime_pipeline_deadline_seconds(),
+        )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_runtime_pipeline_deadline_seconds",
+    "_reassert_bounded_fetch_contract",
+    "_rollover_coordinator",
+    "_coordinator_in_flight_v142",
+    "_canonical_broker_connectivity",
+    "_patch_coordinator_execute",
+    "_patch_publication_generation_fence",
+    "_patch_v137_liveness",
+    "_patch_readiness_truth",
+    "_patch_release_manifest",
+]

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -116,6 +116,89 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
     return True
 
 
+def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
+    """Normalize v142 wrapper proof and pre-v142 in-flight rollover semantics.
+
+    ``functools.wraps`` intentionally copies the wrapped function name, so a
+    wrapper must be proven by its ownership marker rather than by its display
+    name.  This helper also handles a coordinator that was already in-flight
+    before v142 could stamp a generation/start time: once v137 says publication
+    refresh is due (including pre-expiry headroom), the untracked owner is
+    replaced immediately instead of waiting for the immutable publication to
+    expire and forcing another LIVE_ACTIVE -> OFF cycle.
+    """
+    if bool(getattr(publication_liveness, "_nija_startup_chain_prepared", False)):
+        return True
+
+    def marker_chain_contains(callable_obj: Any, *, marker: str, expected_name: str = "") -> bool:
+        del expected_name  # display names are not ownership proof under functools.wraps
+        seen: set[int] = set()
+        current = callable_obj
+        for _ in range(32):
+            if not callable(current) or id(current) in seen:
+                return False
+            seen.add(id(current))
+            if bool(getattr(current, marker, False)):
+                return True
+            current = getattr(current, "__wrapped__", None)
+        return False
+
+    publication_liveness._chain_contains = marker_chain_contains
+
+    original_inflight = getattr(publication_liveness, "_coordinator_in_flight_v142", None)
+    if not callable(original_inflight):
+        return False
+
+    @wraps(original_inflight)
+    def coordinator_in_flight_with_upgrade_rollover(manager: Any) -> bool:
+        coordinator = getattr(manager, "_capital_coordinator", None)
+        if coordinator is None or not bool(getattr(coordinator, "_in_flight", False)):
+            return False
+
+        tracked = bool(getattr(coordinator, "_nija_v142_flight_generation", 0))
+        if not tracked:
+            try:
+                from bot import capital_publication_deadline_v137_patch as v137
+
+                authority = publication_liveness._authority()
+                due, meta = v137._publication_refresh_due(authority, manager)
+            except Exception as exc:
+                logger.warning(
+                    "CAPITAL_PUBLICATION_V142_UPGRADE_PROBE_FAILED marker=%s err=%s:%s "
+                    "existing_owner_preserved=true trading_fail_closed=true",
+                    _MARKER,
+                    type(exc).__name__,
+                    exc,
+                )
+                return True
+
+            if due:
+                replacement = publication_liveness._rollover_coordinator(
+                    manager,
+                    expected_old=coordinator,
+                    reason="untracked_inflight_refresh_due:" + str(meta.get("due_reason") or "due"),
+                )
+                logger.critical(
+                    "CAPITAL_PUBLICATION_V142_UPGRADE_ROLLOVER marker=%s due_reason=%s "
+                    "remaining_s=%s old_id=%s new_id=%s pre_expiry=%s "
+                    "publication_expiry_extended=false trading_fail_closed_until_refresh=true",
+                    _MARKER,
+                    meta.get("due_reason"),
+                    meta.get("remaining_s"),
+                    hex(id(coordinator)),
+                    hex(id(replacement)) if replacement is not None else "none",
+                    str(float(meta.get("remaining_s", 0.0) or 0.0) > 0.0).lower(),
+                )
+                return bool(replacement is coordinator or replacement is None)
+
+        return bool(original_inflight(manager))
+
+    setattr(coordinator_in_flight_with_upgrade_rollover, "_nija_v142_upgrade_rollover", True)
+    publication_liveness._coordinator_in_flight_v142 = coordinator_in_flight_with_upgrade_rollover
+    publication_liveness._nija_startup_chain_prepared = True
+    return True
+
+
 def _install_authority_liveness() -> bool:
     """Chain narrow runtime liveness repairs fail-closed."""
     try:
@@ -158,6 +241,8 @@ def _install_authority_liveness() -> bool:
     try:
         from bot import capital_publication_liveness_v142_patch as publication_liveness
 
+        if not _prepare_capital_publication_liveness(publication_liveness):
+            return False
         installer = getattr(publication_liveness, "install_import_hook", None) or getattr(
             publication_liveness, "install", None
         )
@@ -215,5 +300,6 @@ __all__ = [
     "install_import_hook",
     "_patch_kill_switch_class",
     "_publish_coordinator_truth",
+    "_prepare_capital_publication_liveness",
     "_install_authority_liveness",
 ]

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -150,6 +150,27 @@ def _install_authority_liveness() -> bool:
         )
         return False
 
+    # v142 is chained through this already-required manifest installer so the
+    # runtime release can never publish ready=true without proving the capital
+    # publication liveness repair was installed. v142 itself registers v140,
+    # v141 and v142 as required manifest proofs and advances the canonical
+    # release identity only after its fail-closed install succeeds.
+    try:
+        from bot import capital_publication_liveness_v142_patch as publication_liveness
+
+        installer = getattr(publication_liveness, "install_import_hook", None) or getattr(
+            publication_liveness, "install", None
+        )
+        if not callable(installer) or not bool(installer()):
+            return False
+    except Exception as exc:
+        logger.exception(
+            "CAPITAL_PUBLICATION_LIVENESS_CHAIN_FAILED marker=%s error=%s",
+            _MARKER,
+            exc,
+        )
+        return False
+
     return True
 
 
@@ -178,7 +199,8 @@ def install_import_hook() -> None:
         logger.critical(
             "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
             "risk_gates_unchanged=true authority_liveness_chained=true "
-            "stalled_writer_capital_freshness_chained=true",
+            "stalled_writer_capital_freshness_chained=true "
+            "capital_publication_liveness_chained=true",
             _MARKER,
             str(active).lower(),
         )

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -119,19 +119,22 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
 def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     """Normalize v142 wrapper proof and pre-v142 in-flight rollover semantics.
 
-    ``functools.wraps`` intentionally copies the wrapped function name, so a
-    wrapper must be proven by its ownership marker rather than by its display
-    name.  This helper also handles a coordinator that was already in-flight
-    before v142 could stamp a generation/start time: once v137 says publication
-    refresh is due (including pre-expiry headroom), the untracked owner is
-    replaced immediately instead of waiting for the immutable publication to
-    expire and forcing another LIVE_ACTIVE -> OFF cycle.
+    ``functools.wraps`` copies ``__name__`` and ownership attributes from the
+    wrapped function.  The stable identity of the wrapper implementation is the
+    underlying code object's ``co_name``.  Use that plus the ownership marker so
+    copied attributes on unrelated outer wrappers cannot falsely prove the v35
+    or v78 layer is still present.
+
+    This helper also handles a coordinator that was already in-flight before
+    v142 could stamp a generation/start time: once v137 says publication refresh
+    is due (including pre-expiry headroom), the untracked owner is replaced
+    immediately instead of waiting for immutable publication expiry and forcing
+    another LIVE_ACTIVE -> OFF cycle.
     """
     if bool(getattr(publication_liveness, "_nija_startup_chain_prepared", False)):
         return True
 
     def marker_chain_contains(callable_obj: Any, *, marker: str, expected_name: str = "") -> bool:
-        del expected_name  # display names are not ownership proof under functools.wraps
         seen: set[int] = set()
         current = callable_obj
         for _ in range(32):
@@ -139,7 +142,11 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
                 return False
             seen.add(id(current))
             if bool(getattr(current, marker, False)):
-                return True
+                if not expected_name:
+                    return True
+                code = getattr(current, "__code__", None)
+                if str(getattr(code, "co_name", "") or "") == expected_name:
+                    return True
             current = getattr(current, "__wrapped__", None)
         return False
 

--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -117,19 +117,21 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
 
 
 def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
-    """Normalize v142 wrapper proof and pre-v142 in-flight rollover semantics.
+    """Normalize v142 wrapper proof and coordinator rollover semantics.
 
     ``functools.wraps`` copies ``__name__`` and ownership attributes from the
-    wrapped function.  The stable identity of the wrapper implementation is the
-    underlying code object's ``co_name``.  Use that plus the ownership marker so
+    wrapped function. The stable identity of the wrapper implementation is the
+    underlying code object's ``co_name``. Use that plus the ownership marker so
     copied attributes on unrelated outer wrappers cannot falsely prove the v35
     or v78 layer is still present.
 
-    This helper also handles a coordinator that was already in-flight before
-    v142 could stamp a generation/start time: once v137 says publication refresh
-    is due (including pre-expiry headroom), the untracked owner is replaced
-    immediately instead of waiting for immutable publication expiry and forcing
-    another LIVE_ACTIVE -> OFF cycle.
+    The liveness probe also handles two transition states safely:
+
+    * a coordinator that was already in-flight before v142 was installed is
+      replaced as soon as v137 enters refresh headroom; and
+    * a newly tracked v142 refresh is never considered dead during the tiny
+      interval between publishing ``_in_flight``/generation state and storing
+      the worker-thread handle.
     """
     if bool(getattr(publication_liveness, "_nija_startup_chain_prepared", False)):
         return True
@@ -179,26 +181,71 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
                 )
                 return True
 
-            if due:
-                replacement = publication_liveness._rollover_coordinator(
-                    manager,
-                    expected_old=coordinator,
-                    reason="untracked_inflight_refresh_due:" + str(meta.get("due_reason") or "due"),
-                )
-                logger.critical(
-                    "CAPITAL_PUBLICATION_V142_UPGRADE_ROLLOVER marker=%s due_reason=%s "
-                    "remaining_s=%s old_id=%s new_id=%s pre_expiry=%s "
-                    "publication_expiry_extended=false trading_fail_closed_until_refresh=true",
-                    _MARKER,
-                    meta.get("due_reason"),
-                    meta.get("remaining_s"),
-                    hex(id(coordinator)),
-                    hex(id(replacement)) if replacement is not None else "none",
-                    str(float(meta.get("remaining_s", 0.0) or 0.0) > 0.0).lower(),
-                )
-                return bool(replacement is coordinator or replacement is None)
+            if not due:
+                return True
 
-        return bool(original_inflight(manager))
+            replacement = publication_liveness._rollover_coordinator(
+                manager,
+                expected_old=coordinator,
+                reason="untracked_inflight_refresh_due:" + str(meta.get("due_reason") or "due"),
+            )
+            logger.critical(
+                "CAPITAL_PUBLICATION_V142_UPGRADE_ROLLOVER marker=%s due_reason=%s "
+                "remaining_s=%s old_id=%s new_id=%s pre_expiry=%s "
+                "publication_expiry_extended=false trading_fail_closed_until_refresh=true",
+                _MARKER,
+                meta.get("due_reason"),
+                meta.get("remaining_s"),
+                hex(id(coordinator)),
+                hex(id(replacement)) if replacement is not None else "none",
+                str(float(meta.get("remaining_s", 0.0) or 0.0) > 0.0).lower(),
+            )
+            return bool(replacement is coordinator or replacement is None)
+
+        # A tracked v142 owner has a generation before its worker-thread handle
+        # is published. Treat that brief pre-start window as live unless it has
+        # already exceeded the total runtime deadline. This closes the race where
+        # a concurrent v137 probe could otherwise roll over a healthy refresh.
+        timed_out = bool(getattr(coordinator, "_nija_v142_flight_timed_out", False))
+        age_s = float(publication_liveness._flight_age_s(coordinator))
+        limit_s = float(publication_liveness._runtime_pipeline_deadline_seconds())
+        worker = getattr(coordinator, "_nija_v142_flight_thread", None)
+        alive_fn = getattr(worker, "is_alive", None) if worker is not None else None
+        worker_known = worker is not None and callable(alive_fn)
+        worker_alive = bool(alive_fn()) if worker_known else False
+
+        if not timed_out and age_s <= limit_s + 1.0:
+            if not worker_known or worker_alive:
+                return True
+
+        if timed_out:
+            reason = "coordinator_timeout_flag"
+        elif not worker_known:
+            reason = "coordinator_worker_handle_missing_after_deadline"
+        elif not worker_alive:
+            reason = "coordinator_owner_dead"
+        else:
+            reason = "coordinator_age_exceeded"
+
+        replacement = publication_liveness._rollover_coordinator(
+            manager,
+            expected_old=coordinator,
+            reason=reason,
+        )
+        logger.critical(
+            "CAPITAL_PUBLICATION_V142_TRACKED_ROLLOVER marker=%s reason=%s age_s=%.1f "
+            "limit_s=%.1f worker_known=%s worker_alive=%s old_id=%s new_id=%s "
+            "late_publication_fenced=true trading_fail_closed_until_refresh=true",
+            _MARKER,
+            reason,
+            age_s,
+            limit_s,
+            str(worker_known).lower(),
+            str(worker_alive).lower(),
+            hex(id(coordinator)),
+            hex(id(replacement)) if replacement is not None else "none",
+        )
+        return bool(replacement is coordinator or replacement is None)
 
     setattr(coordinator_in_flight_with_upgrade_rollover, "_nija_v142_upgrade_rollover", True)
     publication_liveness._coordinator_in_flight_v142 = coordinator_in_flight_with_upgrade_rollover
@@ -240,11 +287,6 @@ def _install_authority_liveness() -> bool:
         )
         return False
 
-    # v142 is chained through this already-required manifest installer so the
-    # runtime release can never publish ready=true without proving the capital
-    # publication liveness repair was installed. v142 itself registers v140,
-    # v141 and v142 as required manifest proofs and advances the canonical
-    # release identity only after its fail-closed install succeeds.
     try:
         from bot import capital_publication_liveness_v142_patch as publication_liveness
 

--- a/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
+++ b/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot.kill_switch_coordinator_sync_patch import _prepare_capital_publication_liveness
+
+
+def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
+    def original():
+        return None
+
+    def owned_wrapper():
+        return original()
+
+    owned_wrapper.__name__ = original.__name__
+    owned_wrapper.__wrapped__ = original
+    owned_wrapper._owned = True
+
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: False,
+    )
+    assert _prepare_capital_publication_liveness(fake) is True
+
+    assert fake._chain_contains(
+        owned_wrapper,
+        marker="_owned",
+        expected_name="owned_wrapper",
+    ) is True
+    assert fake._chain_contains(
+        owned_wrapper,
+        marker="_owned",
+        expected_name="different_wrapper",
+    ) is False
+
+
+def test_pre_v142_inflight_rolls_over_when_refresh_enters_headroom(monkeypatch) -> None:
+    from bot import capital_publication_deadline_v137_patch as v137
+
+    old = SimpleNamespace(_in_flight=True)
+    replacement = SimpleNamespace(_in_flight=False)
+    manager = SimpleNamespace(_capital_coordinator=old)
+    authority = SimpleNamespace()
+    reasons: list[str] = []
+
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: True,
+        _authority=lambda: authority,
+    )
+
+    def rollover(target_manager, *, expected_old=None, reason):
+        assert expected_old is old
+        reasons.append(str(reason))
+        target_manager._capital_coordinator = replacement
+        return replacement
+
+    fake._rollover_coordinator = rollover
+    monkeypatch.setattr(
+        v137,
+        "_publication_refresh_due",
+        lambda authority, manager: (
+            True,
+            {
+                "due_reason": "pre_expiry_headroom",
+                "remaining_s": 42.0,
+            },
+        ),
+    )
+
+    assert _prepare_capital_publication_liveness(fake) is True
+    assert fake._coordinator_in_flight_v142(manager) is False
+    assert manager._capital_coordinator is replacement
+    assert reasons == ["untracked_inflight_refresh_due:pre_expiry_headroom"]

--- a/tests/test_capital_publication_liveness_v142.py
+++ b/tests/test_capital_publication_liveness_v142.py
@@ -173,6 +173,11 @@ def test_release_manifest_requires_v140_v141_and_v142(monkeypatch) -> None:
     monkeypatch.setattr(manifest, "_REQUIRED_FLAGS", dict(manifest._REQUIRED_FLAGS))
     monkeypatch.setattr(manifest, "_INSTALLERS", tuple(manifest._INSTALLERS))
     monkeypatch.setattr(manifest, "DECLARED_RELEASE_ID", str(manifest.DECLARED_RELEASE_ID))
+    monkeypatch.setattr(manifest, "RELEASE_ID", str(manifest.RELEASE_ID))
+    monkeypatch.setenv(
+        "NIJA_RUNTIME_RELEASE_ID",
+        str(os.environ.get("NIJA_RUNTIME_RELEASE_ID", manifest.RELEASE_ID)),
+    )
 
     assert v142._patch_release_manifest()
 

--- a/tests/test_capital_publication_liveness_v142.py
+++ b/tests/test_capital_publication_liveness_v142.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from bot import capital_publication_liveness_v142_patch as v142
+
+
+def test_runtime_pipeline_deadline_never_reaches_publication_ttl(monkeypatch) -> None:
+    monkeypatch.setattr(v142, "_freshness_ttl_seconds", lambda: 90.0)
+    monkeypatch.setattr(v142, "_fetch_budget_seconds", lambda: 45.0)
+    monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "999")
+
+    assert v142._runtime_pipeline_deadline_seconds() == 80.0
+    assert v142._runtime_pipeline_deadline_seconds() < 90.0
+
+
+def test_readiness_truth_keeps_hydration_and_connectivity_separate_from_freshness(monkeypatch) -> None:
+    from bot import preactivation_readiness_convergence_v16_patch as v16
+
+    def stale_capital_proof():
+        return (
+            {
+                "broker_connected": False,
+                "balance_hydrated": False,
+                "authority_ready": True,
+                "capital_ready": False,
+                "risk_ready": True,
+                "strategy_ready": True,
+                "execution_ready": True,
+                "nonce_ready": True,
+                "bootstrap_ready": True,
+            },
+            {
+                "capital": {
+                    "hydrated": True,
+                    "stale": True,
+                    "real": 240.07,
+                    "registered": 2,
+                }
+            },
+        )
+
+    monkeypatch.setattr(v16, "_collect_proofs", stale_capital_proof)
+    monkeypatch.setattr(
+        v142,
+        "_canonical_broker_connectivity",
+        lambda: (
+            True,
+            {
+                "reason": "ok",
+                "policy": "optional",
+                "registered": ["coinbase", "kraken", "okx"],
+                "connected": ["coinbase", "kraken", "okx"],
+            },
+        ),
+    )
+
+    assert v142._patch_readiness_truth()
+    proofs, details = v16._collect_proofs()
+
+    assert proofs["broker_connected"] is True
+    assert proofs["balance_hydrated"] is True
+    assert proofs["capital_ready"] is False
+    assert details["v142_readiness_truth"]["capital_stale"] is True
+
+
+def test_retired_generation_cannot_publish_or_poison_current_status(monkeypatch) -> None:
+    from bot import capital_authority as ca
+
+    calls: list[tuple[object, str]] = []
+
+    def permissive_publish(self, snapshot, writer_id):
+        calls.append((snapshot, writer_id))
+        return True
+
+    monkeypatch.setattr(ca.CapitalAuthority, "publish_snapshot", permissive_publish)
+    monkeypatch.setattr(v142, "_ACTIVE_GENERATION", 8)
+    monkeypatch.setattr(v142, "_NEXT_GENERATION", 8)
+    monkeypatch.setattr(v142, "_ROLLOVER_OCCURRED", True)
+    v142._LOCAL.refresh_generation = 7
+
+    assert v142._patch_publication_generation_fence()
+    authority = object.__new__(ca.CapitalAuthority)
+    authority._AUTHORIZED_WRITER_ID = "mabm_capital_refresh_coordinator"
+
+    assert (
+        authority.publish_snapshot(
+            SimpleNamespace(),
+            "mabm_capital_refresh_coordinator",
+        )
+        is False
+    )
+    assert calls == []
+
+    delattr(v142._LOCAL, "refresh_generation")
+
+
+def test_untracked_inflight_is_replaced_once_publication_expired(monkeypatch) -> None:
+    from bot import capital_publication_deadline_v137_patch as v137
+
+    now = datetime.now(timezone.utc)
+    authority = SimpleNamespace(
+        get_snapshot_publication_status=lambda: SimpleNamespace(
+            accepted=True,
+            stale=False,
+            reason="accepted",
+            timestamp=now - timedelta(seconds=91),
+            expiry=now - timedelta(seconds=1),
+        )
+    )
+    old = SimpleNamespace(_in_flight=True)
+    replacement = SimpleNamespace(_in_flight=False)
+    manager = SimpleNamespace(_capital_coordinator=old)
+
+    monkeypatch.setattr(v142, "_authority", lambda: authority)
+
+    def rollover(target_manager, *, expected_old=None, reason):
+        assert expected_old is old
+        assert "untracked" in reason
+        target_manager._capital_coordinator = replacement
+        return replacement
+
+    monkeypatch.setattr(v142, "_rollover_coordinator", rollover)
+
+    current, _meta = v137._publication_meta(authority, now=now)
+    assert current is False
+    assert v142._coordinator_in_flight_v142(manager) is False
+    assert manager._capital_coordinator is replacement
+
+
+def test_rollover_reuses_canonical_fsm_objects_and_hydration(monkeypatch) -> None:
+    from bot import capital_flow_state_machine as flow
+
+    bus = flow.get_capital_event_bus()
+    boot = flow.get_capital_bootstrap_fsm()
+    runtime = flow.get_capital_runtime_fsm()
+    old = flow.CapitalRefreshCoordinator(bus, boot, runtime)
+    old._in_flight = True
+    old._nija_v142_flight_generation = 3
+    old._nija_v142_flight_started_monotonic = 1.0
+    old._nija_v142_flight_trigger = "stuck-test"
+    old._nija_v142_flight_thread = threading.Thread(target=lambda: None)
+
+    manager = SimpleNamespace(
+        _capital_coordinator=old,
+        _capital_event_bus=bus,
+        _capital_bootstrap_fsm=boot,
+        _capital_runtime_fsm=runtime,
+    )
+    monkeypatch.setattr(v142, "_authority", lambda: SimpleNamespace(is_hydrated=True))
+
+    replacement = v142._rollover_coordinator(
+        manager,
+        expected_old=old,
+        reason="test_stuck_runtime_refresh",
+    )
+
+    assert replacement is manager._capital_coordinator
+    assert replacement is not old
+    assert replacement._bus is bus
+    assert replacement._boot is boot
+    assert replacement._runtime is runtime
+    assert replacement.balance_hydrated is True
+    assert replacement.balance_hydrated_event.is_set()
+
+
+def test_release_manifest_requires_v140_v141_and_v142(monkeypatch) -> None:
+    from bot import runtime_release_manifest_patch as manifest
+
+    monkeypatch.setattr(manifest, "_REQUIRED_FLAGS", dict(manifest._REQUIRED_FLAGS))
+    monkeypatch.setattr(manifest, "_INSTALLERS", tuple(manifest._INSTALLERS))
+    monkeypatch.setattr(manifest, "DECLARED_RELEASE_ID", str(manifest.DECLARED_RELEASE_ID))
+
+    assert v142._patch_release_manifest()
+
+    assert manifest.DECLARED_RELEASE_ID == "20260818-runtime-convergence-v142"
+    assert manifest.RELEASE_ID == "20260818-runtime-convergence-v142"
+    assert manifest._REQUIRED_FLAGS["runtime_killswitch_authority_liveness_v140"] == (
+        "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"
+    )
+    assert manifest._REQUIRED_FLAGS["stalled_writer_capital_freshness_v141"] == (
+        "NIJA_STALLED_WRITER_CAPITAL_FRESHNESS_V141_INSTALLED"
+    )
+    assert manifest._REQUIRED_FLAGS["capital_publication_liveness_v142"] == (
+        "NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"
+    )
+    assert (
+        "bot.capital_publication_liveness_v142_patch",
+        "install_import_hook",
+    ) in manifest._INSTALLERS
+
+
+def test_liveness_patch_does_not_clear_or_grant_safety_environment(monkeypatch) -> None:
+    monkeypatch.setenv("NIJA_EMERGENCY_STOP", "1")
+    monkeypatch.setenv("NIJA_NONCE_READY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+
+    v142._runtime_pipeline_deadline_seconds()
+
+    assert os.environ["NIJA_EMERGENCY_STOP"] == "1"
+    assert os.environ["NIJA_NONCE_READY"] == "0"
+    assert os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"

--- a/tests/test_capital_publication_liveness_v142.py
+++ b/tests/test_capital_publication_liveness_v142.py
@@ -18,7 +18,7 @@ def test_runtime_pipeline_deadline_never_reaches_publication_ttl(monkeypatch) ->
 
 
 def test_readiness_truth_keeps_hydration_and_connectivity_separate_from_freshness(monkeypatch) -> None:
-    from bot import preactivation_readiness_convergence_v16_patch as v16
+    import preactivation_readiness_convergence_v16_patch as v16
 
     def stale_capital_proof():
         return (

--- a/tests/test_capital_publication_liveness_v142_race_unittest.py
+++ b/tests/test_capital_publication_liveness_v142_race_unittest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from bot.kill_switch_coordinator_sync_patch import _prepare_capital_publication_liveness
+
+
+class CapitalPublicationLivenessV142RaceTests(unittest.TestCase):
+    def test_tracked_refresh_without_published_worker_handle_is_not_rolled_early(self) -> None:
+        coordinator = SimpleNamespace(
+            _in_flight=True,
+            _nija_v142_flight_generation=11,
+            _nija_v142_flight_timed_out=False,
+        )
+        manager = SimpleNamespace(_capital_coordinator=coordinator)
+        rollovers: list[str] = []
+
+        fake = SimpleNamespace(
+            _nija_startup_chain_prepared=False,
+            _coordinator_in_flight_v142=lambda manager: True,
+            _flight_age_s=lambda owner: 0.01,
+            _runtime_pipeline_deadline_seconds=lambda: 55.0,
+        )
+
+        def rollover(target_manager, *, expected_old=None, reason):
+            rollovers.append(str(reason))
+            return None
+
+        fake._rollover_coordinator = rollover
+
+        self.assertTrue(_prepare_capital_publication_liveness(fake))
+        self.assertTrue(fake._coordinator_in_flight_v142(manager))
+        self.assertEqual(rollovers, [])
+
+    def test_missing_worker_handle_after_deadline_is_rolled_fail_closed(self) -> None:
+        coordinator = SimpleNamespace(
+            _in_flight=True,
+            _nija_v142_flight_generation=12,
+            _nija_v142_flight_timed_out=False,
+        )
+        replacement = SimpleNamespace(_in_flight=False)
+        manager = SimpleNamespace(_capital_coordinator=coordinator)
+        reasons: list[str] = []
+
+        fake = SimpleNamespace(
+            _nija_startup_chain_prepared=False,
+            _coordinator_in_flight_v142=lambda manager: True,
+            _flight_age_s=lambda owner: 61.0,
+            _runtime_pipeline_deadline_seconds=lambda: 55.0,
+        )
+
+        def rollover(target_manager, *, expected_old=None, reason):
+            self.assertIs(expected_old, coordinator)
+            reasons.append(str(reason))
+            target_manager._capital_coordinator = replacement
+            return replacement
+
+        fake._rollover_coordinator = rollover
+
+        self.assertTrue(_prepare_capital_publication_liveness(fake))
+        self.assertFalse(fake._coordinator_in_flight_v142(manager))
+        self.assertIs(manager._capital_coordinator, replacement)
+        self.assertEqual(reasons, ["coordinator_worker_handle_missing_after_deadline"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capital_publication_liveness_v142_unittest.py
+++ b/tests/test_capital_publication_liveness_v142_unittest.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bot import capital_publication_liveness_v142_patch as v142
+from bot.kill_switch_coordinator_sync_patch import _prepare_capital_publication_liveness
+
+
+class CapitalPublicationLivenessV142Tests(unittest.TestCase):
+    def test_runtime_pipeline_deadline_is_strictly_inside_freshness_ttl(self) -> None:
+        with (
+            patch.object(v142, "_freshness_ttl_seconds", return_value=90.0),
+            patch.object(v142, "_fetch_budget_seconds", return_value=45.0),
+            patch.dict(os.environ, {"NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S": "999"}),
+        ):
+            self.assertEqual(v142._runtime_pipeline_deadline_seconds(), 80.0)
+            self.assertLess(v142._runtime_pipeline_deadline_seconds(), 90.0)
+
+    def test_readiness_truth_separates_connectivity_and_hydration_from_freshness(self) -> None:
+        import preactivation_readiness_convergence_v16_patch as v16
+
+        original = v16._collect_proofs
+
+        def stale_capital_proof():
+            return (
+                {
+                    "broker_connected": False,
+                    "balance_hydrated": False,
+                    "authority_ready": True,
+                    "capital_ready": False,
+                    "risk_ready": True,
+                    "strategy_ready": True,
+                    "execution_ready": True,
+                    "nonce_ready": True,
+                    "bootstrap_ready": True,
+                },
+                {
+                    "capital": {
+                        "hydrated": True,
+                        "stale": True,
+                        "real": 240.07,
+                        "registered": 2,
+                    }
+                },
+            )
+
+        try:
+            v16._collect_proofs = stale_capital_proof
+            with patch.object(
+                v142,
+                "_canonical_broker_connectivity",
+                return_value=(
+                    True,
+                    {
+                        "reason": "ok",
+                        "policy": "optional",
+                        "registered": ["coinbase", "kraken", "okx"],
+                        "connected": ["coinbase", "kraken", "okx"],
+                    },
+                ),
+            ):
+                self.assertTrue(v142._patch_readiness_truth())
+                proofs, details = v16._collect_proofs()
+
+            self.assertTrue(proofs["broker_connected"])
+            self.assertTrue(proofs["balance_hydrated"])
+            self.assertFalse(proofs["capital_ready"])
+            self.assertTrue(details["v142_readiness_truth"]["capital_stale"])
+        finally:
+            v16._collect_proofs = original
+
+    def test_retired_generation_is_rejected_without_calling_underlying_publish(self) -> None:
+        calls: list[tuple[object, str]] = []
+
+        class FakeAuthority:
+            _AUTHORIZED_WRITER_ID = "mabm_capital_refresh_coordinator"
+
+            def publish_snapshot(self, snapshot, writer_id):
+                calls.append((snapshot, writer_id))
+                return True
+
+        fake_ca = types.ModuleType("fake_capital_authority_v142")
+        fake_ca.CapitalAuthority = FakeAuthority
+
+        old_active = v142._ACTIVE_GENERATION
+        old_next = v142._NEXT_GENERATION
+        old_rollover = v142._ROLLOVER_OCCURRED
+        prior_local = getattr(v142._LOCAL, "refresh_generation", None)
+        had_prior_local = hasattr(v142._LOCAL, "refresh_generation")
+        try:
+            v142._ACTIVE_GENERATION = 8
+            v142._NEXT_GENERATION = 8
+            v142._ROLLOVER_OCCURRED = True
+            v142._LOCAL.refresh_generation = 7
+            with patch.object(v142, "_import_first", return_value=fake_ca):
+                self.assertTrue(v142._patch_publication_generation_fence())
+                self.assertFalse(
+                    FakeAuthority().publish_snapshot(
+                        SimpleNamespace(),
+                        "mabm_capital_refresh_coordinator",
+                    )
+                )
+            self.assertEqual(calls, [])
+        finally:
+            v142._ACTIVE_GENERATION = old_active
+            v142._NEXT_GENERATION = old_next
+            v142._ROLLOVER_OCCURRED = old_rollover
+            if had_prior_local:
+                v142._LOCAL.refresh_generation = prior_local
+            else:
+                try:
+                    delattr(v142._LOCAL, "refresh_generation")
+                except AttributeError:
+                    pass
+
+    def test_rollover_reuses_manager_fsm_objects_and_preserves_hydration(self) -> None:
+        created: list[object] = []
+
+        class FakeCoordinator:
+            def __init__(self, bus, boot, runtime) -> None:
+                self._bus = bus
+                self._boot = boot
+                self._runtime = runtime
+                self._in_flight = False
+                self.balance_hydrated = False
+                import threading
+                self.balance_hydrated_event = threading.Event()
+                created.append(self)
+
+        fake_flow = types.ModuleType("fake_capital_flow_v142")
+        fake_flow.CapitalRefreshCoordinator = FakeCoordinator
+        bus = object()
+        boot = object()
+        runtime = object()
+        old = SimpleNamespace(
+            _in_flight=True,
+            _nija_v142_flight_generation=3,
+            _nija_v142_flight_started_monotonic=1.0,
+            _nija_v142_flight_trigger="stuck-test",
+            _nija_v142_flight_thread=None,
+        )
+        manager = SimpleNamespace(
+            _capital_coordinator=old,
+            _capital_event_bus=bus,
+            _capital_bootstrap_fsm=boot,
+            _capital_runtime_fsm=runtime,
+        )
+
+        old_active = v142._ACTIVE_GENERATION
+        old_next = v142._NEXT_GENERATION
+        old_rollover = v142._ROLLOVER_OCCURRED
+        try:
+            with (
+                patch.object(v142, "_capital_flow_module", return_value=fake_flow),
+                patch.object(v142, "_authority", return_value=SimpleNamespace(is_hydrated=True)),
+            ):
+                replacement = v142._rollover_coordinator(
+                    manager,
+                    expected_old=old,
+                    reason="test_stuck_runtime_refresh",
+                )
+
+            self.assertIs(replacement, manager._capital_coordinator)
+            self.assertIsNot(replacement, old)
+            self.assertIs(replacement._bus, bus)
+            self.assertIs(replacement._boot, boot)
+            self.assertIs(replacement._runtime, runtime)
+            self.assertTrue(replacement.balance_hydrated)
+            self.assertTrue(replacement.balance_hydrated_event.is_set())
+            self.assertEqual(created, [replacement])
+        finally:
+            v142._ACTIVE_GENERATION = old_active
+            v142._NEXT_GENERATION = old_next
+            v142._ROLLOVER_OCCURRED = old_rollover
+
+    def test_upgrade_rolls_untracked_inflight_owner_before_expiry_when_v137_due(self) -> None:
+        from bot import capital_publication_deadline_v137_patch as v137
+
+        old = SimpleNamespace(_in_flight=True)
+        replacement = SimpleNamespace(_in_flight=False)
+        manager = SimpleNamespace(_capital_coordinator=old)
+        reasons: list[str] = []
+
+        fake = SimpleNamespace(
+            _nija_startup_chain_prepared=False,
+            _coordinator_in_flight_v142=lambda manager: True,
+            _authority=lambda: SimpleNamespace(),
+        )
+
+        def rollover(target_manager, *, expected_old=None, reason):
+            self.assertIs(expected_old, old)
+            reasons.append(str(reason))
+            target_manager._capital_coordinator = replacement
+            return replacement
+
+        fake._rollover_coordinator = rollover
+        with patch.object(
+            v137,
+            "_publication_refresh_due",
+            return_value=(
+                True,
+                {
+                    "due_reason": "pre_expiry_headroom",
+                    "remaining_s": 42.0,
+                },
+            ),
+        ):
+            self.assertTrue(_prepare_capital_publication_liveness(fake))
+            self.assertFalse(fake._coordinator_in_flight_v142(manager))
+
+        self.assertIs(manager._capital_coordinator, replacement)
+        self.assertEqual(reasons, ["untracked_inflight_refresh_due:pre_expiry_headroom"])
+
+    def test_release_manifest_patch_can_be_verified_without_mutating_real_manifest(self) -> None:
+        fake_manifest = SimpleNamespace(
+            _REQUIRED_FLAGS={},
+            _INSTALLERS=(),
+            DECLARED_RELEASE_ID="old-release",
+            RELEASE_ID="old-release",
+        )
+        real_import = v142.importlib.import_module
+
+        def fake_import(name: str):
+            if name == "bot.runtime_release_manifest_patch":
+                return fake_manifest
+            return real_import(name)
+
+        with patch.object(v142.importlib, "import_module", side_effect=fake_import):
+            self.assertTrue(v142._patch_release_manifest())
+
+        self.assertEqual(fake_manifest.DECLARED_RELEASE_ID, v142.RELEASE_ID)
+        self.assertEqual(fake_manifest.RELEASE_ID, v142.RELEASE_ID)
+        self.assertEqual(
+            fake_manifest._REQUIRED_FLAGS["capital_publication_liveness_v142"],
+            "NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY",
+        )
+        self.assertIn(
+            ("bot.capital_publication_liveness_v142_patch", "install_import_hook"),
+            fake_manifest._INSTALLERS,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capital_publication_liveness_v142_unittest.py
+++ b/tests/test_capital_publication_liveness_v142_unittest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import types
 import unittest
 from types import SimpleNamespace
@@ -230,8 +229,12 @@ class CapitalPublicationLivenessV142Tests(unittest.TestCase):
                 return fake_manifest
             return real_import(name)
 
-        with patch.object(v142.importlib, "import_module", side_effect=fake_import):
+        with (
+            patch.object(v142.importlib, "import_module", side_effect=fake_import),
+            patch.dict(os.environ, {}, clear=False),
+        ):
             self.assertTrue(v142._patch_release_manifest())
+            self.assertEqual(os.environ.get("NIJA_RUNTIME_RELEASE_ID"), v142.RELEASE_ID)
 
         self.assertEqual(fake_manifest.DECLARED_RELEASE_ID, v142.RELEASE_ID)
         self.assertEqual(fake_manifest.RELEASE_ID, v142.RELEASE_ID)


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

Fix the production capital-publication liveness failure observed on 2026-08-18. The canonical `CapitalRefreshCoordinator` remained `_in_flight` across the immutable CapitalAuthority freshness window. v137 then correctly coalesced behind the stuck writer, publication freshness expired, and v133 correctly failed `LIVE_ACTIVE -> OFF`.

Production evidence addressed:

- `CAPITAL_PUBLICATION_DEADLINE_V137_DUE ... coordinator_in_flight=True`
- `STALLED_WRITER_CAPITAL_V141_FAIL_CLOSED ... snapshot_expired`
- `POST_ACTIVATION_PROOF_LOSS_V133_FAIL_CLOSED ... LIVE_ACTIVE->OFF`
- later recurrence: `CAPITAL_PUBLICATION_DEADLINE_V137_COALESCED ... canonical_writer_in_flight=true ready=True`
- broker connectivity remained healthy while the old v16 proof incorrectly coupled `broker_connected` and `balance_hydrated` to capital freshness

## Changes

- add `bot/capital_publication_liveness_v142_patch.py`
  - reassert and verify the v35/v36 bounded broker-fetch layer and v78 freshness budget
  - bound the total runtime coordinator pipeline strictly inside the canonical freshness TTL
  - generation-fence timed-out/retired coordinator workers so late publishes cannot overwrite current capital truth
  - roll over a stuck canonical coordinator and let v137 retry through the replacement
  - preserve immutable publication expiry; no freshness extension or force-live fallback
- harden upgrade from the currently deployed v138/v141 runtime
  - v142 is chained through the already-required kill-switch/liveness installer
  - a pre-v142 untracked in-flight coordinator is replaced as soon as v137 enters refresh headroom, instead of waiting for publication expiry
  - wrapper ownership proof uses marker + code-object identity so `functools.wraps` cannot create false positives/negatives
- correct readiness semantics
  - `broker_connected` comes from canonical platform broker registry/connectivity
  - `balance_hydrated` reflects hydration independently of freshness
  - `capital_ready` remains freshness-gated, so stale capital still fails closed through v133
- register v140, v141, and v142 as required runtime-release proofs and advance runtime release identity to `20260818-runtime-convergence-v142` only after successful install
- add focused regressions for deadlines, generation fencing, rollover, readiness truth, wrapper-chain proof, manifest proof requirements, and pre-expiry upgrade rollover

## Risk Assessment

- Risk level: medium
- Impacted areas:
  - canonical capital refresh coordinator
  - capital publication freshness/liveness
  - preactivation readiness proof taxonomy
  - runtime release/liveness installation chain
- Key failure modes:
  - a retired worker could publish late after coordinator rollover
  - a replacement coordinator could lose canonical FSM/event-bus identity
  - stale capital could be mislabeled as connectivity or hydration loss
  - wrapper-chain drift could silently remove the v35/v78 synchronous bounds

All four are explicitly fenced or covered by regression tests. Trading remains fail closed when current capital freshness cannot be proven.

## Rollback Plan

- Revert this PR to restore the deployed v138/v141 behavior.
- No schema migration or persistent data rewrite is introduced.
- Rollback does not require clearing any kill switch, writer lease, nonce state, or capital cache.

## Validation

- [ ] GitHub Actions checks passed
- [x] Monitoring/observability impact reviewed: adds explicit v142 timeout/retirement/rollover/late-publication diagnostics

### NIJA Safety Checks

- [ ] `python -m py_compile` clean on all changed `.py` files (CI/runtime validation pending; local clone unavailable in this execution environment)
- [x] No bypass flags committed (`FORCE_TRADE`, `NIJA_FORCE_ACTIVATION`, `NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK`, `NIJA_DISABLE_WRITER_LOCK`, `NIJA_SKIP_STARTUP_PHASE_GATE`)
- [x] Authority-gate denials are not converted into exchange order rejections
- [x] No strategy/entry model change; backtest not applicable

## Safety Contract

This patch does **not** clear the kill switch, grant nonce/writer/execution authority, bypass risk gates, extend stale publication expiry, fabricate broker connectivity/capital, or force `LIVE_ACTIVE`. If current capital freshness cannot be proven, `capital_ready` remains false and trading stays fail closed.