### PR TITLE
Harden runtime readiness convergence

### DIFF
--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -5,6 +5,12 @@ active/inactive state into StartupCoordinator without clearing the stop,
 changing risk gates, or forcing a coordinator lifecycle state. A state change
 invalidates any prior activation commit and advances the global epoch so a
 fresh activation proof is required after deactivation.
+
+The runtime-quality convergence additions in v153 remain fail-closed. They
+prevent premature authority repair while structural startup proofs are pending,
+preserve a healthy legacy capital-refresh owner during publication headroom,
+and make a broker object's explicit connectivity state authoritative over stale
+manager bookkeeping.
 """
 from __future__ import annotations
 
@@ -16,7 +22,10 @@ from typing import Any
 
 logger = logging.getLogger("nija.kill_switch_coordinator_sync")
 _MARKER = "20260814-kill-switch-coordinator-sync-v1"
+_QUALITY_MARKER = "20260819-runtime-quality-convergence-v153"
 _PATCH_ATTR = "_nija_kill_switch_coordinator_sync_v1"
+_RUNTIME_AUTHORITY_GATE_ATTR = "_nija_runtime_quality_v153_structural_gate"
+_CONNECTIVITY_PATCH_ATTR = "_nija_runtime_quality_v153_truthful_connectivity"
 _LOCK = threading.RLock()
 
 
@@ -116,6 +125,176 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
     return True
 
 
+def _structural_readiness_blockers() -> list[str]:
+    """Return startup proofs that must be true before authority repair may commit.
+
+    Writer/nonce authority are deliberately excluded: the canonical authority
+    repair validates those itself and publishes those two proofs immediately
+    before activation. Everything else here is structural runtime readiness and
+    must already be true, preventing a repair heartbeat from racing strategy,
+    execution-engine, bootstrap, or position-sync publication.
+    """
+    try:
+        try:
+            from bot import readiness_table
+        except ImportError:
+            import readiness_table  # type: ignore[import,no-redef]
+        table = dict(readiness_table.snapshot())
+    except Exception as exc:
+        logger.warning(
+            "RUNTIME_AUTHORITY_STRUCTURAL_GATE_UNAVAILABLE marker=%s error=%s:%s trading_fail_closed=true",
+            _QUALITY_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return ["readiness_table_unavailable"]
+
+    required = [
+        "broker_connected",
+        "balance_hydrated",
+        "capital_ready",
+        "risk_ready",
+        "strategy_ready",
+        "execution_ready",
+        "bootstrap_ready",
+    ]
+    if "position_sync_ready" in table:
+        required.append("position_sync_ready")
+    return [name for name in required if not bool(table.get(name, False))]
+
+
+def _patch_runtime_authority_structural_gate() -> bool:
+    """Defer runtime-authority convergence until structural readiness is complete."""
+    try:
+        try:
+            from bot import runtime_authority_convergence_repair_patch as repair
+        except ImportError:
+            import runtime_authority_convergence_repair_patch as repair  # type: ignore[import,no-redef]
+    except Exception as exc:
+        logger.warning(
+            "RUNTIME_AUTHORITY_STRUCTURAL_GATE_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+            _QUALITY_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    current = getattr(repair, "converge_runtime_authority", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _RUNTIME_AUTHORITY_GATE_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def converge_runtime_authority_v153(source: str = "manual") -> bool:
+        blockers = _structural_readiness_blockers()
+        if blockers:
+            logger.info(
+                "RUNTIME_AUTHORITY_STRUCTURAL_GATE_DEFERRED marker=%s source=%s blockers=%s activation_attempted=false trading_fail_closed=true",
+                _QUALITY_MARKER,
+                source,
+                blockers,
+            )
+            return False
+        return bool(current(source))
+
+    setattr(converge_runtime_authority_v153, _RUNTIME_AUTHORITY_GATE_ATTR, True)
+    setattr(converge_runtime_authority_v153, "__wrapped__", current)
+    repair.converge_runtime_authority = converge_runtime_authority_v153
+    logger.critical(
+        "RUNTIME_AUTHORITY_STRUCTURAL_GATE_INSTALLED marker=%s strategy_execution_bootstrap_position_sync_required=true writer_nonce_checks_unchanged=true",
+        _QUALITY_MARKER,
+    )
+    return True
+
+
+def _install_truthful_connectivity(publication_liveness: Any) -> bool:
+    """Make explicit broker connectivity authoritative over stale manager state."""
+    current = getattr(publication_liveness, "_canonical_broker_connectivity", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _CONNECTIVITY_PATCH_ATTR, False)):
+        return True
+
+    def canonical_broker_connectivity_v153() -> tuple[bool, dict[str, Any]]:
+        manager = publication_liveness._canonical_manager()
+        if manager is None:
+            return False, {"reason": "manager_missing", "connected": [], "registered": []}
+
+        platform = getattr(manager, "_platform_brokers", None)
+        if not isinstance(platform, dict) or not platform:
+            return False, {"reason": "platform_registry_empty", "connected": [], "registered": []}
+
+        registered: list[str] = []
+        connected: list[str] = []
+        probe = getattr(manager, "is_platform_connected", None)
+        state_map = getattr(manager, "_platform_state", {})
+        for raw_key, broker in list(platform.items()):
+            if broker is None:
+                continue
+            name = str(getattr(raw_key, "value", raw_key) or "").strip().lower()
+            if not name:
+                continue
+            registered.append(name)
+
+            direct_observed = False
+            direct_connected = False
+            for attr in ("connected", "is_connected"):
+                if not hasattr(broker, attr):
+                    continue
+                direct_observed = True
+                try:
+                    value = getattr(broker, attr)
+                    direct_connected = bool(value() if callable(value) else value)
+                except Exception:
+                    direct_connected = False
+                break
+
+            # When the canonical broker object exposes connectivity, that truth
+            # wins. Manager/state maps are compatibility fallbacks only for
+            # adapters that do not expose a direct connectivity surface.
+            if direct_observed:
+                if direct_connected:
+                    connected.append(name)
+                continue
+
+            manager_connected = False
+            if callable(probe):
+                try:
+                    manager_connected = bool(probe(raw_key))
+                except Exception:
+                    manager_connected = False
+            state_connected = False
+            if isinstance(state_map, dict):
+                state = state_map.get(name, state_map.get(raw_key))
+                state_value = str(getattr(state, "value", state) or "").strip().lower()
+                state_connected = state_value == "connected"
+            if manager_connected or state_connected:
+                connected.append(name)
+
+        policy = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "optional") or "optional").strip().lower()
+        if policy == "global_all_required":
+            ready = bool(registered and len(set(connected)) == len(set(registered)))
+        else:
+            ready = bool(connected)
+        return ready, {
+            "reason": "ok" if ready else "canonical_platform_connectivity_not_proven",
+            "policy": policy,
+            "registered": sorted(set(registered)),
+            "connected": sorted(set(connected)),
+            "direct_connectivity_authoritative": True,
+        }
+
+    setattr(canonical_broker_connectivity_v153, _CONNECTIVITY_PATCH_ATTR, True)
+    setattr(canonical_broker_connectivity_v153, "__wrapped__", current)
+    publication_liveness._canonical_broker_connectivity = canonical_broker_connectivity_v153
+    logger.critical(
+        "CANONICAL_BROKER_CONNECTIVITY_TRUTH_V153_INSTALLED marker=%s direct_state_authoritative=true stale_manager_override=false",
+        _QUALITY_MARKER,
+    )
+    return True
+
+
 def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     """Normalize v142 wrapper proof and coordinator rollover semantics.
 
