### PR TITLE
Harden runtime readiness convergence

### DIFF
--- a/bot/kill_switch_coordinator_sync_patch.py
+++ b/bot/kill_switch_coordinator_sync_patch.py
@@ -5,6 +5,12 @@ active/inactive state into StartupCoordinator without clearing the stop,
 changing risk gates, or forcing a coordinator lifecycle state. A state change
 invalidates any prior activation commit and advances the global epoch so a
 fresh activation proof is required after deactivation.
+
+The runtime-quality convergence additions in v153 remain fail-closed. They
+prevent premature authority repair while structural startup proofs are pending,
+preserve a healthy legacy capital-refresh owner during publication headroom,
+and make a broker object's explicit connectivity state authoritative over stale
+manager bookkeeping.
 """
 from __future__ import annotations
 
@@ -16,7 +22,10 @@ from typing import Any
 
 logger = logging.getLogger("nija.kill_switch_coordinator_sync")
 _MARKER = "20260814-kill-switch-coordinator-sync-v1"
+_QUALITY_MARKER = "20260819-runtime-quality-convergence-v153"
 _PATCH_ATTR = "_nija_kill_switch_coordinator_sync_v1"
+_RUNTIME_AUTHORITY_GATE_ATTR = "_nija_runtime_quality_v153_structural_gate"
+_CONNECTIVITY_PATCH_ATTR = "_nija_runtime_quality_v153_truthful_connectivity"
 _LOCK = threading.RLock()
 
 
@@ -116,6 +125,176 @@ def _patch_kill_switch_class(kill_switch_cls: type) -> bool:
     return True
 
 
+def _structural_readiness_blockers() -> list[str]:
+    """Return startup proofs that must be true before authority repair may commit.
+
+    Writer/nonce authority are deliberately excluded: the canonical authority
+    repair validates those itself and publishes those two proofs immediately
+    before activation. Everything else here is structural runtime readiness and
+    must already be true, preventing a repair heartbeat from racing strategy,
+    execution-engine, bootstrap, or position-sync publication.
+    """
+    try:
+        try:
+            from bot import readiness_table
+        except ImportError:
+            import readiness_table  # type: ignore[import,no-redef]
+        table = dict(readiness_table.snapshot())
+    except Exception as exc:
+        logger.warning(
+            "RUNTIME_AUTHORITY_STRUCTURAL_GATE_UNAVAILABLE marker=%s error=%s:%s trading_fail_closed=true",
+            _QUALITY_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return ["readiness_table_unavailable"]
+
+    required = [
+        "broker_connected",
+        "balance_hydrated",
+        "capital_ready",
+        "risk_ready",
+        "strategy_ready",
+        "execution_ready",
+        "bootstrap_ready",
+    ]
+    if "position_sync_ready" in table:
+        required.append("position_sync_ready")
+    return [name for name in required if not bool(table.get(name, False))]
+
+
+def _patch_runtime_authority_structural_gate() -> bool:
+    """Defer runtime-authority convergence until structural readiness is complete."""
+    try:
+        try:
+            from bot import runtime_authority_convergence_repair_patch as repair
+        except ImportError:
+            import runtime_authority_convergence_repair_patch as repair  # type: ignore[import,no-redef]
+    except Exception as exc:
+        logger.warning(
+            "RUNTIME_AUTHORITY_STRUCTURAL_GATE_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+            _QUALITY_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    current = getattr(repair, "converge_runtime_authority", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _RUNTIME_AUTHORITY_GATE_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def converge_runtime_authority_v153(source: str = "manual") -> bool:
+        blockers = _structural_readiness_blockers()
+        if blockers:
+            logger.info(
+                "RUNTIME_AUTHORITY_STRUCTURAL_GATE_DEFERRED marker=%s source=%s blockers=%s activation_attempted=false trading_fail_closed=true",
+                _QUALITY_MARKER,
+                source,
+                blockers,
+            )
+            return False
+        return bool(current(source))
+
+    setattr(converge_runtime_authority_v153, _RUNTIME_AUTHORITY_GATE_ATTR, True)
+    setattr(converge_runtime_authority_v153, "__wrapped__", current)
+    repair.converge_runtime_authority = converge_runtime_authority_v153
+    logger.critical(
+        "RUNTIME_AUTHORITY_STRUCTURAL_GATE_INSTALLED marker=%s strategy_execution_bootstrap_position_sync_required=true writer_nonce_checks_unchanged=true",
+        _QUALITY_MARKER,
+    )
+    return True
+
+
+def _install_truthful_connectivity(publication_liveness: Any) -> bool:
+    """Make explicit broker connectivity authoritative over stale manager state."""
+    current = getattr(publication_liveness, "_canonical_broker_connectivity", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _CONNECTIVITY_PATCH_ATTR, False)):
+        return True
+
+    def canonical_broker_connectivity_v153() -> tuple[bool, dict[str, Any]]:
+        manager = publication_liveness._canonical_manager()
+        if manager is None:
+            return False, {"reason": "manager_missing", "connected": [], "registered": []}
+
+        platform = getattr(manager, "_platform_brokers", None)
+        if not isinstance(platform, dict) or not platform:
+            return False, {"reason": "platform_registry_empty", "connected": [], "registered": []}
+
+        registered: list[str] = []
+        connected: list[str] = []
+        probe = getattr(manager, "is_platform_connected", None)
+        state_map = getattr(manager, "_platform_state", {})
+        for raw_key, broker in list(platform.items()):
+            if broker is None:
+                continue
+            name = str(getattr(raw_key, "value", raw_key) or "").strip().lower()
+            if not name:
+                continue
+            registered.append(name)
+
+            direct_observed = False
+            direct_connected = False
+            for attr in ("connected", "is_connected"):
+                if not hasattr(broker, attr):
+                    continue
+                direct_observed = True
+                try:
+                    value = getattr(broker, attr)
+                    direct_connected = bool(value() if callable(value) else value)
+                except Exception:
+                    direct_connected = False
+                break
+
+            # When the canonical broker object exposes connectivity, that truth
+            # wins. Manager/state maps are compatibility fallbacks only for
+            # adapters that do not expose a direct connectivity surface.
+            if direct_observed:
+                if direct_connected:
+                    connected.append(name)
+                continue
+
+            manager_connected = False
+            if callable(probe):
+                try:
+                    manager_connected = bool(probe(raw_key))
+                except Exception:
+                    manager_connected = False
+            state_connected = False
+            if isinstance(state_map, dict):
+                state = state_map.get(name, state_map.get(raw_key))
+                state_value = str(getattr(state, "value", state) or "").strip().lower()
+                state_connected = state_value == "connected"
+            if manager_connected or state_connected:
+                connected.append(name)
+
+        policy = str(os.environ.get("NIJA_SECONDARY_VENUE_POLICY", "optional") or "optional").strip().lower()
+        if policy == "global_all_required":
+            ready = bool(registered and len(set(connected)) == len(set(registered)))
+        else:
+            ready = bool(connected)
+        return ready, {
+            "reason": "ok" if ready else "canonical_platform_connectivity_not_proven",
+            "policy": policy,
+            "registered": sorted(set(registered)),
+            "connected": sorted(set(connected)),
+            "direct_connectivity_authoritative": True,
+        }
+
+    setattr(canonical_broker_connectivity_v153, _CONNECTIVITY_PATCH_ATTR, True)
+    setattr(canonical_broker_connectivity_v153, "__wrapped__", current)
+    publication_liveness._canonical_broker_connectivity = canonical_broker_connectivity_v153
+    logger.critical(
+        "CANONICAL_BROKER_CONNECTIVITY_TRUTH_V153_INSTALLED marker=%s direct_state_authoritative=true stale_manager_override=false",
+        _QUALITY_MARKER,
+    )
+    return True
+
+
 def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     """Normalize v142 wrapper proof and coordinator rollover semantics.
 
