### PR TITLE
Fix runtime capital deadline ownership

### DIFF
--- a/bot/capital_pipeline_margin_v158_patch.py
+++ b/bot/capital_pipeline_margin_v158_patch.py
@@ -1,22 +1,23 @@
 """Bounded post-fetch publication margin for runtime capital refreshes.
 
 Production 2026-08-19 showed v142 retiring otherwise healthy runtime capital
-coordinator generations at 55 seconds while v78 deliberately permits up to 50
-seconds for synchronous broker collection.  That left only ~5 seconds for the
-remaining normalize, confidence, publish, event-dispatch, and downstream
-readiness handoff stages.  Repeated rollovers accumulated retired daemon
-coordinator workers even though the writer/core remained healthy.
+coordinator generations at the legacy 70 second deadline even after the v159
+runtime-readiness layer requested more post-fetch completion headroom.  The
+install order explains the regression: v159 wrapped the v142 deadline first,
+then v158 wrapped that function again and re-applied the legacy
+``NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S=70`` setting.
 
-v158 preserves the existing freshness and fail-closed contracts while giving the
-post-fetch stages a realistic bounded margin:
+v158 is the canonical owner of the runtime capital deadline margin.  It now:
 
-* keep v78's synchronous broker fetch budget unchanged;
-* keep CapitalAuthority's immutable freshness TTL unchanged;
-* cap the total v142 runtime coordinator deadline strictly inside freshness;
-* default the total deadline to fetch_budget + 20s (70s with the current 50s
-  fetch budget), leaving at least 10s before the canonical 90s freshness TTL;
-* never fabricate balances, extend publication expiry, grant execution
-  authority, clear a kill switch, synthesize readiness, or dispatch orders.
+* keeps v78's synchronous broker fetch budget unchanged;
+* keeps CapitalAuthority's immutable freshness TTL unchanged;
+* reserves a bounded post-fetch headroom of 30 seconds by default;
+* treats the old total-deadline environment value as a floor, not a value that
+  may shrink below the required fetch + post-fetch completion envelope;
+* caps the effective deadline strictly inside freshness (80s for the current
+  90s TTL / 50s fetch budget);
+* never fabricates balances, extends publication expiry, grants execution
+  authority, clears a kill switch, synthesizes readiness, or dispatches orders.
 """
 from __future__ import annotations
 
@@ -34,47 +35,50 @@ _PATCH_ATTR = "_nija_capital_pipeline_margin_v158"
 _LOCK = threading.RLock()
 
 
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return default
+
+
 def _bounded_deadline_seconds(v142: Any) -> float:
-    """Return a total coordinator deadline strictly inside capital freshness."""
+    """Return the canonical total coordinator deadline inside capital freshness."""
     ttl_s = max(10.0, float(v142._freshness_ttl_seconds()))
     fetch_budget_s = max(5.0, float(v142._fetch_budget_seconds()))
+
+    # Publication freshness remains authoritative.  Keep at least ten seconds
+    # between the runtime-pipeline deadline and the immutable snapshot TTL.
     ceiling = max(10.0, ttl_s - 10.0)
 
-    try:
-        requested_margin = float(
-            os.environ.get("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", "20.0") or 20.0
-        )
-    except (TypeError, ValueError):
-        requested_margin = 20.0
-    margin_s = max(5.0, min(30.0, requested_margin))
+    # The production 50s fetch budget needs enough room for normalize,
+    # confidence, publish, event dispatch, and readiness handoff after broker
+    # collection completes.  Thirty seconds gives an 80s total deadline while
+    # still preserving the 10s freshness safety margin at the canonical 90s TTL.
+    requested_headroom = _float_env(
+        "NIJA_CAPITAL_RUNTIME_PIPELINE_POST_FETCH_HEADROOM_S",
+        30.0,
+    )
+    headroom_s = max(5.0, min(30.0, requested_headroom))
+    required = min(ceiling, fetch_budget_s + headroom_s)
 
