### PR TITLE
Recover generic Render runtime crashes in-process

### DIFF
--- a/bot/tests/test_render_runtime_recovery_v147.py
+++ b/bot/tests/test_render_runtime_recovery_v147.py
@@ -15,7 +15,7 @@ def test_render_recovery_is_narrow_and_fail_closed() -> None:
         source.index("# Treat SIGTERM (143) as graceful")
     ]
 
-    assert "42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
+    assert "1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
     assert "writer_authority_bypass=false" in recovery
     assert "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py" in recovery
     assert "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true" not in recovery

--- a/render.yaml
+++ b/render.yaml
@@ -149,8 +149,9 @@ services:
         value: "60"
       # Keep the isolated liveness endpoint available while Render-local
       # transient writer/worker exits wait for the old Redis lease to expire.
-      # Unknown exit statuses still terminate the container for platform-level
-      # recovery; no writer, nonce, or execution-authority gate is bypassed.
+      # Generic canonical crashes and known transient exits retry in-process;
+      # other statuses still terminate the container for platform recovery.
+      # No writer, nonce, or execution-authority gate is bypassed.
       - key: NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS
         value: "12"
       - key: NIJA_RENDER_RUNTIME_RECOVERY_DELAY_S

--- a/start.sh
+++ b/start.sh
@@ -1649,7 +1649,7 @@ while true; do
 
     _RENDER_RUNTIME_RECOVERABLE=false
     case "${status}" in
-        42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
+        1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
     esac
 
     if [ "${_RENDER_RUNTIME_RECOVERY}" != "true" ] \
@@ -1659,7 +1659,7 @@ while true; do
 
     _RENDER_RUNTIME_RECOVERY_ATTEMPT=$((_RENDER_RUNTIME_RECOVERY_ATTEMPT + 1))
     if [ "${_RENDER_RUNTIME_RECOVERY_ATTEMPT}" -gt "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" ]; then
-        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v147 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
+        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v148 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
         break
     fi
 
@@ -1667,9 +1667,9 @@ while true; do
     # process is gone. Waiting beyond the lease TTL prevents the replacement
     # from racing a stale Redis owner token. The next canonical interpreter
     # still has to acquire a fresh generation and pass every readiness gate.
-    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v147 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
+    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v148 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
     sleep "${_RENDER_RUNTIME_RECOVERY_DELAY_S}"
-    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v147 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
+    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v148 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
 done
 
 # Treat SIGTERM (143) as graceful to avoid restart loops during platform stop/redeploy


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

Production verification of #2591 showed another full container restart at approximately 236 seconds. Because the v147 supervisor did not intercept it, the canonical launcher most likely returned its generic crash status (`1`) rather than one of the previously enumerated transient statuses. Extend the same bounded Render-only recovery to status `1`, preserving `/healthz` while waiting beyond the Redis lease TTL and starting a fresh canonical interpreter.

## Risk Assessment

- Risk level: medium
- Impacted areas:
  - Render runtime process supervision only
- Key failure modes:
  - A persistent generic crash retries up to 12 times with a 65-second delay, then delegates to Render.
  - A whole-container platform kill/OOM cannot be recovered by this shell path; the next production hold will distinguish that case.

All retries remain fail-closed. A replacement interpreter must acquire a fresh writer generation and satisfy unchanged nonce, reconciliation, readiness, risk, and execution-authority gates.

## Rollback Plan

- Revert this PR to return generic status `1` to Render immediately.
- No migrations or persistent state changes.

## Validation

- [x] 15 focused tests executed directly
- [x] `bash -n start.sh`
- [x] Python compilation, startup patcher idempotence, and diff checks
- [x] No secrets or bypass flags added
- [ ] CI/security checks passed

### NIJA Safety Checks

- [x] Trading logic unchanged; backtest not applicable
- [x] Writer-lock and authority gates unchanged
- [x] Unknown non-runtime statuses continue to exit to the platform