### PR TITLE
Trim Render memory under cgroup pressure

### DIFF
--- a/bot/tests/test_render_memory_pressure_guard_v151.py
+++ b/bot/tests/test_render_memory_pressure_guard_v151.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD_PATH = ROOT / "scripts" / "render_memory_pressure_guard.py"
+LAUNCHER_PATH = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("test_render_memory_guard_v151", GUARD_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_memory_pressure_reads_finite_cgroup_limit() -> None:
+    guard = _load_guard()
+    with TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "memory.current").write_text(str(384 * 1024 * 1024), encoding="utf-8")
+        (root / "memory.max").write_text(str(512 * 1024 * 1024), encoding="utf-8")
+
+        current, maximum, utilization = guard._memory_pressure(root)
+
+    assert current == 384 * 1024 * 1024
+    assert maximum == 512 * 1024 * 1024
+    assert utilization == 0.75
+
+
+def test_memory_trim_collects_and_returns_heap_pages() -> None:
+    guard = _load_guard()
+    calls: list[int] = []
+
+    collected, trimmed = guard._trim_memory(
+        collect=lambda: 7,
+        trim=lambda padding: calls.append(padding) or 1,
+    )
+
+    assert collected == 7
+    assert trimmed is True
+    assert calls == [0]
+
+
+def test_non_render_runtime_does_not_start_guard() -> None:
+    guard = _load_guard()
+    names = (
+        "RENDER",
+        "RENDER_SERVICE_ID",
+        "RENDER_SERVICE_NAME",
+        "RENDER_INSTANCE_ID",
+        "RENDER_GIT_COMMIT",
+    )
+    previous = {name: os.environ.pop(name, None) for name in names}
+    try:
+        assert guard.start() is False
+        assert guard._THREAD is None
+    finally:
+        for name, value in previous.items():
+            if value is not None:
+                os.environ[name] = value
+
+
+def test_launcher_starts_guard_before_bot_package_imports() -> None:
+    source = LAUNCHER_PATH.read_text(encoding="utf-8")
+    main_block = source[source.index("def main() -> int:") :]
+
+    assert main_block.index("_start_render_memory_pressure_guard()") < main_block.index(
+        "install_canonical_startup_guard()"
+    )
+    assert "RENDER_MEMORY_GUARD_PATH.is_file()" in source
+    assert "NIJA_RENDER_MEMORY_PRESSURE_GUARD_V151_READY" in source

--- a/render.yaml
+++ b/render.yaml
@@ -29,6 +29,12 @@ services:
         value: "2"
       - key: MALLOC_TRIM_THRESHOLD_
         value: "131072"
+      - key: NIJA_RENDER_MEMORY_TRIM_THRESHOLD
+        value: "0.72"
+      - key: NIJA_RENDER_MEMORY_GUARD_INTERVAL_S
+        value: "5"
+      - key: NIJA_RENDER_MEMORY_TRIM_MIN_GAP_S
+        value: "10"
       - key: ALLOW_CONSUMER_USD
         value: "true"
 

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -43,6 +43,7 @@ V43_PATH = ROOT / "bot" / "capital_publication_convergence_v43_patch.py"
 V44_PATH = ROOT / "bot" / "kraken_connection_convergence_v44_patch.py"
 V18_PATH = ROOT / "bot" / "production_corrective_set_v18_patch.py"
 V19_PATH = ROOT / "bot" / "entrypoint_writer_epoch_recovery_v19_patch.py"
+RENDER_MEMORY_GUARD_PATH = ROOT / "scripts" / "render_memory_pressure_guard.py"
 MAIN_PATH = ROOT / "main.py"
 LOGGER = logging.getLogger("nija.canonical_runtime_launcher")
 
@@ -57,6 +58,25 @@ def _canonical_import(module_name: str) -> ModuleType:
     if not isinstance(module, ModuleType):
         raise RuntimeError(f"canonical_import_invalid_module:{module_name}")
     return module
+
+
+def _start_render_memory_pressure_guard() -> bool:
+    """Start the stdlib-only Render guard before importing the bot package."""
+    if not RENDER_MEMORY_GUARD_PATH.is_file():
+        raise RuntimeError(
+            f"Render memory pressure guard missing: {RENDER_MEMORY_GUARD_PATH}"
+        )
+    module = _load_module_by_path(
+        "nija_render_memory_pressure_guard_v151",
+        RENDER_MEMORY_GUARD_PATH,
+    )
+    starter = getattr(module, "start", None)
+    if not callable(starter):
+        raise RuntimeError("Render memory pressure guard start callable unavailable")
+    started = bool(starter())
+    if started and os.environ.get("NIJA_RENDER_MEMORY_PRESSURE_GUARD_V151_READY") != "1":
+        raise RuntimeError("Render memory pressure guard did not attest ready")
+    return started
 
 
 def _load_module_by_path(module_name: str, path: Path) -> ModuleType:
