### PR TITLE
Repair pre-authority execution readiness cycle

### DIFF
--- a/bot/runtime_execution_recovery_v154_patch.py
+++ b/bot/runtime_execution_recovery_v154_patch.py
@@ -1,0 +1,120 @@
+"""Repair the pre-activation authority/execution readiness cycle, fail-closed.
+
+v153's structural authority gate included ``execution_ready`` as a prerequisite.
+The canonical preactivation proof defines ``execution_ready`` using
+``authority_ready``. Requiring both before authority convergence creates a
+cycle in which neither proof can become true.
+
+This patch removes only ``execution_ready`` from the *pre-authority structural*
+blocker set. It does not activate trading, clear/deactivate the kill switch,
+change risk policy, mark authority/execution ready, transition the trading FSM,
+or dispatch broker orders. The existing authority convergence path remains
+responsible for kill-switch, capital, writer/nonce and activation checks.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("nija.runtime_execution_recovery_v154")
+_MARKER = "20260819-runtime-execution-recovery-v154"
+_PATCH_ATTR = "_nija_runtime_execution_recovery_v154"
+
+# Proofs that are structurally independent of runtime authority. Writer/nonce
+# are checked by canonical authority convergence. execution_ready is excluded
+# because its canonical preactivation definition depends on authority_ready.
+_REQUIRED_PRE_AUTHORITY = (
+    "broker_connected",
+    "balance_hydrated",
+    "capital_ready",
+    "risk_ready",
+    "strategy_ready",
+    "bootstrap_ready",
+)
+
+
+def _safe_structural_blockers() -> list[str]:
+    """Return only authority-independent structural blockers.
+
+    Failure to read readiness truth is itself a blocker. Position-sync remains
+    required whenever that proof is published by the runtime.
+    """
+    try:
+        try:
+            from bot import readiness_table
+        except ImportError:
+            import readiness_table  # type: ignore[import,no-redef]
+        table = dict(readiness_table.snapshot())
+    except Exception as exc:
+        logger.warning(
+            "V154_READINESS_TABLE_UNAVAILABLE marker=%s error=%s:%s trading_fail_closed=true",
+            _MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return ["readiness_table_unavailable"]
+
+    required = list(_REQUIRED_PRE_AUTHORITY)
+    if "position_sync_ready" in table:
+        required.append("position_sync_ready")
+    return [name for name in required if not bool(table.get(name, False))]
+
+
+def _install_structural_gate_repair() -> bool:
+    """Replace only v153's circular structural-blocker helper."""
+    try:
+        from bot import kill_switch_coordinator_sync_patch as sync_patch
+    except ImportError:
+        import kill_switch_coordinator_sync_patch as sync_patch  # type: ignore[import,no-redef]
+
+    current = getattr(sync_patch, "_structural_readiness_blockers", None)
+    if not callable(current):
+        logger.error(
+            "V154_STRUCTURAL_GATE_MISSING marker=%s trading_fail_closed=true",
+            _MARKER,
+        )
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    def structural_readiness_blockers_v154() -> list[str]:
+        blockers = _safe_structural_blockers()
+        if blockers:
+            logger.info(
+                "V154_PRE_AUTHORITY_BLOCKED marker=%s blockers=%s activation_attempted=false trading_fail_closed=true",
+                _MARKER,
+                blockers,
+            )
+        return blockers
+
+    setattr(structural_readiness_blockers_v154, _PATCH_ATTR, True)
+    setattr(structural_readiness_blockers_v154, "__wrapped__", current)
+    sync_patch._structural_readiness_blockers = structural_readiness_blockers_v154
+    logger.critical(
+        "V154_STRUCTURAL_GATE_REPAIRED marker=%s execution_ready_removed_from_pre_authority_gate=true safety_gates_unchanged=true",
+        _MARKER,
+    )
+    return True
+
+
+def status() -> dict[str, Any]:
+    """Return diagnostic truth without mutating trading state."""
+    try:
+        from bot import kill_switch_coordinator_sync_patch as sync_patch
+    except ImportError:
+        import kill_switch_coordinator_sync_patch as sync_patch  # type: ignore[import,no-redef]
+    current = getattr(sync_patch, "_structural_readiness_blockers", None)
+    return {
+        "marker": _MARKER,
+        "installed": bool(callable(current) and getattr(current, _PATCH_ATTR, False)),
+        "blockers": _safe_structural_blockers(),
+        "live_activation_performed": False,
+        "kill_switch_modified": False,
+    }
+
+
+def install() -> bool:
+    return _install_structural_gate_repair()
+
+
+__all__ = ["install", "status", "_safe_structural_blockers"]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -1,10 +1,11 @@
 """Keep broker-local authority and canonical module identity stable after imports.
 
 Late startup imports can recreate the legacy downstream-risk module alias after the
-initial identity audit.  Runtime authority also historically defaulted to requiring
+initial identity audit. Runtime authority also historically defaulted to requiring
 two valid brokers, contradicting broker-local readiness where one healthy venue may
-trade independently.  This guard continuously restores the canonical alias and sets
-the authority broker threshold from the active readiness policy.
+trade independently. This guard continuously restores the canonical alias, sets
+the authority broker threshold from the active readiness policy, and installs the
+fail-closed v154 pre-authority structural gate repair.
 """
 from __future__ import annotations
 
