### PR TITLE
Harden Render shutdown handoff

### DIFF
--- a/bot/entrypoint_writer_authority.py
+++ b/bot/entrypoint_writer_authority.py
@@ -78,6 +78,40 @@ def _cfg_float(name: str, default: float, *, minimum: float = 0.0) -> float:
         return max(minimum, default)
 
 
+def _process_shutdown_requested() -> bool:
+    """Return whether the canonical process is intentionally shutting down.
+
+    Signal handlers publish shutdown intent before stopping ``TradingLoop``.
+    The writer heartbeat must quiesce during that narrow handoff window rather
+    than reclassifying the deliberately stopped core as terminal writer loss.
+    It does not release or grant authority here; ``bot_main`` retains the sole
+    compare-delete release path, and an interrupted release falls back to TTL.
+    """
+
+    for name in ("bot.bot_main", "bot_main"):
+        module = sys.modules.get(name)
+        event = getattr(module, "_shutdown_event", None) if module else None
+        if event is not None and callable(getattr(event, "is_set", None)):
+            try:
+                if event.is_set():
+                    return True
+            except Exception:
+                pass
+
+    for name in ("bot.bootstrap_utils", "bootstrap_utils"):
+        module = sys.modules.get(name)
+        getter = getattr(module, "get_shutdown_event", None) if module else None
+        if callable(getter):
+            try:
+                event = getter()
+                if event is not None and event.is_set():
+                    return True
+            except Exception:
+                pass
+
+    return False
+
+
 def _cfg_int(name: str, default: int, *, minimum: int = 1) -> int:
     try:
         return max(minimum, int(float(os.environ.get(name, str(default)) or default)))
@@ -1588,7 +1622,23 @@ class EntrypointWriterAuthority:
         first_failure_at = 0.0
 
         while not self._stop.is_set():
+            if _process_shutdown_requested():
+                logger.info(
+                    "ENTRYPOINT_WRITER_HEARTBEAT_QUIESCED marker=%s "
+                    "reason=process_shutdown_requested "
+                    "compare_delete_owner=bot_main lease_ttl_fallback=true",
+                    _MARKER,
+                )
+                return
             ok, reason = self._heartbeat_tick()
+            if ok and reason == "shutdown_requested":
+                logger.info(
+                    "ENTRYPOINT_WRITER_HEARTBEAT_QUIESCED marker=%s "
+                    "reason=process_shutdown_requested_race "
+                    "compare_delete_owner=bot_main lease_ttl_fallback=true",
+                    _MARKER,
+                )
+                return
             if ok:
                 failures = 0
                 first_failure_at = 0.0
@@ -1706,6 +1756,12 @@ class EntrypointWriterAuthority:
         return True, ""
 
     def _heartbeat_tick(self) -> tuple[bool, str]:
+        # SIGTERM/SIGINT handlers publish shutdown intent before stopping the
+        # core.  Quiesce without renewing or classifying that expected stop as
+        # writer loss; bot_main's finally block performs exact compare-delete.
+        if _process_shutdown_requested():
+            return True, "shutdown_requested"
+
         os.environ["NIJA_WRITER_HEARTBEAT_ALIVE_TS"] = str(time.time())
         self._set_writer_state(WriterState.VERIFYING, reason="heartbeat_tick")
 

--- a/bot/terminal_writer_loss_latch.py
+++ b/bot/terminal_writer_loss_latch.py
@@ -237,10 +237,11 @@ def _halt_seak_on_terminal_loss(reason: str) -> None:
         if seak is not None:
             halt = getattr(seak, "emergency_halt", None)
             if callable(halt):