-    default = min(ceiling, fetch_budget_s + margin_s)
+    # Backward compatibility: an existing total-deadline value may request more
+    # room but must no longer shrink the required post-fetch completion window.
+    # This intentionally neutralizes the legacy production value of 70 seconds.
     raw = str(os.environ.get("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "") or "").strip()
     if raw:
         try:
-            requested = float(raw)
+            configured = float(raw)
         except (TypeError, ValueError):
-            requested = default
+            configured = required
+        requested = max(required, configured)
     else:
-        requested = default
+        requested = required
 
-    # Preserve operator ability to choose a stricter deadline, but never allow
-    # this liveness repair to broaden the immutable freshness window.
     return max(10.0, min(requested, ceiling))
 
 
-def _patch_v142_deadline() -> bool:
-    try:
-        v142 = importlib.import_module("bot.capital_publication_liveness_v142_patch")
-    except Exception as exc:
-        LOGGER.error(
-            "CAPITAL_PIPELINE_MARGIN_V158_IMPORT_FAILED marker=%s error=%s:%s trading_fail_closed=true",
-            MARKER,
-            type(exc).__name__,
-            exc,
-        )
-        return False
-
+def _patch_one_v142(v142: Any) -> bool:
     current = getattr(v142, "_runtime_pipeline_deadline_seconds", None)
     if not callable(current):
         return False
@@ -93,16 +97,47 @@ def _patch_v142_deadline() -> bool:
     return True
 
 
+def _patch_v142_deadline() -> bool:
+    modules: list[Any] = []
+    for name in (
+        "bot.capital_publication_liveness_v142_patch",
+        "capital_publication_liveness_v142_patch",
+    ):
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if all(module is not existing for existing in modules):
+            modules.append(module)
+
+    if not modules:
+        LOGGER.error(
+            "CAPITAL_PIPELINE_MARGIN_V158_IMPORT_FAILED marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
+
+    ready = True
+    for module in modules:
+        ready = bool(_patch_one_v142(module)) and ready
+    return ready
+
+
+def _canonical_v142() -> Any:
+    return importlib.import_module("bot.capital_publication_liveness_v142_patch")
+
+
 def install() -> bool:
     with _LOCK:
         ready = _patch_v142_deadline()
         os.environ[_FLAG] = "1" if ready else "0"
         if ready:
-            v142 = importlib.import_module("bot.capital_publication_liveness_v142_patch")
+            v142 = _canonical_v142()
+            effective = float(v142._runtime_pipeline_deadline_seconds())
             LOGGER.critical(
-                "CAPITAL_PIPELINE_MARGIN_V158 marker=%s ready=true deadline_s=%.1f fetch_budget_s=%.1f freshness_ttl_s=%.1f publication_expiry_extended=false safety_gates_bypassed=false",
+                "CAPITAL_PIPELINE_MARGIN_V158 marker=%s ready=true deadline_s=%.1f fetch_budget_s=%.1f freshness_ttl_s=%.1f deadline_owner=v158 legacy_deadline_floor=true publication_expiry_extended=false safety_gates_bypassed=false",
                 MARKER,
-                _bounded_deadline_seconds(v142),
+                effective,
                 float(v142._fetch_budget_seconds()),
                 float(v142._freshness_ttl_seconds()),
             )
@@ -118,5 +153,6 @@ __all__ = [
     "MARKER",
     "install",
     "_bounded_deadline_seconds",
+    "_patch_one_v142",
     "_patch_v142_deadline",
 ]

--- a/tests/test_capital_pipeline_margin_v158.py
+++ b/tests/test_capital_pipeline_margin_v158.py
@@ -12,11 +12,24 @@ def _v142(*, ttl: float = 90.0, fetch: float = 50.0):
     )
 
 
-def test_default_deadline_leaves_publish_margin_inside_freshness(monkeypatch):
+def test_default_deadline_preserves_post_fetch_headroom(monkeypatch):
     monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
-    monkeypatch.delenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", raising=False)
+    monkeypatch.delenv(
+        "NIJA_CAPITAL_RUNTIME_PIPELINE_POST_FETCH_HEADROOM_S",
+        raising=False,
+    )
 
-    assert v158._bounded_deadline_seconds(_v142()) == 70.0
+    assert v158._bounded_deadline_seconds(_v142()) == 80.0
+
+
+def test_legacy_70_second_env_cannot_shrink_required_headroom(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "70")
+    monkeypatch.delenv(
+        "NIJA_CAPITAL_RUNTIME_PIPELINE_POST_FETCH_HEADROOM_S",
+        raising=False,
+    )
+
+    assert v158._bounded_deadline_seconds(_v142(ttl=90.0, fetch=50.0)) == 80.0
 
 
 def test_deadline_never_broadens_immutable_freshness(monkeypatch):
@@ -25,22 +38,40 @@ def test_deadline_never_broadens_immutable_freshness(monkeypatch):
     assert v158._bounded_deadline_seconds(_v142(ttl=90.0, fetch=50.0)) == 80.0
 
 
-def test_stricter_operator_deadline_is_preserved(monkeypatch):
+def test_lower_legacy_deadline_is_also_treated_as_floor(monkeypatch):
     monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "40")
 
-    assert v158._bounded_deadline_seconds(_v142()) == 40.0
+    assert v158._bounded_deadline_seconds(_v142()) == 80.0
 
 
-def test_publish_margin_is_bounded(monkeypatch):
+def test_post_fetch_headroom_is_bounded(monkeypatch):
     monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
-    monkeypatch.setenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", "999")
+    monkeypatch.setenv(
+        "NIJA_CAPITAL_RUNTIME_PIPELINE_POST_FETCH_HEADROOM_S",
+        "999",
+    )
 
-    # margin clamps at 30s and total remains capped at TTL - 10s.
     assert v158._bounded_deadline_seconds(_v142()) == 80.0
 
 
 def test_small_ttl_still_fails_closed_inside_freshness(monkeypatch):
     monkeypatch.delenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", raising=False)
-    monkeypatch.delenv("NIJA_CAPITAL_PIPELINE_PUBLISH_MARGIN_S", raising=False)
+    monkeypatch.delenv(
+        "NIJA_CAPITAL_RUNTIME_PIPELINE_POST_FETCH_HEADROOM_S",
+        raising=False,
+    )
 
     assert v158._bounded_deadline_seconds(_v142(ttl=45.0, fetch=30.0)) == 35.0
+
+
+def test_patch_one_v142_owns_effective_deadline_after_outer_wrapper(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S", "70")
+
+    fake = SimpleNamespace(
+        _freshness_ttl_seconds=lambda: 90.0,
+        _fetch_budget_seconds=lambda: 50.0,
+        _runtime_pipeline_deadline_seconds=lambda: 70.0,
+    )
+
+    assert v158._patch_one_v142(fake) is True
+    assert fake._runtime_pipeline_deadline_seconds() == 80.0


### PR DESCRIPTION
## What changed

- Make v158 the canonical owner of the runtime capital pipeline deadline.
- Default post-fetch completion headroom to 30 seconds, producing an 80 second total deadline for the current 90 second freshness TTL / 50 second fetch budget.
- Treat the legacy `NIJA_CAPITAL_RUNTIME_PIPELINE_DEADLINE_S=70` value as a floor so it can no longer shrink the required completion window back to 70 seconds.
- Patch both canonical v142 module aliases when present.
- Report the effective v142 deadline from telemetry with an explicit `deadline_owner=v158` marker.
- Add regression tests for the exact production case and the freshness ceiling.

## Root cause

The v159 readiness patch raised the v142 deadline, but v158 installs afterward and wrapped the function again. Because v158 preserved the legacy total-deadline environment value, production was pushed back to 70 seconds and generation 15 timed out at exactly 70.0 seconds.

## Safety

This does not extend CapitalAuthority publication expiry, loosen freshness, disable generation fencing, clear the kill switch, grant writer/nonce authority, fabricate capital, or bypass risk/execution gates. True runtime timeouts still fail closed and roll over through the existing v142 path.

## Validation

Regression coverage now requires `TTL=90 / fetch=50 / legacy deadline=70 -> effective deadline=80`, while oversized values remain capped at `TTL - 10s`.