### PR TITLE
Converge startup reconciliation and shutdown v146

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -244,7 +244,34 @@ def _signal_handler(signum: int, frame) -> None:
         signal_shutdown()
     except Exception:
         logger.debug("bootstrap shutdown signal unavailable", exc_info=True)
+    _signal_core_loop_shutdown(f"signal:{sig_name}")
     _shutdown_event.set()
+
+
+def _signal_core_loop_shutdown(reason: str) -> bool:
+    """Wake the canonical core loop without importing it during early startup."""
+    module = sys.modules.get("bot.nija_core_loop") or sys.modules.get("nija_core_loop")
+    if module is None:
+        return False
+    request_stop = getattr(module, "request_trading_engine_stop", None)
+    if not callable(request_stop):
+        logger.warning(
+            "TRADING_ENGINE_STOP_SIGNAL_UNAVAILABLE reason=%s",
+            reason,
+        )
+        return False
+    try:
+        request_stop(reason)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "TRADING_ENGINE_STOP_SIGNAL_FAILED reason=%s error=%s:%s",
+            reason,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        return False
 
 
 def _acquire_writer_authority_before_nonce() -> bool:
@@ -1498,10 +1525,12 @@ def main() -> int:
         # lease is released.
         #
         # Shutdown order:
-        # 1. signal all workers to stop (already done via _shutdown_event.set() above)
+        # 1. signal all workers to stop
         # 2. stop v86 Kraken user supervision (prevents new reconnect jobs)
         # 3. join canonical core thread if it was started
         # 4. release writer authority LAST
+        _signal_core_loop_shutdown(_process_exit_reason or "bot_main_finally")
+
         try:
             from bot.kraken_all_account_supervision_v86 import (
                 stop as _stop_kraken_v86,

--- a/bot/global_runtime_startup_guards.py
+++ b/bot/global_runtime_startup_guards.py
@@ -170,11 +170,16 @@ def install() -> None:
         "runtime_startup_convergence_v145_patch",
         "RUNTIME_STARTUP_CONVERGENCE_V145_GLOBAL_STARTUP_INSTALL_REQUESTED",
     )
