### PR TITLE
Preserve position sync account isolation in v146

### DIFF
--- a/bot/runtime_reconciliation_shutdown_v146_patch.py
+++ b/bot/runtime_reconciliation_shutdown_v146_patch.py
@@ -57,6 +57,24 @@ def _position_sync_truth(module: ModuleType, manager: Any) -> tuple[bool, list[s
         ready, pending, status = v95.position_sync_status(manager)
         normalized = {str(name): bool(value) for name, value in dict(status or {}).items()}
         connected = dict(v95._connected_brokers(manager) or {})
+
+        # v99 intentionally isolates global platform readiness from per-user
+        # copy-trading accounts.  Its patched status function reports only
+        # ``platform:*`` brokers and exposes ``platform_position_sync_status``
+        # as the scope contract.  Apply the independent fetch proof to that
+        # same broker set; comparing platform-only status with every connected
+        # user broker silently undoes v99 and lets a late user connection revoke
+        # the whole platform after activation.  User brokers remain fail closed
+        # behind v99's per-account execution guard and diagnostics.
+        platform_scope = callable(
+            getattr(v95, "platform_position_sync_status", None)
+        )
+        if platform_scope:
+            connected = {
+                str(name): broker
+                for name, broker in connected.items()
+                if str(name).startswith("platform:")
+            }
         connected_names = {str(name) for name in connected}
         status_names = set(normalized)
         fetch_pending = sorted(

--- a/tests/runtime_reconciliation_shutdown_v146_test.py
+++ b/tests/runtime_reconciliation_shutdown_v146_test.py
@@ -109,6 +109,76 @@ class RuntimeReconciliationShutdownV146Tests(unittest.TestCase):
         self.assertEqual(pending, ["platform:coinbase", "platform:kraken"])
         self.assertEqual(status, {"platform:kraken": True})
 
+    def test_v99_platform_scope_does_not_reintroduce_user_brokers(self) -> None:
+        platform = types.SimpleNamespace(
+            _startup_position_sync_adopted=True,
+            _startup_position_sync_fetch_ok=True,
+        )
+        user = types.SimpleNamespace(
+            _startup_position_sync_adopted=False,
+            _startup_position_sync_fetch_ok=None,
+        )
+
+        class V95:
+            platform_position_sync_status = staticmethod(lambda _manager: None)
+
+            @staticmethod
+            def position_sync_status(_manager):
+                return True, [], {"platform:kraken": True}
+
+            @staticmethod
+            def _connected_brokers(_manager):
+                return {
+                    "platform:kraken": platform,
+                    "user:customer:kraken": user,
+                }
+
+        module = types.ModuleType("fake_position_sync_v96_v99_scope")
+        module._v95_module = lambda: V95
+
+        ready, pending, status = v146._position_sync_truth(module, object())
+
+        self.assertTrue(ready)
+        self.assertEqual(pending, [])
+        self.assertEqual(status, {"platform:kraken": True})
+
+    def test_v99_platform_scope_still_requires_every_platform_fetch_proof(self) -> None:
+        kraken = types.SimpleNamespace(_startup_position_sync_fetch_ok=True)
+        coinbase = types.SimpleNamespace(_startup_position_sync_fetch_ok=None)
+
+        class V95:
+            platform_position_sync_status = staticmethod(lambda _manager: None)
+
+            @staticmethod
+            def position_sync_status(_manager):
+                return (
+                    True,
+                    [],
+                    {"platform:kraken": True, "platform:coinbase": True},
+                )
+
+            @staticmethod
+            def _connected_brokers(_manager):
+                return {
+                    "platform:kraken": kraken,
+                    "platform:coinbase": coinbase,
+                    "user:customer:kraken": types.SimpleNamespace(
+                        _startup_position_sync_fetch_ok=True
+                    ),
+                }
+
+        module = types.ModuleType("fake_position_sync_v96_v99_fetch")
+        module._v95_module = lambda: V95
+
+        ready, pending, status = v146._position_sync_truth(module, object())
+
+        self.assertFalse(ready)
+        self.assertEqual(pending, ["platform:coinbase"])
+        self.assertEqual(
+            status,
+            {"platform:kraken": True, "platform:coinbase": True},
+        )
+
     def test_position_sync_regression_revokes_clean_proof(self) -> None:
         os.environ["NIJA_RECONCILIATION_STATUS"] = "CLEAN_START"
         os.environ["NIJA_RECONCILIATION_COMPLETE"] = "true"


### PR DESCRIPTION
## Summary
- make v146 apply independent fetch proof to the same global broker scope selected by v99
- preserve platform-only global readiness when user copy-trading accounts connect later
- keep every connected platform broker fail closed without its own fetch proof
- retain v99 per-user execution blocking and user-sync diagnostics

## Production evidence
After PR #2589, Render proved the original repair by publishing `CLEAN_START` and `position_sync_ready=true`. When the user Kraken account connected later, v146 compared v99's platform-only status keys against v95's platform-plus-user broker set and revoked global reconciliation. The public health endpoint correctly stayed fail closed.

## Validation
- 63 surrounding startup/reconciliation/Render tests passed
- 49 focused reconciliation/account-isolation tests passed
- changed Python compiles and shell entrypoints parse
- unsafe-bypass and secret-pattern scan clean
- no strategy, risk sizing, writer-lock, nonce, broker API, or order-dispatch behavior changed