@@ -125,16 +304,14 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     copied attributes on unrelated outer wrappers cannot falsely prove the v35
     or v78 layer is still present.
 
-    The liveness probe also handles two transition states safely:
-
-    * a coordinator that was already in-flight before v142 was installed is
-      replaced as soon as v137 enters refresh headroom; and
-    * a newly tracked v142 refresh is never considered dead during the tiny
-      interval between publishing ``_in_flight``/generation state and storing
-      the worker-thread handle.
+    v153 also preserves a pre-v142/untracked refresh owner while the current
+    capital publication is still valid. The underlying v142 liveness function
+    already retires that owner once publication truth is no longer current, so
+    replacing it merely because refresh headroom opened created unnecessary
+    duplicate coordinators and rejected late untagged publications.
     """
     if bool(getattr(publication_liveness, "_nija_startup_chain_prepared", False)):
-        return True
+        return _install_truthful_connectivity(publication_liveness)
 
     def marker_chain_contains(callable_obj: Any, *, marker: str, expected_name: str = "") -> bool:
         seen: set[int] = set()
@@ -166,41 +343,16 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
 
         tracked = bool(getattr(coordinator, "_nija_v142_flight_generation", 0))
         if not tracked:
-            try:
-                from bot import capital_publication_deadline_v137_patch as v137
-
-                authority = publication_liveness._authority()
-                due, meta = v137._publication_refresh_due(authority, manager)
-            except Exception as exc:
-                logger.warning(
-                    "CAPITAL_PUBLICATION_V142_UPGRADE_PROBE_FAILED marker=%s err=%s:%s "
-                    "existing_owner_preserved=true trading_fail_closed=true",
-                    _MARKER,
-                    type(exc).__name__,
-                    exc,
-                )
-                return True
-
-            if not due:
-                return True
-
-            replacement = publication_liveness._rollover_coordinator(
-                manager,
-                expected_old=coordinator,
-                reason="untracked_inflight_refresh_due:" + str(meta.get("due_reason") or "due"),
+            # Preserve the existing owner during freshness headroom. The base
+            # v142 probe is already fail-closed and only retires an untracked
+            # owner once the immutable publication is no longer current.
+            result = bool(original_inflight(manager))
+            logger.debug(
+                "CAPITAL_PUBLICATION_V153_UNTRACKED_OWNER_PROBE marker=%s in_flight=%s rollover_on_headroom=false",
+                _QUALITY_MARKER,
+                result,
             )
-            logger.critical(
-                "CAPITAL_PUBLICATION_V142_UPGRADE_ROLLOVER marker=%s due_reason=%s "
-                "remaining_s=%s old_id=%s new_id=%s pre_expiry=%s "
-                "publication_expiry_extended=false trading_fail_closed_until_refresh=true",
-                _MARKER,
-                meta.get("due_reason"),
-                meta.get("remaining_s"),
-                hex(id(coordinator)),
-                hex(id(replacement)) if replacement is not None else "none",
-                str(float(meta.get("remaining_s", 0.0) or 0.0) > 0.0).lower(),
-            )
-            return bool(replacement is coordinator or replacement is None)
+            return result
 
         # A tracked v142 owner has a generation before its worker-thread handle
         # is published. Treat that brief pre-start window as live unless it has
@@ -250,7 +402,7 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     setattr(coordinator_in_flight_with_upgrade_rollover, "_nija_v142_upgrade_rollover", True)
     publication_liveness._coordinator_in_flight_v142 = coordinator_in_flight_with_upgrade_rollover
     publication_liveness._nija_startup_chain_prepared = True
-    return True
+    return _install_truthful_connectivity(publication_liveness)
 
 
 def _install_authority_liveness() -> bool:
@@ -297,6 +449,10 @@ def _install_authority_liveness() -> bool:
         )
         if not callable(installer) or not bool(installer()):
             return False
+        # v142 installation can replace its own connectivity function; reassert
+        # v153 truth semantics after the installer completes.
+        if not _install_truthful_connectivity(publication_liveness):
+            return False
     except Exception as exc:
         logger.exception(
             "CAPITAL_PUBLICATION_LIVENESS_CHAIN_FAILED marker=%s error=%s",
@@ -321,6 +477,8 @@ def _install_authority_liveness() -> bool:
         )
         return False
 
+    if not _patch_runtime_authority_structural_gate():
+        return False
     return True
 
 
@@ -346,14 +504,18 @@ def install_import_hook() -> None:
 
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_INSTALLED"] = "1"
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_READY"] = "1"
+        os.environ["NIJA_RUNTIME_QUALITY_CONVERGENCE_V153_READY"] = "1"
         logger.critical(
             "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
             "risk_gates_unchanged=true authority_liveness_chained=true "
             "stalled_writer_capital_freshness_chained=true "
             "capital_publication_liveness_chained=true "
-            "kill_switch_persistence_provenance_chained=true",
+            "kill_switch_persistence_provenance_chained=true "
+            "runtime_quality_marker=%s authority_structural_gate=true "
+            "truthful_broker_connectivity=true untracked_refresh_owner_preserved=true",
             _MARKER,
             str(active).lower(),
+            _QUALITY_MARKER,
         )
 
 
@@ -368,4 +530,7 @@ __all__ = [
     "_publish_coordinator_truth",
     "_prepare_capital_publication_liveness",
     "_install_authority_liveness",
+    "_structural_readiness_blockers",
+    "_patch_runtime_authority_structural_gate",
+    "_install_truthful_connectivity",
 ]

--- a/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
+++ b/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
@@ -64,10 +64,9 @@ def test_pre_v142_inflight_is_preserved_during_refresh_headroom() -> None:
 
 
 def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_state() -> None:
-    broker_key = SimpleNamespace(value="kraken")
     broker = SimpleNamespace(connected=False)
     manager = SimpleNamespace(
-        _platform_brokers={broker_key: broker},
+        _platform_brokers={"kraken": broker},
         _platform_state={"kraken": "connected"},
         is_platform_connected=lambda raw_key: True,
     )
@@ -88,10 +87,9 @@ def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_
 
 
 def test_direct_broker_connectivity_true_remains_connected() -> None:
-    broker_key = SimpleNamespace(value="coinbase")
     broker = SimpleNamespace(connected=True)
     manager = SimpleNamespace(
-        _platform_brokers={broker_key: broker},
+        _platform_brokers={"coinbase": broker},
         _platform_state={"coinbase": "disconnected"},
         is_platform_connected=lambda raw_key: False,
     )

--- a/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
+++ b/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from bot.kill_switch_coordinator_sync_patch import _prepare_capital_publication_liveness
+from bot.kill_switch_coordinator_sync_patch import (
+    _prepare_capital_publication_liveness,
+    _structural_readiness_blockers,
+)
 
 
 def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
@@ -19,6 +22,8 @@ def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
     fake = SimpleNamespace(
         _nija_startup_chain_prepared=False,
         _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: None,
     )
     assert _prepare_capital_publication_liveness(fake) is True
 
@@ -34,41 +39,98 @@ def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
     ) is False
 
 
-def test_pre_v142_inflight_rolls_over_when_refresh_enters_headroom(monkeypatch) -> None:
-    from bot import capital_publication_deadline_v137_patch as v137
-
+def test_pre_v142_inflight_is_preserved_during_refresh_headroom() -> None:
     old = SimpleNamespace(_in_flight=True)
-    replacement = SimpleNamespace(_in_flight=False)
     manager = SimpleNamespace(_capital_coordinator=old)
-    authority = SimpleNamespace()
-    reasons: list[str] = []
+    rollover_calls: list[str] = []
 
     fake = SimpleNamespace(
         _nija_startup_chain_prepared=False,
         _coordinator_in_flight_v142=lambda manager: True,
-        _authority=lambda: authority,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: None,
     )
 
     def rollover(target_manager, *, expected_old=None, reason):
-        assert expected_old is old
-        reasons.append(str(reason))
-        target_manager._capital_coordinator = replacement
-        return replacement
+        rollover_calls.append(str(reason))
+        return expected_old
 
     fake._rollover_coordinator = rollover
-    monkeypatch.setattr(
-        v137,
-        "_publication_refresh_due",
-        lambda authority, manager: (
-            True,
-            {
-                "due_reason": "pre_expiry_headroom",
-                "remaining_s": 42.0,
-            },
-        ),
+
+    assert _prepare_capital_publication_liveness(fake) is True
+    assert fake._coordinator_in_flight_v142(manager) is True
+    assert manager._capital_coordinator is old
+    assert rollover_calls == []
+
+
+def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_state() -> None:
+    broker_key = SimpleNamespace(value="kraken")
+    broker = SimpleNamespace(connected=False)
+    manager = SimpleNamespace(
+        _platform_brokers={broker_key: broker},
+        _platform_state={"kraken": "connected"},
+        is_platform_connected=lambda raw_key: True,
+    )
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (True, {}),
+        _canonical_manager=lambda: manager,
     )
 
     assert _prepare_capital_publication_liveness(fake) is True
-    assert fake._coordinator_in_flight_v142(manager) is False
-    assert manager._capital_coordinator is replacement
-    assert reasons == ["untracked_inflight_refresh_due:pre_expiry_headroom"]
+    ready, meta = fake._canonical_broker_connectivity()
+
+    assert ready is False
+    assert meta["registered"] == ["kraken"]
+    assert meta["connected"] == []
+    assert meta["direct_connectivity_authoritative"] is True
+
+
+def test_direct_broker_connectivity_true_remains_connected() -> None:
+    broker_key = SimpleNamespace(value="coinbase")
+    broker = SimpleNamespace(connected=True)
+    manager = SimpleNamespace(
+        _platform_brokers={broker_key: broker},
+        _platform_state={"coinbase": "disconnected"},
+        is_platform_connected=lambda raw_key: False,
+    )
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: manager,
+    )
+
+    assert _prepare_capital_publication_liveness(fake) is True
+    ready, meta = fake._canonical_broker_connectivity()
+
+    assert ready is True
+    assert meta["connected"] == ["coinbase"]
+
+
+def test_structural_readiness_blockers_include_runtime_handoff_proofs(monkeypatch) -> None:
+    from bot import readiness_table
+
+    monkeypatch.setattr(
+        readiness_table,
+        "snapshot",
+        lambda: {
+            "broker_connected": True,
+            "balance_hydrated": True,
+            "authority_ready": False,
+            "capital_ready": True,
+            "risk_ready": True,
+            "strategy_ready": False,
+            "execution_ready": False,
+            "nonce_ready": False,
+            "bootstrap_ready": True,
+            "position_sync_ready": False,
+        },
+    )
+
+    assert _structural_readiness_blockers() == [
+        "strategy_ready",
+        "execution_ready",
+        "position_sync_ready",
+    ]


### PR DESCRIPTION
## What changed

- Gate runtime-authority convergence on structural startup readiness before any activation repair attempt.
- Make direct canonical broker connectivity authoritative, so stale manager state cannot relabel a disconnected venue as connected.
- Preserve healthy pre-v142 capital-refresh ownership during publication headroom instead of creating duplicate coordinators and rejecting late untagged publications.
- Add regression coverage for all three behaviors.

## Why

The 2026-08-19 production log showed an early authority repair racing incomplete startup readiness, a Kraken connectivity contradiction, and repeated untracked capital coordinator rollover before the runtime later converged to `LIVE_ACTIVE`.

## Safety

This remains fail-closed. It does not force `LIVE_ACTIVE`, fabricate balances/connectivity, bypass writer or nonce authority, clear kill switches, extend capital freshness, or relax risk/execution gates.

## Validation target

CI plus the added regression tests. Production should no longer emit premature activation-repair attempts while structural readiness is pending, should classify Kraken using the canonical broker object's direct connection state, and should avoid headroom-only legacy coordinator rollover.