### PR TITLE
Fix persisted kill-switch provenance liveness v143

### DIFF
--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -305,6 +305,22 @@ def _install_authority_liveness() -> bool:
         )
         return False
 
+    try:
+        from bot import kill_switch_persistence_provenance_v143_patch as provenance_liveness
+
+        installer = getattr(provenance_liveness, "install_import_hook", None) or getattr(
+            provenance_liveness, "install", None
+        )
+        if not callable(installer) or not bool(installer()):
+            return False
+    except Exception as exc:
+        logger.exception(
+            "KILL_SWITCH_PERSISTENCE_PROVENANCE_V143_CHAIN_FAILED marker=%s error=%s",
+            _MARKER,
+            exc,
+        )
+        return False
+
     return True
 
 
@@ -334,7 +350,8 @@ def install_import_hook() -> None:
             "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
             "risk_gates_unchanged=true authority_liveness_chained=true "
             "stalled_writer_capital_freshness_chained=true "
-            "capital_publication_liveness_chained=true",
+            "capital_publication_liveness_chained=true "
+            "kill_switch_persistence_provenance_chained=true",
             _MARKER,
             str(active).lower(),
         )

--- a/bot/kill_switch_persistence_provenance_v143_patch.py
+++ b/bot/kill_switch_persistence_provenance_v143_patch.py
@@ -1,0 +1,335 @@
+"""Preserve kill-switch activation provenance across repeated restart persistence.
+
+Production 2026-08-18 showed an otherwise healthy runtime remaining in
+``EMERGENCY_STOP`` with only ``authority_ready``/``execution_ready`` false.
+The canonical KillSwitch exposes only ``recent_history[-5:]``. Every restart
+while ``EMERGENCY_STOP`` exists appends another ``FILE_SYSTEM / Kill switch file
+detected`` record, so the original activation can age out of that five-record
+window. v140 then cannot prove that a persisted stop came from the retired
+authority-heartbeat/core-death race and correctly refuses recovery.
+
+v143 repairs provenance only; it does not clear a kill switch itself:
+
+* derive one compact persisted-stop causal record from the KillSwitch's full
+  in-memory history while keeping the public ``recent_history`` window intact;
+* traverse any number of consecutive restart-persistence records;
+* treat every source-less deactivation record as a hard provenance boundary;
+* feed the bounded causal record to v140, v131, and v130 so their existing
+  narrow heartbeat-only recovery policy can make the decision;
+* preserve manual/UI/CLI, unrelated automatic risk, unknown-source, direct new
+  heartbeat, and post-deactivation file stops fail-closed.
+
+No live state, execution authority, risk gate, nonce, writer lease, SEAK state,
+capital freshness, or publication expiry is changed by this patch.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.kill_switch_persistence_provenance_v143")
+MARKER = "20260818-kill-switch-persistence-provenance-v143"
+RELEASE_ID = "20260818-runtime-convergence-v143"
+_FLAG = "NIJA_KILL_SWITCH_PERSISTENCE_PROVENANCE_V143_READY"
+_PATCH_ATTR = "_nija_kill_switch_persistence_provenance_v143"
+_META_KEY = "_nija_persisted_cause_v143"
+_DEPTH_KEY = "_nija_persistence_history_depth_v143"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_LAST_PROVENANCE_SIGNATURE = ""
+
+
+def _restart_persistence_record(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    source = str(item.get("source") or "").strip().upper()
+    reason = str(item.get("reason") or "")
+    return source == "FILE_SYSTEM" and "Kill switch file detected" in reason
+
+
+def _derive_persisted_cause(history: object) -> dict[str, Any] | None:
+    """Return one bounded causal record for the current restart-persisted stop.
+
+    A source-less record is written by ``KillSwitch.deactivate`` and therefore
+    terminates provenance. Crossing that boundary could misattribute a later
+    manually-created ``EMERGENCY_STOP`` file to an older automatic heartbeat
+    activation, so v143 deliberately refuses to scan past it.
+    """
+    if not isinstance(history, list) or not history:
+        return None
+    latest = history[-1]
+    if not _restart_persistence_record(latest):
+        return None
+
+    skipped = 0
+    for item in reversed(history[:-1]):
+        if not isinstance(item, dict):
+            return {
+                "blocked": "malformed_history_boundary",
+                "persistence_records_skipped": skipped,
+            }
+
+        source = str(item.get("source") or "").strip()
+        reason = str(item.get("reason") or "")
+
+        if not source:
+            return {
+                "blocked": "deactivation_boundary",
+                "persistence_records_skipped": skipped,
+            }
+
+        if _restart_persistence_record(item):
+            skipped += 1
+            continue
+
+        return {
+            "source": source,
+            "reason": reason,
+            "persistence_records_skipped": skipped,
+        }
+
+    return {
+        "blocked": "origin_unavailable",
+        "persistence_records_skipped": skipped,
+    }
+
+
+def _announce_provenance(meta: dict[str, Any], depth: int) -> None:
+    global _LAST_PROVENANCE_SIGNATURE
+    blocked = str(meta.get("blocked") or "")
+    source = str(meta.get("source") or "")
+    reason = str(meta.get("reason") or "")
+    skipped = int(meta.get("persistence_records_skipped") or 0)
+    signature = f"{blocked}|{source}|{reason}|{skipped}|{depth}"
+    with _LOCK:
+        if signature == _LAST_PROVENANCE_SIGNATURE:
+            return
+        _LAST_PROVENANCE_SIGNATURE = signature
+
+    if blocked:
+        LOGGER.critical(
+            "KILL_SWITCH_PROVENANCE_V143_PRESERVED marker=%s block=%s history_depth=%d "
+            "persistence_records_skipped=%d auto_clear=false trading_fail_closed=true",
+            MARKER,
+            blocked,
+            depth,
+            skipped,
+        )
+    else:
+        LOGGER.critical(
+            "KILL_SWITCH_PROVENANCE_V143_RECONSTRUCTED marker=%s history_depth=%d "
+            "persistence_records_skipped=%d causal_source=%s causal_reason=%s "
+            "recovery_decision_delegated=true generic_auto_clear=false",
+            MARKER,
+            depth,
+            skipped,
+            source or "unknown",
+            reason or "unknown",
+        )
+
+
+def _patch_kill_switch_status() -> bool:
+    module = importlib.import_module("bot.kill_switch")
+    cls = getattr(module, "KillSwitch", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "get_status", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def get_status_v143(self: Any) -> dict[str, Any]:
+        raw = current(self)
+        status = dict(raw or {}) if isinstance(raw, dict) else {}
+        try:
+            lock = getattr(self, "_lock", None)
+            if lock is not None:
+                with lock:
+                    history = list(getattr(self, "_activation_history", []) or [])
+            else:
+                history = list(getattr(self, "_activation_history", []) or [])
+        except Exception as exc:
+            LOGGER.warning(
+                "KILL_SWITCH_PROVENANCE_V143_HISTORY_PROBE_FAILED marker=%s err=%s:%s "
+                "existing_status_preserved=true trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return status
+
+        meta = _derive_persisted_cause(history)
+        if meta is not None:
+            status[_META_KEY] = dict(meta)
+            status[_DEPTH_KEY] = len(history)
+            _announce_provenance(meta, len(history))
+        return status
+
+    setattr(get_status_v143, _PATCH_ATTR, True)
+    setattr(get_status_v143, "_nija_v143_original", current)
+    cls.get_status = get_status_v143
+    return True
+
+
+def _causal_activation_from_status(
+    status: dict[str, Any],
+    fallback: Any = None,
+) -> tuple[str, str]:
+    history = list(status.get("recent_history") or [])
+    latest = history[-1] if history and isinstance(history[-1], dict) else {}
+    if _restart_persistence_record(latest):
+        meta = status.get(_META_KEY)
+        if isinstance(meta, dict):
+            blocked = str(meta.get("blocked") or "").strip()
+            if blocked:
+                return f"v143_provenance_blocked:{blocked}", "PROVENANCE_BOUNDARY"
+            source = str(meta.get("source") or "").strip()
+            reason = str(meta.get("reason") or "")
+            if source:
+                return reason, source
+
+    if callable(fallback):
+        try:
+            result = fallback(status)
+            if isinstance(result, tuple) and len(result) >= 2:
+                return str(result[0] or ""), str(result[1] or "")
+        except Exception:
+            pass
+
+    if not history:
+        return "", ""
+    return str(latest.get("reason") or ""), str(latest.get("source") or "")
+
+
+def _patch_causal_readers() -> bool:
+    v140 = importlib.import_module("bot.runtime_killswitch_authority_liveness_patch")
+    v131 = importlib.import_module("bot.readiness_killswitch_causality_v131_patch")
+    v130 = importlib.import_module("bot.kill_switch_stale_heartbeat_recovery_v130_patch")
+
+    current_v140 = getattr(v140, "_causal_activation", None)
+    current_v131 = getattr(v131, "_causal_activation", None)
+    if not callable(current_v140) or not callable(current_v131):
+        return False
+
+    if getattr(current_v140, _PATCH_ATTR, False) and getattr(current_v131, _PATCH_ATTR, False):
+        v130._latest_activation = current_v140
+        return True
+
+    @wraps(current_v140)
+    def causal_activation_v143(status: dict[str, Any]) -> tuple[str, str]:
+        return _causal_activation_from_status(status, current_v140)
+
+    setattr(causal_activation_v143, _PATCH_ATTR, True)
+    setattr(causal_activation_v143, "_nija_v143_v140_fallback", current_v140)
+    v140._causal_activation = causal_activation_v143
+
+    @wraps(current_v131)
+    def causal_activation_v143_v131(status: dict[str, Any]) -> tuple[str, str]:
+        return _causal_activation_from_status(status, current_v131)
+
+    setattr(causal_activation_v143_v131, _PATCH_ATTR, True)
+    setattr(causal_activation_v143_v131, "_nija_v143_v131_fallback", current_v131)
+    v131._causal_activation = causal_activation_v143_v131
+
+    # v130 captured v131's old function object during its installer. Re-anchor
+    # that compatibility pointer so direct v130 recovery sees the same bounded
+    # provenance record as v132/v140.
+    v130._latest_activation = causal_activation_v143_v131
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict) or not isinstance(installers, tuple):
+        return False
+
+    required["kill_switch_persistence_provenance_v143"] = _FLAG
+    own = ("bot.kill_switch_persistence_provenance_v143_patch", "install_import_hook")
+    if own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+
+    manifest.DECLARED_RELEASE_ID = RELEASE_ID
+    manifest.RELEASE_ID = RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+    return True
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        if _INSTALLED and os.environ.get(_FLAG) == "1":
+            return True
+
+        # v143 is a follow-on to the existing narrow v140 recovery and the v142
+        # runtime release. Refuse partial installation rather than widening any
+        # recovery path in an unknown runtime composition.
+        if os.environ.get("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY") != "1":
+            os.environ.pop(_FLAG, None)
+            return False
+        if os.environ.get("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY") != "1":
+            os.environ.pop(_FLAG, None)
+            return False
+
+        try:
+            ok = bool(
+                _patch_kill_switch_status()
+                and _patch_causal_readers()
+                and _patch_release_manifest()
+            )
+        except Exception as exc:
+            LOGGER.critical(
+                "KILL_SWITCH_PROVENANCE_V143_INSTALL_FAILED marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            ok = False
+
+        if not ok:
+            os.environ.pop(_FLAG, None)
+            os.environ["NIJA_RUNTIME_RELEASE_READY"] = "0"
+            return False
+
+        os.environ[_FLAG] = "1"
+        first = not _INSTALLED
+        _INSTALLED = True
+
+    if first:
+        LOGGER.critical(
+            "KILL_SWITCH_PROVENANCE_V143_INSTALLED marker=%s release=%s "
+            "repeated_restart_provenance=true deactivation_boundary_authoritative=true "
+            "manual_ui_cli_stops_preserved=true risk_stops_preserved=true "
+            "direct_new_stops_preserved=true generic_auto_clear=false "
+            "execution_authority_unchanged=true risk_gates_unchanged=true force_live=false",
+            MARKER,
+            RELEASE_ID,
+        )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_derive_persisted_cause",
+    "_causal_activation_from_status",
+    "_patch_kill_switch_status",
+    "_patch_causal_readers",
+    "_patch_release_manifest",
+]

--- a/bot/test_authority_heartbeat_startup_grace_v129.py
+++ b/bot/test_authority_heartbeat_startup_grace_v129.py
@@ -44,7 +44,7 @@ def test_v129_does_not_resume_seak_clear_shutdown_or_grant_execution():
     source = Path(patch.__file__).read_text(encoding="utf-8")
     assert ".resume(" not in source
     assert "_halt_event.clear(" not in source
-    assert "shutdown_requested"] = " not in source
+    assert 'shutdown_requested"] = ' not in source
     assert "mark_ready(" not in source
     assert 'NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "1"' not in source
     assert "post_registration_core_death_fatal=true" in source

--- a/tests/test_kill_switch_persistence_provenance_v143_unittest.py
+++ b/tests/test_kill_switch_persistence_provenance_v143_unittest.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "bot" / "kill_switch_persistence_provenance_v143_patch.py"
+SPEC = importlib.util.spec_from_file_location("v143_under_test", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+HEARTBEAT = (
+    "AUTHORITY_HEARTBEAT_EXPIRED: core_thread_dead - "
+    "NIJA_CORE_THREAD_ALIVE is not set"
+)
+FILE = {"source": "FILE_SYSTEM", "reason": "Kill switch file detected"}
+
+
+class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
+    def test_reconstructs_origin_beyond_recent_five_window(self) -> None:
+        history = [{"source": "MANUAL", "reason": HEARTBEAT}] + [dict(FILE) for _ in range(7)]
+        meta = mod._derive_persisted_cause(history)
+        self.assertIsNotNone(meta)
+        assert meta is not None
+        self.assertEqual(meta.get("source"), "MANUAL")
+        self.assertEqual(meta.get("reason"), HEARTBEAT)
+        self.assertEqual(meta.get("persistence_records_skipped"), 6)
+
+        # Canonical public status would expose only five FILE_SYSTEM records.
+        status = {
+            "is_active": True,
+            "recent_history": history[-5:],
+            mod._META_KEY: meta,
+        }
+        reason, source = mod._causal_activation_from_status(status)
+        self.assertEqual(reason, HEARTBEAT)
+        self.assertEqual(source, "MANUAL")
+
+    def test_deactivation_is_hard_provenance_boundary(self) -> None:
+        history = [
+            {"source": "AUTOMATIC", "reason": HEARTBEAT},
+            {"reason": "verified recovery from retired authority-heartbeat/core-death restart persistence"},
+            dict(FILE),
+            dict(FILE),
+        ]
+        meta = mod._derive_persisted_cause(history)
+        self.assertIsNotNone(meta)
+        assert meta is not None
+        self.assertEqual(meta.get("blocked"), "deactivation_boundary")
+
+        status = {
+            "is_active": True,
+            "recent_history": history,
+            mod._META_KEY: meta,
+        }
+        reason, source = mod._causal_activation_from_status(status)
+        self.assertEqual(reason, "v143_provenance_blocked:deactivation_boundary")
+        self.assertEqual(source, "PROVENANCE_BOUNDARY")
+
+    def test_new_manual_stop_after_deactivation_wins(self) -> None:
+        history = [
+            {"source": "AUTOMATIC", "reason": HEARTBEAT},
+            {"reason": "operator verified prior recovery"},
+            {"source": "MANUAL", "reason": "operator manual stop for maintenance"},
+            dict(FILE),
+            dict(FILE),
+        ]
+        meta = mod._derive_persisted_cause(history)
+        self.assertIsNotNone(meta)
+        assert meta is not None
+        self.assertEqual(meta.get("source"), "MANUAL")
+        self.assertEqual(meta.get("reason"), "operator manual stop for maintenance")
+
+    def test_direct_new_stop_has_no_persistence_metadata(self) -> None:
+        history = [{"source": "AUTOMATIC", "reason": HEARTBEAT}]
+        self.assertIsNone(mod._derive_persisted_cause(history))
+
+    def test_get_status_wrapper_keeps_recent_window_but_adds_compact_cause(self) -> None:
+        class FakeKillSwitch:
+            def __init__(self) -> None:
+                self._lock = threading.Lock()
+                self._activation_history = [
+                    {"source": "MANUAL", "reason": HEARTBEAT},
+                    *[dict(FILE) for _ in range(8)],
+                ]
+
+            def get_status(self):
+                with self._lock:
+                    return {
+                        "is_active": True,
+                        "recent_history": self._activation_history[-5:],
+                    }
+
+        original_import = mod.importlib.import_module
+        mod.importlib.import_module = lambda name: type("M", (), {"KillSwitch": FakeKillSwitch}) if name == "bot.kill_switch" else original_import(name)
+        try:
+            self.assertTrue(mod._patch_kill_switch_status())
+            status = FakeKillSwitch().get_status()
+        finally:
+            mod.importlib.import_module = original_import
+
+        self.assertEqual(len(status["recent_history"]), 5)
+        self.assertEqual(status[mod._DEPTH_KEY], 9)
+        self.assertEqual(status[mod._META_KEY].get("source"), "MANUAL")
+        self.assertNotIn("full_history", status)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Production on 2026-08-18 reached a healthy runtime proof set for broker connectivity, capital hydration/freshness, risk, strategy, nonce, bootstrap, and position sync, but remained in `EMERGENCY_STOP` with only `authority_ready=false` and downstream `execution_ready=false`. The runtime also logged `KILL_SWITCH_V132_PRESERVED ... detail=causal_source_forbidden`.

The canonical `KillSwitch.get_status()` exposes only the last five history records. Every restart while the `EMERGENCY_STOP` file remains present appends another `FILE_SYSTEM / Kill switch file detected` record. After enough restarts, the original activation cause can age out of the five-record window, so the narrow v140/v132 heartbeat-stop recovery cannot prove provenance and correctly preserves the stop indefinitely.

This PR adds v143 to preserve enough provenance for that existing narrow recovery path without adding any generic auto-clear behavior.

### v143 behavior

- derives one compact causal record from the full in-memory kill-switch history while leaving public `recent_history[-5:]` unchanged;
- traverses repeated restart-persistence records to recover the immediate causal activation;
- treats any source-less deactivation record as a hard provenance boundary, preventing a later manual/file stop from inheriting an older heartbeat cause;
- re-anchors the v140, v131, and v130 causal readers to the compact provenance record;
- delegates the actual recovery decision to the existing v140 heartbeat-only eligibility and runtime-health proofs;
- chains v143 after v140/v141/v142 through the canonical kill-switch startup installer and advances the dynamic runtime release to `20260818-runtime-convergence-v143`.

## Safety contract

v143 does **not** clear the kill switch itself and does not add a generic recovery path. Manual/UI/CLI stops, unrelated automatic/risk stops, unknown provenance, direct new heartbeat stops, and any stop separated from an older activation by a deactivation boundary remain fail-closed. It does not grant execution/live state, writer/nonce authority, alter SEAK/risk gates, fabricate readiness, or extend capital publication freshness/expiry.

## Validation

Local targeted validation completed before publication:

- `python -m py_compile` for the v143 module, v143 unittest, and updated kill-switch startup chain;
- 5 unittest regressions pass covering history saturation beyond five records, deactivation-boundary protection, newer manual-stop precedence, direct-new-stop preservation, and compact status metadata while keeping the public five-record window.

Repository-wide GitHub Actions are expected to run on this draft PR.