@@ -382,6 +402,7 @@ def main() -> int:
     os.environ["NIJA_CANONICAL_ENTRYPOINT_FAST_PATH"] = "1"
     if not MAIN_PATH.is_file():
         raise RuntimeError(f"canonical main.py missing: {MAIN_PATH}")
+    _start_render_memory_pressure_guard()
     install_canonical_startup_guard()
     bot_entry, bot_main = _bootstrap_writer_first()
     print(

--- a/scripts/render_entrypoint.sh
+++ b/scripts/render_entrypoint.sh
@@ -69,6 +69,7 @@ python3 -S -m py_compile \
     bot/tests/test_writer_generation_handoff_v45.py \
     bot/tests/test_canonical_writer_first_v59.py \
     scripts/canonical_runtime_launcher_v26.py \
+    scripts/render_memory_pressure_guard.py \
     scripts/apply_canonical_launcher_v26.py \
     scripts/apply_writer_generation_handoff_v45.py \
     scripts/apply_direct_broker_prebootstrap_v27.py \
@@ -85,6 +86,7 @@ grep -Fq '_install_writer_generation_handoff_v45()' scripts/canonical_runtime_la
 grep -Fq 'CANONICAL_EARLY_WRITER_BOOTSTRAP_VERIFIED' scripts/canonical_runtime_launcher_v26.py
 grep -Fq 'CANONICAL_BOT_SINGLE_IDENTITY_HANDOFF' scripts/canonical_runtime_launcher_v26.py
 grep -Fq 'NIJA_CANONICAL_WRITER_FIRST_V59_READY' scripts/canonical_runtime_launcher_v26.py
+grep -Fq '_start_render_memory_pressure_guard()' scripts/canonical_runtime_launcher_v26.py
 grep -Fq 'bind_entrypoint_writer_authority_aliases(runtime)' bot/bot_main.py
 grep -Fq 'NIJA_ENTRYPOINT_WRITER_MODULE_IDENTITY_CONVERGED' bot/entrypoint_writer_authority.py
 grep -Fq 'heartbeat_telemetry_mutation=false' bot/broker_manager.py

--- a/scripts/render_memory_pressure_guard.py
+++ b/scripts/render_memory_pressure_guard.py
@@ -1,0 +1,142 @@
+"""Render-only memory pressure trimming for the canonical NIJA process.
+
+The guard never changes trading state. It observes the container's cgroup usage
+and, only above a configured threshold, asks Python to collect unreachable
+cycles and glibc to return free heap pages to the kernel. This creates headroom
+for transient strategy-import and scan allocations on a 512 MiB worker.
+"""
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+
+LOGGER = logging.getLogger("nija.render_memory_pressure_guard_v151")
+MARKER = "20260818-render-memory-pressure-guard-v151"
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_LOCK = threading.Lock()
+_THREAD: Optional[threading.Thread] = None
+
+
+def _truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _is_render_runtime() -> bool:
+    if _truthy(os.environ.get("RENDER")):
+        return True
+    return any(
+        str(os.environ.get(name, "") or "").strip()
+        for name in (
+            "RENDER_SERVICE_ID",
+            "RENDER_SERVICE_NAME",
+            "RENDER_INSTANCE_ID",
+            "RENDER_GIT_COMMIT",
+        )
+    )
+
+
+def _bounded_float(name: str, default: float, minimum: float, maximum: float) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _memory_pressure(cgroup_root: Path = Path("/sys/fs/cgroup")) -> Optional[tuple[int, int, float]]:
+    try:
+        current = int((cgroup_root / "memory.current").read_text(encoding="utf-8").strip())
+        maximum_raw = (cgroup_root / "memory.max").read_text(encoding="utf-8").strip()
+        if maximum_raw == "max":
+            return None
+        maximum = int(maximum_raw)
+    except (FileNotFoundError, PermissionError, OSError, TypeError, ValueError):
+        return None
+    if current < 0 or maximum <= 0:
+        return None
+    return current, maximum, current / maximum
+
+
+def _trim_memory(
+    *,
+    collect: Optional[Callable[[], int]] = None,
+    trim: Optional[Callable[[int], int]] = None,
+) -> tuple[int, bool]:
+    collector = collect or gc.collect
+    collected = int(collector())
+    trimmed = False
+    try:
+        if trim is None:
+            import ctypes
+
+            candidate = getattr(ctypes.CDLL(None), "malloc_trim", None)
+            trim = candidate if callable(candidate) else None
+        if trim is not None:
+            trimmed = bool(trim(0))
+    except Exception:
+        LOGGER.debug("RENDER_MEMORY_TRIM_UNAVAILABLE marker=%s", MARKER, exc_info=True)
+    return collected, trimmed
+
+
+def _guard_loop() -> None:
+    threshold = _bounded_float("NIJA_RENDER_MEMORY_TRIM_THRESHOLD", 0.72, 0.50, 0.95)
+    interval_s = _bounded_float("NIJA_RENDER_MEMORY_GUARD_INTERVAL_S", 5.0, 2.0, 60.0)
+    minimum_gap_s = _bounded_float("NIJA_RENDER_MEMORY_TRIM_MIN_GAP_S", 10.0, 2.0, 120.0)
+    last_trim = 0.0
+    while True:
+        pressure = _memory_pressure()
+        now = time.monotonic()
+        if pressure is not None and pressure[2] >= threshold and now - last_trim >= minimum_gap_s:
+            current, maximum, utilization = pressure
+            collected, trimmed = _trim_memory()
+            last_trim = now
+            after = _memory_pressure()
+            after_current = after[0] if after is not None else current
+            LOGGER.warning(
+                "RENDER_MEMORY_PRESSURE_TRIM marker=%s before_mb=%.2f after_mb=%.2f "
+                "limit_mb=%.2f utilization=%.3f collected=%d malloc_trim=%s "
+                "trading_state_unchanged=true authority_gates_unchanged=true",
+                MARKER,
+                current / (1024 * 1024),
+                after_current / (1024 * 1024),
+                maximum / (1024 * 1024),
+                utilization,
+                collected,
+                str(trimmed).lower(),
+            )
+        time.sleep(interval_s)
+
+
+def start() -> bool:
+    """Start the Render-only daemon once; return whether it is active."""
+    global _THREAD
+    if not _is_render_runtime():
+        return False
+    with _LOCK:
+        if _THREAD is not None and _THREAD.is_alive():
+            return True
+        thread = threading.Thread(
+            target=_guard_loop,
+            name="RenderMemoryPressureGuardV151",
+            daemon=True,
+        )
+        _THREAD = thread
+        thread.start()
+    os.environ["NIJA_RENDER_MEMORY_PRESSURE_GUARD_V151_READY"] = "1"
+    LOGGER.warning(
+        "RENDER_MEMORY_PRESSURE_GUARD_STARTED marker=%s threshold=%.3f interval_s=%.1f "
+        "trading_state_unchanged=true authority_gates_unchanged=true",
+        MARKER,
+        _bounded_float("NIJA_RENDER_MEMORY_TRIM_THRESHOLD", 0.72, 0.50, 0.95),
+        _bounded_float("NIJA_RENDER_MEMORY_GUARD_INTERVAL_S", 5.0, 2.0, 60.0),
+    )
+    return True
+
+
+__all__ = ["MARKER", "start", "_memory_pressure", "_trim_memory"]


### PR DESCRIPTION
## Owner

- Primary owner: @dantelrharrell-debug

## Purpose

v150 telemetry observed the live Render cgroup at 460 MB of its 512 MB limit (90%) immediately before the cgroup restarted. Add a Render-only, standard-library pressure guard before any bot-package import. Above 72% cgroup utilization it runs `gc.collect()` and glibc `malloc_trim(0)` at most once per 10 seconds, returning unused heap pages to the kernel before transient strategy/scan allocations exhaust the worker.

## Risk Assessment

- Risk level: medium
- Impacted areas: Render memory lifecycle and canonical launcher startup
- Key failure modes:
  - GC can briefly pause the Python process only while memory is already above 72%.
  - Platforms without finite cgroup v2 metrics skip trimming safely.
  - If trimming is insufficient, the existing bounded supervisor and all fail-closed gates remain intact.

The guard does not mutate strategy, broker, order, risk, nonce, writer, readiness, reconciliation, or execution-authority state.

## Rollback Plan

Revert this PR to remove the daemon and its launcher attestation. No migrations or persistent state changes.

## Validation

- [x] 25 focused tests executed directly
- [x] Python compilation and shell syntax
- [x] Startup patcher idempotence, line length, secret, bypass, and diff checks
- [x] Guard starts before bot imports and skips non-Render runtimes
- [ ] CI/security checks passed

### NIJA Safety Checks

- [x] Trading logic unchanged; backtest not applicable
- [x] Writer-lock and authority gates unchanged
- [x] Guard logs explicitly attest trading/authority state unchanged