### PR TITLE
Bound Render memory pressure and expose OOM telemetry

### DIFF
--- a/bot/tests/test_render_memory_observability_v150.py
+++ b/bot/tests/test_render_memory_observability_v150.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import render_liveness_server as server
+
+
+def test_memory_snapshot_reports_cgroup_pressure_and_runtime_rss() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        cgroup = root / "cgroup"
+        proc = root / "proc"
+        runtime = proc / "321"
+        cgroup.mkdir()
+        runtime.mkdir(parents=True)
+
+        (cgroup / "memory.current").write_text(str(384 * 1024 * 1024), encoding="utf-8")
+        (cgroup / "memory.max").write_text(str(512 * 1024 * 1024), encoding="utf-8")
+        (cgroup / "memory.peak").write_text(str(448 * 1024 * 1024), encoding="utf-8")
+        (cgroup / "memory.events").write_text(
+            "low 0\nhigh 3\nmax 9\noom 2\noom_kill 1\n",
+            encoding="utf-8",
+        )
+        (runtime / "cmdline").write_bytes(
+            b"python\0-u\0scripts/canonical_runtime_launcher_v26.py\0"
+        )
+        (runtime / "status").write_text(
+            "Name:\tpython\nVmRSS:\t262144 kB\nThreads:\t17\n",
+            encoding="utf-8",
+        )
+
+        details = server._memory_snapshot(cgroup, proc)
+
+    assert details["memory_current_mb"] == 384.0
+    assert details["memory_limit_mb"] == 512.0
+    assert details["memory_peak_mb"] == 448.0
+    assert details["memory_utilization_percent"] == 75.0
+    assert details["memory_oom_count"] == 2
+    assert details["memory_oom_kill_count"] == 1
+    assert details["runtime_pid"] == 321
+    assert details["runtime_rss_mb"] == 256.0
+    assert details["runtime_threads"] == 17
+
+
+def test_memory_snapshot_is_safe_when_cgroup_files_are_missing() -> None:
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        details = server._memory_snapshot(root / "missing-cgroup", root / "missing-proc")
+
+    assert details["memory_current_mb"] is None
+    assert details["memory_limit_mb"] is None
+    assert details["memory_utilization_percent"] is None
+    assert details["memory_oom_kill_count"] == 0
+    assert "runtime_pid" not in details
+
+
+def test_render_blueprint_bounds_native_memory_concurrency() -> None:
+    source = (Path(__file__).resolve().parents[2] / "render.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for name in (
+        "OPENBLAS_NUM_THREADS",
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    ):
+        assert f"key: {name}\n        value: \"1\"" in source
+    assert 'key: MALLOC_ARENA_MAX\n        value: "2"' in source
+    assert 'key: MALLOC_TRIM_THRESHOLD_\n        value: "131072"' in source

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,21 @@ services:
         value: "5000"
       - key: WEB_CONCURRENCY
         value: "1"
+      # Bound native numerical-library threads and glibc allocation arenas on
+      # the memory-constrained Render worker. This changes resource usage only;
+      # strategy calculations and live-trading safety gates are unchanged.
+      - key: OPENBLAS_NUM_THREADS
+        value: "1"
+      - key: OMP_NUM_THREADS
+        value: "1"
+      - key: MKL_NUM_THREADS
+        value: "1"
+      - key: NUMEXPR_NUM_THREADS
+        value: "1"
+      - key: MALLOC_ARENA_MAX
+        value: "2"
+      - key: MALLOC_TRIM_THRESHOLD_
+        value: "131072"
       - key: ALLOW_CONSUMER_USD
         value: "true"
 

