### PR TITLE
Add bounded capital pipeline publication margin

### DIFF
--- a/bot/capital_pipeline_margin_v158_patch.py
+++ b/bot/capital_pipeline_margin_v158_patch.py
@@ -1,0 +1,122 @@
+"""Bounded post-fetch publication margin for runtime capital refreshes.
+
+Production 2026-08-19 showed v142 retiring otherwise healthy runtime capital
+coordinator generations at 55 seconds while v78 deliberately permits up to 50
+seconds for synchronous broker collection.  That left only ~5 seconds for the
+remaining normalize, confidence, publish, event-dispatch, and downstream
+readiness handoff stages.  Repeated rollovers accumulated retired daemon
+coordinator workers even though the writer/core remained healthy.
+
+v158 preserves the existing freshness and fail-closed contracts while giving the
+post-fetch stages a realistic bounded margin:
+
+* keep v78's synchronous broker fetch budget unchanged;
+* keep CapitalAuthority's immutable freshness TTL unchanged;
+* cap the total v142 runtime coordinator deadline strictly inside freshness;
+* default the total deadline to fetch_budget + 20s (70s with the current 50s
+  fetch budget), leaving at least 10s before the canonical 90s freshness TTL;
+* never fabricate balances, extend publication expiry, grant execution
+  authority, clear a kill switch, synthesize readiness, or dispatch orders.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.capital_pipeline_margin_v158")
+MARKER = "20260819-capital-pipeline-margin-v158"
+_FLAG = "NIJA_CAPITAL_PIPELINE_MARGIN_V158_READY"
+_PATCH_ATTR = "_nija_capital_pipeline_margin_v158"
+_LOCK = threading.RLock()
+
+
+def _bounded_deadline_seconds(v142: Any) -> float:
+    """Return a total coordinator deadline strictly inside capital freshness."""
+    ttl_s = max(10.0, float(v142._freshness_ttl_seconds()))
+    fetch_budget_s = max(5.0, float(v142._fetch_budget_seconds()))
+    ceiling = max(10.0, ttl_s - 10.0)
+
+    try:
+        requested_margin = float(
+            os.environ.get("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", "20.0") or 20.0
+        )
+    except (TypeError, ValueError):
+        requested_margin = 20.0
+    margin_s = max(5.0, min(30.0, requested_margin))
+
+    default = min(ceiling, fetch_budget_s + margin_s)
+    raw = str(os.environ.get("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "") or "").strip()
+    if raw:
+        try:
+            requested = float(raw)
+        except (TypeError, ValueError):
+            requested = default
+    else:
+        requested = default
+
+    # Preserve operator ability to choose a stricter deadline, but never allow
+    # this liveness repair to broaden the immutable freshness window.
+    return max(10.0, min(requested, ceiling))
+
+
+def _patch_v142_deadline() -> bool:
+    try:
+        v142 = importlib.import_module("bot.capital_publication_liveness_v142_patch")
+    except Exception as exc:
+        LOGGER.error(
+            "CAPITAL_PIPELINE_MARGIN_V158_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    current = getattr(v142, "_runtime_pipeline_deadline_seconds", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def runtime_pipeline_deadline_v158() -> float:
+        return _bounded_deadline_seconds(v142)
+
+    setattr(runtime_pipeline_deadline_v158, _PATCH_ATTR, True)
+    setattr(runtime_pipeline_deadline_v158, "__wrapped__", original)
+    v142._runtime_pipeline_deadline_seconds = runtime_pipeline_deadline_v158
+    return True
+
+
+def install() -> bool:
+    with _LOCK:
+        ready = _patch_v142_deadline()
+        os.environ[_FLAG] = "1" if ready else "0"
+        if ready:
+            v142 = importlib.import_module("bot.capital_publication_liveness_v142_patch")
+            LOGGER.critical(
+                "CAPITAL_PIPELINE_MARGIN_V158 marker=%s ready=true deadline_s=%.1f fetch_budget_s=%.1f freshness_ttl_s=%.1f publication_expiry_extended=false safety_gates_bypassed=false",
+                MARKER,
+                _bounded_deadline_seconds(v142),
+                float(v142._fetch_budget_seconds()),
+                float(v142._freshness_ttl_seconds()),
+            )
+        else:
+            LOGGER.critical(
+                "CAPITAL_PIPELINE_MARGIN_V158 marker=%s ready=false trading_fail_closed=true",
+                MARKER,
+            )
+        return ready
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "_bounded_deadline_seconds",
+    "_patch_v142_deadline",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -6,7 +6,8 @@ two valid brokers, contradicting broker-local readiness where one healthy venue 
 trade independently. This guard continuously restores the canonical alias, sets
 the authority broker threshold from the active readiness policy, installs the
 fail-closed v154 pre-authority structural gate repair, the v155 same-lease nonce
-maturity verifier, and the v157 post-activation runtime-quality convergence repair.
+maturity verifier, the v157 post-activation runtime-quality convergence repair,
+and the v158 bounded capital-pipeline publication-margin repair.
 """
 from __future__ import annotations
 
