### PR TITLE
Fix runtime capital and trading-state convergence

### DIFF
--- a/bot/tests/test_runtime_capital_state_convergence_repair.py
+++ b/bot/tests/test_runtime_capital_state_convergence_repair.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import bot.trading_state_dispatch_latch_repair_patch as patch
+
+
+def test_unknown_state_uses_canonical_env(monkeypatch):
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    assert patch._canonical_trading_state("UNKNOWN") == "LIVE_ACTIVE"
+
+
+def test_explicit_safety_state_is_never_upgraded(monkeypatch):
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    assert patch._canonical_trading_state("OFF") == "OFF"
+    assert patch._canonical_trading_state("EMERGENCY_STOP") == "EMERGENCY_STOP"
+
+
+def test_capital_ready_requires_complete_authority(monkeypatch):
+    monkeypatch.setattr(
+        patch,
+        "_capital_probe",
+        lambda: {
+            "hydrated": True,
+            "first_snap": True,
+            "valid_brokers": 2,
+            "registered_brokers": 2,
+            "expected_brokers": 3,
+            "brokers_complete": False,
+            "real": 95.12,
+            "usable": 93.22,
+            "fresh": True,
+            "source": "capital_authority",
+        },
+    )
+    ready, detail = patch._capital_ready()
+    assert ready is False
+    assert "complete=False" in detail
+    assert "registered_brokers=2 expected_brokers=3" in detail
+
+
+def test_core_normalizer_does_not_inflate_broker_completeness(monkeypatch):
+    module = ModuleType("fake_core")
+
+    def original():
+        return {
+            "ca_total_capital": 95.12,
+            "ca_valid_brokers": 3,
+            "aggregation_normalized": True,
+        }
+
+    module._capture_cycle_capital_state = original
+    monkeypatch.setattr(
+        patch,
+        "_capital_probe",
+        lambda: {
+            "hydrated": True,
+            "valid_brokers": 2,
+            "registered_brokers": 2,
+            "expected_brokers": 3,
+            "brokers_complete": False,
+            "real": 95.12,
+            "usable": 93.22,
+            "fresh": True,
+            "source": "capital_authority",
+        },
+    )
+
+    assert patch._install_core_loop_patch_on_module(module) is True
+    result = dict(module._capture_cycle_capital_state())
+    assert result["ca_valid_brokers"] == 2
+    assert result["aggregation_normalized"] is False
+
+
+def test_partial_snapshot_cannot_downgrade_fresh_complete_state():
+    module = ModuleType("fake_capital_authority")
+
+    class CapitalAuthority:
+        def __init__(self):
+            self.expected_brokers = 3
+            self._broker_balances = {"kraken": 235.0, "coinbase": 95.0, "okx": 0.1}
+            self.original_calls = 0
+
+        def is_fresh(self):
+            return True
+
+        def publish_snapshot(self, snapshot, writer_id):
+            self.original_calls += 1
+            self._broker_balances = dict(snapshot.broker_balances)
+            return True
+
+    module.CapitalAuthority = CapitalAuthority
+    assert patch._install_capital_authority_patch_on_module(module) is True
+    authority = CapitalAuthority()
+
+    class Snapshot:
+        broker_balances = {"coinbase": 95.0, "okx": 0.1}
+
+    assert authority.publish_snapshot(Snapshot(), "mabm_capital_refresh_coordinator") is False
+    assert authority.original_calls == 0
+    assert set(authority._broker_balances) == {"kraken", "coinbase", "okx"}
+
+
+def test_complete_snapshot_still_flows_to_original():
+    module = ModuleType("fake_capital_authority_complete")
+
+    class CapitalAuthority:
+        def __init__(self):
+            self.expected_brokers = 3
+            self._broker_balances = {"kraken": 235.0, "coinbase": 95.0, "okx": 0.1}
+            self.original_calls = 0
+
+        def is_fresh(self):
+            return True
+
+        def publish_snapshot(self, snapshot, writer_id):
+            self.original_calls += 1
+            self._broker_balances = dict(snapshot.broker_balances)
+            return True
+
+    module.CapitalAuthority = CapitalAuthority
+    assert patch._install_capital_authority_patch_on_module(module) is True
+    authority = CapitalAuthority()
+
+    class Snapshot:
+        broker_balances = {"kraken": 236.0, "coinbase": 95.0, "okx": 0.1}
+
+    assert authority.publish_snapshot(Snapshot(), "mabm_capital_refresh_coordinator") is True
+    assert authority.original_calls == 1
+    assert authority._broker_balances["kraken"] == 236.0
+
+
+def test_startup_coordinator_wrapper_canonicalizes_only_unknown(monkeypatch):
+    module = ModuleType("fake_startup_coordinator")
+
+    class StartupCoordinator:
+        def build_snapshot(self, *, trading_state, activation_intent):
+            return trading_state, activation_intent
+
+    module.StartupCoordinator = StartupCoordinator
+    monkeypatch.setenv("NIJA_RUNTIME_TRADING_STATE", "LIVE_ACTIVE")
+    assert patch._install_startup_coordinator_patch_on_module(module) is True
+    coordinator = StartupCoordinator()
+    assert coordinator.build_snapshot(trading_state="UNKNOWN", activation_intent=True) == (
+        "LIVE_ACTIVE",
+        True,
+    )
+    assert coordinator.build_snapshot(trading_state="OFF", activation_intent=True) == (
+        "OFF",
+        True,
+    )

