### PR TITLE
Package Render memory guard in image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -113,6 +113,7 @@ scripts/*
 !scripts/apply_canonical_launcher_v26.py
 !scripts/apply_writer_generation_handoff_v45.py
 !scripts/canonical_runtime_launcher_v26.py
+!scripts/render_memory_pressure_guard.py
 !scripts/apply_direct_broker_prebootstrap_v27.py
 !scripts/install_sitecustomize_defer_guard.py
 !scripts/runtime_entrypoint_attestation.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN NIJA_DEFER_RUNTIME_SITE_HOOKS=1 python -S -m py_compile \
         /app/scripts/apply_canonical_launcher_v26.py \
         /app/scripts/apply_writer_generation_handoff_v45.py \
         /app/scripts/canonical_runtime_launcher_v26.py \
+        /app/scripts/render_memory_pressure_guard.py \
         /app/scripts/runtime_entrypoint_attestation.py \
         /app/render_liveness_server.py \
         /app/render_readiness_state_bridge.py \
@@ -109,6 +110,7 @@ RUN test -f /app/scripts/redis_connectivity_check.sh && \
     test -f /app/scripts/apply_canonical_launcher_v26.py && \
     test -f /app/scripts/apply_writer_generation_handoff_v45.py && \
     test -f /app/scripts/canonical_runtime_launcher_v26.py && \
+    test -f /app/scripts/render_memory_pressure_guard.py && \
     test -f /app/bot/writer_generation_handoff_v45_patch.py && \
     chmod +x /app/scripts/redis_connectivity_check.sh \
              /app/scripts/production_bootstrap.sh \

--- a/bot/tests/test_render_memory_pressure_guard_v151.py
+++ b/bot/tests/test_render_memory_pressure_guard_v151.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 ROOT = Path(__file__).resolve().parents[2]
 GUARD_PATH = ROOT / "scripts" / "render_memory_pressure_guard.py"
 LAUNCHER_PATH = ROOT / "scripts" / "canonical_runtime_launcher_v26.py"
+DOCKERIGNORE_PATH = ROOT / ".dockerignore"
+DOCKERFILE_PATH = ROOT / "Dockerfile"
 
 
 def _load_guard():
@@ -75,3 +77,12 @@ def test_launcher_starts_guard_before_bot_package_imports() -> None:
     )
     assert "RENDER_MEMORY_GUARD_PATH.is_file()" in source
     assert "NIJA_RENDER_MEMORY_PRESSURE_GUARD_V151_READY" in source
+
+
+def test_render_image_packages_and_validates_memory_guard() -> None:
+    dockerignore = DOCKERIGNORE_PATH.read_text(encoding="utf-8")
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+
+    assert "!scripts/render_memory_pressure_guard.py" in dockerignore
+    assert "/app/scripts/render_memory_pressure_guard.py" in dockerfile
+    assert "test -f /app/scripts/render_memory_pressure_guard.py" in dockerfile


### PR DESCRIPTION
## What changed
- re-include `scripts/render_memory_pressure_guard.py` in the Docker build context
- compile the guard during the image build
- fail the build if the guard is missing from `/app`
- add a regression test covering the Docker packaging contract

## Root cause
The memory guard was committed and referenced by the canonical launcher, but `.dockerignore` excluded `scripts/*` and did not whitelist the new file. Render therefore built an image whose startup preflight failed with `[Errno 2] No such file or directory: 'scripts/render_memory_pressure_guard.py'`.

## Impact
Restores Render startup without changing strategy, broker routing, risk limits, writer fencing, nonce ownership, or execution-authority gates. The deployment remains fail closed.

## Validation
- `git diff --check`
- Python compile for the guard and regression test
- `bash -n scripts/render_entrypoint.sh start.sh`
- `python -m unittest -q bot.test_startup_convergence_and_writer_loss` (8 passed)
- direct memory-guard regression assertions passed
- secret/bypass scan of changed files clean

No trading logic was changed.