@@ -141,6 +142,22 @@ def _install_v157_runtime_quality() -> bool:
         return False
 
 
+def _install_v158_capital_margin() -> bool:
+    try:
+        module = importlib.import_module("bot.capital_pipeline_margin_v158_patch")
+        install_fn = getattr(module, "install", None)
+        if not callable(install_fn):
+            raise RuntimeError("v158_install_missing")
+        return bool(install_fn())
+    except Exception as exc:
+        logger.error(
+            "CAPITAL_PIPELINE_MARGIN_V158_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -148,6 +165,7 @@ def _iteration() -> bool:
     v154_installed = _install_v154_recovery()
     v155_installed = _install_v155_nonce_maturity()
     v157_installed = _install_v157_runtime_quality()
+    v158_installed = _install_v158_capital_margin()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -157,7 +175,7 @@ def _iteration() -> bool:
             _ALIAS,
         )
     logger.debug(
-        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s v154_installed=%s v155_installed=%s v157_installed=%s",
+        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -165,8 +183,9 @@ def _iteration() -> bool:
         str(v154_installed).lower(),
         str(v155_installed).lower(),
         str(v157_installed).lower(),
+        str(v158_installed).lower(),
     )
-    return bool(v154_installed and v155_installed and v157_installed)
+    return bool(v154_installed and v155_installed and v157_installed and v158_installed)
 
 
 def _watchdog() -> None:
@@ -190,7 +209,7 @@ def install() -> bool:
                 daemon=True,
             ).start()
         logger.critical(
-            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true",
+            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true v158_capital_margin=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -208,5 +227,6 @@ __all__ = [
     "_install_v154_recovery",
     "_install_v155_nonce_maturity",
     "_install_v157_runtime_quality",
+    "_install_v158_capital_margin",
     "_iteration",
 ]

--- a/tests/test_capital_pipeline_margin_v158.py
+++ b/tests/test_capital_pipeline_margin_v158.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot import capital_pipeline_margin_v158_patch as v158
+
+
+def _v142(*, ttl: float = 90.0, fetch: float = 50.0):
+    return SimpleNamespace(
+        _freshness_ttl_seconds=lambda: ttl,
+        _fetch_budget_seconds=lambda: fetch,
+    )
+
+
+def test_default_deadline_leaves_publish_margin_inside_freshness(monkeypatch):
+    monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", raising=False)
+
+    assert v158._bounded_deadline_seconds(_v142()) == 70.0
+
+
+def test_deadline_never_broadens_immutable_freshness(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "500")
+
+    assert v158._bounded_deadline_seconds(_v142(ttl=90.0, fetch=50.0)) == 80.0
+
+
+def test_stricter_operator_deadline_is_preserved(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "40")
+
+    assert v158._bounded_deadline_seconds(_v142()) == 40.0
+
+
+def test_publish_margin_is_bounded(monkeypatch):
+    monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
+    monkeypatch.setenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", "999")
+
+    # margin clamps at 30s and total remains capped at TTL - 10s.
+    assert v158._bounded_deadline_seconds(_v142()) == 80.0
+
+
+def test_small_ttl_still_fails_closed_inside_freshness(monkeypatch):
+    monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
+    monkeypatch.delenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", raising=False)
+
+    assert v158._bounded_deadline_seconds(_v142(ttl=45.0, fetch=30.0)) == 35.0


### PR DESCRIPTION
## What changed
- Add v158 runtime patch that raises v142's total runtime coordinator deadline from the effective 55s default to 70s with the current 50s fetch budget.
- Hard-cap the total deadline at freshness TTL - 10s (80s with the current 90s TTL).
- Reinstall v158 from the runtime post-import convergence watchdog.
- Add regression tests for the default, freshness cap, stricter operator override, margin cap, and shorter TTL behavior.

## Why
Production `d870563715ad459a704d3853868d5a208f845195` showed v142 retiring generation 36 exactly at 55s while the old worker remained alive, immediately rolling to a new coordinator. Keepalive telemetry also showed several retired `capital-runtime-refresh-v142` generations still alive. v78 already intentionally bounds synchronous broker collection to 50s, leaving only about 5s for normalize, confidence, publish, event-dispatch, and readiness handoff stages.

## Safety
- Does not extend the capital freshness TTL or publication expiry.
- Does not fabricate balances or readiness.
- Does not change kill switch, nonce, reconciliation, risk, strategy, execution authority, or order-dispatch behavior.
- Retired late publications remain generation-fenced and trading remains fail-closed if freshness expires.