-                halt(
-                    f"terminal_writer_loss:{reason}",
-                    source="terminal_writer_loss_latch",
-                )
+                # SingleExecutionAuthorityKernel.emergency_halt() accepts one
+                # positional reason.  Keep source provenance in the structured
+                # log instead of passing an unsupported keyword at the most
+                # important fail-closed boundary.
+                halt(f"terminal_writer_loss:{reason}")
                 logger.critical(
                     "SEAK_HALT_DIAGNOSTIC reason=terminal_writer_loss "
                     "source=terminal_writer_loss_latch "

--- a/bot/test_startup_convergence_and_writer_loss.py
+++ b/bot/test_startup_convergence_and_writer_loss.py
@@ -149,8 +149,7 @@ class TestTerminalWriterLossLatch(unittest.TestCase):
         self.assertTrue(self.latch.private_io_suppressed("post_latch"))
         hooks["revoke_spy"].assert_called_once()
         hooks["seak"].emergency_halt.assert_called_once_with(
-            "terminal_writer_loss:lease_no_longer_owned",
-            source="terminal_writer_loss_latch",
+            "terminal_writer_loss:lease_no_longer_owned"
         )
         hooks["shutdown"].assert_called_once_with()
         hooks["request_exit"].assert_called_once_with(

--- a/bot/tests/test_render_runtime_recovery_v147.py
+++ b/bot/tests/test_render_runtime_recovery_v147.py
@@ -15,8 +15,13 @@ def test_render_recovery_is_narrow_and_fail_closed() -> None:
         source.index("# Treat SIGTERM (143) as graceful")
     ]
 
-    assert "0|1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
+    assert "0|1|42|75|134|137) _RENDER_RUNTIME_RECOVERABLE=true" in recovery
     assert "143) _RENDER_RUNTIME_RECOVERABLE=true" not in recovery
+    assert "_RENDER_RUNTIME_TERMINATION_REQUESTED" in recovery
+    assert "RENDER_RUNTIME_TERMINATION_OBSERVED" in recovery
+    assert recovery.index("RENDER_RUNTIME_TERMINATION_OBSERVED") < recovery.index(
+        "_RENDER_RUNTIME_RECOVERABLE=false"
+    )
     assert "writer_authority_bypass=false" in recovery
     assert "NIJA_DEFER_RUNTIME_SITE_HOOKS=1 $PY -u scripts/canonical_runtime_launcher_v26.py" in recovery
     assert "NIJA_UNSAFE_BYPASS_DISTRIBUTED_LOCK=true" not in recovery

--- a/bot/tests/test_shutdown_handoff_v152.py
+++ b/bot/tests/test_shutdown_handoff_v152.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+import threading
+from types import ModuleType
+from unittest.mock import MagicMock
+
+from bot import entrypoint_writer_authority as authority
+
+
+def test_process_shutdown_detects_canonical_bot_main_event(monkeypatch) -> None:
+    shutdown = threading.Event()
+    shutdown.set()
+    bot_main = ModuleType("bot.bot_main")
+    bot_main._shutdown_event = shutdown
+    monkeypatch.setitem(sys.modules, "bot.bot_main", bot_main)
+    monkeypatch.delenv("NIJA_PROCESS_EXIT_REQUESTED", raising=False)
+
+    assert authority._process_shutdown_requested() is True
+
+
+def test_shutdown_race_quiesces_before_writer_or_core_mutation(monkeypatch) -> None:
+    runtime = authority.EntrypointWriterAuthority()
+    runtime._heartbeat_tick = MagicMock(side_effect=AssertionError("heartbeat must not run"))
+    runtime._release_owned_lock_for_reelection = MagicMock()
+    monkeypatch.setattr(authority, "_process_shutdown_requested", lambda: True)
+
+    runtime._heartbeat_loop()
+
+    runtime._heartbeat_tick.assert_not_called()
+    runtime._release_owned_lock_for_reelection.assert_not_called()
+    assert runtime.lost is False
+
+
+def test_tick_quiesces_if_shutdown_arrives_after_loop_probe(monkeypatch) -> None:
+    runtime = authority.EntrypointWriterAuthority()
+    runtime._release_owned_lock_for_reelection = MagicMock()
+    monkeypatch.setattr(authority, "_process_shutdown_requested", lambda: True)
+
+    ok, reason = runtime._heartbeat_tick()
+
+    assert (ok, reason) == (True, "shutdown_requested")
+    runtime._release_owned_lock_for_reelection.assert_not_called()
+    assert runtime.lost is False

--- a/bot/tests/test_terminal_writer_loss_seak_v118.py
+++ b/bot/tests/test_terminal_writer_loss_seak_v118.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib.util
 import sys
+from pathlib import Path
 from types import ModuleType
 
 
@@ -42,3 +44,25 @@ def test_terminal_writer_loss_patch_is_idempotent(monkeypatch):
     first = latch_mod._halt_seak_on_terminal_loss
     assert patch._patch_terminal_latch() is True
     assert latch_mod._halt_seak_on_terminal_loss is first
+
+
+def test_canonical_terminal_latch_uses_positional_seak_reason(monkeypatch):
+    calls: list[str] = []
+
+    class FakeSEAK:
+        def emergency_halt(self, reason: str = "emergency halt") -> None:
+            calls.append(reason)
+
+    seak_mod = ModuleType("bot.single_execution_authority_kernel")
+    seak_mod.get_seak = lambda: FakeSEAK()
+    monkeypatch.setitem(sys.modules, "bot.single_execution_authority_kernel", seak_mod)
+
+    path = Path(__file__).resolve().parents[1] / "terminal_writer_loss_latch.py"
+    spec = importlib.util.spec_from_file_location("test_terminal_writer_loss_latch_base", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module._halt_seak_on_terminal_loss("core_thread_dead")
+
+    assert calls == ["terminal_writer_loss:core_thread_dead"]

--- a/start.sh
+++ b/start.sh
@@ -1610,7 +1610,13 @@ _cleanup_pid_lock() {
         echo "🔓 PID_LOCK_RELEASED pid=$$"
     fi
 }
-trap '_cleanup_pid_lock' EXIT INT TERM
+_RENDER_RUNTIME_TERMINATION_REQUESTED=false
+_record_runtime_termination_request() {
+    _RENDER_RUNTIME_TERMINATION_REQUESTED=true
+    _cleanup_pid_lock
+}
+trap '_cleanup_pid_lock' EXIT
+trap '_record_runtime_termination_request' INT TERM
 
 _RENDER_RUNTIME_RECOVERY=false
 if _is_truthy_flag "${RENDER:-0}" \
@@ -1647,9 +1653,19 @@ while true; do
     echo "🧭 STARTUP_HANDOFF_RUNTIME_EXIT status=${status}"
     set -e
 
+    # Bash defers a trapped SIGTERM while it waits for the foreground Python
+    # runtime.  Record that platform intent before classifying the child's
+    # status so a native abort during interpreter teardown cannot start a new
+    # runtime inside an instance Render is deliberately replacing.
+    if [ "${_RENDER_RUNTIME_TERMINATION_REQUESTED}" = "true" ]; then
+        echo "🛑 RENDER_RUNTIME_TERMINATION_OBSERVED marker=20260818-render-runtime-recovery-v152 original_status=${status} action=graceful_platform_stop"
+        status=143
+        break
+    fi
+
     _RENDER_RUNTIME_RECOVERABLE=false
     case "${status}" in
-        0|1|42|75|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
+        0|1|42|75|134|137) _RENDER_RUNTIME_RECOVERABLE=true ;;
     esac
 
     if [ "${_RENDER_RUNTIME_RECOVERY}" != "true" ] \
@@ -1659,7 +1675,7 @@ while true; do
 
     _RENDER_RUNTIME_RECOVERY_ATTEMPT=$((_RENDER_RUNTIME_RECOVERY_ATTEMPT + 1))
     if [ "${_RENDER_RUNTIME_RECOVERY_ATTEMPT}" -gt "${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS}" ]; then
-        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v149 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
+        echo "❌ RENDER_RUNTIME_RECOVERY_EXHAUSTED marker=20260818-render-runtime-recovery-v152 status=${status} attempts=${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} action=delegate_to_platform"
         break
     fi
 
@@ -1667,9 +1683,9 @@ while true; do
     # process is gone. Waiting beyond the lease TTL prevents the replacement
     # from racing a stale Redis owner token. The next canonical interpreter
     # still has to acquire a fresh generation and pass every readiness gate.
-    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v149 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
+    echo "⚠️ RENDER_RUNTIME_RECOVERY_SCHEDULED marker=20260818-render-runtime-recovery-v152 status=${status} attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT}/${_RENDER_RUNTIME_RECOVERY_MAX_ATTEMPTS} delay_s=${_RENDER_RUNTIME_RECOVERY_DELAY_S} liveness_preserved=true writer_authority_bypass=false"
     sleep "${_RENDER_RUNTIME_RECOVERY_DELAY_S}"
-    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v149 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
+    echo "🔄 RENDER_RUNTIME_RECOVERY_RETRY marker=20260818-render-runtime-recovery-v152 attempt=${_RENDER_RUNTIME_RECOVERY_ATTEMPT} canonical=launcher-v26"
 done
 
 # Treat SIGTERM (143) as graceful to avoid restart loops during platform stop/redeploy


### PR DESCRIPTION
## What changed

- quiesce the canonical Redis writer heartbeat when bot_main or bootstrap shutdown intent is already published
- keep exact compare-delete ownership in bot_main's existing final release path; interrupted release still falls back to lease TTL
- call `SingleExecutionAuthorityKernel.emergency_halt()` with its canonical positional-only reason contract
- treat native abort status 134 as Render-recoverable only within the existing bounded, lease-safe supervisor
- record platform SIGTERM/INT intent before status classification so a deliberate Render replacement never starts a recovery loop
- add focused shutdown-handoff, SEAK, and Render recovery regression coverage

## Root cause

The production excerpt showed a Render-era shutdown race on revision `81fd7d35`: `TradingLoop` stopped after shutdown intent, but the writer heartbeat observed the dead thread first and reclassified the deliberate stop as terminal writer loss. That path then passed an unsupported `source` keyword to SEAK and the native runtime aborted with status 134.

## Safety impact

This does not change strategy, order routing, sizing, broker credentials, capital calculations, or readiness thresholds. It creates no authority. Unexpected core death remains terminal and fail-closed. Redis release remains exact-owner compare-delete with TTL fallback, and Render recovery remains bounded with a delay longer than the lease TTL. SIGTERM 143 remains non-recoverable and graceful.

## Validation

- 11 focused shutdown/SEAK/recovery assertions passed
- 8 terminal-writer-loss unit tests passed
- Python compilation passed for all changed Python files
- `bash -n start.sh`
- startup handoff patcher idempotence check
- `git diff --check`
- secret and unsafe-bypass scan clean
- two unchanged legacy fixture failures reproduced in `bot.test_production_startup_repair_v26`

## Risk and rollback

Medium operational risk because startup and writer-heartbeat shutdown sequencing changes. Roll back this PR to restore the prior shutdown behavior. No live-trading safety gate is weakened.