--- a/bot/trading_state_dispatch_latch_repair_patch.py
+++ b/bot/trading_state_dispatch_latch_repair_patch.py
@@ -16,14 +16,25 @@ _PATCHED = False
 _KILL_SWITCH_PATCHED = False
 _CORE_LOOP_PATCHED = False
 _LEASE_GENERATION_PATCHED = False
+_CAPITAL_AUTHORITY_PATCHED = False
+_STARTUP_COORDINATOR_PATCHED = False
 _MONITOR_STARTED = False
 _INSTALL_LOCK = threading.Lock()
 _LOG_THROTTLE_LOCK = threading.Lock()
 _LOG_THROTTLE_STATE: Dict[str, Tuple[str, float, int]] = {}
+_VALID_TRADING_STATES = {
+    "OFF",
+    "DRY_RUN",
+    "LIVE_PENDING_CONFIRMATION",
+    "LIVE_ACTIVE",
+    "EMERGENCY_STOP",
+}
 
 
 def _truthy(name: str, default: str = "") -> bool:
-    return str(os.environ.get(name, default)).strip().lower() in {"1", "true", "yes", "enabled", "on", "y"}
+    return str(os.environ.get(name, default)).strip().lower() in {
+        "1", "true", "yes", "enabled", "on", "y"
+    }
 
 
 def _float_env(name: str, default: float) -> float:
@@ -41,18 +52,31 @@ def _emit_throttled(
     level: int = logging.CRITICAL,
     interval_s: Optional[float] = None,
 ) -> None:
-    interval = float(interval_s if interval_s is not None else _float_env("NIJA_PATCH_LOG_THROTTLE_S", 30.0))
+    interval = float(
+        interval_s
+        if interval_s is not None
+        else _float_env("NIJA_PATCH_LOG_THROTTLE_S", 30.0)
+    )
     now = time.monotonic()
     suppressed = 0
     with _LOG_THROTTLE_LOCK:
-        last_sig, last_ts, last_suppressed = _LOG_THROTTLE_STATE.get(key, ("", 0.0, 0))
+        last_sig, last_ts, last_suppressed = _LOG_THROTTLE_STATE.get(
+            key, ("", 0.0, 0)
+        )
         if signature == last_sig and (now - last_ts) < interval:
-            _LOG_THROTTLE_STATE[key] = (last_sig, last_ts, last_suppressed + 1)
+            _LOG_THROTTLE_STATE[key] = (
+                last_sig, last_ts, last_suppressed + 1
+            )
             return
         suppressed = last_suppressed
         _LOG_THROTTLE_STATE[key] = (signature, now, 0)
     if suppressed:
-        logger.info("NIJA_PATCH_LOG_THROTTLED key=%s signature=%s suppressed=%d", key, signature, suppressed)
+        logger.info(
+            "NIJA_PATCH_LOG_THROTTLED key=%s signature=%s suppressed=%d",
+            key,
+            signature,
+            suppressed,
+        )
     logger.log(level, message, *args)
 
 
