### PR TITLE
Fix runtime startup convergence and stale capital workers v145

### DIFF
--- a/bot/global_runtime_startup_guards.py
+++ b/bot/global_runtime_startup_guards.py
@@ -37,14 +37,7 @@ def _live_runtime_expected() -> bool:
 
 
 def _install_source_runtime_guards() -> bool:
-    """Install venue readiness before this module imports any ``bot.*`` code.
-
-    ``main.py`` loads this file directly from disk, so the root bootstrap can be
-    imported without executing ``bot.__init__``. Live failures are converted to
-    ``SystemExit`` so main's optional-guard ``except Exception`` cannot swallow
-    the failure and continue trading without venue isolation.
-    """
-
+    """Install venue readiness before this module imports any ``bot.*`` code."""
     try:
         bootstrap = importlib.import_module("source_runtime_guard_bootstrap")
         installer = getattr(bootstrap, "install", None)
@@ -102,6 +95,7 @@ def _set_defaults() -> None:
     os.environ.setdefault("NIJA_PRE_TRADE_STALE_EXPOSURE_TOLERANCE_USD", "5")
     os.environ.setdefault("NIJA_LIVE_AI_GATE_REQUIRED", "true")
     os.environ.setdefault("NIJA_RUNTIME_RELEASE_REENTRY_AUDIT_MIN_S", "30")
+    os.environ.setdefault("NIJA_ACTIVATION_DEFER_LOG_INTERVAL_S", "15")
 
 
 def _install_kraken_patch_log_dedupe() -> None:
@@ -136,7 +130,10 @@ def _install_module(module_name: str, marker: str) -> bool:
             module = importlib.import_module(module_name)
         installer = getattr(module, "install_import_hook", None) or getattr(module, "install", None)
         if callable(installer):
-            installer()
+            result = installer()
+            if result is False:
+                logger.warning("%s_FAILED marker=20260706b reason=installer_returned_false", marker)
+                return False
             if module_name == "preactivation_readiness_convergence_v16_patch":
                 original_mark = getattr(module, "_mark_proven_readiness", None)
                 if callable(original_mark) and not getattr(original_mark, "_nija_publish_once", False):
@@ -146,11 +143,11 @@ def _install_module(module_name: str, marker: str) -> bool:
                         return _original(proofs)
                     setattr(_mark_once, "_nija_publish_once", True)
                     setattr(module, "_mark_proven_readiness", _mark_once)
-            logger.warning("%s marker=20260706b", marker)
+            logger.info("%s marker=20260706b", marker)
             return True
         logger.warning("%s_SKIPPED marker=20260706b reason=installer_missing", marker)
     except Exception as exc:
-        logger.warning("%s_FAILED marker=20260706b error=%s", marker, exc)
+        logger.warning("%s_FAILED marker=20260706b error=%s", marker, exc, exc_info=True)
     return False
 
 
@@ -160,6 +157,7 @@ def install() -> None:
     source_guards_ok = _install_source_runtime_guards()
     _set_defaults()
     _install_kraken_patch_log_dedupe()
+
     runtime_quality_v144_ok = _install_module(
         "runtime_quality_hardening_v144_patch",
         "RUNTIME_QUALITY_HARDENING_V144_GLOBAL_STARTUP_INSTALL_REQUESTED",
@@ -168,16 +166,31 @@ def install() -> None:
         "runtime_quality_hardening_v144_entry_classifier_patch",
         "RUNTIME_QUALITY_HARDENING_V144_ENTRY_CLASSIFIER_GLOBAL_STARTUP_INSTALL_REQUESTED",
     )
+    runtime_startup_v145_ok = _install_module(
+        "runtime_startup_convergence_v145_patch",
+        "RUNTIME_STARTUP_CONVERGENCE_V145_GLOBAL_STARTUP_INSTALL_REQUESTED",
+    )
+
+    hardening_ready = bool(
+        runtime_quality_v144_ok
+        and runtime_quality_v144_classifier_ok
+        and runtime_startup_v145_ok
+    )
     os.environ["NIJA_RUNTIME_QUALITY_HARDENING_V144_STARTUP_READY"] = (
         "1" if runtime_quality_v144_ok and runtime_quality_v144_classifier_ok else "0"
     )
-    if _live_runtime_expected() and not (
-        runtime_quality_v144_ok and runtime_quality_v144_classifier_ok
-    ):
+    os.environ["NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_STARTUP_READY"] = (
+        "1" if runtime_startup_v145_ok else "0"
+    )
+    if _live_runtime_expected() and not hardening_ready:
         logger.critical(
-            "RUNTIME_QUALITY_HARDENING_V144_REQUIRED_STARTUP_FAILED marker=20260818-runtime-quality-hardening-v144 live=true trading_fail_closed=true"
+            "RUNTIME_HARDENING_REQUIRED_STARTUP_FAILED marker=20260818-runtime-startup-convergence-v145 v144=%s classifier=%s v145=%s live=true trading_fail_closed=true",
+            runtime_quality_v144_ok,
+            runtime_quality_v144_classifier_ok,
+            runtime_startup_v145_ok,
         )
         raise SystemExit(78)