@@ -125,16 +304,14 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     copied attributes on unrelated outer wrappers cannot falsely prove the v35
     or v78 layer is still present.
 
-    The liveness probe also handles two transition states safely:
-
-    * a coordinator that was already in-flight before v142 was installed is
-      replaced as soon as v137 enters refresh headroom; and
-    * a newly tracked v142 refresh is never considered dead during the tiny
-      interval between publishing ``_in_flight``/generation state and storing
-      the worker-thread handle.
+    v153 also preserves a pre-v142/untracked refresh owner while the current
+    capital publication is still valid. The underlying v142 liveness function
+    already retires that owner once publication truth is no longer current, so
+    replacing it merely because refresh headroom opened created unnecessary
+    duplicate coordinators and rejected late untagged publications.
     """
     if bool(getattr(publication_liveness, "_nija_startup_chain_prepared", False)):
-        return True
+        return _install_truthful_connectivity(publication_liveness)
 
     def marker_chain_contains(callable_obj: Any, *, marker: str, expected_name: str = "") -> bool:
         seen: set[int] = set()
@@ -166,41 +343,16 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
 
         tracked = bool(getattr(coordinator, "_nija_v142_flight_generation", 0))
         if not tracked:
-            try:
-                from bot import capital_publication_deadline_v137_patch as v137
-
-                authority = publication_liveness._authority()
-                due, meta = v137._publication_refresh_due(authority, manager)
-            except Exception as exc:
-                logger.warning(
-                    "CAPITAL_PUBLICATION_V142_UPGRADE_PROBE_FAILED marker=%s err=%s:%s "
-                    "existing_owner_preserved=true trading_fail_closed=true",
-                    _MARKER,
-                    type(exc).__name__,
-                    exc,
-                )
-                return True
-
-            if not due:
-                return True
-
-            replacement = publication_liveness._rollover_coordinator(
-                manager,
-                expected_old=coordinator,
-                reason="untracked_inflight_refresh_due:" + str(meta.get("due_reason") or "due"),
+            # Preserve the existing owner during freshness headroom. The base
+            # v142 probe is already fail-closed and only retires an untracked
+            # owner once the immutable publication is no longer current.
+            result = bool(original_inflight(manager))
+            logger.debug(
+                "CAPITAL_PUBLICATION_V153_UNTRACKED_OWNER_PROBE marker=%s in_flight=%s rollover_on_headroom=false",
+                _QUALITY_MARKER,
+                result,
             )
-            logger.critical(
-                "CAPITAL_PUBLICATION_V142_UPGRADE_ROLLOVER marker=%s due_reason=%s "
-                "remaining_s=%s old_id=%s new_id=%s pre_expiry=%s "
-                "publication_expiry_extended=false trading_fail_closed_until_refresh=true",
-                _MARKER,
-                meta.get("due_reason"),
-                meta.get("remaining_s"),
-                hex(id(coordinator)),
-                hex(id(replacement)) if replacement is not None else "none",
-                str(float(meta.get("remaining_s", 0.0) or 0.0) > 0.0).lower(),
-            )
-            return bool(replacement is coordinator or replacement is None)
+            return result
 
         # A tracked v142 owner has a generation before its worker-thread handle
         # is published. Treat that brief pre-start window as live unless it has
@@ -250,7 +402,7 @@ def _prepare_capital_publication_liveness(publication_liveness: Any) -> bool:
     setattr(coordinator_in_flight_with_upgrade_rollover, "_nija_v142_upgrade_rollover", True)
     publication_liveness._coordinator_in_flight_v142 = coordinator_in_flight_with_upgrade_rollover
     publication_liveness._nija_startup_chain_prepared = True
-    return True
+    return _install_truthful_connectivity(publication_liveness)
 
 
 def _install_authority_liveness() -> bool:
@@ -297,6 +449,10 @@ def _install_authority_liveness() -> bool:
         )
         if not callable(installer) or not bool(installer()):
             return False
+        # v142 installation can replace its own connectivity function; reassert
+        # v153 truth semantics after the installer completes.
+        if not _install_truthful_connectivity(publication_liveness):
+            return False
     except Exception as exc:
         logger.exception(
             "CAPITAL_PUBLICATION_LIVENESS_CHAIN_FAILED marker=%s error=%s",
@@ -321,6 +477,8 @@ def _install_authority_liveness() -> bool:
         )
         return False
 
+    if not _patch_runtime_authority_structural_gate():
+        return False
     return True
 
 
@@ -346,14 +504,18 @@ def install_import_hook() -> None:
 
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_INSTALLED"] = "1"
         os.environ["NIJA_KILL_SWITCH_COORDINATOR_SYNC_READY"] = "1"
+        os.environ["NIJA_RUNTIME_QUALITY_CONVERGENCE_V153_READY"] = "1"
         logger.critical(
             "KILL_SWITCH_COORDINATOR_SYNC_INSTALLED marker=%s active=%s auto_clear=false "
             "risk_gates_unchanged=true authority_liveness_chained=true "
             "stalled_writer_capital_freshness_chained=true "
             "capital_publication_liveness_chained=true "
-            "kill_switch_persistence_provenance_chained=true",
+            "kill_switch_persistence_provenance_chained=true "
+            "runtime_quality_marker=%s authority_structural_gate=true "
+            "truthful_broker_connectivity=true untracked_refresh_owner_preserved=true",
             _MARKER,
             str(active).lower(),
+            _QUALITY_MARKER,
         )
 
 
@@ -368,4 +530,7 @@ __all__ = [
     "_publish_coordinator_truth",
     "_prepare_capital_publication_liveness",
     "_install_authority_liveness",
+    "_structural_readiness_blockers",
+    "_patch_runtime_authority_structural_gate",
+    "_install_truthful_connectivity",
 ]

--- a/bot/liquidity_routing_system.py
+++ b/bot/liquidity_routing_system.py
@@ -1,488 +1,163 @@
-"""
-NIJA Liquidity Routing System
-==============================
-
-Smart order routing for best execution across multiple liquidity sources.
-
-Features:
-- Best price discovery across exchanges
-- Slippage minimization
-- Order splitting for large trades
-- Liquidity aggregation
-- Smart routing algorithms
-- Real-time execution optimization
-
-This ensures best possible execution prices by routing to optimal venues.
-
-Author: NIJA Trading Systems
-Version: 1.0 (Path 3)
-Date: January 30, 2026
-"""
-
-import logging
-from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass, field
+"""NIJA exchange-aware smart liquidity routing."""
+import logging, math
+from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from decimal import Decimal
-import heapq
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger("nija.liquidity_routing")
 
-
 class Exchange(Enum):
-    """Supported exchanges"""
-    COINBASE = "coinbase"
-    KRAKEN = "kraken"
-    BINANCE = "binance"
-    OKX = "okx"
-
-
+    COINBASE="coinbase"; KRAKEN="kraken"; BINANCE="binance"; OKX="okx"
 class OrderType(Enum):
-    """Order types"""
-    MARKET = "market"
-    LIMIT = "limit"
-
+    MARKET="market"; LIMIT="limit"
 
 @dataclass
 class LiquidityLevel:
-    """Single level of liquidity (bid or ask)"""
-    exchange: Exchange
-    price: Decimal
-    size: Decimal
-    
-    def __lt__(self, other):
-        """For heap comparison (best price first)"""
-        return self.price < other.price
-
+    exchange: Exchange; price: Decimal; size: Decimal
+    def __lt__(self, other): return self.price < other.price
 
 @dataclass
 class OrderBook:
-    """Aggregated order book from an exchange"""
-    exchange: Exchange
-    symbol: str
-    bids: List[LiquidityLevel]  # Sorted descending (best bid first)
-    asks: List[LiquidityLevel]  # Sorted ascending (best ask first)
-    timestamp: datetime
-    
-    def get_best_bid(self) -> Optional[LiquidityLevel]:
-        """Get best bid"""
-        return self.bids[0] if self.bids else None
-    
-    def get_best_ask(self) -> Optional[LiquidityLevel]:
-        """Get best ask"""
-        return self.asks[0] if self.asks else None
-    
-    def to_dict(self) -> Dict:
-        """Convert to dictionary"""
-        return {
-            'exchange': self.exchange.value,
-            'symbol': self.symbol,
-            'best_bid': float(self.bids[0].price) if self.bids else None,
-            'best_ask': float(self.asks[0].price) if self.asks else None,
-            'bid_depth': sum(float(level.size) for level in self.bids),
-            'ask_depth': sum(float(level.size) for level in self.asks),
-            'timestamp': self.timestamp.isoformat()
-        }
-
+    exchange: Exchange; symbol: str; bids: List[LiquidityLevel]; asks: List[LiquidityLevel]; timestamp: datetime
+    def get_best_bid(self): return self.bids[0] if self.bids else None
+    def get_best_ask(self): return self.asks[0] if self.asks else None
+    def to_dict(self):
+        return {"exchange":self.exchange.value,"symbol":self.symbol,
+                "best_bid":float(self.bids[0].price) if self.bids else None,
+                "best_ask":float(self.asks[0].price) if self.asks else None,
+                "bid_depth":sum(float(x.size) for x in self.bids),
+                "ask_depth":sum(float(x.size) for x in self.asks),"timestamp":self.timestamp.isoformat()}
 
 @dataclass
 class RouteSegment:
-    """A segment of a routed order"""
-    exchange: Exchange
-    price: Decimal
-    size: Decimal
-    side: str  # 'buy' or 'sell'
-    estimated_fee: Decimal
-    
-    def total_cost(self) -> Decimal:
-        """Calculate total cost including fees"""
-        base_cost = self.price * self.size
-        return base_cost + self.estimated_fee
-    
-    def to_dict(self) -> Dict:
-        """Convert to dictionary"""
-        return {
-            'exchange': self.exchange.value,
-            'price': float(self.price),
-            'size': float(self.size),
-            'side': self.side,
-            'estimated_fee': float(self.estimated_fee),
-            'total_cost': float(self.total_cost())
-        }
-
+    exchange: Exchange; price: Decimal; size: Decimal; side: str; estimated_fee: Decimal
+    def total_cost(self): return self.price*self.size+self.estimated_fee
+    def to_dict(self):
+        return {"exchange":self.exchange.value,"price":float(self.price),"size":float(self.size),
+                "side":self.side,"estimated_fee":float(self.estimated_fee),"total_cost":float(self.total_cost())}
 
 @dataclass
 class RoutedOrder:
-    """Order routing plan"""
-    symbol: str
-    side: str  # 'buy' or 'sell'
-    total_size: Decimal
-    segments: List[RouteSegment]
-    avg_price: Decimal
-    total_cost: Decimal
-    total_fees: Decimal
-    slippage_pct: float
-    created_at: datetime
-    
-    def to_dict(self) -> Dict:
-        """Convert to dictionary"""
-        return {
-            'symbol': self.symbol,
-            'side': self.side,
-            'total_size': float(self.total_size),
-            'segments': [seg.to_dict() for seg in self.segments],
-            'avg_price': float(self.avg_price),
-            'total_cost': float(self.total_cost),
-            'total_fees': float(self.total_fees),
-            'slippage_pct': self.slippage_pct,
-            'num_venues': len(set(seg.exchange for seg in self.segments)),
-            'created_at': self.created_at.isoformat()
-        }
-
+    symbol:str; side:str; total_size:Decimal; segments:List[RouteSegment]; avg_price:Decimal
+    total_cost:Decimal; total_fees:Decimal; slippage_pct:float; created_at:datetime
+    def to_dict(self):
+        return {"symbol":self.symbol,"side":self.side,"total_size":float(self.total_size),
+                "segments":[x.to_dict() for x in self.segments],"avg_price":float(self.avg_price),
+                "total_cost":float(self.total_cost),"total_fees":float(self.total_fees),
+                "slippage_pct":self.slippage_pct,"num_venues":len({x.exchange for x in self.segments}),
+                "created_at":self.created_at.isoformat()}
 
 class LiquidityRoutingSystem:
-    """
-    Smart order routing system for optimal execution
-    
-    How it works:
-    1. Aggregate liquidity from multiple exchanges
-    2. Sort by best price
-    3. Split order across venues for best execution
-    4. Calculate total cost including fees and slippage
-    5. Route to minimize total cost
-    
-    Example:
-        Want to buy 5 BTC
-        Coinbase: 1 BTC @ $50,000
-        Kraken: 2 BTC @ $49,990
-        Binance: 3 BTC @ $50,010
-        
-        Optimal route:
-        1. Buy 2 BTC on Kraken @ $49,990
-        2. Buy 1 BTC on Coinbase @ $50,000
-        3. Buy 2 BTC on Binance @ $50,010
-        Avg price: $49,998 (saved $60 vs buying all on Coinbase)
-    """
-    
-    def __init__(self, config: Dict = None):
-        """
-        Initialize liquidity routing system
-        
-        Args:
-            config: Optional configuration dictionary
-        """
-        self.config = config or {}
-        
-        # Fee structures
-        self.fee_rates = {
-            Exchange.COINBASE: Decimal('0.006'),  # 0.6%
-            Exchange.KRAKEN: Decimal('0.0026'),  # 0.26%
-            Exchange.BINANCE: Decimal('0.001'),  # 0.1%
-            Exchange.OKX: Decimal('0.001')  # 0.1%
-        }
-        
-        # Order books
-        self.order_books: Dict[Exchange, Dict[str, OrderBook]] = {}
-        
-        # Routing statistics
-        self.total_orders_routed = 0
-        self.total_savings_usd = Decimal('0')
-        
-        logger.info("LiquidityRoutingSystem initialized")
-    
-    def update_order_book(
-        self,
-        exchange: Exchange,
-        symbol: str,
-        bids: List[Tuple[Decimal, Decimal]],
-        asks: List[Tuple[Decimal, Decimal]]
-    ):
-        """
-        Update order book for an exchange
-        
-        Args:
-            exchange: Exchange name
-            symbol: Trading symbol
-            bids: List of (price, size) tuples
-            asks: List of (price, size) tuples
-        """
-        # Convert to LiquidityLevel objects
-        bid_levels = [
-            LiquidityLevel(exchange=exchange, price=price, size=size)
-            for price, size in bids
-        ]
-        ask_levels = [
-            LiquidityLevel(exchange=exchange, price=price, size=size)
-            for price, size in asks
-        ]
-        
-        # Sort: bids descending, asks ascending
-        bid_levels.sort(key=lambda x: x.price, reverse=True)
-        ask_levels.sort(key=lambda x: x.price)
-        
-        # Create order book
-        order_book = OrderBook(
-            exchange=exchange,
-            symbol=symbol,
-            bids=bid_levels,
-            asks=ask_levels,
-            timestamp=datetime.now()
-        )
-        
-        # Store
-        if exchange not in self.order_books:
-            self.order_books[exchange] = {}
-        self.order_books[exchange][symbol] = order_book
-    
-    def find_best_route(
-        self,
-        symbol: str,
-        side: str,
-        size: Decimal,
-        max_slippage_pct: float = 1.0
-    ) -> Optional[RoutedOrder]:
-        """
-        Find best routing for an order
-        
-        Args:
-            symbol: Trading symbol
-            side: 'buy' or 'sell'
-            size: Order size
-            max_slippage_pct: Maximum allowed slippage percentage
-        
-        Returns:
-            RoutedOrder or None if routing not possible
-        """
-        # Aggregate liquidity across exchanges
-        if side == 'buy':
-            liquidity = self._aggregate_asks(symbol)
-            is_ascending = True  # Best price is lowest
-        else:
-            liquidity = self._aggregate_bids(symbol)
-            is_ascending = False  # Best price is highest
-        
-        if not liquidity:
-            logger.warning(f"No liquidity available for {symbol}")
-            return None
-        
-        # Sort by price (best first)
-        liquidity.sort(key=lambda x: x.price, reverse=not is_ascending)
-        
-        # Route order across venues
-        segments = []
-        remaining_size = size
-        total_cost = Decimal('0')
-        total_fees = Decimal('0')
-        
-        for level in liquidity:
-            if remaining_size <= 0:
-                break
-            
-            # How much to fill at this level
-            fill_size = min(remaining_size, level.size)
-            
-            # Calculate fee
-            fee_rate = self.fee_rates.get(level.exchange, Decimal('0.001'))
-            fee = fill_size * level.price * fee_rate
-            
-            # Create segment
-            segment = RouteSegment(
-                exchange=level.exchange,
-                price=level.price,
-                size=fill_size,
-                side=side,
-                estimated_fee=fee
-            )
-            
-            segments.append(segment)
-            remaining_size -= fill_size
-            total_cost += segment.total_cost()
-            total_fees += fee
-        
-        # Check if we filled the entire order
-        if remaining_size > 0:
-            logger.warning(
-                f"Insufficient liquidity: requested {size}, only {size - remaining_size} available"
-            )
-            # Partial fill is still valid
-        
-        # Calculate average price
-        filled_size = size - remaining_size
-        if filled_size == 0:
-            return None
-        
-        avg_price = (total_cost - total_fees) / filled_size
-        
-        # Calculate slippage vs best price
-        best_price = liquidity[0].price
-        slippage_pct = float(abs(avg_price - best_price) / best_price * 100)
-        
-        # Check slippage tolerance
-        if slippage_pct > max_slippage_pct:
-            logger.warning(
-                f"Slippage {slippage_pct:.2f}% exceeds max {max_slippage_pct:.2f}%"
-            )
-            # Could return None here to reject order, or proceed anyway
-        
-        # Create routed order
-        routed_order = RoutedOrder(
-            symbol=symbol,
-            side=side,
-            total_size=filled_size,
-            segments=segments,
-            avg_price=avg_price,
-            total_cost=total_cost,
-            total_fees=total_fees,
-            slippage_pct=slippage_pct,
-            created_at=datetime.now()
-        )
-        
-        self.total_orders_routed += 1
-        
-        # Calculate savings vs worst case (single venue)
-        worst_case_cost = self._calculate_worst_case_cost(symbol, side, size)
-        if worst_case_cost:
-            savings = worst_case_cost - total_cost
-            self.total_savings_usd += savings
-            logger.info(f"Routing savings: ${savings:.2f}")
-        
-        logger.info(
-            f"Route found: {side.upper()} {filled_size} {symbol} | "
-            f"Avg price: ${avg_price:.2f} | Slippage: {slippage_pct:.2f}% | "
-            f"Venues: {len(set(seg.exchange for seg in segments))}"
-        )
-        
-        return routed_order
-    
-    def _aggregate_asks(self, symbol: str) -> List[LiquidityLevel]:
-        """Aggregate all ask liquidity for a symbol"""
-        all_asks = []
-        
-        for exchange, books in self.order_books.items():
-            if symbol in books:
-                all_asks.extend(books[symbol].asks)
-        
-        return all_asks
-    
-    def _aggregate_bids(self, symbol: str) -> List[LiquidityLevel]:
-        """Aggregate all bid liquidity for a symbol"""
-        all_bids = []
-        
-        for exchange, books in self.order_books.items():
-            if symbol in books:
-                all_bids.extend(books[symbol].bids)
-        
-        return all_bids
-    
-    def _calculate_worst_case_cost(
-        self,
-        symbol: str,
-        side: str,
-        size: Decimal
-    ) -> Optional[Decimal]:
-        """Calculate cost of filling entire order on single worst venue"""
-        # For simplicity, assume worst = most expensive
-        # In practice, would walk the book
-        if side == 'buy':
-            liquidity = self._aggregate_asks(symbol)
-            if not liquidity:
-                return None
-            worst_price = max(level.price for level in liquidity)
-        else:
-            liquidity = self._aggregate_bids(symbol)
-            if not liquidity:
-                return None
-            worst_price = min(level.price for level in liquidity)
-        
-        # Assume average fee
-        avg_fee_rate = sum(self.fee_rates.values()) / len(self.fee_rates)
-        
-        return size * worst_price * (Decimal('1') + avg_fee_rate)
-    
-    def get_best_price(
-        self,
-        symbol: str,
-        side: str
-    ) -> Optional[Tuple[Exchange, Decimal]]:
-        """
-        Get best price across all exchanges
-        
-        Args:
-            symbol: Trading symbol
-            side: 'buy' or 'sell'
-        
-        Returns:
-            Tuple of (exchange, price) or None
-        """
-        if side == 'buy':
-            liquidity = self._aggregate_asks(symbol)
-            if not liquidity:
-                return None
-            best = min(liquidity, key=lambda x: x.price)
-        else:
-            liquidity = self._aggregate_bids(symbol)
-            if not liquidity:
-                return None
-            best = max(liquidity, key=lambda x: x.price)
-        
-        return (best.exchange, best.price)
-    
-    def get_liquidity_summary(self, symbol: str) -> Dict:
-        """Get liquidity summary for a symbol"""
-        total_bid_size = Decimal('0')
-        total_ask_size = Decimal('0')
-        exchanges_with_liquidity = []
-        
-        for exchange, books in self.order_books.items():
-            if symbol in books:
-                book = books[symbol]
-                bid_size = sum(level.size for level in book.bids)
-                ask_size = sum(level.size for level in book.asks)
-                
-                if bid_size > 0 or ask_size > 0:
-                    exchanges_with_liquidity.append(exchange.value)
-                    total_bid_size += bid_size
-                    total_ask_size += ask_size
-        
-        # Get best prices
-        best_bid = self.get_best_price(symbol, 'sell')
-        best_ask = self.get_best_price(symbol, 'buy')
-        
-        return {
-            'symbol': symbol,
-            'total_bid_size': float(total_bid_size),
-            'total_ask_size': float(total_ask_size),
-            'best_bid': {
-                'exchange': best_bid[0].value,
-                'price': float(best_bid[1])
-            } if best_bid else None,
-            'best_ask': {
-                'exchange': best_ask[0].value,
-                'price': float(best_ask[1])
-            } if best_ask else None,
-            'spread_pct': float((best_ask[1] - best_bid[1]) / best_bid[1] * 100) if best_bid and best_ask else None,
-            'exchanges': exchanges_with_liquidity,
-            'num_exchanges': len(exchanges_with_liquidity)
-        }
-    
-    def get_stats(self) -> Dict:
-        """Get routing statistics"""
-        return {
-            'total_orders_routed': self.total_orders_routed,
-            'total_savings_usd': float(self.total_savings_usd),
-            'avg_savings_per_order': (
-                float(self.total_savings_usd / self.total_orders_routed)
-                if self.total_orders_routed > 0 else 0.0
-            ),
-            'exchanges_tracked': len(self.order_books),
-            'symbols_available': len(set(
-                symbol
-                for books in self.order_books.values()
-                for symbol in books.keys()
-            ))
-        }
+    """Routes using price/fees plus venue depth, spread, and realized volatility."""
+    DEFAULT_PROFILE={"depth_weight":.40,"spread_weight":.25,"volatility_weight":.25,
+                     "fee_weight":.10,"volatility_soft_limit_pct":1.5,"max_participation_rate":.80}
+    def __init__(self, config:Dict=None):
+        self.config=config or {}
+        self.fee_rates={Exchange.COINBASE:Decimal("0.006"),Exchange.KRAKEN:Decimal("0.0026"),
+                        Exchange.BINANCE:Decimal("0.001"),Exchange.OKX:Decimal("0.001")}
+        for k,v in self.config.get("fee_rates",{}).items():
+            e=self._exchange(k)
+            if e: self.fee_rates[e]=Decimal(str(v))
+        self.order_books={}; self._mid_history={}; self.total_orders_routed=0; self.total_savings_usd=Decimal("0")
+        self._window=max(3,int(self.config.get("volatility_window",24)))
+        self._max_penalty_bps=max(0.,float(self.config.get("max_microstructure_penalty_bps",20.)))
+    @staticmethod
+    def _exchange(v):
+        if isinstance(v,Exchange): return v
+        try: return Exchange(str(v).lower())
+        except (ValueError,TypeError): return None
+    def _profile(self,e):
+        p=dict(self.DEFAULT_PROFILE); p.update(self.config.get("venue_profiles",{}).get(e.value,{}) or {}); return p
+    def update_order_book(self,exchange,symbol,bids,asks):
+        exchange=self._exchange(exchange)
+        if exchange is None: raise ValueError("Unsupported exchange")
+        b=[LiquidityLevel(exchange,p,s) for p,s in bids]; a=[LiquidityLevel(exchange,p,s) for p,s in asks]
+        b.sort(key=lambda x:x.price,reverse=True); a.sort(key=lambda x:x.price)
+        book=OrderBook(exchange,symbol,b,a,datetime.now()); self.order_books.setdefault(exchange,{})[symbol]=book
+        if b and a and b[0].price>0 and a[0].price>0:
+            h=self._mid_history.setdefault(exchange,{}).setdefault(symbol,[]); h.append((b[0].price+a[0].price)/2)
+            if len(h)>self._window: del h[:-self._window]
+    def _vol_pct(self,e,symbol):
+        h=self._mid_history.get(e,{}).get(symbol,[]); r=[float((c-p)/p) for p,c in zip(h,h[1:]) if p>0]
+        if len(r)<2:return 0.0
+        m=sum(r)/len(r); return math.sqrt(sum((x-m)**2 for x in r)/len(r))*100
+    def get_venue_metrics(self,exchange,symbol,side,target_size=None):
+        e=self._exchange(exchange); book=self.order_books.get(e,{}).get(symbol) if e else None
+        if not book or not book.bids or not book.asks:return None
+        side=side.lower(); levels=book.asks if side=="buy" else book.bids
+        bid,ask=book.bids[0],book.asks[0]; spread=max(0.,float((ask.price-bid.price)/bid.price*100))
+        depth=sum((x.size for x in levels),Decimal("0")); target=target_size if target_size and target_size>0 else depth
+        depth_score=min(1.,float(depth/target)) if target>0 else 0.; p=self._profile(e)
+        vol=self._vol_pct(e,symbol); vol_score=1/(1+vol/max(.01,float(p["volatility_soft_limit_pct"])))
+        spread_score=1/(1+spread/max(.01,float(self.config.get("spread_soft_limit_pct",.20))))
+        fee=float(self.fee_rates.get(e,Decimal("0.001"))*100); fee_score=1/(1+fee/max(.01,float(self.config.get("fee_soft_limit_pct",.60))))
+        weights=[float(p[x]) for x in ("depth_weight","spread_weight","volatility_weight","fee_weight")]; total=sum(weights) or 1
+        score=sum(v*w/total for v,w in zip((depth_score,spread_score,vol_score,fee_score),weights))
+        return {"exchange":e.value,"symbol":symbol,"side":side,"venue_score":max(0.,min(1.,score)),
+                "spread_pct":spread,"side_depth":float(depth),"top5_depth":float(sum((x.size for x in levels[:5]),Decimal("0"))),
+                "depth_score":depth_score,"realized_volatility_pct":vol,"volatility_score":vol_score,
+                "fee_pct":fee,"fee_score":fee_score,"max_participation_rate":float(p["max_participation_rate"])}
+    def _effective(self,level,symbol,side,size):
+        m=self.get_venue_metrics(level.exchange,symbol,side,size); score=m["venue_score"] if m else 0
+        fee=self.fee_rates.get(level.exchange,Decimal("0.001")); penalty=Decimal(str((1-score)*self._max_penalty_bps/10000))
+        return level.price*(1+fee+penalty) if side=="buy" else level.price*(1-fee-penalty)
+    def _levels(self,symbol,side):
+        attr="asks" if side=="buy" else "bids"
+        return [x for books in self.order_books.values() if symbol in books for x in getattr(books[symbol],attr)]
+    def find_best_route(self,symbol,side,size,max_slippage_pct=1.0):
+        side=side.lower()
+        if side not in {"buy","sell"}: raise ValueError("side must be 'buy' or 'sell'")
+        if size<=0: raise ValueError("size must be positive")
+        levels=self._levels(symbol,side)
+        if not levels:return None
+        levels.sort(key=lambda x:self._effective(x,symbol,side,size),reverse=side=="sell")
+        venues={x.exchange for x in levels}; caps={}
+        for e in venues:
+            m=self.get_venue_metrics(e,symbol,side,size); p=self._profile(e)
+            if len(venues)==1: caps[e]=size
+            elif m:
+                rate=min(1.,max(.05,float(p["max_participation_rate"])*max(.25,m["volatility_score"])))
+                caps[e]=min(size,Decimal(str(m["side_depth"]))*Decimal(str(rate)))
+            else:caps[e]=Decimal("0")
+        used={e:Decimal("0") for e in venues}; remain=size; seg=[]; total=Decimal("0"); fees=Decimal("0")
+        for level in levels:
+            room=max(Decimal("0"),caps[level.exchange]-used[level.exchange]); fill=min(remain,level.size,room)
+            if fill<=0:continue
+            fee=fill*level.price*self.fee_rates.get(level.exchange,Decimal("0.001")); s=RouteSegment(level.exchange,level.price,fill,side,fee)
+            seg.append(s); used[level.exchange]+=fill; remain-=fill; total+=s.total_cost(); fees+=fee
+            if remain<=0:break
+        filled=size-remain
+        if filled<=0:return None
+        avg=(total-fees)/filled; raw=[x.price for x in levels]; best=min(raw) if side=="buy" else max(raw)
+        slippage=float(abs(avg-best)/best*100); self.total_orders_routed+=1
+        return RoutedOrder(symbol,side,filled,seg,avg,total,fees,slippage,datetime.now())
+    def get_best_price(self,symbol,side):
+        levels=self._levels(symbol,side)
+        if not levels:return None
+        x=min(levels,key=lambda y:y.price) if side=="buy" else max(levels,key=lambda y:y.price); return x.exchange,x.price
+    def get_best_venue(self,symbol,side,target_size):
+        out=[]
+        for e,books in self.order_books.items():
+            if symbol not in books:continue
+            m=self.get_venue_metrics(e,symbol,side,target_size)
+            if not m:continue
+            level=books[symbol].get_best_ask() if side=="buy" else books[symbol].get_best_bid(); m=dict(m)
+            m["best_price"]=float(level.price); m["effective_unit_price"]=float(self._effective(level,symbol,side,target_size)); out.append(m)
+        if not out:return None
+        return min(out,key=lambda x:x["effective_unit_price"]) if side=="buy" else max(out,key=lambda x:x["effective_unit_price"])
+    def get_liquidity_summary(self,symbol):
+        bid=sum((x.size for x in self._levels(symbol,"sell")),Decimal("0")); ask=sum((x.size for x in self._levels(symbol,"buy")),Decimal("0"))
+        ex=[e.value for e,b in self.order_books.items() if symbol in b]; bb=self.get_best_price(symbol,"sell"); ba=self.get_best_price(symbol,"buy")
+        return {"symbol":symbol,"total_bid_size":float(bid),"total_ask_size":float(ask),
+                "best_bid":{"exchange":bb[0].value,"price":float(bb[1])} if bb else None,
+                "best_ask":{"exchange":ba[0].value,"price":float(ba[1])} if ba else None,
+                "spread_pct":float((ba[1]-bb[1])/bb[1]*100) if bb and ba else None,"exchanges":ex,"num_exchanges":len(ex),
+                "venue_metrics":{e:{"buy":self.get_venue_metrics(Exchange(e),symbol,"buy"),"sell":self.get_venue_metrics(Exchange(e),symbol,"sell")} for e in ex}}
+    def get_stats(self):
+        return {"total_orders_routed":self.total_orders_routed,"total_savings_usd":float(self.total_savings_usd),
+                "avg_savings_per_order":float(self.total_savings_usd/self.total_orders_routed) if self.total_orders_routed else 0.,
+                "exchanges_tracked":len(self.order_books),"symbols_available":len({s for b in self.order_books.values() for s in b}),"venue_aware_routing":True}
 
-
-# Global instance
-liquidity_routing_system = LiquidityRoutingSystem()
+liquidity_routing_system=LiquidityRoutingSystem()

--- a/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
+++ b/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
@@ -64,10 +64,9 @@ def test_pre_v142_inflight_is_preserved_during_refresh_headroom() -> None:
 
 
 def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_state() -> None:
-    broker_key = SimpleNamespace(value="kraken")
     broker = SimpleNamespace(connected=False)
     manager = SimpleNamespace(
-        _platform_brokers={broker_key: broker},
+        _platform_brokers={"kraken": broker},
         _platform_state={"kraken": "connected"},
         is_platform_connected=lambda raw_key: True,
     )
@@ -88,10 +87,9 @@ def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_
 
 
 def test_direct_broker_connectivity_true_remains_connected() -> None:
-    broker_key = SimpleNamespace(value="coinbase")
     broker = SimpleNamespace(connected=True)
     manager = SimpleNamespace(
-        _platform_brokers={broker_key: broker},
+        _platform_brokers={"coinbase": broker},
         _platform_state={"coinbase": "disconnected"},
         is_platform_connected=lambda raw_key: False,
     )

--- a/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
+++ b/bot/tests/test_capital_publication_liveness_v142_startup_chain.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from bot.kill_switch_coordinator_sync_patch import _prepare_capital_publication_liveness
+from bot.kill_switch_coordinator_sync_patch import (
+    _prepare_capital_publication_liveness,
+    _structural_readiness_blockers,
+)
 
 
 def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
@@ -19,6 +22,8 @@ def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
     fake = SimpleNamespace(
         _nija_startup_chain_prepared=False,
         _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: None,
     )
     assert _prepare_capital_publication_liveness(fake) is True
 
@@ -34,41 +39,98 @@ def test_wrapper_proof_uses_code_identity_not_copied_display_name() -> None:
     ) is False
 
 
-def test_pre_v142_inflight_rolls_over_when_refresh_enters_headroom(monkeypatch) -> None:
-    from bot import capital_publication_deadline_v137_patch as v137
-
+def test_pre_v142_inflight_is_preserved_during_refresh_headroom() -> None:
     old = SimpleNamespace(_in_flight=True)
-    replacement = SimpleNamespace(_in_flight=False)
     manager = SimpleNamespace(_capital_coordinator=old)
-    authority = SimpleNamespace()
-    reasons: list[str] = []
+    rollover_calls: list[str] = []
 
     fake = SimpleNamespace(
         _nija_startup_chain_prepared=False,
         _coordinator_in_flight_v142=lambda manager: True,
-        _authority=lambda: authority,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: None,
     )
 
     def rollover(target_manager, *, expected_old=None, reason):
-        assert expected_old is old
-        reasons.append(str(reason))
-        target_manager._capital_coordinator = replacement
-        return replacement
+        rollover_calls.append(str(reason))
+        return expected_old
 
     fake._rollover_coordinator = rollover
-    monkeypatch.setattr(
-        v137,
-        "_publication_refresh_due",
-        lambda authority, manager: (
-            True,
-            {
-                "due_reason": "pre_expiry_headroom",
-                "remaining_s": 42.0,
-            },
-        ),
+
+    assert _prepare_capital_publication_liveness(fake) is True
+    assert fake._coordinator_in_flight_v142(manager) is True
+    assert manager._capital_coordinator is old
+    assert rollover_calls == []
+
+
+def test_direct_broker_connectivity_false_cannot_be_overridden_by_stale_manager_state() -> None:
+    broker_key = SimpleNamespace(value="kraken")
+    broker = SimpleNamespace(connected=False)
+    manager = SimpleNamespace(
+        _platform_brokers={broker_key: broker},
+        _platform_state={"kraken": "connected"},
+        is_platform_connected=lambda raw_key: True,
+    )
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (True, {}),
+        _canonical_manager=lambda: manager,
     )
 
     assert _prepare_capital_publication_liveness(fake) is True
-    assert fake._coordinator_in_flight_v142(manager) is False
-    assert manager._capital_coordinator is replacement
-    assert reasons == ["untracked_inflight_refresh_due:pre_expiry_headroom"]
+    ready, meta = fake._canonical_broker_connectivity()
+
+    assert ready is False
+    assert meta["registered"] == ["kraken"]
+    assert meta["connected"] == []
+    assert meta["direct_connectivity_authoritative"] is True
+
+
+def test_direct_broker_connectivity_true_remains_connected() -> None:
+    broker_key = SimpleNamespace(value="coinbase")
+    broker = SimpleNamespace(connected=True)
+    manager = SimpleNamespace(
+        _platform_brokers={broker_key: broker},
+        _platform_state={"coinbase": "disconnected"},
+        is_platform_connected=lambda raw_key: False,
+    )
+    fake = SimpleNamespace(
+        _nija_startup_chain_prepared=False,
+        _coordinator_in_flight_v142=lambda manager: False,
+        _canonical_broker_connectivity=lambda: (False, {}),
+        _canonical_manager=lambda: manager,
+    )
+
+    assert _prepare_capital_publication_liveness(fake) is True
+    ready, meta = fake._canonical_broker_connectivity()
+
+    assert ready is True
+    assert meta["connected"] == ["coinbase"]
+
+
+def test_structural_readiness_blockers_include_runtime_handoff_proofs(monkeypatch) -> None:
+    from bot import readiness_table
+
+    monkeypatch.setattr(
+        readiness_table,
+        "snapshot",
+        lambda: {
+            "broker_connected": True,
+            "balance_hydrated": True,
+            "authority_ready": False,
+            "capital_ready": True,
+            "risk_ready": True,
+            "strategy_ready": False,
+            "execution_ready": False,
+            "nonce_ready": False,
+            "bootstrap_ready": True,
+            "position_sync_ready": False,
+        },
+    )
+
+    assert _structural_readiness_blockers() == [
+        "strategy_ready",
+        "execution_ready",
+        "position_sync_ready",
+    ]

--- a/bot/tests/test_liquidity_routing_exchange_microstructure.py
+++ b/bot/tests/test_liquidity_routing_exchange_microstructure.py
@@ -1,0 +1,117 @@
+from decimal import Decimal
+
+from bot.liquidity_routing_system import Exchange, LiquidityRoutingSystem
+
+
+def D(value):
+    return Decimal(str(value))
+
+
+def test_backward_compatible_order_book_update_and_summary():
+    router = LiquidityRoutingSystem()
+    router.update_order_book(
+        Exchange.COINBASE,
+        "BTC-USD",
+        bids=[(D(100), D(2))],
+        asks=[(D(101), D(2))],
+    )
+    summary = router.get_liquidity_summary("BTC-USD")
+    assert summary["num_exchanges"] == 1
+    assert summary["venue_metrics"]["coinbase"]["buy"]["side_depth"] == 2.0
+
+
+def test_deeper_lower_volatility_venue_can_beat_tiny_price_edge():
+    router = LiquidityRoutingSystem(
+        {
+            "fee_rates": {"coinbase": 0.001, "kraken": 0.001},
+            "max_microstructure_penalty_bps": 30,
+            "venue_profiles": {
+                "coinbase": {"max_participation_rate": 1.0},
+                "kraken": {"max_participation_rate": 1.0},
+            },
+        }
+    )
+
+    for bid, ask in [(100, 100.10), (96, 96.10), (104, 104.10), (99, 99.10), (100, 100.10)]:
+        router.update_order_book(
+            Exchange.COINBASE,
+            "BTC-USD",
+            bids=[(D(bid), D("0.10"))],
+            asks=[(D(ask), D("0.10"))],
+        )
+
+    for bid, ask in [(100, 100.12)] * 5:
+        router.update_order_book(
+            Exchange.KRAKEN,
+            "BTC-USD",
+            bids=[(D(bid), D("5"))],
+            asks=[(D(ask), D("5"))],
+        )
+
+    coinbase = router.get_venue_metrics(Exchange.COINBASE, "BTC-USD", "buy", D(1))
+    kraken = router.get_venue_metrics(Exchange.KRAKEN, "BTC-USD", "buy", D(1))
+    assert kraken["venue_score"] > coinbase["venue_score"]
+    assert kraken["realized_volatility_pct"] < coinbase["realized_volatility_pct"]
+    assert kraken["side_depth"] > coinbase["side_depth"]
+
+    best = router.get_best_venue("BTC-USD", "buy", D(1))
+    assert best["exchange"] == "kraken"
+
+    route = router.find_best_route("BTC-USD", "buy", D(1))
+    assert route is not None
+    assert route.segments[0].exchange == Exchange.KRAKEN
+
+
+def test_exchange_specific_profile_override_changes_sensitivity():
+    router = LiquidityRoutingSystem(
+        {
+            "fee_rates": {"coinbase": 0.001, "kraken": 0.001},
+            "venue_profiles": {
+                "coinbase": {
+                    "depth_weight": 0.10,
+                    "spread_weight": 0.70,
+                    "volatility_weight": 0.10,
+                    "fee_weight": 0.10,
+                },
+                "kraken": {
+                    "depth_weight": 0.70,
+                    "spread_weight": 0.10,
+                    "volatility_weight": 0.10,
+                    "fee_weight": 0.10,
+                },
+            },
+        }
+    )
+    router.update_order_book(
+        Exchange.COINBASE,
+        "ETH-USD",
+        bids=[(D(100), D(1))],
+        asks=[(D("100.01"), D(1))],
+    )
+    router.update_order_book(
+        Exchange.KRAKEN,
+        "ETH-USD",
+        bids=[(D(100), D(10))],
+        asks=[(D("100.10"), D(10))],
+    )
+    cb = router.get_venue_metrics(Exchange.COINBASE, "ETH-USD", "buy", D(5))
+    kr = router.get_venue_metrics(Exchange.KRAKEN, "ETH-USD", "buy", D(5))
+    assert cb["depth_score"] < kr["depth_score"]
+    assert cb["spread_pct"] < kr["spread_pct"]
+    assert 0 <= cb["venue_score"] <= 1
+    assert 0 <= kr["venue_score"] <= 1
+
+
+def test_single_venue_keeps_full_participation_capacity():
+    router = LiquidityRoutingSystem(
+        {"venue_profiles": {"kraken": {"max_participation_rate": 0.10}}}
+    )
+    router.update_order_book(
+        Exchange.KRAKEN,
+        "BTC-USD",
+        bids=[(D(100), D(10))],
+        asks=[(D(101), D(10))],
+    )
+    route = router.find_best_route("BTC-USD", "buy", D(2))
+    assert route is not None
+    assert route.total_size == D(2)


### PR DESCRIPTION
## What changed

- Gate runtime-authority convergence on structural startup readiness before any activation repair attempt.
- Make direct canonical broker connectivity authoritative, so stale manager state cannot relabel a disconnected venue as connected.
- Preserve healthy pre-v142 capital-refresh ownership during publication headroom instead of creating duplicate coordinators and rejecting late untagged publications.
- Make smart liquidity routing exchange-aware using live order-book depth, spread, fees, and rolling realized volatility rather than treating venues as interchangeable.
- Apply adaptive per-venue participation caps so shallow or volatile books receive less flow, while keeping exchange-specific profile overrides configurable and evidence-driven.
- Add regression coverage for runtime convergence and venue-aware routing behavior.

## Why

The 2026-08-19 production log showed an early authority repair racing incomplete startup readiness, a Kraken connectivity contradiction, and repeated untracked capital coordinator rollover before the runtime later converged to `LIVE_ACTIVE`. External strategy feedback also highlighted that Kraken and Coinbase should not be assumed to have identical liquidity, depth, or volatility characteristics.

## Safety

This remains fail-closed. It does not force `LIVE_ACTIVE`, fabricate balances/connectivity, bypass writer or nonce authority, clear kill switches, extend capital freshness, or relax risk/execution gates. Venue routing uses measured market quality with a bounded scoring penalty; it does not hard-code one exchange as always superior.

## Validation target

CI plus the added regression tests. Production should no longer emit premature activation-repair attempts while structural readiness is pending, should classify Kraken using the canonical broker object's direct connection state, should avoid headroom-only legacy coordinator rollover, and should route close venue choices using observed liquidity/depth/volatility quality.