@@ -61,7 +85,38 @@ def _current_state_value(sm: Any) -> str:
         cur = getattr(sm, "get_current_state", lambda: None)()
         return str(getattr(cur, "value", cur) or "unknown").upper()
     except Exception:
-        return "unknown"
+        return "UNKNOWN"
+
+
+def _canonical_trading_state(incoming: Any) -> str:
+    """Replace only invalid/UNKNOWN input with canonical runtime state."""
+    normalized = str(getattr(incoming, "value", incoming) or "").strip().upper()
+    if normalized in _VALID_TRADING_STATES:
+        return normalized
+
+    env_state = str(os.environ.get("NIJA_RUNTIME_TRADING_STATE", "")).strip().upper()
+    if env_state in _VALID_TRADING_STATES:
+        return env_state
+
+    for module_name in ("bot.trading_state_machine", "trading_state_machine"):
+        module = sys.modules.get(module_name)
+        if not isinstance(module, ModuleType):
+            continue
+        getter = getattr(module, "get_trading_state_machine", None)
+        if callable(getter):
+            try:
+                state = _current_state_value(getter())
+                if state in _VALID_TRADING_STATES:
+                    return state
+            except Exception:
+                pass
+        singleton = getattr(module, "trading_state_machine", None)
+        if singleton is not None:
+            state = _current_state_value(singleton)
+            if state in _VALID_TRADING_STATES:
+                return state
+
+    return normalized or "OFF"
 
 
 def _capital_probe() -> Dict[str, Any]:
@@ -69,9 +124,12 @@ def _capital_probe() -> Dict[str, Any]:
         "hydrated": False,
         "first_snap": False,
         "valid_brokers": 0,
+        "registered_brokers": 0,
+        "expected_brokers": 1,
+        "brokers_complete": False,
         "real": 0.0,
         "usable": 0.0,
-        "fresh": True,
+        "fresh": False,
         "source": "unavailable",
     }
     try:
@@ -87,28 +145,44 @@ def _capital_probe() -> Dict[str, Any]:
             or getattr(ca, "_first_snap_accepted", False)
             or getattr(ca, "first_snapshot_accepted", False)
         )
-        for attr in ("valid_broker_count", "registered_broker_count", "ca_valid_brokers"):
+        try:
+            detail["valid_brokers"] = int(
+                getattr(ca, "valid_broker_count", 0) or 0
+            )
+        except Exception:
+            pass
+        try:
+            detail["registered_brokers"] = int(
+                getattr(ca, "registered_broker_count", 0) or 0
+            )
+        except Exception:
+            pass
+        try:
+            detail["expected_brokers"] = max(
+                1, int(getattr(ca, "expected_brokers", 1) or 1)
+            )
+        except Exception:
+            pass
+        complete_getter = getattr(ca, "is_brokers_complete", None)
+        if callable(complete_getter):
             try:
-                detail["valid_brokers"] = max(int(detail["valid_brokers"]), int(getattr(ca, attr, 0) or 0))
+                detail["brokers_complete"] = bool(complete_getter())
             except Exception:
                 pass
-        balances = getattr(ca, "broker_balances", None) or getattr(ca, "_broker_balances", None)
-        if isinstance(balances, dict):
-            detail["valid_brokers"] = max(int(detail["valid_brokers"]), len([v for v in balances.values() if v is not None]))
-        for attr in ("total_capital", "real_capital", "usable_capital", "available_capital"):
-            try:
-                value = float(getattr(ca, attr, 0.0) or 0.0)
-                if "usable" in attr or "available" in attr:
-                    detail["usable"] = max(float(detail["usable"]), value)
-                else:
-                    detail["real"] = max(float(detail["real"]), value)
-            except Exception:
-                pass
-        for method_name, target in (("get_real_capital", "real"), ("get_usable_capital", "usable")):
+        else:
+            detail["brokers_complete"] = bool(
+                int(detail["registered_brokers"])
+                >= int(detail["expected_brokers"])
+            )
+
+        for method_name, target in (
+            ("get_real_capital", "real"),
+            ("get_usable_capital", "usable"),
+        ):
             getter = getattr(ca, method_name, None)
             if callable(getter):
                 try:
-                    detail[target] = max(float(detail[target]), float(getter() or 0.0))
+                    detail[target] = float(getter() or 0.0)
                 except Exception:
                     pass
         fresh_getter = getattr(ca, "is_fresh", None)
@@ -122,28 +196,7 @@ def _capital_probe() -> Dict[str, Any]:
     except Exception as exc:
         detail["source"] = f"capital_authority_error:{exc}"
 
-    try:
-        try:
-            from bot.multi_account_broker_manager import multi_account_broker_manager as mabm
-        except ImportError:
-            from multi_account_broker_manager import multi_account_broker_manager as mabm  # type: ignore[import]
-        if mabm is not None:
-            for attr in ("_capital_last_valid_brokers", "valid_broker_count", "registered_broker_count"):
-                try:
-                    detail["valid_brokers"] = max(int(detail["valid_brokers"]), int(getattr(mabm, attr, 0) or 0))
-                except Exception:
-                    pass
-            for broker_map_name in ("platform_brokers", "brokers"):
-                broker_map = getattr(mabm, broker_map_name, None)
-                if isinstance(broker_map, dict):
-                    connected_count = sum(1 for b in broker_map.values() if b is not None and bool(getattr(b, "connected", False)))
-                    detail["valid_brokers"] = max(int(detail["valid_brokers"]), connected_count)
-    except Exception:
-        pass
-
     if float(detail["usable"]) <= 0.0 and float(detail["real"]) > 0.0:
-        # Usable-capital hydration often trails total-capital hydration by one startup cycle.
-        # Do not classify that transient as "capital below minimum".
         detail["usable"] = float(detail["real"])
     return detail
 
@@ -163,19 +216,26 @@ def _capital_ready() -> tuple[bool, str]:
     try:
         probe = _capital_probe()
         hydrated = bool(probe["hydrated"])
-        first_snap = bool(probe["first_snap"])
         valid_brokers = int(probe["valid_brokers"] or 0)
+        registered = int(probe["registered_brokers"] or 0)
+        expected = max(1, int(probe["expected_brokers"] or 1))
+        complete = bool(probe["brokers_complete"] and registered >= expected)
         real = float(probe["real"] or 0.0)
         usable = float(probe["usable"] or 0.0)
         fresh = bool(probe["fresh"])
-        # Dispatch repair needs a confirmed capital view; it must not require
-        # the optional first_snap flag when CapitalAuthority already has real,
-        # fresh, broker-backed capital. This prevents the 0-capital transient
-        # from being misreported as capital_below_min.
-        ok = hydrated and valid_brokers > 0 and real > 0.0 and usable > 0.0 and fresh
+        ok = bool(
+            hydrated
+            and complete
+            and valid_brokers > 0
+            and real > 0.0
+            and usable > 0.0
+            and fresh
+        )
         return ok, (
-            f"hydrated={hydrated} first_snap={first_snap} valid_brokers={valid_brokers} "
-            f"real={real:.2f} usable={usable:.2f} fresh={fresh} source={probe.get('source')}"
+            f"hydrated={hydrated} complete={complete} "
+            f"registered_brokers={registered} expected_brokers={expected} "
+            f"valid_brokers={valid_brokers} real={real:.2f} usable={usable:.2f} "
+            f"fresh={fresh} source={probe.get('source')}"
         )
     except Exception as exc:
         return False, f"capital_probe_failed:{exc}"
@@ -224,11 +284,10 @@ def _install_kill_switch_patch_on_module(module: ModuleType) -> bool:
         if not exists:
             return None
         active_before = bool(getattr(self, "_is_active", False))