+    runtime_reconciliation_v146_ok = _install_module(
+        "runtime_reconciliation_shutdown_v146_patch",
+        "RUNTIME_RECONCILIATION_SHUTDOWN_V146_GLOBAL_STARTUP_INSTALL_REQUESTED",
+    )
 
     hardening_ready = bool(
         runtime_quality_v144_ok
         and runtime_quality_v144_classifier_ok
         and runtime_startup_v145_ok
+        and runtime_reconciliation_v146_ok
     )
     os.environ["NIJA_RUNTIME_QUALITY_HARDENING_V144_STARTUP_READY"] = (
         "1" if runtime_quality_v144_ok and runtime_quality_v144_classifier_ok else "0"
@@ -182,12 +187,19 @@ def install() -> None:
     os.environ["NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_STARTUP_READY"] = (
         "1" if runtime_startup_v145_ok else "0"
     )
+    os.environ["NIJA_RUNTIME_RECONCILIATION_SHUTDOWN_V146_STARTUP_READY"] = (
+        "1" if runtime_reconciliation_v146_ok else "0"
+    )
     if _live_runtime_expected() and not hardening_ready:
         logger.critical(
-            "RUNTIME_HARDENING_REQUIRED_STARTUP_FAILED marker=20260818-runtime-startup-convergence-v145 v144=%s classifier=%s v145=%s live=true trading_fail_closed=true",
+            "RUNTIME_HARDENING_REQUIRED_STARTUP_FAILED "
+            "marker=20260818-runtime-reconciliation-shutdown-v146 "
+            "v144=%s classifier=%s v145=%s v146=%s "
+            "live=true trading_fail_closed=true",
             runtime_quality_v144_ok,
             runtime_quality_v144_classifier_ok,
             runtime_startup_v145_ok,
+            runtime_reconciliation_v146_ok,
         )
         raise SystemExit(78)
 
@@ -202,11 +214,16 @@ def install() -> None:
 
     setattr(builtins, "_NIJA_GLOBAL_RUNTIME_STARTUP_GUARDS_20260706B", True)
     logger.info(
-        "GLOBAL_RUNTIME_STARTUP_GUARDS_INSTALLED marker=20260706b source_venue_guards=%s runtime_quality_v144=%s runtime_quality_v144_classifier=%s runtime_startup_v145=%s preactivation_v16=%s held_cap=%s global_trailing=%s profit_position=%s stale_exposure=%s cap=%s",
+        "GLOBAL_RUNTIME_STARTUP_GUARDS_INSTALLED marker=20260706b "
+        "source_venue_guards=%s runtime_quality_v144=%s "
+        "runtime_quality_v144_classifier=%s runtime_startup_v145=%s "
+        "runtime_reconciliation_v146=%s preactivation_v16=%s held_cap=%s "
+        "global_trailing=%s profit_position=%s stale_exposure=%s cap=%s",
         source_guards_ok,
         runtime_quality_v144_ok,
         runtime_quality_v144_classifier_ok,
         runtime_startup_v145_ok,
+        runtime_reconciliation_v146_ok,
         preactivation_ok,
         held_ok,
         trailing_ok,

--- a/bot/nija_core_loop.py
+++ b/bot/nija_core_loop.py
@@ -5657,6 +5657,7 @@ _loop_guard = threading.Lock()
 _loop_running = False
 _engine_start_guard = threading.Lock()
 _engine_thread: Optional[threading.Thread] = None
+_engine_stop_event = threading.Event()
 # Hard trading-active flag.  Set to True only after BOTH the hydration and CSM
 # barriers have passed.  The main while-loop is conditioned on this flag so the
 # loop body never executes until the bot is genuinely ready to trade.
@@ -5670,6 +5671,40 @@ _exec_test_fired = False
 # here — the earlier definition is the canonical one.  The FORCE_TRADE check
 # that sets this event lives in run_trading_loop() so it is evaluated at
 # runtime, not at module import time.
+
+
+def request_trading_engine_stop(reason: str = "shutdown_requested") -> None:
+    """Stop the scheduler and wake any interruptible core-loop wait.
+
+    This is a process-local lifecycle signal only.  It never grants execution
+    authority or releases the distributed writer lease; ``bot_main`` retains
+    ownership of that ordered shutdown sequence.
+    """
+    global _trading_active
+    _trading_active = False
+    _engine_stop_event.set()
+    logger.info("TRADING_ENGINE_STOP_REQUESTED reason=%s", reason)
+
+
+def _interruptible_sleep(timeout_s: float) -> bool:
+    """Wait up to ``timeout_s`` and return True when shutdown interrupted it."""
+    try:
+        timeout = max(0.0, float(timeout_s))
+    except (TypeError, ValueError):
+        timeout = 0.0
+    return _engine_stop_event.wait(timeout=timeout)
+
+
+def _wait_for_engine_ready_or_stop(timeout_s: float) -> bool:
+    """Wait for the start gate while remaining immediately stoppable."""
+    deadline = time.monotonic() + max(0.0, float(timeout_s))
+    while not TRADING_ENGINE_READY.is_set():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            break
+        if _engine_stop_event.wait(timeout=min(0.25, remaining)):
+            return False
+    return TRADING_ENGINE_READY.is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -5861,6 +5896,11 @@ def start_trading_engine(strategy: Any) -> threading.Thread:
             if getattr(strategy, "broker", None) is not None
             else "none",
         )
+
+        # A previous stopped worker must not leak its process-local stop signal
+        # into a deliberate replacement start. Existing live workers are
+        # returned above and therefore never have their stop request cleared.
+        _engine_stop_event.clear()
 
         # Install graceful shutdown handling before spawning the trading thread.
         if _GRACEFUL_HANDOFF_AVAILABLE and _get_handoff_coordinator is not None:
@@ -6271,7 +6311,13 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     _loop_guard.release()
             return
 
-        if not TRADING_ENGINE_READY.wait(timeout=30):
+        if not _wait_for_engine_ready_or_stop(30.0):
+            if _engine_stop_event.is_set():
+                logger.info(
+                    "TRADING_ENGINE_START_GATE_STOPPED elapsed=%.1fs",
+                    time.monotonic() - _start_gate_t0,
+                )
+                return
             logger.critical(
                 "TIMEOUT_WAITING_FOR_TRADING_ENGINE_READY "
                 "(iter=%d elapsed=%.0fs remaining=%.0fs)",
@@ -6717,7 +6763,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                 time.monotonic() - _cap_precheck_t0,
                 _cap_precheck_timeout,
             )
-            time.sleep(1.0)
+            if _interruptible_sleep(1.0):
+                logger.info("TRADING_ENGINE_STOPPED phase=capital_precheck")
+                return
         if not _cap_precheck_ok:
             _precheck_snap = _capture_cycle_capital_state()
             _precheck_total = float(_precheck_snap.get("ca_total_capital", 0.0) or 0.0)
@@ -6870,7 +6918,7 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     _loop_guard.release()
             return
         logger.critical("LIFECYCLE: entering cycle scheduler")
-        while _trading_active:
+        while _trading_active and not _engine_stop_event.is_set():
             try:
                 # Graceful shutdown gate: stop accepting new cycles when SIGTERM
                 # has been received.  The shutdown handler waits for in-flight
@@ -7413,7 +7461,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                             _skipped_cycles * cycle_secs,
                             _sleep_s,
                         )
