### PR TITLE
Publish Render readiness on canonical startup

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -22,6 +22,11 @@ logger = logging.getLogger("nija.bot_entrypoint")
 _FAST_PATH_MARKER = "20260816-canonical-fast-entrypoint-v110"
 
 _FAST_PATH_INSTALLERS = (
+    # The Render liveness server is a sibling process, so canonical runtime
+    # state must be published through the existing atomic bridge.  The legacy
+    # main.py fanout installs this bridge, but the canonical fast path skips
+    # that fanout by design.
+    ("render_readiness_state_bridge", "RENDER_READINESS_STATE_BRIDGE"),
     ("bot.writer_reelection_loss_reason_v46_patch", "WRITER_REELECTION_LOSS_REASON_V46"),
     ("bot.writer_generation_state_gate_v50_patch", "WRITER_GENERATION_STATE_GATE_V50"),
     ("bot.writer_distributed_loss_watchdog_v52_patch", "WRITER_DISTRIBUTED_LOSS_WATCHDOG_V52"),

--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -78,6 +78,8 @@ def test_bot_entrypoint_fast_path_is_small_and_fail_closed() -> None:
     fast_block = source.split("_FAST_PATH_INSTALLERS = (", 1)[1].split(
         ")\n\n_LEGACY_INSTALLERS", 1
     )[0]
+    assert "render_readiness_state_bridge" in fast_block
+    assert "RENDER_READINESS_STATE_BRIDGE" in fast_block
     assert "writer_reelection_loss_reason_v46_patch" in fast_block
     assert "WRITER_REELECTION_LOSS_REASON_V46" in fast_block
     assert "writer_generation_state_gate_v50_patch" in fast_block


### PR DESCRIPTION
## Summary
- install the existing atomic Render readiness bridge on the canonical fast path
- expose the deployed commit and live fail-closed runtime state to `/healthz` and `/readyz`
- add a canonical-entrypoint regression assertion

## Verification
- 26 focused tests passed
- Python compilation and shell syntax checks passed
- canonical frozen-import probe wrote commit/state/authority correctly
- one unrelated fast-path unit test remains a verified baseline failure on the prior production commit