@@ -93,10 +94,27 @@ def _patch_quiescence_audit() -> bool:
     return True
 
 
+def _install_v154_recovery() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_execution_recovery_v154_patch")
+        install_fn = getattr(module, "install", None)
+        if not callable(install_fn):
+            raise RuntimeError("v154_install_missing")
+        return bool(install_fn())
+    except Exception as exc:
+        logger.error(
+            "RUNTIME_EXECUTION_RECOVERY_V154_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
     patched = _patch_quiescence_audit()
+    v154_installed = _install_v154_recovery()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -106,13 +124,14 @@ def _iteration() -> bool:
             _ALIAS,
         )
     logger.debug(
-        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s",
+        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s v154_installed=%s",
         _MARKER,
         _policy(),
         required,
         str(patched).lower(),
+        str(v154_installed).lower(),
     )
-    return True
+    return bool(v154_installed)
 
 
 def _watchdog() -> None:
@@ -136,7 +155,7 @@ def install() -> bool:
                 daemon=True,
             ).start()
         logger.critical(
-            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true",
+            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true v154_recovery=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -151,5 +170,6 @@ __all__ = [
     "_apply_broker_threshold",
     "_canonicalize_alias",
     "_patch_quiescence_audit",
+    "_install_v154_recovery",
     "_iteration",
 ]

--- a/tests/test_runtime_execution_recovery_v154.py
+++ b/tests/test_runtime_execution_recovery_v154.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from bot import runtime_execution_recovery_v154_patch as v154
+
+
+def _install_readiness_table(monkeypatch, snapshot):
+    fake = types.ModuleType("bot.readiness_table")
+    fake.snapshot = lambda: dict(snapshot)
+    monkeypatch.setitem(sys.modules, "bot.readiness_table", fake)
+
+
+def test_execution_ready_is_not_a_pre_authority_blocker(monkeypatch):
+    _install_readiness_table(
+        monkeypatch,
+        {
+            "broker_connected": True,
+            "balance_hydrated": True,
+            "capital_ready": True,
+            "risk_ready": True,
+            "strategy_ready": True,
+            "execution_ready": False,
+            "bootstrap_ready": True,
+            "position_sync_ready": True,
+        },
+    )
+
+    assert v154._safe_structural_blockers() == []
+
+
+def test_structural_readiness_remains_fail_closed(monkeypatch):
+    _install_readiness_table(
+        monkeypatch,
+        {
+            "broker_connected": True,
+            "balance_hydrated": True,
+            "capital_ready": False,
+            "risk_ready": True,
+            "strategy_ready": False,
+            "execution_ready": False,
+            "bootstrap_ready": True,
+            "position_sync_ready": False,
+        },
+    )
+
+    assert v154._safe_structural_blockers() == [
+        "capital_ready",
+        "strategy_ready",
+        "position_sync_ready",
+    ]
+
+
+def test_missing_readiness_table_fails_closed(monkeypatch):
+    monkeypatch.delitem(sys.modules, "bot.readiness_table", raising=False)
+    monkeypatch.delitem(sys.modules, "readiness_table", raising=False)
+
+    # Force imports to fail regardless of what the repository environment has.
+    original_import = __import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"bot.readiness_table", "readiness_table"} or (
+            name == "bot" and fromlist and "readiness_table" in fromlist
+        ):
+            raise ImportError("readiness table unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    assert v154._safe_structural_blockers() == ["readiness_table_unavailable"]


### PR DESCRIPTION
## What changed
- Add v154 fail-closed readiness recovery that removes only `execution_ready` from the pre-authority structural blocker set.
- Preserve kill-switch, capital, risk, writer/nonce, FSM, and dispatch controls unchanged.
- Install v154 continuously through the runtime post-import convergence watchdog.
- Add regression tests proving `execution_ready=False` no longer creates a circular wait while capital/strategy/position-sync failures still block.

## Why
v153 required `execution_ready` before runtime-authority convergence, while canonical preactivation readiness computes `execution_ready` using `authority_ready`. This creates a circular wait in which neither proof can become true.

## Safety
This PR does not clear/deactivate the kill switch, mark authority or execution ready, transition the live trading state machine, or submit broker orders. It only repairs the dependency graph so canonical safety-controlled convergence can proceed when independent prerequisites are actually healthy.

## Validation
Focused regression tests were added but have not been executed in this environment because the GitHub CLI/local checkout path is unavailable. The branch is isolated and remains fail-closed pending CI/runtime verification.