-        signature = f"{kill_file}:active={active_before}"
         _emit_throttled(
             "kill_switch_file_detected",
-            signature,
-            "🚨 Kill switch file detected: %s active=%s",
+            f"{kill_file}:active={active_before}",
+            "Kill switch file detected: %s active=%s",
             kill_file,
             active_before,
             level=logging.WARNING,
@@ -243,7 +302,7 @@ def _install_kill_switch_patch_on_module(module: ModuleType) -> bool:
     setattr(_patched_check_file_activation, "_nija_kill_switch_file_log_throttle_wrapped", True)
     setattr(cls, "_check_file_activation", _patched_check_file_activation)
     _KILL_SWITCH_PATCHED = True
-    logger.warning("KILL_SWITCH_FILE_LOG_THROTTLE_PATCHED module=%s", getattr(module, "__name__", "<unknown>"))
+    logger.warning("KILL_SWITCH_FILE_LOG_THROTTLE_PATCHED module=%s", module.__name__)
     return True
 
 
@@ -263,35 +322,37 @@ def _install_core_loop_patch_on_module(module: ModuleType) -> bool:
         except Exception:
             return snapshot
         try:
-            total = float(result.get("ca_total_capital", 0.0) or 0.0)
-            valid = int(result.get("ca_valid_brokers", 0) or 0)
             probe = _capital_probe()
             real = float(probe.get("real", 0.0) or 0.0)
-            probe_valid = int(probe.get("valid_brokers", 0) or 0)
+            registered = int(probe.get("registered_brokers", 0) or 0)
+            expected = max(1, int(probe.get("expected_brokers", 1) or 1))
+            complete = bool(probe.get("brokers_complete") and registered >= expected)
             changed = False
-            if real > 0.0 and total <= 0.0:
+            if real > 0.0 and float(result.get("ca_total_capital", 0.0) or 0.0) <= 0.0:
                 result["ca_total_capital"] = real
-                result["ca_is_hydrated"] = True
-                result["is_post_hydration"] = True
+                result["ca_is_hydrated"] = bool(probe.get("hydrated"))
+                result["is_post_hydration"] = bool(probe.get("hydrated"))
                 result["snapshot_source"] = "capital_authority"
                 changed = True
-            if probe_valid > valid:
-                result["ca_valid_brokers"] = probe_valid
+
+            ca_valid = int(probe.get("valid_brokers", 0) or 0)
+            if int(result.get("ca_valid_brokers", 0) or 0) != ca_valid:
+                result["ca_valid_brokers"] = ca_valid
                 changed = True
-            if float(result.get("ca_total_capital", 0.0) or 0.0) > 0.0 and int(result.get("ca_valid_brokers", 0) or 0) > 0:
-                if not bool(result.get("aggregation_normalized", True)):
-                    changed = True
-                result["aggregation_normalized"] = True
+            if bool(result.get("aggregation_normalized", False)) != complete:
+                result["aggregation_normalized"] = complete
+                changed = True
+
             if changed:
                 _emit_throttled(
                     "cycle_capital_snapshot_repaired",
-                    f"{result.get('ca_total_capital')}:{result.get('ca_valid_brokers')}:{result.get('snapshot_source')}",
-                    "CYCLE_CAPITAL_SNAPSHOT_REPAIRED | total=%.8f | valid_brokers=%s | source=%s | probe=%s",
+                    f"{result.get('ca_total_capital')}:{registered}/{expected}:{complete}",
+                    "CYCLE_CAPITAL_SNAPSHOT_REPAIRED total=%.8f registered=%d expected=%d complete=%s probe=%s",
                     float(result.get("ca_total_capital", 0.0) or 0.0),
-                    result.get("ca_valid_brokers"),
-                    result.get("snapshot_source"),
+                    registered,
+                    expected,
+                    complete,
                     probe,
-                    level=logging.CRITICAL,
                     interval_s=_float_env("NIJA_CAPITAL_REPAIR_LOG_THROTTLE_S", 30.0),
                 )
                 return MappingProxyType(result)
@@ -302,7 +363,92 @@ def _install_core_loop_patch_on_module(module: ModuleType) -> bool:
     setattr(_patched_capture_cycle_capital_state, "_nija_cycle_capital_normalizer_wrapped", True)
     setattr(module, "_capture_cycle_capital_state", _patched_capture_cycle_capital_state)
     _CORE_LOOP_PATCHED = True
-    logger.warning("CYCLE_CAPITAL_NORMALIZER_PATCHED module=%s", getattr(module, "__name__", "<unknown>"))
+    logger.warning("CYCLE_CAPITAL_NORMALIZER_PATCHED module=%s", module.__name__)
+    return True
+
+
+def _install_capital_authority_patch_on_module(module: ModuleType) -> bool:
+    global _CAPITAL_AUTHORITY_PATCHED
+    cls = getattr(module, "CapitalAuthority", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "publish_snapshot", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_complete_snapshot_regression_guard_wrapped", False):
+        _CAPITAL_AUTHORITY_PATCHED = True
+        return True
+
+    def _patched_publish_snapshot(self: Any, snapshot: Any, writer_id: str) -> bool:
+        try:
+            incoming_balances = dict(getattr(snapshot, "broker_balances", {}) or {})
+            incoming_count = len(incoming_balances)
+            expected = max(1, int(getattr(self, "expected_brokers", 1) or 1))
+            current_balances = dict(getattr(self, "_broker_balances", {}) or {})
+            current_count = len(current_balances)
+            fresh_getter = getattr(self, "is_fresh", None)
+            current_fresh = bool(fresh_getter()) if callable(fresh_getter) else False
+            if (
+                incoming_count < expected
+                and current_count >= expected
+                and current_fresh
+            ):
+                logger.critical(
+                    "CAPITAL_PARTIAL_SNAPSHOT_REGRESSION_REJECTED incoming=%d expected=%d current=%d writer_id=%s state_preserved=true",
+                    incoming_count,
+                    expected,
+                    current_count,
+                    writer_id,
+                )
+                return False
+        except Exception as exc:
+            logger.warning("capital partial-snapshot guard probe failed: %s", exc)
+        return bool(original(self, snapshot, writer_id))
+
+    setattr(_patched_publish_snapshot, "_nija_complete_snapshot_regression_guard_wrapped", True)
+    setattr(cls, "publish_snapshot", _patched_publish_snapshot)
+    _CAPITAL_AUTHORITY_PATCHED = True
+    logger.warning("CAPITAL_PARTIAL_SNAPSHOT_REGRESSION_GUARD_PATCHED module=%s", module.__name__)
+    return True
+
+
+def _install_startup_coordinator_patch_on_module(module: ModuleType) -> bool:
+    global _STARTUP_COORDINATOR_PATCHED
+    cls = getattr(module, "StartupCoordinator", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "build_snapshot", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_canonical_trading_state_input_wrapped", False):
+        _STARTUP_COORDINATOR_PATCHED = True
+        return True
+
+    def _patched_build_snapshot(
+        self: Any, *, trading_state: str, activation_intent: bool
+    ) -> Any:
+        canonical = _canonical_trading_state(trading_state)
+        incoming = str(getattr(trading_state, "value", trading_state) or "").strip().upper()
+        if canonical != incoming:
+            _emit_throttled(
+                "startup_trading_state_canonicalized",
+                f"{incoming}->{canonical}",
+                "STARTUP_TRADING_STATE_CANONICALIZED incoming=%s canonical=%s",
+                incoming or "<empty>",
+                canonical,
+                level=logging.WARNING,
+                interval_s=30.0,
+            )
+        return original(
+            self,
+            trading_state=canonical,
+            activation_intent=bool(activation_intent),
+        )
+
+    setattr(_patched_build_snapshot, "_nija_canonical_trading_state_input_wrapped", True)
+    setattr(cls, "build_snapshot", _patched_build_snapshot)
+    _STARTUP_COORDINATOR_PATCHED = True
+    logger.warning("STARTUP_CANONICAL_TRADING_STATE_PATCHED module=%s", module.__name__)
     return True
 
 
@@ -340,8 +486,6 @@ def _install_lease_generation_patch_on_module(module: ModuleType) -> bool:
             prev,
             current,
             bool(expected_raw and expected_raw != str(current)),
-            level=logging.CRITICAL,
-            interval_s=_float_env("NIJA_LEASE_GENERATION_REPAIR_LOG_THROTTLE_S", 30.0),
         )
         try:
             return original(*args, **kwargs)
@@ -351,7 +495,7 @@ def _install_lease_generation_patch_on_module(module: ModuleType) -> bool:
     setattr(_patched_writer_lease_generation_gate, "_nija_lease_generation_regression_repair_wrapped", True)
     setattr(module, "_writer_lease_generation_gate", _patched_writer_lease_generation_gate)
     _LEASE_GENERATION_PATCHED = True
-    logger.warning("LEASE_GENERATION_REGRESSION_REPAIR_PATCHED module=%s", getattr(module, "__name__", "<unknown>"))
+    logger.warning("LEASE_GENERATION_REGRESSION_REPAIR_PATCHED module=%s", module.__name__)
     return True
 
 
@@ -373,7 +517,10 @@ def _install_on_module(module: ModuleType) -> bool:
             if bool(original(self, *args, **kwargs)):
                 return True
         except Exception as exc:
-            logger.warning("TRADING_STATE_DISPATCH_LATCH_REPAIR original_can_dispatch_failed err=%s", exc)
+            logger.warning(
+                "TRADING_STATE_DISPATCH_LATCH_REPAIR original_can_dispatch_failed err=%s",
+                exc,
+            )
         ready, detail = _strict_live_dispatch_ready(self)
         if ready:
             try:
@@ -389,14 +536,12 @@ def _install_on_module(module: ModuleType) -> bool:
                 os.environ.get("NIJA_WRITER_FENCING_TOKEN", "")[:8],
                 os.environ.get("NIJA_WRITER_LEASE_GENERATION", ""),
             )
-            print(f"[NIJA-PRINT] TRADING_STATE_DISPATCH_LATCH_REPAIR_APPLIED | {detail}", flush=True)
             return True
         _emit_throttled(
             "trading_state_dispatch_latch_waiting",
             str(detail),
             "TRADING_STATE_DISPATCH_LATCH_REPAIR_WAITING detail=%s",
             detail,
-            level=logging.CRITICAL,
             interval_s=_float_env("NIJA_DISPATCH_LATCH_WAIT_LOG_THROTTLE_S", 30.0),
         )
         return False
@@ -404,7 +549,7 @@ def _install_on_module(module: ModuleType) -> bool:
     setattr(_patched_can_dispatch_trades, "_nija_trading_state_dispatch_latch_repair_wrapped", True)
     setattr(cls, "can_dispatch_trades", _patched_can_dispatch_trades)
     _PATCHED = True
-    logger.warning("TRADING_STATE_DISPATCH_LATCH_REPAIR_PATCHED module=%s", getattr(module, "__name__", "<unknown>"))
+    logger.warning("TRADING_STATE_DISPATCH_LATCH_REPAIR_PATCHED module=%s", module.__name__)
     return True
 
 
@@ -422,7 +567,26 @@ def _try_patch_loaded() -> bool:
         module = sys.modules.get(name)
         if isinstance(module, ModuleType):
             _install_core_loop_patch_on_module(module)
+    for name in ("bot.capital_authority", "capital_authority"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _install_capital_authority_patch_on_module(module)
+    for name in ("bot.startup_coordinator", "startup_coordinator"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            _install_startup_coordinator_patch_on_module(module)
     return patched
+
+
+def _all_patches_ready() -> bool:
+    return bool(
+        _PATCHED
+        and _KILL_SWITCH_PATCHED
+        and _CORE_LOOP_PATCHED
+        and _LEASE_GENERATION_PATCHED
+        and _CAPITAL_AUTHORITY_PATCHED
+        and _STARTUP_COORDINATOR_PATCHED
+    )
 
 
 def _start_monitor() -> None:
@@ -432,21 +596,29 @@ def _start_monitor() -> None:
     _MONITOR_STARTED = True
 
     def _monitor() -> None:
-        deadline = time.time() + float(os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "240") or "240")
+        deadline = time.time() + float(
+            os.environ.get("NIJA_PATCH_MONITOR_SECONDS", "240") or "240"
+        )
         while time.time() < deadline:
             _try_patch_loaded()
-            if _PATCHED and _KILL_SWITCH_PATCHED and _CORE_LOOP_PATCHED and _LEASE_GENERATION_PATCHED:
+            if _all_patches_ready():
                 return
             time.sleep(0.25)
         logger.warning(
-            "TRADING_STATE_DISPATCH_LATCH_REPAIR_MONITOR_EXPIRED patched=%s kill_switch_patched=%s core_loop_patched=%s lease_generation_patched=%s",
+            "TRADING_STATE_DISPATCH_LATCH_REPAIR_MONITOR_EXPIRED trading=%s kill=%s core=%s lease=%s capital=%s startup=%s",
             _PATCHED,
             _KILL_SWITCH_PATCHED,
             _CORE_LOOP_PATCHED,
             _LEASE_GENERATION_PATCHED,
+            _CAPITAL_AUTHORITY_PATCHED,
+            _STARTUP_COORDINATOR_PATCHED,
         )
 
-    threading.Thread(target=_monitor, name="trading-state-dispatch-latch-repair-monitor", daemon=True).start()
+    threading.Thread(
+        target=_monitor,
+        name="trading-state-dispatch-latch-repair-monitor",
+        daemon=True,
+    ).start()
     logger.warning("TRADING_STATE_DISPATCH_LATCH_REPAIR_MONITOR_STARTED")
 
 
@@ -457,11 +629,8 @@ def install_import_hook() -> None:
         _start_monitor()
         if _ORIGINAL_IMPORT_MODULE is not None:
             logger.warning(
-                "TRADING_STATE_DISPATCH_LATCH_REPAIR_INSTALL_COMPLETE already_installed=True patched=%s kill_switch_patched=%s core_loop_patched=%s lease_generation_patched=%s",
-                _PATCHED,
-                _KILL_SWITCH_PATCHED,
-                _CORE_LOOP_PATCHED,
-                _LEASE_GENERATION_PATCHED,
+                "TRADING_STATE_DISPATCH_LATCH_REPAIR_INSTALL_COMPLETE already_installed=True all_ready=%s",
+                _all_patches_ready(),
             )
             return
         _ORIGINAL_IMPORT_MODULE = importlib.import_module
@@ -474,13 +643,20 @@ def install_import_hook() -> None:
                 _install_kill_switch_patch_on_module(module)
             elif name in {"bot.nija_core_loop", "nija_core_loop"}:
                 _install_core_loop_patch_on_module(module)
+            elif name in {"bot.capital_authority", "capital_authority"}:
+                _install_capital_authority_patch_on_module(module)
+            elif name in {"bot.startup_coordinator", "startup_coordinator"}:
+                _install_startup_coordinator_patch_on_module(module)
             return module
 
         importlib.import_module = _wrapped_import_module  # type: ignore[assignment]
         logger.warning(
-            "TRADING_STATE_DISPATCH_LATCH_REPAIR_INSTALL_COMPLETE patched=%s kill_switch_patched=%s core_loop_patched=%s lease_generation_patched=%s",
+            "TRADING_STATE_DISPATCH_LATCH_REPAIR_INSTALL_COMPLETE all_ready=%s trading=%s kill=%s core=%s lease=%s capital=%s startup=%s",
+            _all_patches_ready(),
             _PATCHED,
             _KILL_SWITCH_PATCHED,
             _CORE_LOOP_PATCHED,
             _LEASE_GENERATION_PATCHED,
+            _CAPITAL_AUTHORITY_PATCHED,
+            _STARTUP_COORDINATOR_PATCHED,
         )


### PR DESCRIPTION
## What changed

- Require CapitalAuthority's own broker map to be complete before the dispatch-latch repair can authorize live dispatch.
- Stop the core-loop normalizer from inflating CA broker counts from MABM connectivity or marking partial aggregation as normalized.
- Reject a partial coordinator snapshot when it would overwrite a fresh, already-complete CapitalAuthority state.
- Canonicalize only invalid/`UNKNOWN` startup trading-state inputs from the runtime state; explicit `OFF`, `DRY_RUN`, `LIVE_PENDING_CONFIRMATION`, `LIVE_ACTIVE`, and `EMERGENCY_STOP` values remain authoritative.
- Add regression tests for incomplete-capital gating, partial snapshot regression, false normalization, and state canonicalization.

## Why

Production logs showed all three brokers connected while the canonical CapitalAuthority snapshot contained only Coinbase and OKX (`2/3` completeness). At the same time, the dispatch repair could report three viable brokers by mixing MABM connectivity into CA readiness, and startup reconciliation repeatedly received `UNKNOWN` even while the canonical trading FSM was `LIVE_ACTIVE`.

These changes fix the underlying convergence behavior without bypassing safety gates or inventing missing broker capital.

## Validation

- Replacement runtime patch and test module were Python syntax-checked with `py_compile` before publishing.
- Branch diff is limited to the existing runtime repair module plus a focused regression-test file.
- Full repository CI should run on this draft PR before merge.