### PR TITLE
Keep Render live during transient runtime exits

### DIFF
--- a/bot/tests/test_render_runtime_recovery_v147.py
+++ b/bot/tests/test_render_runtime_recovery_v147.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+START_SCRIPT = ROOT / "start.sh"
+RENDER_BLUEPRINT = ROOT / "render.yaml"
+
+
+def test_render_recovery_is_narrow_and_fail_closed() -> None:
+    source = START_SCRIPT.read_text(encoding="utf-8")
+    recovery = source[
+        source.index("_RENDER_RUNTIME_RECOVERY=false") :
+        source.index("# Treat SIGTERM (143) as graceful")
+    ]
+
+    assert "42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
+    assert "writer_authority_bypass=false" in recovery
+    assert "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py" in recovery
+    assert "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true" not in recovery
+    assert "NIJA_DISABLE_WRITER_LOCK=true" not in recovery
+    assert "NIJA_SKIP_STARTUP_PHASE_GATE=true" not in recovery
+
+
+def test_render_recovery_waits_beyond_the_writer_lease() -> None:
+    source = START_SCRIPT.read_text(encoding="utf-8")
+
+    assert "(_LEASE_TTL_FOR_RECOVERY_MS + 999) / 1000 + 5" in source
+    assert '_RENDER_RUNTIME_RECOVERY_DELAY_S="${NIJA_RENDER_RUNTIME_RECOVERY_DELAY_S:-}"' in source
+    assert 'sleep "${_RENDER_RUNTIME_RECOVERY_DELAY_S}"' in source
+    assert "_RENDER_RUNTIME_RECOVERY_DELAY_S=15" in source
+    assert "_RENDER_RUNTIME_RECOVERY_DELAY_S=120" in source
+
+
+def test_render_recovery_is_bounded_and_unknown_failures_escape() -> None:
+    source = START_SCRIPT.read_text(encoding="utf-8")
+
+    assert '_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS="${NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS:-12}"' in source
+    assert "RENDER_RUNTIME_RECOVERY_EXHAUSTED" in source
+    assert '[ "${_RENDER_RUNTIME_RECOVERABLE}" != "true" ]' in source
+    assert source.index("RENDER_RUNTIME_RECOVERY_EXHAUSTED") < source.index('echo "❌ Bot crashed! Exit code: $status"')
+
+
+def test_render_blueprint_pins_recovery_window() -> None:
+    source = RENDER_BLUEPRINT.read_text(encoding="utf-8")
+
+    assert "NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS" in source
+    assert 'value: "12"' in source
+    assert "NIJA_RENDER_RUNTIME_RECOVERY_DELAY_S" in source
+    assert 'value: "65"' in source

--- a/render.yaml
+++ b/render.yaml
@@ -147,6 +147,14 @@ services:
         value: "5"
       - key: NIJA_RENDER_STARTUP_RECOVERY_MAX_ATTEMPTS
         value: "60"
+      # Keep the isolated liveness endpoint available while Render-local
+      # transient writer/worker exits wait for the old Redis lease to expire.
+      # Unknown exit statuses still terminate the container for platform-level
+      # recovery; no writer, nonce, or execution-authority gate is bypassed.
+      - key: NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS
+        value: "12"
+      - key: NIJA_RENDER_RUNTIME_RECOVERY_DELAY_S
+        value: "65"
       - key: NIJA_CAPITAL_WATCHDOG_INTERVAL_S
         value: "5"
       - key: NIJA_CAPITAL_STARTUP_INVARIANT_TIMEOUT_S

--- a/start.sh
+++ b/start.sh
@@ -1612,11 +1612,65 @@ _cleanup_pid_lock() {
 }
 trap '_cleanup_pid_lock' EXIT INT TERM
 