-                    time.sleep(_sleep_s)
+                    if _interruptible_sleep(_sleep_s):
+                        logger.info("TRADING_ENGINE_STOPPED phase=broker_reconnect_backoff")
+                        return
                     logger.debug("🚧 LOOP BLOCKED PATH REACHED — no broker connected, skipping cycle")
                     continue
 
@@ -7472,7 +7522,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                             _runtime_authority = ""
                     except Exception as _exec_gate_err:
                         logger.warning("Execution gate probe failed; skipping strategy cycle: %s", _exec_gate_err)
-                        time.sleep(cycle_secs)
+                        if _interruptible_sleep(cycle_secs):
+                            logger.info("TRADING_ENGINE_STOPPED phase=activation_wait")
+                            return
                         continue
 
                     # No operator flag can bypass the lifecycle commit.  A cycle
@@ -7529,7 +7581,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                                     _dispatch_reason or "not_reported",
                                     _activation_retry_sleep_s,
                                 )
-                            time.sleep(_activation_retry_sleep_s)
+                            if _interruptible_sleep(_activation_retry_sleep_s):
+                                logger.info("TRADING_ENGINE_STOPPED phase=activation_retry")
+                                return
                             continue
                     else:
                         _last_cycle_skip_signature = None
@@ -7643,7 +7697,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     _missing_ref_retry_s = float(
                         os.getenv("NIJA_MISSING_REF_RETRY_S", "15") or 15
                     )
-                    time.sleep(_missing_ref_retry_s)
+                    if _interruptible_sleep(_missing_ref_retry_s):
+                        logger.info("TRADING_ENGINE_STOPPED phase=missing_reference_retry")
+                        return
                     continue
                 # ── End Fix 4 ─────────────────────────────────────────────────
 
@@ -7905,7 +7961,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     _cycle_elapsed,
                     _next_sleep_s,
                 )
-                time.sleep(_next_sleep_s)
+                if _interruptible_sleep(_next_sleep_s):
+                    logger.info("TRADING_ENGINE_STOPPED phase=between_cycles")
+                    return
 
             except Exception as _err:
                 _activation_retry_count += 1
@@ -7920,7 +7978,9 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                     _watchdog_backoff_enabled,
                     _watchdog_backoff_max_multiplier,
                 )
-                time.sleep(_error_sleep_s)
+                if _interruptible_sleep(_error_sleep_s):
+                    logger.info("TRADING_ENGINE_STOPPED phase=error_backoff")
+                    return
 
     except Exception as e:
         logger.exception("💥 FATAL ERROR IN TRADING LOOP: %s", e)