+
     preactivation_ok = _install_module(
         "preactivation_readiness_convergence_v16_patch",
         "PREACTIVATION_READINESS_V16_GLOBAL_STARTUP_INSTALL_REQUESTED",
@@ -186,12 +199,14 @@ def install() -> None:
     trailing_ok = _install_module("global_trailing_protection_patch", "GLOBAL_TRAILING_PROTECTION_GLOBAL_STARTUP_INSTALL_REQUESTED")
     profit_position_ok = _install_module("profit_position_protection_patch", "PROFIT_POSITION_PROTECTION_GLOBAL_STARTUP_INSTALL_REQUESTED")
     stale_exposure_ok = _install_module("pre_trade_stale_exposure_reconcile_patch", "PRE_TRADE_STALE_EXPOSURE_RECONCILE_GLOBAL_STARTUP_INSTALL_REQUESTED")
+
     setattr(builtins, "_NIJA_GLOBAL_RUNTIME_STARTUP_GUARDS_20260706B", True)
-    logger.warning(
-        "GLOBAL_RUNTIME_STARTUP_GUARDS_INSTALLED marker=20260706b source_venue_guards=%s runtime_quality_v144=%s runtime_quality_v144_classifier=%s preactivation_v16=%s held_cap=%s global_trailing=%s profit_position=%s stale_exposure=%s cap=%s",
+    logger.info(
+        "GLOBAL_RUNTIME_STARTUP_GUARDS_INSTALLED marker=20260706b source_venue_guards=%s runtime_quality_v144=%s runtime_quality_v144_classifier=%s runtime_startup_v145=%s preactivation_v16=%s held_cap=%s global_trailing=%s profit_position=%s stale_exposure=%s cap=%s",
         source_guards_ok,
         runtime_quality_v144_ok,
         runtime_quality_v144_classifier_ok,
+        runtime_startup_v145_ok,
         preactivation_ok,
         held_ok,
         trailing_ok,

--- a/bot/post_activation_proof_loss_v133_patch.py
+++ b/bot/post_activation_proof_loss_v133_patch.py
@@ -1,20 +1,9 @@
 """Fail closed when critical current proofs are lost after LIVE_ACTIVE.
 
-v133 closes the post-activation gap exposed by v132: v132 detected false
-current proofs while LIVE_ACTIVE but intentionally left the readiness table
-sticky after activation.  That allowed the public trading state to remain live
-while broker/balance/capital truth had already fallen false.
-
-Safety contract:
-- never fabricate or copy readiness from coarse/sticky state;
-- never clear kill switch or SEAK;
-- never grant writer, nonce, or execution authority;
-- never force LIVE_ACTIVE;
-- use the canonical TradingStateMachine transition for LIVE_ACTIVE -> OFF so
-  activation commitment, dispatch permission, and execution authority are
-  revoked atomically by the existing state machine;
-- leave recovery/reactivation to the existing canonical activation path after
-  all current proofs become true again.
+v133 keeps current readiness truth authoritative while avoiding repeated
+CRITICAL telemetry for unchanged pre-live/pending state. A real loss of proof
+from LIVE_ACTIVE still transitions through the canonical FSM to OFF and remains
+CRITICAL.
 """
 from __future__ import annotations
 
@@ -30,6 +19,7 @@ RELEASE_ID = "20260817-runtime-convergence-v133"
 _FLAG = "NIJA_POST_ACTIVATION_PROOF_LOSS_V133_INSTALLED"
 _LOCK = threading.RLock()
 _INSTALLED = False
+_LAST_SYNC_SIGNATURE = ""
 
 _CRITICAL_KEYS = (
     "broker_connected",
@@ -84,9 +74,6 @@ def _fail_closed_live_state(sm: Any, pending: list[str]) -> bool:
         trading_state = getattr(tsm, "TradingState")
         sm.transition_to(trading_state.OFF, reason=reason)
     except Exception as exc:
-        # Do not invent a secondary state mutation if the canonical transition
-        # fails.  Emit a hard diagnostic; existing dispatch gates still observe
-        # the revoked readiness table and false readiness env.
         LOGGER.critical(
             "POST_ACTIVATION_PROOF_LOSS_V133_TRANSITION_FAILED marker=%s pending=%s "
             "err=%s:%s canonical_state_unchanged=true trading_fail_closed_requested=true",
@@ -109,6 +96,7 @@ def _fail_closed_live_state(sm: Any, pending: list[str]) -> bool:
 
 
 def _truth_sync_v133(proofs: dict[str, bool]) -> tuple[bool, list[str]]:
+    global _LAST_SYNC_SIGNATURE
     table = importlib.import_module("bot.readiness_table")
     before = dict(table.snapshot())
     sm = _state_machine()
@@ -118,22 +106,39 @@ def _truth_sync_v133(proofs: dict[str, bool]) -> tuple[bool, list[str]]:
     failed_closed = _fail_closed_live_state(sm, pending)
     state_after = _state_value(sm)
 
-    LOGGER.critical(
-        "PREACTIVATION_READINESS_V133_TRUTH_SYNC marker=%s state_before=%s state_after=%s "
-        "before=%s after=%s pending=%s fail_closed_transition=%s",
-        MARKER,
-        state_before,
-        state_after,
-        before,
-        after,
-        pending,
-        str(failed_closed).lower(),
-    )
+    signature = f"{state_before}|{state_after}|{pending}|{before != after}|{failed_closed}"
+    changed_signature = signature != _LAST_SYNC_SIGNATURE
+    _LAST_SYNC_SIGNATURE = signature
+
+    if failed_closed:
+        LOGGER.critical(
+            "PREACTIVATION_READINESS_V133_TRUTH_SYNC marker=%s state_before=%s state_after=%s "
+            "pending=%s fail_closed_transition=true",
+            MARKER,
+            state_before,
+            state_after,
+            pending,
+        )
+    elif before != after or changed_signature:
+        LOGGER.info(
+            "PREACTIVATION_READINESS_V133_TRUTH_SYNC marker=%s state_before=%s state_after=%s "
+            "pending=%s table_changed=%s fail_closed_transition=false",
+            MARKER,
+            state_before,
+            state_after,
+            pending,
+            str(before != after).lower(),
+        )
+    else:
+        LOGGER.debug(
+            "PREACTIVATION_READINESS_V133_UNCHANGED marker=%s state=%s pending=%s",
+            MARKER,
+            state_after,
+            pending,
+        )
     return (not pending), pending
 
 
-# Keep compatibility ownership markers so v132's durability watchdog does not
-# replace this stricter successor with the older pre-live-only function.
 _truth_sync_v133._nija_v61_truth_sync = True  # type: ignore[attr-defined]
 _truth_sync_v133._nija_v132_truth_sync = True  # type: ignore[attr-defined]
 _truth_sync_v133._nija_v133_truth_sync = True  # type: ignore[attr-defined]
@@ -144,7 +149,6 @@ def _anchor_owner() -> bool:
     v58 = importlib.import_module("bot.final_production_activation_repair_v58_patch")
     v132 = importlib.import_module("bot.readiness_killswitch_durability_v132_patch")
 
-    # Replace every compatibility export that can be replayed later.
     v132._durable_truth_sync = _truth_sync_v133
     v58._incremental_mark_proven_readiness = _truth_sync_v133
     v16._mark_proven_readiness = _truth_sync_v133
@@ -155,18 +159,16 @@ def _anchor_owner() -> bool:
             v132._durable_truth_sync = _truth_sync_v133
             v58._incremental_mark_proven_readiness = _truth_sync_v133
             v16._mark_proven_readiness = _truth_sync_v133
-            LOGGER.critical(
-                "READINESS_V133_OWNER_REASSERTED marker=%s source=v58_patch_readiness "
-                "post_activation_fail_closed=true",
+            LOGGER.debug(
+                "READINESS_V133_OWNER_REASSERTED marker=%s source=v58_patch_readiness post_activation_fail_closed=true",
                 MARKER,
             )
             return True
         patch_readiness_v133._nija_v133_owner = True  # type: ignore[attr-defined]
         v58._patch_readiness = patch_readiness_v133
 
-    LOGGER.critical(
-        "READINESS_V133_OWNER_ANCHORED marker=%s v132_export_replaced=true "
-        "v58_export_replaced=true v16_owner=true post_activation_fail_closed=true",
+    LOGGER.info(
+        "READINESS_V133_OWNER_ANCHORED marker=%s v132_export_replaced=true v58_export_replaced=true v16_owner=true post_activation_fail_closed=true",
         MARKER,
     )
     return True
@@ -178,7 +180,8 @@ def _patch_release_manifest() -> bool:
     if not isinstance(required, dict):
         return False
     required["post_activation_proof_loss_v133"] = _FLAG
-    manifest.RELEASE_ID = RELEASE_ID
+    # Register proof only. Older convergence modules must never downgrade the
+    # canonical release identity owned by the newest manifest.
     return True
 
 
@@ -191,8 +194,7 @@ def install() -> bool:
             ok = _anchor_owner() and _patch_release_manifest()
         except Exception as exc:
             LOGGER.critical(
-                "POST_ACTIVATION_PROOF_LOSS_V133_INSTALL_FAILED marker=%s err=%s:%s "
-                "trading_fail_closed=true",
+                "POST_ACTIVATION_PROOF_LOSS_V133_INSTALL_FAILED marker=%s err=%s:%s trading_fail_closed=true",
                 MARKER,
                 type(exc).__name__,
                 exc,
@@ -204,13 +206,9 @@ def install() -> bool:
             return False
         os.environ[_FLAG] = "1"
         _INSTALLED = True
-        LOGGER.critical(
-            "POST_ACTIVATION_PROOF_LOSS_V133_INSTALLED marker=%s release=%s "
-            "post_activation_false_proofs_revoke_readiness=true canonical_off_transition=true "
-            "kill_switch_unchanged=true seak_unchanged=true nonce_gates_unchanged=true "
-            "risk_gates_unchanged=true force_live=false",
+        LOGGER.info(
+            "POST_ACTIVATION_PROOF_LOSS_V133_INSTALLED marker=%s post_activation_false_proofs_revoke_readiness=true canonical_off_transition=true kill_switch_unchanged=true seak_unchanged=true nonce_gates_unchanged=true risk_gates_unchanged=true force_live=false",
             MARKER,
-            RELEASE_ID,
         )
         return True
 

--- a/bot/readiness_table.py
+++ b/bot/readiness_table.py
@@ -2,7 +2,7 @@
 NIJA Startup Readiness Truth Table
 ===================================
 
-Single source of truth for startup readiness.  Replaces the previous system
+Single source of truth for startup readiness. Replaces the previous system
 of eight ``threading.Event`` objects, a ``StartupReadinessGate`` with
 ``threading.Condition`` / callback / catch-up logic, a
 ``_compute_system_ready`` function that re-derived the same truth from the
@@ -10,15 +10,10 @@ object graph, and a set of global boolean locals re-computed at thread launch.
 
 Design rules
 ------------
-* **One write path per component**: each subsystem calls ``mark_ready(key)``
-  exactly once.  There are no events to set, no gates to signal, and no
-  catch-up replays.
-* **No blocking reads**: ``is_ready()`` is a pure boolean read.  The startup
-  path polls with a bounded deadline; there is no ``Condition.wait()`` and
-  therefore no possibility of deadlock.
-* **Lock only on write**: ``_LOCK`` is only held during writes.  Reads of
-  Python ``bool`` values are atomic in CPython, so ``is_ready()`` and
-  ``snapshot()`` do not need the lock.
+* **One write path per component**: each subsystem calls ``mark_ready(key)``.
+* **No blocking reads**: ``is_ready()`` is a pure boolean read.
+* **Lock only on write**: readiness writes are serialized and versioned.
+* **Idempotent telemetry**: repeated writes of the same truth are DEBUG only.
 * **Diagnosable**: ``snapshot()`` returns a copy of the full table in O(n).
 
 Keys
@@ -42,10 +37,6 @@ from typing import Dict, Iterable
 
 logger = logging.getLogger("nija.readiness_table")
 
-# ---------------------------------------------------------------------------
-# Canonical keys
-# ---------------------------------------------------------------------------
-
 KEYS: tuple[str, ...] = (
     "broker_connected",
     "balance_hydrated",
@@ -58,115 +49,91 @@ KEYS: tuple[str, ...] = (
     "bootstrap_ready",
 )
 
-# ---------------------------------------------------------------------------
-# Module-level truth table
-# ---------------------------------------------------------------------------
-
 _TABLE: Dict[str, bool] = {k: False for k in KEYS}
 _LOCK = threading.Lock()
 _VERSION = 0
-
-# A threading.Event that is set (and immediately cleared) whenever _VERSION
-# increments.  Consumers that want an immediate retry on readiness change
-# (e.g. the activation-pending commit monitor) can wait on this event with a
-# bounded timeout instead of sleeping a full polling interval.
 READINESS_CHANGED_EVENT: threading.Event = threading.Event()
 
-
-# ---------------------------------------------------------------------------
-# Write API
-# ---------------------------------------------------------------------------
 
 def set_ready(
     component: str,
     value: bool,
     *,
     allow_regression: bool = False,
-) -> None:
-    """Set readiness while preventing ordinary true-to-false regressions.
+) -> bool:
+    """Set readiness and return whether the canonical truth actually changed.
 
-    Runtime authority loss is intentionally different from an ordinary startup
-    update: a previously valid writer/nonce proof must be revocable.  Callers
-    should use :func:`revoke_ready` for that explicit terminal transition.
+    Ordinary true-to-false regressions are rejected. Runtime authority loss is
+    intentionally different: callers use :func:`revoke_ready`, which explicitly
+    permits a terminal regression.
     """
     global _VERSION
-    _snapshot = None
-    _changed = False
+    snapshot: Dict[str, bool]
+    changed = False
     with _LOCK:
         if component not in _TABLE:
             logger.debug("readiness_table: auto-registering unknown key '%s'", component)
             _TABLE[component] = False
-            _changed = True
-        current = _TABLE.get(component)
-        if current is True and value is False and not allow_regression:
+        current = bool(_TABLE.get(component, False))
+        desired = bool(value)
+        if current and not desired and not allow_regression:
             logger.warning("Prevented readiness regression | %s", component)
-            return
-        if current != bool(value):
-            _changed = True
-        _TABLE[component] = bool(value)
-        if _changed:
+            return False
+        if current != desired:
+            _TABLE[component] = desired
             _VERSION += 1
-        _snapshot = dict(_TABLE)
+            changed = True
+        version = int(_VERSION)
+        snapshot = dict(_TABLE)
 
-    # Notify any waiter (e.g. activation monitor) that the version changed.
-    # The event is a fire-and-forget pulse: set immediately then clear so that
-    # a consumer polling `wait(timeout=T)` wakes up once per version increment
-    # rather than staying set across multiple later polls.
-    if _changed:
+    if changed:
         READINESS_CHANGED_EVENT.set()
         READINESS_CHANGED_EVENT.clear()
-
-    try:
         try:
-            from bot.startup_coordinator import get_startup_coordinator
-        except ImportError:
-            from startup_coordinator import get_startup_coordinator  # type: ignore[import]
-        get_startup_coordinator().record_readiness(
-            key=component,
-            value=bool(value),
-            version=_VERSION,
-            table=_snapshot or {},
-        )
-    except Exception:
-        logger.debug("readiness_table: coordinator update skipped", exc_info=True)
+            try:
+                from bot.startup_coordinator import get_startup_coordinator
+            except ImportError:
+                from startup_coordinator import get_startup_coordinator  # type: ignore[import]
+            get_startup_coordinator().record_readiness(
+                key=component,
+                value=bool(value),
+                version=version,
+                table=snapshot,
+            )
+        except Exception:
+            logger.debug("readiness_table: coordinator update skipped", exc_info=True)
+    return changed
 
 
 def mark_ready(component: str) -> None:
-    """Mark *component* as ready.
-
-    If *component* is not one of the canonical keys it is accepted anyway so
-    that callers do not need to track the exact key list.
-    """
-    set_ready(component, True)
-    logger.critical(
-        "✅ READINESS_TABLE mark_ready=%s table=%s",
-        component,
-        _TABLE,
-    )
+    """Mark *component* ready without re-emitting unchanged success state."""
+    changed = set_ready(component, True)
+    if changed:
+        logger.info("READINESS_TABLE_READY component=%s table=%s", component, snapshot())
+    else:
+        logger.debug("READINESS_TABLE_UNCHANGED component=%s ready=true", component)
 
 
 def revoke_ready(component: str, *, reason: str) -> None:
     """Revoke a dynamic readiness proof after terminal runtime invalidation."""
-
-    set_ready(component, False, allow_regression=True)
-    logger.critical(
-        "READINESS_TABLE_REVOKED component=%s reason=%s table=%s",
-        component,
-        reason,
-        _TABLE,
-    )
+    changed = set_ready(component, False, allow_regression=True)
+    if changed:
+        logger.warning(
+            "READINESS_TABLE_REVOKED component=%s reason=%s table=%s",
+            component,
+            reason,
+            snapshot(),
+        )
+    else:
+        logger.debug(
+            "READINESS_TABLE_UNCHANGED component=%s ready=false reason=%s",
+            component,
+            reason,
+        )
 
 
 def revoke_many(components: Iterable[str], *, reason: str) -> None:
-    """Atomically revoke several runtime readiness proofs.
-
-    Writer loss invalidates authority, nonce, and execution as one event.  A
-    sequence of individual writes exposes impossible intermediate snapshots
-    (for example ``authority_ready=False`` while ``execution_ready=True``) to
-    coordinator readers.  This bulk API publishes one versioned snapshot so
-    every consumer observes the same fail-closed transition.
-    """
-
+    """Atomically revoke several runtime readiness proofs as one transition."""
     global _VERSION
     normalized = tuple(dict.fromkeys(str(name) for name in components if str(name)))
     if not normalized:
@@ -177,7 +144,6 @@ def revoke_many(components: Iterable[str], *, reason: str) -> None:
         for component in normalized:
             if component not in _TABLE:
                 _TABLE[component] = False
-                changed = True
             elif _TABLE[component]:
                 _TABLE[component] = False
                 changed = True
@@ -189,53 +155,54 @@ def revoke_many(components: Iterable[str], *, reason: str) -> None:
     if changed:
         READINESS_CHANGED_EVENT.set()
         READINESS_CHANGED_EVENT.clear()
-
-    try:
         try:
-            from bot.startup_coordinator import get_startup_coordinator
-        except ImportError:
-            from startup_coordinator import get_startup_coordinator  # type: ignore[import]
-        get_startup_coordinator().record_readiness(
-            key="__bulk_revoke__",
-            value=False,
-            version=version,
-            table=table,
+            try:
+                from bot.startup_coordinator import get_startup_coordinator
+            except ImportError:
+                from startup_coordinator import get_startup_coordinator  # type: ignore[import]
+            get_startup_coordinator().record_readiness(
+                key="__bulk_revoke__",
+                value=False,
+                version=version,
+                table=table,
+            )
+        except Exception:
+            logger.debug("readiness_table: coordinator bulk revoke skipped", exc_info=True)
+        logger.warning(
+            "READINESS_TABLE_BULK_REVOKED components=%s reason=%s version=%d table=%s",
+            ",".join(normalized),
+            reason,
+            version,
+            table,
         )
-    except Exception:
-        logger.debug("readiness_table: coordinator bulk revoke skipped", exc_info=True)
-
-    logger.critical(
-        "READINESS_TABLE_BULK_REVOKED components=%s reason=%s version=%d table=%s",
-        ",".join(normalized),
-        reason,
-        version,
-        table,
-    )
+    else:
+        logger.debug(
+            "READINESS_TABLE_BULK_UNCHANGED components=%s reason=%s version=%d",
+            ",".join(normalized),
+            reason,
+            version,
+        )
 
 
 def mark_not_applicable(component: str, *, reason: str = "not configured") -> None:
-    """Mark *component* as not applicable (treated as ready for gate evaluation).
+    """Mark an optional subsystem as ready for gate evaluation."""
+    changed = set_ready(component, True)
+    if changed:
+        logger.info(
+            "READINESS_TABLE_NOT_APPLICABLE component=%s reason=%s",
+            component,
+            reason,
+        )
+    else:
+        logger.debug(
+            "READINESS_TABLE_NOT_APPLICABLE_UNCHANGED component=%s reason=%s",
+            component,
+            reason,
+        )
 
-    Use this for optional subsystems that are skipped in the current
-    deployment (e.g. ``nonce_ready`` on a Coinbase-only bot).
-    """
-    set_ready(component, True)
-    logger.info(
-        "⏩ READINESS_TABLE mark_not_applicable=%s reason=%s",
-        component,
-        reason,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Read API
-# ---------------------------------------------------------------------------
 
 def is_ready() -> bool:
-    """Return True when every key in the table is True.
-
-    Acquires the lock to produce a consistent view across all keys.
-    """
+    """Return True when every registered key is True."""
     with _LOCK:
         return all(_TABLE.values())
 
@@ -264,15 +231,13 @@ def pending() -> list[str]:
         return sorted(k for k, v in _TABLE.items() if not v)
 
 
-# ---------------------------------------------------------------------------
-# Reset (for warm restarts / tests)
-# ---------------------------------------------------------------------------
-
 def reset() -> None:
     """Reset all keys to False (use before a fresh startup attempt)."""
     global _VERSION
     with _LOCK:
-        for k in list(_TABLE):
-            _TABLE[k] = False
+        for key in list(_TABLE):
+            _TABLE[key] = False
         _VERSION += 1
-    logger.info("🔄 READINESS_TABLE reset — all keys False")
+    READINESS_CHANGED_EVENT.set()
+    READINESS_CHANGED_EVENT.clear()
+    logger.info("READINESS_TABLE_RESET all_keys=false")

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,9 +10,11 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260818-runtime-convergence-v144"
-# Canonical owner used by the release-identity guard. Older convergence
-# installers may register flags, but may not downgrade this manifest identity.
+# Keep the static bootstrap identity at v138 for the v139 write-barrier contract.
+# v144/v145 promote DECLARED_RELEASE_ID during runtime convergence only after
+# their safety layers are attached; this lets CI detect legacy downgrade attempts
+# while production publishes the newest successfully installed runtime release.
+RELEASE_ID = "20260817-runtime-convergence-v138"
 DECLARED_RELEASE_ID = RELEASE_ID
 _INSTALLED = False
 _LOCK = threading.RLock()
@@ -56,8 +58,6 @@ _INSTALLERS = (
     ("bot.activation_publication_convergence_v136_patch", "install_import_hook"),
     ("bot.capital_publication_deadline_v137_patch", "install_import_hook"),
     ("bot.final_execution_state_router_convergence_patch", "install_import_hook"),
-    # v144 is part of the canonical release contract, not an optional late
-    # monkey-patch. If either installer cannot attach, ready=false is published.
     ("bot.runtime_quality_hardening_v144_patch", "install_import_hook"),
     ("bot.runtime_quality_hardening_v144_entry_classifier_patch", "install_import_hook"),
 )

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -10,8 +10,8 @@ import time
 from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
-RELEASE_ID = "20260817-runtime-convergence-v138"
-# Immutable owner used by the v139 release-identity guard. Older convergence
+RELEASE_ID = "20260818-runtime-convergence-v144"
+# Canonical owner used by the release-identity guard. Older convergence
 # installers may register flags, but may not downgrade this manifest identity.
 DECLARED_RELEASE_ID = RELEASE_ID
 _INSTALLED = False
@@ -19,7 +19,6 @@ _LOCK = threading.RLock()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 _INSTALLERS = (
-    # Repair policy and module aliases before any identity/quiescence audit.
     ("bot.runtime_post_import_convergence_patch", "install"),
     ("runtime_module_identity_convergence_patch", "install_import_hook"),
     ("scan_wrapper_depth_convergence_patch", "install_import_hook"),
@@ -50,38 +49,17 @@ _INSTALLERS = (
     ("bot.kraken_exit_only_recovery_phase_guard_patch", "install_import_hook"),
     ("bot.kraken_profit_realization_guard_patch", "install_import_hook"),
     ("bot.coinbase_pem_quarantine_patch", "install_import_hook"),
-    # v78 bounds synchronous balance-fetch waits inside the canonical 90-second
-    # capital freshness contract. It is safe and idempotent, and does not extend
-    # stale fallback age or broker timeouts.
     ("bot.capital_refresh_live_continuity_v78_patch", "install_import_hook"),
-    # v139 must run before v134-v136. Those legacy convergence modules register
-    # runtime flags but historically also rewrote the parent manifest RELEASE_ID.
-    # The guard makes their registration flag-only before any of them executes,
-    # keeps the canonical release identity immutable, and converts later healthy
-    # audits to verify-first behavior instead of replaying every installer.
     ("bot.runtime_release_identity_guard_patch", "install_import_hook"),
-    # Must run after v133 and the activation/readiness modules it converges.
-    # The installer is idempotent and reasserts ownership if older convergence
-    # layers replay later in a long-running process.
     ("bot.readiness_proof_convergence_v134_patch", "install_import_hook"),
-    # v135 prevents writer-only authority bootstrap under a protected stop and
-    # makes publication expiry authoritative at read time. It also reasserts
-    # the v78 dependency for long-running processes.
     ("bot.activation_stop_capital_freshness_v135_patch", "install_import_hook"),
-    # v136 makes the activation snapshot bridge observational only. Current
-    # v134 proof plus the non-expired v135 publication are required before cycle
-    # snapshot augmentation, and TradingStateMachine.commit_activation remains
-    # the sole transition authority.
     ("bot.activation_publication_convergence_v136_patch", "install_import_hook"),
-    # v137 schedules a canonical coordinator refresh before immutable capital
-    # publication expiry, coalesces duplicate in-flight refreshes, and clamps
-    # legacy-ready results when the publication proof is not current.
     ("bot.capital_publication_deadline_v137_patch", "install_import_hook"),
-    # v138 makes the final execution/startup/router convergence probe idempotent,
-    # targets StartupCoordinator.build_snapshot on the canonical class, and
-    # terminates the 200 ms convergence watchdog once all three components are
-    # already converged. No readiness, nonce, risk, or execution gate is relaxed.
     ("bot.final_execution_state_router_convergence_patch", "install_import_hook"),
+    # v144 is part of the canonical release contract, not an optional late
+    # monkey-patch. If either installer cannot attach, ready=false is published.
+    ("bot.runtime_quality_hardening_v144_patch", "install_import_hook"),
+    ("bot.runtime_quality_hardening_v144_entry_classifier_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -117,6 +95,9 @@ _REQUIRED_FLAGS = {
     "activation_publication_convergence_v136": "NIJA_ACTIVATION_PUBLICATION_CONVERGENCE_V136_INSTALLED",
     "capital_publication_deadline_v137": "NIJA_CAPITAL_PUBLICATION_DEADLINE_V137_INSTALLED",
     "final_execution_state_router_v138": "NIJA_FINAL_EXECUTION_STATE_ROUTER_READY",
+    "runtime_quality_hardening_v144": "NIJA_RUNTIME_QUALITY_HARDENING_V144_READY",
+    "runtime_quality_v144_entry_classifier": "NIJA_RUNTIME_QUALITY_HARDENING_V144_ENTRY_CLASSIFIER_INSTALLED",
+    "runtime_quality_v144_release_contract": "NIJA_RUNTIME_QUALITY_HARDENING_V144_RELEASE_CONTRACT_READY",
 }
 
 
@@ -136,7 +117,9 @@ def _invoke(module_name: str, function_name: str) -> tuple[bool, str]:
     try:
         module = importlib.import_module(module_name)
         installer: Callable = getattr(module, function_name)
-        installer()
+        result = installer()
+        if result is False:
+            return False, "installer_returned_false"
         return True, "ok"
     except Exception as exc:
         return False, f"{type(exc).__name__}:{exc}"
@@ -196,7 +179,7 @@ def _runtime_limits_consistent() -> tuple[bool, str]:
 def _audit() -> tuple[bool, dict[str, str]]:
     results: dict[str, str] = {}
     ready = True
-    for module_name, function_name in _INSTALLERS:
+    for module_name, function_name in tuple(_INSTALLERS):
         ok, reason = _invoke(module_name, function_name)
         results[module_name] = reason
         ready = ready and ok
@@ -227,7 +210,7 @@ def _audit() -> tuple[bool, dict[str, str]]:
     else:
         results["scan_wrapper_release"] = scan_release
 
-    for label, flag in _REQUIRED_FLAGS.items():
+    for label, flag in dict(_REQUIRED_FLAGS).items():
         value = str(os.environ.get(flag, "") or "").strip()
         if value != "1":
             ready = False
@@ -246,24 +229,33 @@ def _audit() -> tuple[bool, dict[str, str]]:
 
 def _publish(ready: bool, details: dict[str, str]) -> None:
     previous = os.environ.get("NIJA_RUNTIME_RELEASE_READY", "")
-    # Re-anchor the mutable compatibility name before publishing. This is a
-    # second line of defense if an older module was reloaded between audits.
     global RELEASE_ID
     RELEASE_ID = DECLARED_RELEASE_ID
     os.environ["NIJA_RUNTIME_RELEASE_ID"] = DECLARED_RELEASE_ID
     os.environ["NIJA_RUNTIME_RELEASE_READY"] = "1" if ready else "0"
-    logger.critical(
-        "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=%s python_pid=%s details=%s",
-        DECLARED_RELEASE_ID, _deployment_sha(), str(ready).lower(), os.getpid(), details,
-    )
-    if not ready:
+    if ready:
+        logger.info(
+            "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=true python_pid=%s details=%s",
+            DECLARED_RELEASE_ID,
+            _deployment_sha(),
+            os.getpid(),
+            details,
+        )
+        if previous == "0":
+            logger.warning(
+                "RUNTIME_RELEASE_CONVERGENCE_RECOVERED release=%s action=broker_order_gates_may_follow_normal_authority_checks",
+                DECLARED_RELEASE_ID,
+            )
+    else:
+        logger.critical(
+            "NIJA_RUNTIME_RELEASE_MANIFEST release=%s deployment_sha=%s ready=false python_pid=%s details=%s",
+            DECLARED_RELEASE_ID,
+            _deployment_sha(),
+            os.getpid(),
+            details,
+        )
         logger.critical(
             "RUNTIME_RELEASE_INCOMPLETE_EXECUTION_UNSAFE release=%s action=keep_broker_order_gates_fail_closed",
-            DECLARED_RELEASE_ID,
-        )
-    elif previous == "0":
-        logger.critical(
-            "RUNTIME_RELEASE_CONVERGENCE_RECOVERED release=%s action=broker_order_gates_may_follow_normal_authority_checks",
             DECLARED_RELEASE_ID,
         )
 
@@ -290,7 +282,7 @@ def install_import_hook() -> None:
         if not _INSTALLED:
             _INSTALLED = True
             threading.Thread(target=_watchdog, name="RuntimeReleaseManifest", daemon=True).start()
-    logger.critical("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s", DECLARED_RELEASE_ID)
+    logger.info("NIJA_RUNTIME_RELEASE_MANIFEST_INSTALLED release=%s ready=%s", DECLARED_RELEASE_ID, str(ready).lower())
 
 
 __all__ = [

--- a/bot/runtime_startup_convergence_v145_patch.py
+++ b/bot/runtime_startup_convergence_v145_patch.py
@@ -1,0 +1,324 @@
+"""NIJA runtime startup convergence v145.
+
+Closes the production startup/liveness gaps observed after v144 deployment:
+
+* an alive but already-expired capital balance worker must never be reused by a
+  later refresh cycle;
+* superseded workers are sequence-fenced so a late return cannot become a fresh
+  capital observation;
+* expected repeated activation deferrals are coalesced without changing their
+  fail-closed decision; and
+* v145 becomes the terminal release owner while preserving all v144 entry and
+  AI safety gates.
+
+No balance is fabricated, no freshness TTL is extended, no broker timeout is
+relaxed, and no activation/entry gate is bypassed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_startup_convergence_v145")
+MARKER = "20260818-runtime-startup-convergence-v145"
+RELEASE_ID = "20260818-runtime-convergence-v145"
+_FLAG = "NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY"
+_PATCH_ATTR = "_nija_runtime_startup_convergence_v145"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _expired_alive_flight(flight: Any, now: float | None = None) -> bool:
+    """Return True only for a live worker whose own hard deadline has elapsed."""
+    if flight is None:
+        return False
+    thread = getattr(flight, "thread", None)
+    if thread is None or not callable(getattr(thread, "is_alive", None)):
+        return False
+    try:
+        alive = bool(thread.is_alive())
+    except Exception:
+        return False
+    if not alive:
+        return False
+    try:
+        started = float(getattr(flight, "started_monotonic", 0.0) or 0.0)
+        timeout_s = max(0.0, float(getattr(flight, "timeout_s", 0.0) or 0.0))
+    except Exception:
+        return False
+    current = time.monotonic() if now is None else float(now)
+    return bool(started > 0.0 and timeout_s > 0.0 and current >= started + timeout_s)
+
+
+def _fence_expired_flight(guard: ModuleType, broker_id: str, now: float | None = None) -> bool:
+    """Evict and sequence-fence an expired worker without cancelling its thread.
+
+    Python cannot safely terminate a blocking network thread. Instead, the old
+    worker is removed from the reusable in-flight registry and a non-usable
+    sequence fence is installed in the observation table. If the old worker
+    later returns, its lower sequence cannot overwrite the fence. A new batch
+    then starts a fresh worker with a strictly newer sequence.
+    """
+    bid = str(broker_id or "").strip().lower()
+    if not bid:
+        return False
+
+    inflight = getattr(guard, "_IN_FLIGHT", None)
+    inflight_lock = getattr(guard, "_IN_FLIGHT_LOCK", None)
+    sequences = getattr(guard, "_BROKER_SEQUENCE", None)
+    observations = getattr(guard, "_OBSERVATIONS", None)
+    observation_lock = getattr(guard, "_OBSERVATION_LOCK", None)
+    observation_cls = getattr(guard, "_Observation", None)
+    if not isinstance(inflight, dict) or not isinstance(sequences, dict):
+        return False
+    if not isinstance(observations, dict) or observation_cls is None:
+        return False
+    if inflight_lock is None or observation_lock is None:
+        return False
+
+    current = time.monotonic() if now is None else float(now)
+    # Observation -> in-flight lock ordering is safe here: the worker publishes
+    # an observation and releases that lock before entering its final in-flight
+    # cleanup, so it never holds the reverse pair simultaneously.
+    with observation_lock:
+        with inflight_lock:
+            existing = inflight.get(bid)
+            if not _expired_alive_flight(existing, current):
+                return False
+
+            old_seq = int(getattr(existing, "sequence", 0) or 0)
+            age_s = max(
+                0.0,
+                current - float(getattr(existing, "started_monotonic", current) or current),
+            )
+            timeout_s = max(0.0, float(getattr(existing, "timeout_s", 0.0) or 0.0))
+            inflight.pop(bid, None)
+
+            # Reserve a sequence strictly newer than the expired worker. The
+            # original batch constructor will increment again for the new flight.
+            fence_seq = max(int(sequences.get(bid, 0) or 0), old_seq) + 1
+            sequences[bid] = fence_seq
+
+            previous = observations.get(bid)
+            if previous is not None:
+                value = float(getattr(previous, "value", 0.0) or 0.0)
+                observed_mono = float(getattr(previous, "observed_monotonic", 0.0) or 0.0)
+                observed_epoch = float(getattr(previous, "observed_epoch", 0.0) or 0.0)
+            else:
+                # Zero with zero timestamps is intentionally unusable as a
+                # freshness fallback; it exists only as a sequence fence.
+                value = 0.0
+                observed_mono = 0.0
+                observed_epoch = 0.0
+            try:
+                observations[bid] = observation_cls(
+                    value=value,
+                    observed_monotonic=observed_mono,
+                    observed_epoch=observed_epoch,
+                    sequence=fence_seq,
+                )
+            except TypeError:
+                observations[bid] = observation_cls(
+                    value,
+                    observed_mono,
+                    observed_epoch,
+                    fence_seq,
+                )
+
+    LOGGER.warning(
+        "CAPITAL_REFRESH_EXPIRED_INFLIGHT_SUPERSEDED marker=%s broker=%s old_seq=%d fence_seq=%d age_s=%.3f timeout_s=%.3f late_result_fenced=true new_worker_required=true",
+        MARKER,
+        bid,
+        old_seq,
+        fence_seq,
+        age_s,
+        timeout_s,
+    )
+    return True
+
+
+def _patch_capital_guard(guard: ModuleType) -> bool:
+    batch_cls = getattr(guard, "_BalanceFetchBatch", None)
+    current = getattr(batch_cls, "__init__", None) if isinstance(batch_cls, type) else None
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def init_v145(self: Any, broker_map: dict[str, Any]) -> None:
+        now = time.monotonic()
+        for broker_id in tuple((broker_map or {}).keys()):
+            try:
+                _fence_expired_flight(guard, str(broker_id), now)
+            except Exception as exc:
+                # Failure to fence must not silently permit stale reuse. Remove
+                # only an expired registry entry; the old daemon may finish but
+                # result_for will not be handed that object by a new batch.
+                LOGGER.exception(
+                    "CAPITAL_REFRESH_EXPIRED_INFLIGHT_FENCE_ERROR marker=%s broker=%s error=%s",
+                    MARKER,
+                    broker_id,
+                    exc,
+                )
+                raise
+        current(self, broker_map)
+
+    setattr(init_v145, _PATCH_ATTR, True)
+    setattr(init_v145, "__wrapped__", current)
+    batch_cls.__init__ = init_v145
+    return True
+
+
+def _patch_activation_deferral(module: ModuleType) -> bool:
+    current = getattr(module, "_log_activation_deferred", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    state = {"signature": "", "ts": 0.0, "suppressed": 0}
+    gate = threading.Lock()
+
+    @wraps(current)
+    def log_deferred_v145(trigger: str, blockers: list[str], details: dict[str, Any]) -> None:
+        signature = "|".join(
+            (
+                str(trigger or ""),
+                ",".join(str(v) for v in blockers),
+                str(details.get("generation", 0)),
+                str(details.get("bootstrap_state", "")),
+                str(details.get("core_registered", False)),
+                str(details.get("core_alive", False)),
+            )
+        )
+        now = time.monotonic()
+        try:
+            interval = max(
+                1.0,
+                float(os.environ.get("NIJA_ACTIVATION_DEFER_LOG_INTERVAL_S", "15") or 15.0),
+            )
+        except Exception:
+            interval = 15.0
+        with gate:
+            if signature == state["signature"] and now - float(state["ts"]) < interval:
+                state["suppressed"] = int(state["suppressed"]) + 1
+                logging.getLogger("nija.final_production_activation_repair_v61").debug(
+                    "ACTIVATION_SINGLE_FLIGHT_DEFERRED_COALESCED marker=%s trigger=%s blockers=%s suppressed=%d trading_fail_closed=true",
+                    MARKER,
+                    trigger,
+                    blockers,
+                    state["suppressed"],
+                )
+                return
+            suppressed = int(state["suppressed"])
+            state["signature"] = signature
+            state["ts"] = now
+            state["suppressed"] = 0
+        current(trigger, blockers, details)
+        if suppressed:
+            logging.getLogger("nija.final_production_activation_repair_v61").info(
+                "ACTIVATION_DEFER_REPEAT_SUMMARY marker=%s trigger=%s suppressed=%d",
+                MARKER,
+                trigger,
+                suppressed,
+            )
+
+    setattr(log_deferred_v145, _PATCH_ATTR, True)
+    setattr(log_deferred_v145, "__wrapped__", current)
+    module._log_activation_deferred = log_deferred_v145
+    return True
+
+
+def _own_release() -> bool:
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["runtime_startup_convergence_v145"] = _FLAG
+    manifest.DECLARED_RELEASE_ID = RELEASE_ID
+    manifest.RELEASE_ID = RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+
+    # v144's monitor is intentionally retained; update its terminal identity so
+    # any later reassertion preserves, rather than downgrades, the v145 release.
+    try:
+        v144 = importlib.import_module("bot.runtime_quality_hardening_v144_patch")
+        v144.RELEASE_ID = RELEASE_ID
+    except Exception:
+        return False
+    return True
+
+
+def _patch_loaded() -> dict[str, bool]:
+    results: dict[str, bool] = {}
+    try:
+        guard = importlib.import_module("bot.capital_refresh_stall_guard_v35")
+        results["capital_expired_flight_fence"] = _patch_capital_guard(guard)
+    except Exception:
+        results["capital_expired_flight_fence"] = False
+        LOGGER.exception("RUNTIME_STARTUP_V145_CAPITAL_PATCH_FAILED marker=%s", MARKER)
+
+    try:
+        activation = importlib.import_module("bot.final_production_activation_repair_v61_patch")
+        results["activation_defer_coalescing"] = _patch_activation_deferral(activation)
+    except Exception:
+        # Telemetry coalescing is not authority-critical.
+        results["activation_defer_coalescing"] = False
+        LOGGER.debug("RUNTIME_STARTUP_V145_ACTIVATION_LOG_PATCH_PENDING marker=%s", MARKER, exc_info=True)
+
+    try:
+        results["release_owner"] = _own_release()
+    except Exception:
+        results["release_owner"] = False
+        LOGGER.exception("RUNTIME_STARTUP_V145_RELEASE_OWNER_FAILED marker=%s", MARKER)
+    return results
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        results = _patch_loaded()
+        # The capital fence and release ownership are safety/liveness critical.
+        ready = bool(results.get("capital_expired_flight_fence") and results.get("release_owner"))
+        if ready:
+            os.environ[_FLAG] = "1"
+            _INSTALLED = True
+            LOGGER.info(
+                "RUNTIME_STARTUP_CONVERGENCE_V145_INSTALLED marker=%s release=%s results=%s stale_flight_reuse=false late_result_fenced=true activation_gates_unchanged=true",
+                MARKER,
+                RELEASE_ID,
+                results,
+            )
+            return True
+        os.environ[_FLAG] = "0"
+        LOGGER.critical(
+            "RUNTIME_STARTUP_CONVERGENCE_V145_FAILED marker=%s results=%s trading_fail_closed=true",
+            MARKER,
+            results,
+        )
+        return False
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_expired_alive_flight",
+    "_fence_expired_flight",
+    "_patch_capital_guard",
+    "_patch_activation_deferral",
+    "_own_release",
+]

--- a/tests/test_runtime_startup_convergence_v145_unittest.py
+++ b/tests/test_runtime_startup_convergence_v145_unittest.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import threading
+import types
+import unittest
+from collections import namedtuple
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH_PATH = ROOT / "bot" / "runtime_startup_convergence_v145_patch.py"
+SPEC = importlib.util.spec_from_file_location("runtime_startup_convergence_v145_under_test", PATCH_PATH)
+assert SPEC is not None and SPEC.loader is not None
+v145 = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(v145)
+
+
+Observation = namedtuple(
+    "Observation",
+    "value observed_monotonic observed_epoch sequence",
+)
+Flight = namedtuple(
+    "Flight",
+    "thread result_queue sequence started_monotonic timeout_s",
+)
+
+
+class AliveThread:
+    def __init__(self, alive: bool = True) -> None:
+        self.alive = alive
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+
+class RuntimeStartupConvergenceV145Tests(unittest.TestCase):
+    def _guard(self) -> types.ModuleType:
+        guard = types.ModuleType("fake_capital_guard")
+        guard._IN_FLIGHT = {}
+        guard._IN_FLIGHT_LOCK = threading.Lock()
+        guard._BROKER_SEQUENCE = {}
+        guard._OBSERVATIONS = {}
+        guard._OBSERVATION_LOCK = threading.Lock()
+        guard._Observation = Observation
+        return guard
+
+    def test_alive_flight_before_deadline_is_reusable(self) -> None:
+        flight = Flight(AliveThread(True), None, 4, 100.0, 75.0)
+        self.assertFalse(v145._expired_alive_flight(flight, now=174.999))
+
+    def test_alive_flight_at_deadline_is_expired(self) -> None:
+        flight = Flight(AliveThread(True), None, 4, 100.0, 75.0)
+        self.assertTrue(v145._expired_alive_flight(flight, now=175.0))
+
+    def test_dead_thread_is_not_classified_as_expired_alive(self) -> None:
+        flight = Flight(AliveThread(False), None, 4, 100.0, 75.0)
+        self.assertFalse(v145._expired_alive_flight(flight, now=1000.0))
+
+    def test_expired_flight_is_evicted_and_sequence_fenced(self) -> None:
+        guard = self._guard()
+        old = Flight(AliveThread(True), None, 5, 100.0, 75.0)
+        guard._IN_FLIGHT["kraken"] = old
+        guard._BROKER_SEQUENCE["kraken"] = 5
+
+        changed = v145._fence_expired_flight(guard, "kraken", now=180.0)
+
+        self.assertTrue(changed)
+        self.assertNotIn("kraken", guard._IN_FLIGHT)
+        self.assertEqual(guard._BROKER_SEQUENCE["kraken"], 6)
+        fence = guard._OBSERVATIONS["kraken"]
+        self.assertEqual(fence.sequence, 6)
+        self.assertEqual(fence.value, 0.0)
+        self.assertEqual(fence.observed_monotonic, 0.0)
+        self.assertEqual(fence.observed_epoch, 0.0)
+
+    def test_expired_flight_preserves_prior_observation_but_advances_sequence(self) -> None:
+        guard = self._guard()
+        guard._IN_FLIGHT["kraken"] = Flight(AliveThread(True), None, 9, 100.0, 75.0)
+        guard._BROKER_SEQUENCE["kraken"] = 9
+        guard._OBSERVATIONS["kraken"] = Observation(154.49, 90.0, 1000.0, 8)
+
+        self.assertTrue(v145._fence_expired_flight(guard, "kraken", now=180.0))
+        fenced = guard._OBSERVATIONS["kraken"]
+        self.assertEqual(fenced.value, 154.49)
+        self.assertEqual(fenced.observed_monotonic, 90.0)
+        self.assertEqual(fenced.observed_epoch, 1000.0)
+        self.assertEqual(fenced.sequence, 10)
+
+    def test_late_superseded_worker_cannot_overwrite_fence(self) -> None:
+        guard = self._guard()
+        old_seq = 5
+        guard._IN_FLIGHT["kraken"] = Flight(AliveThread(True), None, old_seq, 100.0, 75.0)
+        guard._BROKER_SEQUENCE["kraken"] = old_seq
+        self.assertTrue(v145._fence_expired_flight(guard, "kraken", now=180.0))
+
+        # Mirror the existing worker's guarded observation publication rule.
+        previous = guard._OBSERVATIONS.get("kraken")
+        if previous is None or old_seq >= previous.sequence:
+            guard._OBSERVATIONS["kraken"] = Observation(999.0, 181.0, 2000.0, old_seq)
+
+        fenced = guard._OBSERVATIONS["kraken"]
+        self.assertEqual(fenced.sequence, 6)
+        self.assertEqual(fenced.value, 0.0)
+
+    def test_nonexpired_flight_is_not_evicted(self) -> None:
+        guard = self._guard()
+        old = Flight(AliveThread(True), None, 3, 100.0, 75.0)
+        guard._IN_FLIGHT["kraken"] = old
+        guard._BROKER_SEQUENCE["kraken"] = 3
+
+        self.assertFalse(v145._fence_expired_flight(guard, "kraken", now=150.0))
+        self.assertIs(guard._IN_FLIGHT["kraken"], old)
+        self.assertEqual(guard._BROKER_SEQUENCE["kraken"], 3)
+        self.assertNotIn("kraken", guard._OBSERVATIONS)
+
+    def test_batch_patch_removes_expired_flight_before_original_constructor(self) -> None:
+        guard = self._guard()
+        observed = {"stale_present_in_original": None}
+
+        class Batch:
+            def __init__(self, broker_map):
+                observed["stale_present_in_original"] = "kraken" in guard._IN_FLIGHT
+                self.broker_map = broker_map
+
+        guard._BalanceFetchBatch = Batch
+        guard._IN_FLIGHT["kraken"] = Flight(AliveThread(True), None, 7, 100.0, 10.0)
+        guard._BROKER_SEQUENCE["kraken"] = 7
+
+        self.assertTrue(v145._patch_capital_guard(guard))
+        with patch.object(v145.time, "monotonic", return_value=120.0):
+            Batch({"kraken": object()})
+
+        self.assertFalse(observed["stale_present_in_original"])
+        self.assertGreater(guard._BROKER_SEQUENCE["kraken"], 7)
+
+    def test_activation_deferral_coalescing_never_changes_decision_path(self) -> None:
+        module = types.ModuleType("fake_activation")
+        calls = []
+
+        def log_deferred(trigger, blockers, details):
+            calls.append((trigger, tuple(blockers), dict(details)))
+
+        module._log_activation_deferred = log_deferred
+        self.assertTrue(v145._patch_activation_deferral(module))
+        details = {
+            "generation": 4238,
+            "bootstrap_state": "THREADS_STARTING",
+            "core_registered": False,
+            "core_alive": False,
+        }
+        with patch.dict("os.environ", {"NIJA_ACTIVATION_DEFER_LOG_INTERVAL_S": "15"}, clear=False):
+            with patch.object(v145.time, "monotonic", side_effect=[100.0, 101.0, 116.0]):
+                module._log_activation_deferred("v15", ["core_registered"], details)
+                module._log_activation_deferred("v15", ["core_registered"], details)
+                module._log_activation_deferred("v15", ["core_registered"], details)
+
+        self.assertEqual(len(calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- make readiness-table writes idempotent and reserve WARNING/CRITICAL for actual transitions/failures
- coalesce unchanged v133 preactivation truth-sync telemetry while preserving canonical LIVE_ACTIVE -> OFF fail-closed behavior
- make v144 part of the canonical runtime release contract instead of allowing a v143 manifest to publish ready without it
- add v145 startup convergence hardening at the global startup boundary
- supersede alive-but-expired capital balance workers instead of reusing an already-dead deadline in later refresh cycles
- sequence-fence superseded workers so late returns cannot become fresh capital observations
- preserve prior observation timestamp/age when one exists; otherwise use an intentionally unusable zero-timestamp sequence fence
- coalesce repeated identical activation-deferral warnings without changing activation decisions
- add focused v145 regression tests for worker expiry, supersession, late-result fencing, nonexpired reuse, and activation-log coalescing

## Production evidence / root cause

Post-v144 runtime validation showed all three venues authenticated and market-ready, but Kraken capital refresh cycles repeatedly inherited the exact same old fetch start timestamp after the 75-second worker deadline had already expired. Every later cycle therefore immediately timed out the same worker, excluded Kraken from the capital snapshot, and let capital publication expire. The same deployment also continued publishing a v143 release manifest and repeated unchanged readiness truth at CRITICAL severity.

## Safety properties

- no balance is fabricated
- no freshness TTL is extended
- no broker timeout is relaxed
- no kill-switch, nonce, writer, position-sync, risk, sizing, reconciliation, or AI gate is bypassed
- exits/reductions remain available under the existing v144 contract
- an abandoned blocking network thread is not forcibly terminated; it is removed from reuse and sequence-fenced so its late result cannot poison current capital truth
- live startup remains fail-closed if v144/v145 hardening cannot install

## Validation

Dedicated unittest coverage is included. Keep this PR draft until repository CI is green and the release/runtime integration checks confirm v145 ownership.