-set +e
-NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py
-status=$?
-echo "🧭 STARTUP_HANDOFF_RUNTIME_EXIT status=${status}"
-set -e
+_RENDER_RUNTIME_RECOVERY=false
+if _is_truthy_flag "${RENDER:-0}" \
+    || [ -n "${RENDER_SERVICE_ID:-}${RENDER_SERVICE_NAME:-}${RENDER_INSTANCE_ID:-}${RENDER_GIT_COMMIT:-}" ]; then
+    _RENDER_RUNTIME_RECOVERY=true
+fi
+
+_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS="${NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS:-12}"
+if ! printf "%s" "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" | grep -Eq '^[0-9]+$' \
+    || [ "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" -le 0 ]; then
+    _RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS=12
+fi
+
+_RENDER_RUNTIME_RECOVERY_DELAY_S="${NIJA_RENDER_RUNTIME_RECOVERY_DELAY_S:-}"
+if ! printf "%s" "${_RENDER_RUNTIME_RECOVERY_DELAY_S}" | grep -Eq '^[0-9]+$' \
+    || [ "${_RENDER_RUNTIME_RECOVERY_DELAY_S:-0}" -le 0 ]; then
+    _LEASE_TTL_FOR_RECOVERY_MS="${NIJA_REDIS_LEASE_TTL_MS:-60000}"
+    if ! printf "%s" "${_LEASE_TTL_FOR_RECOVERY_MS}" | grep -Eq '^[0-9]+$'; then
+        _LEASE_TTL_FOR_RECOVERY_MS=60000
+    fi
+    _RENDER_RUNTIME_RECOVERY_DELAY_S=$(((_LEASE_TTL_FOR_RECOVERY_MS + 999) / 1000 + 5))
+fi
+if [ "${_RENDER_RUNTIME_RECOVERY_DELAY_S}" -lt 15 ]; then
+    _RENDER_RUNTIME_RECOVERY_DELAY_S=15
+elif [ "${_RENDER_RUNTIME_RECOVERY_DELAY_S}" -gt 120 ]; then
+    _RENDER_RUNTIME_RECOVERY_DELAY_S=120
+fi
+
+_RENDER_RUNTIME_RECOVERY_ATTEMPT=0
+while true; do
+    set +e
+    NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py
+    status=$?
+    echo "🧭 STARTUP_HANDOFF_RUNTIME_EXIT status=${status}"
+    set -e
+
+    _RENDER_RUNTIME_RECOVERABLE=false
+    case "${status}" in
+        42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
+    esac
+
+    if [ "${_RENDER_RUNTIME_RECOVERY}" != "true" ] \
+        || [ "${_RENDER_RUNTIME_RECOVERABLE}" != "true" ]; then
+        break
+    fi
+
+    _RENDER_RUNTIME_RECOVERY_ATTEMPT=$((_RENDER_RUNTIME_RECOVERY_ATTEMPT + 1))
+    if [ "${_RENDER_RUNTIME_RECOVERY_ATTEMPT}" -gt "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" ]; then
+        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v147 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
+        break
+    fi
+
+    # The isolated liveness server remains online while the failed writer
+    # process is gone. Waiting beyond the lease TTL prevents the replacement
+    # from racing a stale Redis owner token. The next canonical interpreter
+    # still has to acquire a fresh generation and pass every readiness gate.
+    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v147 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
+    sleep "${_RENDER_RUNTIME_RECOVERY_DELAY_S}"
+    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v147 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
+done
 
 # Treat SIGTERM (143) as graceful to avoid restart loops during platform stop/redeploy
 if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

Keep Render's isolated `/healthz` process online when the canonical bot subprocess exits with an already-defined fail-closed transient status: writer-lock contention (42), terminal writer loss (75), or killed worker (137). The supervisor waits 65 seconds—beyond the 60-second Redis lease TTL—then launches a fresh canonical interpreter that must reacquire writer authority and pass every readiness gate. Unknown exits still terminate the container for Render-level recovery.

## Risk Assessment

- Risk level: medium
- Impacted areas:
  - Render startup/runtime process supervision
  - Redis writer-lease handoff timing
- Key failure modes:
  - A persistent transient failure retries repeatedly; retries are bounded to 12 before delegating to Render.
  - An unknown crash is not recovered in-process and continues to use Render's normal restart behavior.

No trading strategy, broker execution, risk sizing, nonce, writer-lock, or execution-authority rule is changed or bypassed.

## Rollback Plan

- Revert strategy:
  - Revert this PR to restore platform-level restarts for all nonzero canonical runtime exits.
- Data/state considerations:
  - No migrations or persistent data changes. Redis fencing tokens and lease generations remain authoritative.

## Validation

- [x] Local checks passed (15 focused tests executed directly; shell syntax, Python compilation, patcher idempotence, and diff checks passed)
- [ ] CI checks passed
- [x] Monitoring/observability impact reviewed

### NIJA Safety Checks

- [x] `python -m py_compile` clean on all changed `.py` files
- [x] No bypass flags committed (FORCE_TRADE, NIJA_FORCE_ACTIVATION, NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK, NIJA_DISABLE_WRITER_LOCK, NIJA_SKIP_STARTUP_PHASE_GATE)
- [x] Authority-gate denials are NOT recorded as exchange order rejections (kill-switch feedback loop invariant preserved)
- [x] Trading logic unchanged; backtest not applicable