### PR TITLE
Restore authoritative position sync fetch proof

### DIFF
--- a/bot/position_sync_failure_truth_v98_patch.py
+++ b/bot/position_sync_failure_truth_v98_patch.py
@@ -83,6 +83,41 @@ def _patch_startup_sync(module: ModuleType) -> bool:
             raise
 
         synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
+        fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None)
+
+        # The canonical adopter is the authority boundary: it sets ``adopted``
+        # only after the returned snapshot (including a genuine empty snapshot)
+        # has been fully reconciled.  Publish the corresponding fetch proof here
+        # after the pre-fetch revocation above.  Preserve an explicit False from
+        # an inner transport wrapper; a masked fetch failure must never be turned
+        # into an authoritative empty snapshot.
+        if synced and fetch_ok is not False:
+            try:
+                setattr(broker, "_startup_position_sync_fetch_ok", True)
+                setattr(broker, "_startup_position_sync_error", None)
+            except Exception:
+                synced = False
+                try:
+                    setattr(broker, "_startup_position_sync_adopted", False)
+                    setattr(broker, "_startup_position_sync_symbols", tuple())
+                except Exception:
+                    pass
+                LOGGER.exception(
+                    "POSITION_SYNC_V98_FETCH_PROOF_PUBLISH_FAILED marker=%s "
+                    "broker=%s fail_closed=true",
+                    MARKER,
+                    broker_name,
+                )
+        elif synced:
+            # An explicit fetch failure is stronger than a legacy adopter that
+            # accepted a compatibility-layer ``[]`` fallback.
+            synced = False
+            try:
+                setattr(broker, "_startup_position_sync_adopted", False)
+                setattr(broker, "_startup_position_sync_symbols", tuple())
+            except Exception:
+                pass
+
         if not synced:
             os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "0"
             os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "0"
@@ -91,6 +126,13 @@ def _patch_startup_sync(module: ModuleType) -> bool:
                 MARKER,
                 broker_name,
                 str(previous).lower(),
+            )
+        else:
+            LOGGER.info(
+                "POSITION_SYNC_V98_FETCH_PROOF_READY marker=%s broker=%s "
+                "authoritative_snapshot=true positions_adopted=true",
+                MARKER,
+                broker_name,
             )
         return result
 

--- a/bot/tests/test_position_sync_failure_truth_v98.py
+++ b/bot/tests/test_position_sync_failure_truth_v98.py
@@ -62,6 +62,82 @@ def test_v98_allows_fresh_success_to_reestablish_sync() -> None:
     assert module._adopt_broker_positions(broker, "user:test:kraken", None) == 0
     assert broker._startup_position_sync_adopted is True
     assert broker._startup_position_sync_symbols == tuple()
