### PR TITLE
Make v145 authoritative in runtime manifest v146

### DIFF
--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -60,6 +60,7 @@ _INSTALLERS = (
     ("bot.final_execution_state_router_convergence_patch", "install_import_hook"),
     ("bot.runtime_quality_hardening_v144_patch", "install_import_hook"),
     ("bot.runtime_quality_hardening_v144_entry_classifier_patch", "install_import_hook"),
+    ("bot.runtime_startup_convergence_v145_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -98,6 +99,7 @@ _REQUIRED_FLAGS = {
     "runtime_quality_hardening_v144": "NIJA_RUNTIME_QUALITY_HARDENING_V144_READY",
     "runtime_quality_v144_entry_classifier": "NIJA_RUNTIME_QUALITY_HARDENING_V144_ENTRY_CLASSIFIER_INSTALLED",
     "runtime_quality_v144_release_contract": "NIJA_RUNTIME_QUALITY_HARDENING_V144_RELEASE_CONTRACT_READY",
+    "runtime_startup_convergence_v145": "NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY",
 }
 
 

--- a/tests/test_runtime_manifest_v145_ownership_v146_unittest.py
+++ b/tests/test_runtime_manifest_v145_ownership_v146_unittest.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib
+import os
+import unittest
+
+
+class RuntimeManifestV145OwnershipV146Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+
+    def test_manifest_installs_v145_directly(self) -> None:
+        self.assertIn(
+            ("bot.runtime_startup_convergence_v145_patch", "install_import_hook"),
+            tuple(self.manifest._INSTALLERS),
+        )
+
+    def test_manifest_requires_v145_ready_proof(self) -> None:
+        self.assertEqual(
+            self.manifest._REQUIRED_FLAGS.get("runtime_startup_convergence_v145"),
+            "NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY",
+        )
+
+    def test_missing_v145_proof_cannot_publish_ready(self) -> None:
+        required = dict(self.manifest._REQUIRED_FLAGS)
+        installers = tuple(self.manifest._INSTALLERS)
+        original_invoke = self.manifest._invoke
+        original_scan_release = self.manifest._expected_scan_wrapper_release
+        original_scan_compatible = self.manifest._scan_release_compatible
+        original_limits = self.manifest._runtime_limits_consistent
+        original_contract = self.manifest._readiness_contract_consistent
+        original_import = self.manifest.importlib.import_module
+        env_backup = dict(os.environ)
+        try:
+            for flag in required.values():
+                os.environ[flag] = "1"
+            os.environ.pop("NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY", None)
+            os.environ["NIJA_SCAN_WRAPPER_RELEASE"] = "test-release"
+
+            self.manifest._invoke = lambda *_args, **_kwargs: (True, "ok")
+            self.manifest._expected_scan_wrapper_release = lambda: "test-release"
+            self.manifest._scan_release_compatible = lambda actual, expected: actual == expected
+            self.manifest._runtime_limits_consistent = lambda: (True, "ok")
+            self.manifest._readiness_contract_consistent = lambda: (True, "ok")
+
+            class _AuditModule:
+                @staticmethod
+                def audit():
+                    return True, "ok"
+
+            def _fake_import(name: str):
+                if name in {
+                    "runtime_module_identity_convergence_patch",
+                    "runtime_convergence_quiescence_patch",
+                    "scan_wrapper_depth_convergence_patch",
+                }:
+                    return _AuditModule()
+                return original_import(name)
+
+            self.manifest.importlib.import_module = _fake_import
+            ready, details = self.manifest._audit()
+            self.assertFalse(ready)
+            self.assertEqual(details["runtime_startup_convergence_v145"], "missing")
+        finally:
+            self.manifest._invoke = original_invoke
+            self.manifest._expected_scan_wrapper_release = original_scan_release
+            self.manifest._scan_release_compatible = original_scan_compatible
+            self.manifest._runtime_limits_consistent = original_limits
+            self.manifest._readiness_contract_consistent = original_contract
+            self.manifest.importlib.import_module = original_import
+            os.environ.clear()
+            os.environ.update(env_backup)
+            self.manifest._INSTALLERS = installers
+            self.manifest._REQUIRED_FLAGS = required
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

Production at deployment SHA `fcc02ebc38db213c89d6680b2fe4f555e9f3c842` (the merged v145 commit) still published `NIJA_RUNTIME_RELEASE_MANIFEST release=20260818-runtime-convergence-v144 ready=true`. The v145 installer was only wired through `global_runtime_startup_guards`, while the canonical runtime manifest itself statically installed/required only through v144. On startup paths where the manifest ran without the global guard owning v145 first, the watchdog could repeatedly publish v144 `ready=true` even though the v145 stale-capital-worker fence was not installed.

## Changes

- add `bot.runtime_startup_convergence_v145_patch.install_import_hook` to the manifest `_INSTALLERS` chain
- require `NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY=1` in `_REQUIRED_FLAGS`
- add a focused regression proving the manifest cannot return `ready=True` when the v145 proof is absent

## Safety

- no activation gate is relaxed
- no writer/core registration rule is bypassed
- no reconciliation requirement is bypassed
- no balance/capital value is fabricated
- no freshness TTL or broker timeout is extended
- no risk, sizing, nonce, kill-switch, or execution-authority rule changes

The production slice also shows `core_registered=False/core_alive=False` while startup is still pre-core and Kraken balance hydration is completing. That is not changed here because the canonical `bot_main` path intentionally registers the real core thread later, before setting `_startup_complete=True`; the observed fallback registration warnings alone do not prove a core deadlock.

## Validation target

CI should run the new `tests/test_runtime_manifest_v145_ownership_v146_unittest.py` plus the normal runtime convergence/import suite before this PR is marked ready.