--- a/bot/runtime_reconciliation_shutdown_v146_patch.py
+++ b/bot/runtime_reconciliation_shutdown_v146_patch.py
@@ -1,0 +1,319 @@
+"""NIJA startup reconciliation and shutdown convergence v146.
+
+The v144 entry gate correctly requires explicit restart-reconciliation truth,
+but the canonical startup path already performs account-scoped, authoritative
+position snapshots through ``position_sync_dispatch_authority_v96_patch`` and
+did not bridge that proof into ``NIJA_RECONCILIATION_*``.  As a result, a
+healthy live startup remained permanently fail-closed with ``status=missing``.
+
+This patch publishes ``CLEAN_START`` only when at least one connected broker is
+present and every connected platform/user broker has completed its authoritative
+startup position snapshot.  A missing or regressed snapshot revokes the proof
+before readiness-table publication.  Explicit discrepancy/failure outcomes are
+never overwritten.
+
+The companion source changes in ``nija_core_loop`` and ``bot_main`` make normal
+core-loop waits interruptible so a failed startup can release writer authority
+without waiting on an unrelated 30/150 second sleep.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+
+LOGGER = logging.getLogger("nija.runtime_reconciliation_shutdown_v146")
+MARKER = "20260818-runtime-reconciliation-shutdown-v146"
+RELEASE_ID = "20260818-runtime-convergence-v146"
+_FLAG = "NIJA_RUNTIME_RECONCILIATION_SHUTDOWN_V146_READY"
+_PATCH_ATTR = "_nija_runtime_reconciliation_shutdown_v146"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_TERMINAL_FAILURE_STATUSES = {
+    "DISCREPANCIES_FOUND",
+    "FAILED",
+    "FAILURE",
+    "ERROR",
+    "UNSAFE",
+}
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _position_sync_truth(module: ModuleType, manager: Any) -> tuple[bool, list[str], dict[str, bool]]:
+    """Return strict position-sync truth without treating zero brokers as ready."""
+    if manager is None:
+        return False, [], {}
+    try:
+        v95 = module._v95_module()
+        ready, pending, status = v95.position_sync_status(manager)
+        normalized = {str(name): bool(value) for name, value in dict(status or {}).items()}
+        connected = dict(v95._connected_brokers(manager) or {})
+        connected_names = {str(name) for name in connected}
+        status_names = set(normalized)
+        fetch_pending = sorted(
+            str(name)
+            for name, broker in connected.items()
+            if getattr(broker, "_startup_position_sync_fetch_ok", None) is not True
+        )
+        all_pending = sorted(
+            set(str(name) for name in (pending or []))
+            | set(fetch_pending)
+            | connected_names.symmetric_difference(status_names)
+        )
+        authoritative = (
+            bool(connected_names)
+            and connected_names == status_names
+            and bool(ready)
+            and not all_pending
+        )
+        return authoritative, all_pending, normalized
+    except Exception as exc:
+        LOGGER.warning(
+            "STARTUP_RECONCILIATION_V146_POSITION_SYNC_ERROR marker=%s error=%s:%s fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False, [], {}
+
+
+def _publish_reconciliation_truth(
+    ready: bool,
+    pending: list[str],
+    status: dict[str, bool],
+    *,
+    source: str,
+) -> bool:
+    """Publish or revoke reconciliation truth in fail-closed write order."""
+    authoritative = bool(ready and status and all(status.values()))
+    previous_status = str(os.environ.get("NIJA_RECONCILIATION_STATUS", "") or "").strip().upper()
+    previous_complete = _truthy(os.environ.get("NIJA_RECONCILIATION_COMPLETE"))
+
+    # An explicit discrepancy/failure is stronger evidence than a later
+    # position-only snapshot and must remain fail-closed for review, even if
+    # its producer failed before publishing the completion bit.
+    if previous_status in _TERMINAL_FAILURE_STATUSES:
+        LOGGER.error(
+            "STARTUP_RECONCILIATION_V146_FAILURE_PRESERVED marker=%s source=%s status=%s position_sync_ready=%s",
+            MARKER,
+            source,
+            previous_status,
+            str(authoritative).lower(),
+        )
+        return False
+
+    if authoritative:
+        # Promotion order is safety-sensitive: publish the accepted status
+        # before flipping completion true so readers never see complete+missing.
+        final_status = previous_status if previous_status in {"CLEAN", "CLEAN_START"} else "CLEAN_START"
+        os.environ["NIJA_RECONCILIATION_STATUS"] = final_status
+        os.environ["NIJA_RECONCILIATION_COMPLETE"] = "true"
+        changed = not previous_complete or previous_status != final_status
+        log = LOGGER.warning if changed else LOGGER.debug
+        log(
+            "STARTUP_RECONCILIATION_V146_READY marker=%s source=%s status=%s brokers=%s authoritative_snapshots=true",
+            MARKER,
+            source,
+            final_status,
+            sorted(status),
+        )
+        return True
+
+    # Revocation order is the inverse: completion becomes false before the
+    # descriptive status changes, preventing a transient complete+clean read.
+    os.environ["NIJA_RECONCILIATION_COMPLETE"] = "false"
+    os.environ["NIJA_RECONCILIATION_STATUS"] = "PENDING"
+    changed = previous_complete or previous_status != "PENDING"
+    log = LOGGER.warning if changed else LOGGER.debug
+    log(
+        "STARTUP_RECONCILIATION_V146_PENDING marker=%s source=%s pending=%s status=%s fail_closed=true",
+        MARKER,
+        source,
+        sorted(str(value) for value in pending),
+        status,
+    )
+    return False
+
+
+def _patch_position_sync_publication(module: ModuleType) -> bool:
+    """Bridge position truth before v96 emits the readiness-table edge."""
+    current = getattr(module, "publish_position_sync_readiness", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def publish_v146(manager: Any, *, source: str) -> tuple[bool, list[str], dict[str, bool]]:
+        # Publish reconciliation first. v96 then writes position_sync_ready and
+        # synchronously notifies StartupCoordinator, which now observes both
+        # proofs in the same readiness transition.
+        ready, pending, status = _position_sync_truth(module, manager)
+        _publish_reconciliation_truth(ready, pending, status, source=source)
+
+        reported_ready, reported_pending, reported_status = current(
+            manager,
+            source=source,
+        )
+        final_ready, final_pending, final_status = _position_sync_truth(
+            module,
+            manager,
+        )
+
+        # v95's historical status only inspected the adopted marker. Correct a
+        # stale/legacy true result when its independent fetch proof is absent.
+        if bool(reported_ready) != final_ready:
+            try:
+                readiness = module._readiness_module()
+                readiness.set_ready(
+                    module.READINESS_KEY,
+                    final_ready,
+                    allow_regression=True,
+                )
+                os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = (
+                    "1" if final_ready else "0"
+                )
+                os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = (
+                    "1" if final_ready else "0"
+                )
+                LOGGER.warning(
+                    "STARTUP_RECONCILIATION_V146_FETCH_PROOF_CORRECTED marker=%s "
+                    "source=%s reported_ready=%s final_ready=%s "
+                    "reported_pending=%s reported_status=%s",
+                    MARKER,
+                    source,
+                    str(bool(reported_ready)).lower(),
+                    str(final_ready).lower(),
+                    list(reported_pending or []),
+                    dict(reported_status or {}),
+                )
+            except Exception:
+                final_ready = False
+                final_pending = sorted(set(final_pending) | {"readiness_correction_failed"})
+                LOGGER.exception(
+                    "STARTUP_RECONCILIATION_V146_READINESS_CORRECTION_FAILED "
+                    "marker=%s source=%s fail_closed=true",
+                    MARKER,
+                    source,
+                )
+
+        # Reconcile a broker-set race that occurred between the pre-publication
+        # snapshot and v96's own snapshot. A regression is immediately revoked;
+        # a promotion is followed by an explicit coordinator reconciliation.
+        if (
+            final_ready != ready
+            or final_pending != pending
+            or final_status != status
+        ):
+            promoted = _publish_reconciliation_truth(
+                final_ready,
+                final_pending,
+                final_status,
+                source=f"{source}:post_publish_race",
+            )
+            if promoted and not ready:
+                try:
+                    from bot.readiness_table import get_version, snapshot
+                    from bot.startup_coordinator import get_startup_coordinator
+
+                    get_startup_coordinator().record_readiness(
+                        key="startup_reconciliation",
+                        value=True,
+                        version=get_version(),
+                        table=snapshot(),
+                    )
+                except Exception:
+                    LOGGER.debug(
+                        "STARTUP_RECONCILIATION_V146_RECONCILE_NOTIFY_SKIPPED marker=%s",
+                        MARKER,
+                        exc_info=True,
+                    )
+        return final_ready, final_pending, final_status
+
+    setattr(publish_v146, _PATCH_ATTR, True)
+    setattr(publish_v146, "__wrapped__", current)
+    module.publish_position_sync_readiness = publish_v146
+    return True
+
+
+def _own_release() -> bool:
+    """Make v146 the terminal runtime manifest owner after successful install."""
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["runtime_reconciliation_shutdown_v146"] = _FLAG
+    manifest.DECLARED_RELEASE_ID = RELEASE_ID
+    manifest.RELEASE_ID = RELEASE_ID
+    os.environ["NIJA_RUNTIME_RELEASE_ID"] = RELEASE_ID
+
+    for module_name in (
+        "bot.runtime_quality_hardening_v144_patch",
+        "bot.runtime_startup_convergence_v145_patch",
+    ):
+        module = importlib.import_module(module_name)
+        module.RELEASE_ID = RELEASE_ID
+    return True
+
+
+def install_import_hook() -> bool:
+    """Install the reconciliation bridge and publish the v146 release proof."""
+    global _INSTALLED
+    with _LOCK:
+        try:
+            position_sync = importlib.import_module(
+                "bot.position_sync_dispatch_authority_v96_patch"
+            )
+            installer = getattr(position_sync, "install_import_hook", None)
+            if callable(installer) and installer() is False:
+                raise RuntimeError("position_sync_v96_installer_returned_false")
+            bridge_ok = _patch_position_sync_publication(position_sync)
+            release_ok = _own_release()
+            ready = bool(bridge_ok and release_ok)
+        except Exception as exc:
+            ready = False
+            LOGGER.critical(
+                "RUNTIME_RECONCILIATION_SHUTDOWN_V146_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+
+        os.environ[_FLAG] = "1" if ready else "0"
+        _INSTALLED = ready
+        if ready:
+            LOGGER.info(
+                "RUNTIME_RECONCILIATION_SHUTDOWN_V146_INSTALLED marker=%s "
+                "release=%s authoritative_position_bridge=true "
+                "zero_broker_fail_closed=true discrepancy_preserved=true "
+                "shutdown_interruptible=true",
+                MARKER,
+                RELEASE_ID,
+            )
+        return ready
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_position_sync_truth",
+    "_publish_reconciliation_truth",
+    "_patch_position_sync_publication",
+    "_own_release",
+]

--- a/bot/runtime_release_manifest_patch.py
+++ b/bot/runtime_release_manifest_patch.py
@@ -11,7 +11,7 @@ from typing import Callable
 
 logger = logging.getLogger("nija.runtime_release_manifest")
 # Keep the static bootstrap identity at v138 for the v139 write-barrier contract.
-# v144/v145 promote DECLARED_RELEASE_ID during runtime convergence only after
+# v144-v146 promote DECLARED_RELEASE_ID during runtime convergence only after
 # their safety layers are attached; this lets CI detect legacy downgrade attempts
 # while production publishes the newest successfully installed runtime release.
 RELEASE_ID = "20260817-runtime-convergence-v138"
@@ -61,6 +61,7 @@ _INSTALLERS = (
     ("bot.runtime_quality_hardening_v144_patch", "install_import_hook"),
     ("bot.runtime_quality_hardening_v144_entry_classifier_patch", "install_import_hook"),
     ("bot.runtime_startup_convergence_v145_patch", "install_import_hook"),
+    ("bot.runtime_reconciliation_shutdown_v146_patch", "install_import_hook"),
 )
 
 _REQUIRED_FLAGS = {
@@ -100,6 +101,7 @@ _REQUIRED_FLAGS = {
     "runtime_quality_v144_entry_classifier": "NIJA_RUNTIME_QUALITY_HARDENING_V144_ENTRY_CLASSIFIER_INSTALLED",
     "runtime_quality_v144_release_contract": "NIJA_RUNTIME_QUALITY_HARDENING_V144_RELEASE_CONTRACT_READY",
     "runtime_startup_convergence_v145": "NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY",
+    "runtime_reconciliation_shutdown_v146": "NIJA_RUNTIME_RECONCILIATION_SHUTDOWN_V146_READY",
 }
 
 

--- a/tests/runtime_reconciliation_shutdown_v146_test.py
+++ b/tests/runtime_reconciliation_shutdown_v146_test.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOT = ROOT / "bot"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+v146 = _load(
+    "runtime_reconciliation_shutdown_v146_under_test",
+    BOT / "runtime_reconciliation_shutdown_v146_patch.py",
+)
+
+
+class RuntimeReconciliationShutdownV146Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        for key in (
+            "NIJA_RECONCILIATION_STATUS",
+            "NIJA_RECONCILIATION_COMPLETE",
+        ):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self.env.stop()
+
+    @staticmethod
+    def _position_module(result):
+        module = types.ModuleType("fake_position_sync_v96")
+        broker_status = dict(result[2] or {})
+        brokers = {
+            name: types.SimpleNamespace(_startup_position_sync_fetch_ok=True)
+            for name in broker_status
+        }
+
+        class V95:
+            @staticmethod
+            def position_sync_status(_manager):
+                return result
+
+            @staticmethod
+            def _connected_brokers(_manager):
+                return brokers
+
+        module._v95_module = lambda: V95
+        return module
+
+    def test_zero_connected_brokers_never_proves_reconciliation(self) -> None:
+        module = self._position_module((True, [], {}))
+        ready, pending, status = v146._position_sync_truth(module, object())
+        self.assertFalse(ready)
+        self.assertEqual(pending, [])
+        self.assertEqual(status, {})
+
+    def test_all_connected_brokers_publish_clean_start(self) -> None:
+        published = v146._publish_reconciliation_truth(
+            True,
+            [],
+            {"platform:coinbase": True, "platform:kraken": True},
+            source="unit_test",
+        )
+        self.assertTrue(published)
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_STATUS"], "CLEAN_START")
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_COMPLETE"], "true")
+
+    def test_adopted_snapshot_without_fetch_proof_stays_fail_closed(self) -> None:
+        module = self._position_module((True, [], {"platform:kraken": True}))
+        module._v95_module()._connected_brokers(object())[
+            "platform:kraken"
+        ]._startup_position_sync_fetch_ok = None
+
+        ready, pending, status = v146._position_sync_truth(module, object())
+
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:kraken"])
+        self.assertEqual(status, {"platform:kraken": True})
+
+    def test_broker_set_race_stays_fail_closed(self) -> None:
+        module = self._position_module((True, [], {"platform:kraken": True}))
+        coinbase = types.SimpleNamespace(_startup_position_sync_fetch_ok=True)
+        module._v95_module = lambda: types.SimpleNamespace(
+            position_sync_status=lambda _manager: (
+                True,
+                [],
+                {"platform:kraken": True},
+            ),
+            _connected_brokers=lambda _manager: {"platform:coinbase": coinbase},
+        )
+
+        ready, pending, status = v146._position_sync_truth(module, object())
+
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:coinbase", "platform:kraken"])
+        self.assertEqual(status, {"platform:kraken": True})
+
+    def test_position_sync_regression_revokes_clean_proof(self) -> None:
+        os.environ["NIJA_RECONCILIATION_STATUS"] = "CLEAN_START"
+        os.environ["NIJA_RECONCILIATION_COMPLETE"] = "true"
+        published = v146._publish_reconciliation_truth(
+            False,
+            ["user:customer:kraken"],
+            {"platform:kraken": True, "user:customer:kraken": False},
+            source="late_broker",
+        )
+        self.assertFalse(published)
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_STATUS"], "PENDING")
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_COMPLETE"], "false")
+
+    def test_explicit_discrepancy_is_never_overwritten(self) -> None:
+        os.environ["NIJA_RECONCILIATION_STATUS"] = "DISCREPANCIES_FOUND"
+        os.environ["NIJA_RECONCILIATION_COMPLETE"] = "true"
+        published = v146._publish_reconciliation_truth(
+            True,
+            [],
+            {"platform:kraken": True},
+            source="unit_test",
+        )
+        self.assertFalse(published)
+        self.assertEqual(
+            os.environ["NIJA_RECONCILIATION_STATUS"],
+            "DISCREPANCIES_FOUND",
+        )
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_COMPLETE"], "true")
+
+    def test_incomplete_explicit_failure_is_never_overwritten(self) -> None:
+        os.environ["NIJA_RECONCILIATION_STATUS"] = "FAILED"
+        os.environ["NIJA_RECONCILIATION_COMPLETE"] = "false"
+
+        published = v146._publish_reconciliation_truth(
+            True,
+            [],
+            {"platform:kraken": True},
+            source="unit_test",
+        )
+
+        self.assertFalse(published)
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_STATUS"], "FAILED")
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_COMPLETE"], "false")
+
+    def test_reconciliation_is_visible_before_v96_readiness_edge(self) -> None:
+        status = {"platform:kraken": True}
+        module = self._position_module((True, [], status))
+        observed = []
+
+        def publish_position_sync_readiness(_manager, *, source):
+            observed.append(
+                (
+                    source,
+                    os.environ.get("NIJA_RECONCILIATION_STATUS"),
+                    os.environ.get("NIJA_RECONCILIATION_COMPLETE"),
+                )
+            )
+            return True, [], status
+
+        module.publish_position_sync_readiness = publish_position_sync_readiness
+        self.assertTrue(v146._patch_position_sync_publication(module))
+        ready, pending, final_status = module.publish_position_sync_readiness(
+            object(),
+            source="startup_position_sync_complete",
+        )
+
+        self.assertTrue(ready)
+        self.assertEqual(pending, [])
+        self.assertEqual(final_status, status)
+        self.assertEqual(
+            observed,
+            [("startup_position_sync_complete", "CLEAN_START", "true")],
+        )
+
+    def test_v96_adopted_true_cannot_override_missing_fetch_proof(self) -> None:
+        status = {"platform:kraken": True}
+        module = self._position_module((True, [], status))
+        module._v95_module()._connected_brokers(object())[
+            "platform:kraken"
+        ]._startup_position_sync_fetch_ok = None
+        readiness_calls = []
+        module.READINESS_KEY = "position_sync_ready"
+        module._readiness_module = lambda: types.SimpleNamespace(
+            set_ready=lambda *args, **kwargs: readiness_calls.append((args, kwargs))
+        )
+        module.publish_position_sync_readiness = lambda _manager, *, source: (
+            True,
+            [],
+            status,
+        )
+
+        self.assertTrue(v146._patch_position_sync_publication(module))
+        ready, pending, final_status = module.publish_position_sync_readiness(
+            object(),
+            source="unit_test",
+        )
+
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:kraken"])
+        self.assertEqual(final_status, status)
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_STATUS"], "PENDING")
+        self.assertEqual(os.environ["NIJA_RECONCILIATION_COMPLETE"], "false")
+        self.assertEqual(
+            readiness_calls,
+            [(('position_sync_ready', False), {"allow_regression": True})],
+        )
+
+    def test_bot_main_finalizer_can_wake_loaded_core_without_importing(self) -> None:
+        bot_main = _load("bot_main_v146_under_test", BOT / "bot_main.py")
+        calls = []
+        fake_core = types.ModuleType("bot.nija_core_loop")
+        fake_core.request_trading_engine_stop = calls.append
+
+        with patch.dict(sys.modules, {"bot.nija_core_loop": fake_core}):
+            self.assertTrue(bot_main._signal_core_loop_shutdown("unit_test"))
+
+        self.assertEqual(calls, ["unit_test"])
+
+    def test_core_waits_and_finalizer_are_wired_to_stop_signal(self) -> None:
+        core_source = (BOT / "nija_core_loop.py").read_text(encoding="utf-8")
+        main_source = (BOT / "bot_main.py").read_text(encoding="utf-8")
+        self.assertIn("def request_trading_engine_stop(", core_source)
+        self.assertIn("_engine_stop_event.wait", core_source)
+        self.assertIn(
+            '_signal_core_loop_shutdown(_process_exit_reason or "bot_main_finally")',
+            main_source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_manifest_v145_ownership_v146_unittest.py
+++ b/tests/test_runtime_manifest_v145_ownership_v146_unittest.py
@@ -21,6 +21,23 @@ class RuntimeManifestV145OwnershipV146Tests(unittest.TestCase):
             "NIJA_RUNTIME_STARTUP_CONVERGENCE_V145_READY",
         )
 
+    def test_manifest_installs_v146_reconciliation_shutdown_convergence(self) -> None:
+        self.assertIn(
+            (
+                "bot.runtime_reconciliation_shutdown_v146_patch",
+                "install_import_hook",
+            ),
+            tuple(self.manifest._INSTALLERS),
+        )
+
+    def test_manifest_requires_v146_ready_proof(self) -> None:
+        self.assertEqual(
+            self.manifest._REQUIRED_FLAGS.get(
+                "runtime_reconciliation_shutdown_v146"
+            ),
+            "NIJA_RUNTIME_RECONCILIATION_SHUTDOWN_V146_READY",
+        )
+
     def test_missing_v145_proof_cannot_publish_ready(self) -> None:
         required = dict(self.manifest._REQUIRED_FLAGS)
         installers = tuple(self.manifest._INSTALLERS)


### PR DESCRIPTION
## What changed

- Bridge authoritative multi-broker startup position synchronization into the strict restart-reconciliation gate.
- Require a non-empty, exactly covered connected-broker set with successful fetch proof for every broker.
- Preserve explicit discrepancy/failure outcomes and revoke readiness on regressions.
- Make TradingLoop startup, retry, and scheduler waits interruptible before writer-authority release.
- Require the v146 proof in global startup guards and the runtime release manifest.

## Root cause

The v144 gate correctly required `NIJA_RECONCILIATION_STATUS` and `NIJA_RECONCILIATION_COMPLETE`, but the canonical multi-broker startup sync never published that proof. Healthy production startup therefore remained fail-closed. When startup convergence exited, TradingLoop could still be blocked in a 30/150-second wait, causing the 10-second shutdown join to time out.

## Safety impact

No writer, nonce, capital, risk, sizing, kill-switch, or exit protection is weakened. Missing fetch proof, zero brokers, broker-set races, regressions, and explicit reconciliation failures remain fail-closed.

## Validation

- 52 targeted pytest tests passed
- 45 unittest discovery tests passed
- Python compilation passed
- v146 manifest integration smoke passed
- core shutdown wake smoke passed
- diff, secret, and unsafe-bypass scans passed