+    assert broker._startup_position_sync_fetch_ok is True
+    assert broker._startup_position_sync_error is None
+
+
+def test_v98_preserves_explicit_fetch_failure_over_legacy_empty_adoption() -> None:
+    patch = importlib.import_module("bot.position_sync_failure_truth_v98_patch")
+    module = ModuleType("startup_position_sync_test_v98_masked_failure")
+    module.__file__ = "/tmp/startup_position_sync.py"
+
+    def adopt(broker, broker_name, eps):
+        del broker_name, eps
+        broker._startup_position_sync_fetch_ok = False
+        broker._startup_position_sync_error = "TimeoutError:position snapshot timed out"
+        broker._startup_position_sync_adopted = True
+        broker._startup_position_sync_symbols = tuple()
+        return 0
+
+    module._adopt_broker_positions = adopt
+    assert patch._patch_startup_sync(module)
+
+    broker = SimpleNamespace(_startup_position_sync_adopted=False)
+    os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "1"
+    os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "1"
+
+    assert module._adopt_broker_positions(broker, "platform:okx", None) == 0
+    assert broker._startup_position_sync_fetch_ok is False
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_symbols == tuple()
+    assert os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] == "0"
+    assert os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] == "0"
+
+
+def test_v98_success_satisfies_v146_independent_fetch_proof() -> None:
+    patch = importlib.import_module("bot.position_sync_failure_truth_v98_patch")
+    v146 = importlib.import_module("bot.runtime_reconciliation_shutdown_v146_patch")
+    startup = ModuleType("startup_position_sync_test_v98_v146")
+    startup.__file__ = "/tmp/startup_position_sync.py"
+
+    def adopt(broker, broker_name, eps):
+        del broker_name, eps
+        broker.get_positions()
+        broker._startup_position_sync_adopted = True
+        broker._startup_position_sync_symbols = tuple()
+        return 0
+
+    startup._adopt_broker_positions = adopt
+    assert patch._patch_startup_sync(startup)
+
+    broker = SimpleNamespace(
+        is_connected=True,
+        _startup_position_sync_adopted=False,
+        get_positions=lambda: [],
+    )
+    assert startup._adopt_broker_positions(broker, "platform:kraken", None) == 0
+
+    manager = SimpleNamespace(platform_brokers={"kraken": broker}, user_brokers={})
+
+    class V95:
+        @staticmethod
+        def _connected_brokers(value):
+            assert value is manager
+            return {"platform:kraken": broker}
+
+        @staticmethod
+        def position_sync_status(value):
+            assert value is manager
+            return True, [], {"platform:kraken": True}
+
+    publication = ModuleType("position_sync_publication_test_v146")
+    publication._v95_module = lambda: V95
+
+    ready, pending, status = v146._position_sync_truth(publication, manager)
+
+    assert ready is True
+    assert pending == []
+    assert status == {"platform:kraken": True}
 
 
 def test_v98_installer_is_mandatory_after_v97() -> None:

--- a/bot/tests/test_render_liveness_readiness.py
+++ b/bot/tests/test_render_liveness_readiness.py
@@ -18,6 +18,10 @@ def _reset(monkeypatch, tmp_path):
     for name in (
         "NIJA_RUNTIME_TRADING_STATE",
         "NIJA_RUNTIME_EXECUTION_AUTHORITY",
+        "NIJA_RECONCILIATION_COMPLETE",
+        "NIJA_RECONCILIATION_STATUS",
+        "NIJA_POSITION_SYNC_ACTIVATION_READY",
+        "NIJA_RUNTIME_RELEASE_ID",
         "NIJA_REQUIRE_SECONDARY_VENUES_READY",
         "NIJA_SECONDARY_VENUE_POLICY",
         "NIJA_REQUIRED_VENUES_READY",
@@ -50,6 +54,9 @@ def test_broker_local_readiness_allows_healthy_kraken_when_secondaries_are_missi
     monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
     monkeypatch.setenv("NIJA_MULTI_BROKER_TRADING_READY", "1")
     monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+    monkeypatch.setenv("NIJA_RECONCILIATION_COMPLETE", "true")
+    monkeypatch.setenv("NIJA_RECONCILIATION_STATUS", "CLEAN_START")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
 
     ready, details = server._readiness()
@@ -73,6 +80,10 @@ def test_global_all_required_policy_blocks_until_required_venues_are_ready(monke
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_READY", "0")
     monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
     monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+    monkeypatch.setenv("NIJA_RECONCILIATION_COMPLETE", "true")
+    monkeypatch.setenv("NIJA_RECONCILIATION_STATUS", "CLEAN_START")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_RELEASE_ID", "20260818-runtime-convergence-v146")
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
 
     ready, details = server._readiness()
@@ -120,6 +131,9 @@ def test_readiness_passes_with_all_required_venues_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("NIJA_OKX_ACTIVATION_STATE", "ready")
     monkeypatch.setenv("NIJA_OKX_CONNECTED", "1")
     monkeypatch.setenv("NIJA_OKX_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_RECONCILIATION_COMPLETE", "true")
+    monkeypatch.setenv("NIJA_RECONCILIATION_STATUS", "CLEAN_START")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
 
     ready, details = server._readiness()
 
@@ -141,6 +155,10 @@ def test_bridge_normalizes_contradictory_required_venue_state(monkeypatch, tmp_p
     monkeypatch.setenv("NIJA_REQUIRED_VENUES_MISSING", "coinbase,okx")
     monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
     monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+    monkeypatch.setenv("NIJA_RECONCILIATION_COMPLETE", "true")
+    monkeypatch.setenv("NIJA_RECONCILIATION_STATUS", "CLEAN_START")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "1")
+    monkeypatch.setenv("NIJA_RUNTIME_RELEASE_ID", "20260818-runtime-convergence-v146")
 
     payload = bridge.publish_once()
 
@@ -163,6 +181,32 @@ def test_bridge_normalizes_contradictory_required_venue_state(monkeypatch, tmp_p
     assert details["writer_authority"] == "1"
     assert details["required_venues_ready"] is False
     assert details["global_trading_ready"] is True
+    assert details["reconciliation_complete"] is True
+    assert details["reconciliation_status"] == "CLEAN_START"
+    assert details["reconciliation_ready"] is True
+    assert details["position_sync_ready"] is True
+    assert details["runtime_release_id"] == "20260818-runtime-convergence-v146"
+
+
+def test_shared_readiness_fails_closed_when_reconciliation_regresses(monkeypatch, tmp_path):
+    _reset(monkeypatch, tmp_path)
+    monkeypatch.setenv("RENDER", "true")
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "1")
+    monkeypatch.setenv("NIJA_SECONDARY_VENUE_POLICY", "broker_local")
+    monkeypatch.setenv("NIJA_GLOBAL_TRADING_READY", "1")
+    monkeypatch.setenv("NIJA_ACTIVE_LIVE_VENUES", "kraken")
+    monkeypatch.setenv("NIJA_RECONCILIATION_COMPLETE", "false")
+    monkeypatch.setenv("NIJA_RECONCILIATION_STATUS", "PENDING")
+    monkeypatch.setenv("NIJA_POSITION_SYNC_ACTIVATION_READY", "0")
+
+    bridge.publish_once()
+    ready, details = server._readiness()
+
+    assert ready is False
+    assert details["state"] == "LIVE_ACTIVE"
+    assert details["reconciliation_ready"] is False
+    assert details["position_sync_ready"] is False
 
 
 def test_render_without_fresh_shared_state_is_safely_not_ready(monkeypatch, tmp_path):

--- a/render_liveness_server.py
+++ b/render_liveness_server.py
@@ -92,6 +92,16 @@ def _environment_snapshot() -> dict[str, Any]:
     return {
         "state": os.environ.get("NIJA_RUNTIME_TRADING_STATE", "OFF"),
         "writer_authority": os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0"),
+        "reconciliation_complete": os.environ.get(
+            "NIJA_RECONCILIATION_COMPLETE", "false"
+        ),
+        "reconciliation_status": os.environ.get(
+            "NIJA_RECONCILIATION_STATUS", "PENDING"
+        ),
+        "position_sync_ready": os.environ.get(
+            "NIJA_POSITION_SYNC_ACTIVATION_READY", "0"
+        ),
+        "runtime_release_id": os.environ.get("NIJA_RUNTIME_RELEASE_ID", "unknown"),
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "false"
         ),
@@ -145,6 +155,10 @@ def _safe_render_startup_snapshot() -> dict[str, Any]:
     return {
         "state": "OFF",
         "writer_authority": "0",
+        "reconciliation_complete": "0",
+        "reconciliation_status": "PENDING",
+        "position_sync_ready": "0",
+        "runtime_release_id": os.environ.get("NIJA_RUNTIME_RELEASE_ID", "unknown"),
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "true"
         ),
@@ -211,6 +225,24 @@ def _readiness() -> tuple[bool, dict[str, object]]:
     policy = _normalised_policy(snapshot)
     required_ready = _truthy_value(snapshot.get("required_venues_ready"))
     global_ready = _global_ready_from_snapshot(snapshot, required_ready)
+    reconciliation_reported = any(
+        key in snapshot
+        for key in ("reconciliation_complete", "reconciliation_status")
+    )
+    reconciliation_complete = _truthy_value(snapshot.get("reconciliation_complete"))
+    reconciliation_status = str(
+        snapshot.get("reconciliation_status") or "PENDING"
+    ).strip().upper()
+    reconciliation_ready = (
+        reconciliation_complete
+        and reconciliation_status in {"CLEAN", "CLEAN_START"}
+    ) if reconciliation_reported else True
+    position_sync_reported = "position_sync_ready" in snapshot
+    position_sync_ready = (
+        _truthy_value(snapshot.get("position_sync_ready"))
+        if position_sync_reported
+        else True
+    )
 
     if policy == "global_all_required":
         venue_policy_ready = required_ready
@@ -219,12 +251,23 @@ def _readiness() -> tuple[bool, dict[str, object]]:
         # executable live venue but do not require every secondary venue.
         venue_policy_ready = global_ready
 
-    ready = state == "LIVE_ACTIVE" and writer_ready and venue_policy_ready
+    ready = (
+        state == "LIVE_ACTIVE"
+        and writer_ready
+        and venue_policy_ready
+        and reconciliation_ready
+        and position_sync_ready
+    )
 
     details: dict[str, object] = {
         "status": "ready" if ready else "not_ready",
         "state": state,
         "writer_authority": writer_raw,
+        "reconciliation_complete": reconciliation_complete,
+        "reconciliation_status": reconciliation_status,
+        "reconciliation_ready": reconciliation_ready,
+        "position_sync_ready": position_sync_ready,
+        "runtime_release_id": snapshot.get("runtime_release_id", "unknown"),
         "strict_secondary_venues": strict,
         "secondary_venue_policy": policy,
         "required_venues_ready": required_ready,

--- a/render_readiness_state_bridge.py
+++ b/render_readiness_state_bridge.py
@@ -91,6 +91,16 @@ def _payload() -> dict[str, Any]:
         "pid": os.getpid(),
         "state": os.environ.get("NIJA_RUNTIME_TRADING_STATE", "OFF"),
         "writer_authority": os.environ.get("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0"),
+        "reconciliation_complete": "1"
+        if _truthy(os.environ.get("NIJA_RECONCILIATION_COMPLETE", "false"))
+        else "0",
+        "reconciliation_status": str(
+            os.environ.get("NIJA_RECONCILIATION_STATUS", "PENDING") or "PENDING"
+        ).strip().upper(),
+        "position_sync_ready": "1"
+        if _truthy(os.environ.get("NIJA_POSITION_SYNC_ACTIVATION_READY", "0"))
+        else "0",
+        "runtime_release_id": os.environ.get("NIJA_RUNTIME_RELEASE_ID", "unknown"),
         "strict_secondary_venues": os.environ.get(
             "NIJA_REQUIRE_SECONDARY_VENUES_READY", "false"
         ),


### PR DESCRIPTION
## Summary
- restore independent fetch proof after the canonical position snapshot is fully adopted
- preserve explicit transport failures over legacy empty-snapshot fallbacks
- publish reconciliation and position-sync proof through the Render readiness bridge
- make public trading readiness fail closed when either proof regresses

## Production evidence
The 2026-08-18 Render logs repeatedly show all connected snapshots adopted while v146 corrects `reported_ready=true` to `final_ready=false` because `_startup_position_sync_fetch_ok` was never republished. The latest excerpt still reports `position_sync_ready` as the first activation blocker.

## Validation
- 61 surrounding startup/reconciliation tests passed
- 14 Render health/readiness tests passed
- 23 focused regression tests passed
- all changed Python files compile
- Render/production shell entrypoints pass `bash -n`
- unsafe-bypass and secret-pattern scan clean
- no trading strategy, risk sizing, broker API, writer-lock, nonce, or order-dispatch logic changed

One pre-existing AST harness test in `test_fast_path_import_v110.py` still raises `NameError: logger`; the same failure exists on `main` and is unrelated to this patch.