### PR TITLE
Recover unexpected clean Render runtime returns

### DIFF
--- a/bot/tests/test_render_runtime_recovery_v147.py
+++ b/bot/tests/test_render_runtime_recovery_v147.py
@@ -15,7 +15,8 @@ def test_render_recovery_is_narrow_and_fail_closed() -> None:
         source.index("# Treat SIGTERM (143) as graceful")
     ]
 
-    assert "1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
+    assert "0|1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
+    assert "143) _RENDER_RUNTIME_RECOVERABLE=true" not in recovery
     assert "writer_authority_bypass=false" in recovery
     assert "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py" in recovery
     assert "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true" not in recovery

--- a/render.yaml
+++ b/render.yaml
@@ -149,8 +149,9 @@ services:
         value: "60"
       # Keep the isolated liveness endpoint available while Render-local
       # transient writer/worker exits wait for the old Redis lease to expire.
-      # Generic canonical crashes and known transient exits retry in-process;
-      # other statuses still terminate the container for platform recovery.
+      # A clean return is unexpected for this continuous service. Clean returns,
+      # generic canonical crashes, and known transient exits retry in-process;
+      # SIGTERM and other statuses still terminate for platform recovery.
       # No writer, nonce, or execution-authority gate is bypassed.
       - key: NIJA_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS
         value: "12"

--- a/start.sh
+++ b/start.sh
@@ -1649,7 +1649,7 @@ while true; do
 
     _RENDER_RUNTIME_RECOVERABLE=false
     case "${status}" in
-        1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
+        0|1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
     esac
 
     if [ "${_RENDER_RUNTIME_RECOVERY}" != "true" ] \
@@ -1659,7 +1659,7 @@ while true; do
 
     _RENDER_RUNTIME_RECOVERY_ATTEMPT=$((_RENDER_RUNTIME_RECOVERY_ATTEMPT + 1))
     if [ "${_RENDER_RUNTIME_RECOVERY_ATTEMPT}" -gt "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" ]; then
-        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v148 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
+        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v149 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
         break
     fi
 
@@ -1667,9 +1667,9 @@ while true; do
     # process is gone. Waiting beyond the lease TTL prevents the replacement
     # from racing a stale Redis owner token. The next canonical interpreter
     # still has to acquire a fresh generation and pass every readiness gate.
-    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v148 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
+    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v149 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
     sleep "${_RENDER_RUNTIME_RECOVERY_DELAY_S}"
-    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v148 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
+    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v149 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
 done
 
 # Treat SIGTERM (143) as graceful to avoid restart loops during platform stop/redeploy


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

The v148 production hold stayed active past the prior reset boundary, then the Render liveness process restarted at approximately 360 seconds without v148 intercepting statuses 1/42/75/137. For this continuous live service, a canonical launcher return of status `0` is unexpected unless the platform is stopping the service. Recover status `0` in-process on Render, while explicitly leaving SIGTERM (`143`) outside recovery so deployments and shutdowns remain graceful.

## Risk Assessment

- Risk level: medium
- Impacted areas: Render runtime process supervision only
- Key failure modes:
  - Repeated clean returns retry up to 12 times with 65-second lease-safe spacing, then delegate to Render.
  - Platform SIGTERM remains terminal and is not intercepted.

Every restarted interpreter must reacquire a fresh Redis writer generation and pass unchanged nonce, reconciliation, readiness, risk, and execution-authority gates.

## Rollback Plan

Revert this PR to restore immediate container exit after status `0`. No migrations or persistent state changes.

## Validation

- [x] 15 focused tests executed directly
- [x] `bash -n start.sh`
- [x] Python compilation, startup patcher idempotence, and diff checks
- [x] No secrets or bypass flags added
- [ ] CI/security checks passed

### NIJA Safety Checks

- [x] Trading logic unchanged; backtest not applicable
- [x] Writer-lock and authority gates unchanged
- [x] SIGTERM remains a graceful platform stop