--- a/render_liveness_server.py
+++ b/render_liveness_server.py
@@ -23,6 +23,121 @@ _STARTED_AT = time.time()
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 
 
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+
+
+def _bytes_to_mb(value: Optional[str]) -> Optional[float]:
+    if value is None or value == "max":
+        return None
+    try:
+        return round(max(0, int(value)) / (1024 * 1024), 3)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_proc_status(path: Path) -> dict[str, str]:
+    raw = _read_text(path)
+    if raw is None:
+        return {}
+    parsed: dict[str, str] = {}
+    for line in raw.splitlines():
+        key, separator, value = line.partition(":")
+        if separator:
+            parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _runtime_process_snapshot(proc_root: Path = Path("/proc")) -> dict[str, object]:
+    """Return bounded runtime RSS/thread telemetry without importing psutil."""
+    try:
+        candidates = sorted(
+            (path for path in proc_root.iterdir() if path.name.isdigit()),
+            key=lambda path: int(path.name),
+        )
+    except (FileNotFoundError, PermissionError, OSError):
+        return {}
+
+    for process_dir in candidates:
+        try:
+            command = (process_dir / "cmdline").read_bytes().replace(b"\0", b" ").decode(
+                "utf-8", errors="replace"
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if "canonical_runtime_launcher_v26.py" not in command:
+            continue
+
+        status = _parse_proc_status(process_dir / "status")
+        rss_text = str(status.get("VmRSS", "0 kB")).split()[0]
+        try:
+            rss_mb = round(max(0, int(rss_text)) / 1024, 3)
+        except (TypeError, ValueError):
+            rss_mb = None
+        try:
+            thread_count: Optional[int] = max(0, int(status.get("Threads", "0")))
+        except (TypeError, ValueError):
+            thread_count = None
+        return {
+            "runtime_pid": int(process_dir.name),
+            "runtime_rss_mb": rss_mb,
+            "runtime_threads": thread_count,
+        }
+    return {}
+
+
+def _memory_snapshot(
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+    proc_root: Path = Path("/proc"),
+) -> dict[str, object]:
+    """Read cgroup v2/v1 memory pressure plus canonical runtime RSS."""
+    current_raw = _read_text(cgroup_root / "memory.current")
+    limit_raw = _read_text(cgroup_root / "memory.max")
+    peak_raw = _read_text(cgroup_root / "memory.peak")
+    events_raw = _read_text(cgroup_root / "memory.events")
+
+    if current_raw is None:
+        legacy = cgroup_root / "memory"
+        current_raw = _read_text(legacy / "memory.usage_in_bytes")
+        limit_raw = _read_text(legacy / "memory.limit_in_bytes")
+        peak_raw = _read_text(legacy / "memory.max_usage_in_bytes")
+        events_raw = _read_text(legacy / "memory.failcnt")
+
+    current_mb = _bytes_to_mb(current_raw)
+    limit_mb = _bytes_to_mb(limit_raw)
+    peak_mb = _bytes_to_mb(peak_raw)
+    details: dict[str, object] = {
+        "memory_current_mb": current_mb,
+        "memory_limit_mb": limit_mb,
+        "memory_peak_mb": peak_mb,
+        "memory_utilization_percent": (
+            round(current_mb * 100 / limit_mb, 2)
+            if current_mb is not None and limit_mb not in {None, 0}
+            else None
+        ),
+    }
+
+    events: dict[str, int] = {}
+    if events_raw is not None:
+        for line in events_raw.splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                try:
+                    events[parts[0]] = int(parts[1])
+                except ValueError:
+                    continue
+        if not events and events_raw.isdigit():
+            events["failcnt"] = int(events_raw)
+    details["memory_oom_count"] = events.get("oom", 0)
+    details["memory_oom_kill_count"] = events.get("oom_kill", 0)
+    details["memory_fail_count"] = events.get("failcnt", 0)
+    details.update(_runtime_process_snapshot(proc_root))
+    return details
+
+
 def _truthy_value(value: Any) -> bool:
     return str(value or "").strip().lower() in _TRUE
 
@@ -297,6 +412,7 @@ def _readiness() -> tuple[bool, dict[str, object]]:
         "uptime_seconds": round(time.time() - _STARTED_AT, 3),
         "commit": snapshot.get("commit", os.environ.get("GIT_COMMIT_SHORT", "unknown")),
     }
+    details.update(_memory_snapshot())
     return ready, details
 
 


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

Production holds across #2591–#2593 show the entire Render liveness process restarting even when every canonical runtime return status is supervised. This isolates the reset outside NIJA's subprocess exit path and makes platform resource pressure/OOM the leading remaining cause.

Apply the no-cost mitigation appropriate for a memory-constrained worker:

- limit OpenBLAS, OpenMP, MKL, and NumExpr to one native thread;
- cap glibc allocation arenas at two and enable a 128 KiB trim threshold;
- expose cgroup current/peak/limit, OOM counters, and canonical runtime RSS/thread count on `/healthz` using standard-library-only `/proc` and cgroup reads.

## Risk Assessment

- Risk level: medium
- Impacted areas: Render resource usage and health telemetry
- Key failure modes:
  - Single-thread numerical work may take longer, but strategy formulas and results are unchanged.
  - Unsupported cgroup files yield null metrics without affecting liveness or readiness.

No strategy, broker, order, risk, nonce, writer-lock, reconciliation, or execution-authority logic changes.

## Rollback Plan

Revert this PR to restore native library defaults and remove memory telemetry. No migrations or persistent state changes.

## Validation

- [x] 18 focused tests executed directly
- [x] Python compilation, shell syntax, startup patcher idempotence, line length, secret, bypass, and diff checks
- [x] Standard-library-only liveness contract preserved
- [ ] CI/security checks passed

### NIJA Safety Checks

- [x] Trading logic unchanged; backtest not applicable
- [x] Writer-lock and authority gates unchanged
- [x] Health readiness calculation unchanged