### PR TITLE
Fix runtime capital and position convergence v161

### DIFF
--- a/bot/runtime_capital_late_observation_fence_v162_patch.py
+++ b/bot/runtime_capital_late_observation_fence_v162_patch.py
@@ -1,0 +1,186 @@
+"""Fence retired broker-balance observations after v161 flight rotation.
+
+v161 safely rotates a v35 balance flight before it can consume the full capital
+publication budget. The underlying daemon cannot be killed safely, however, and
+v35 records a successful worker result in its global observation cache before
+checking whether that flight is still the process-authoritative in-flight
+request. A retired response could therefore become a newly-fresh fallback even
+though v142 correctly prevents its retired coordinator generation from
+publishing.
+
+v162 closes that narrow race. Before v161 removes a stale flight, this wrapper
+advances the broker sequence and carries the last authoritative observation
+forward under that new fence. If no prior observation exists, it installs a
+zero-value, age-invalid tombstone. The retired worker's lower sequence can no
+longer replace the cache; the next live worker receives a still-higher sequence
+and can publish a real fresh observation normally.
+
+No capital value is invented, no stale value is refreshed, and no trading gate
+is bypassed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_late_observation_fence_v162")
+MARKER = "20260819-runtime-capital-late-observation-fence-v162"
+_PATCH_ATTR = "_nija_runtime_capital_late_observation_fence_v162"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_LATE_OBSERVATION_FENCE_V162_READY"
+_LOCK = threading.RLock()
+
+
+def _v161():
+    return importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
+
+
+def _fence_observation(guard: Any, broker_id: str, retired_sequence: int) -> int:
+    bid = str(broker_id).strip().lower()
+    sequence_map = getattr(guard, "_BROKER_SEQUENCE", None)
+    current_sequence = int(sequence_map.get(bid, 0) or 0) if isinstance(sequence_map, dict) else 0
+    fence_sequence = max(current_sequence, int(retired_sequence)) + 1
+    if isinstance(sequence_map, dict):
+        sequence_map[bid] = fence_sequence
+
+    observations = getattr(guard, "_OBSERVATIONS", None)
+    observation_cls = getattr(guard, "_Observation", None)
+    observation_lock = getattr(guard, "_OBSERVATION_LOCK", None)
+    if not isinstance(observations, dict) or observation_cls is None:
+        return fence_sequence
+
+    def apply() -> None:
+        previous = observations.get(bid)
+        if previous is None:
+            values = (0.0, 0.0, 0.0, fence_sequence)
+        else:
+            values = (
+                float(getattr(previous, "value", 0.0) or 0.0),
+                float(getattr(previous, "observed_monotonic", 0.0) or 0.0),
+                float(getattr(previous, "observed_epoch", 0.0) or 0.0),
+                fence_sequence,
+            )
+        try:
+            observations[bid] = observation_cls(
+                value=values[0],
+                observed_monotonic=values[1],
+                observed_epoch=values[2],
+                sequence=values[3],
+            )
+        except TypeError:
+            observations[bid] = observation_cls(*values)
+
+    if observation_lock is None:
+        apply()
+    else:
+        with observation_lock:
+            apply()
+    return fence_sequence
+
+
+def _supersede_with_observation_fence(guard: Any, broker_map: dict[str, Any]) -> None:
+    """v161 stale-flight rotation plus a cache-generation fence."""
+    v161 = _v161()
+    in_flight = getattr(guard, "_IN_FLIGHT", None)
+    in_flight_lock = getattr(guard, "_IN_FLIGHT_LOCK", None)
+    if not isinstance(in_flight, dict) or in_flight_lock is None:
+        return
+
+    now = time.monotonic()
+    with in_flight_lock:
+        for broker_id in broker_map:
+            bid = str(broker_id).strip().lower()
+            flight = in_flight.get(bid)
+            if flight is None:
+                continue
+            thread = getattr(flight, "thread", None)
+            is_alive = getattr(thread, "is_alive", None)
+            if not callable(is_alive) or not bool(is_alive()):
+                continue
+            try:
+                age_s = max(0.0, now - float(getattr(flight, "started_monotonic", now) or now))
+            except (TypeError, ValueError):
+                age_s = 0.0
+            stale_after_s = float(v161._stale_flight_after_seconds(bid))
+            if age_s < stale_after_s:
+                continue
+
+            orphans = v161._prune_orphans(bid)
+            max_orphans = int(v161._max_orphaned_flights())
+            if len(orphans) >= max_orphans:
+                LOGGER.warning(
+                    "CAPITAL_V162_STALE_FLIGHT_ROTATION_CAPPED marker=%s broker=%s age_s=%.2f "
+                    "stale_after_s=%.2f live_orphans=%d max_orphans=%d current_reused=true",
+                    MARKER,
+                    bid,
+                    age_s,
+                    stale_after_s,
+                    len(orphans),
+                    max_orphans,
+                )
+                continue
+            if in_flight.get(bid) is not flight:
+                continue
+
+            retired_sequence = int(getattr(flight, "sequence", 0) or 0)
+            fence_sequence = _fence_observation(guard, bid, retired_sequence)
+            in_flight.pop(bid, None)
+            orphans.append(flight)
+            v161._ORPHANED_FLIGHTS[bid] = orphans
+            LOGGER.critical(
+                "CAPITAL_V162_STALE_FLIGHT_SUPERSEDED marker=%s broker=%s retired_sequence=%d "
+                "fence_sequence=%d age_s=%.2f stale_after_s=%.2f live_orphans=%d "
+                "late_observation_fenced=true new_fetch_allowed=true freshness_extended=false",
+                MARKER,
+                bid,
+                retired_sequence,
+                fence_sequence,
+                age_s,
+                stale_after_s,
+                len(orphans),
+            )
+
+
+def install() -> bool:
+    with _LOCK:
+        v161 = _v161()
+        current = getattr(v161, "_supersede_stale_guard_flights", None)
+        if not callable(current):
+            os.environ[_READY_FLAG] = "0"
+            return False
+        if not bool(getattr(current, _PATCH_ATTR, False)):
+            @wraps(current)
+            def fenced(guard: Any, broker_map: dict[str, Any]) -> None:
+                _supersede_with_observation_fence(guard, broker_map)
+
+            setattr(fenced, _PATCH_ATTR, True)
+            setattr(fenced, "__wrapped__", current)
+            v161._supersede_stale_guard_flights = fenced
+
+        try:
+            manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+            required = getattr(manifest, "_REQUIRED_FLAGS", None)
+            if isinstance(required, dict):
+                required["runtime_capital_late_observation_fence_v162"] = _READY_FLAG
+        except Exception:
+            os.environ[_READY_FLAG] = "0"
+            return False
+
+        os.environ[_READY_FLAG] = "1"
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_LATE_OBSERVATION_FENCE_V162 marker=%s ready=true "
+            "retired_worker_cache_write_fenced=true freshness_extended=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "install", "install_import_hook", "_fence_observation", "_supersede_with_observation_fence"]

--- a/bot/runtime_capital_position_convergence_v161_patch.py
+++ b/bot/runtime_capital_position_convergence_v161_patch.py
@@ -1,0 +1,603 @@
+"""Runtime capital/position convergence repair v161.
+
+Production on 2026-08-19 exposed two liveness defects that remained after the
+v158 deadline-owner repair:
+
+* a broker balance worker (most visibly Kraken) could outlive the synchronous
+  capital publication budget and remain the reusable v35 in-flight request.
+  Coordinator rollover therefore created a fresh coordinator while still
+  inheriting the same stuck broker worker, allowing repeated partial 2/3
+  CapitalAuthority snapshots and eventual 80-second runtime-pipeline rollover;
+* platform position reconciliation retried only when the adopter returned
+  normally. A bounded TimeoutError escaped the v108 retry loop, so canonical
+  ``position_sync_ready`` could remain false even after the broker recovered.
+
+v161 repairs those liveness paths without fabricating capital, positions, or
+execution authority:
+
+* seed the capital guard only from a broker-owned, timestamped balance that is
+  still inside the canonical freshness TTL;
+* supersede a v35 broker flight once it has consumed almost the entire v78
+  synchronous fetch budget, with a strict cap on simultaneously orphaned daemon
+  workers; v35 sequence checks keep older late results from overwriting newer
+  observations;
+* retry ordinary position-sync exceptions inside the existing bounded v108
+  attempt loop instead of abandoning the worker after the first timeout;
+* run a small periodic platform-position convergence tick independent of capital
+  refresh. It only dispatches the existing authoritative adopter and republishes
+  canonical readiness from observed broker state;
+* attest this repair in the runtime release manifest.
+
+The patch does not extend capital freshness/publication expiry, change risk
+limits, clear kill switches, grant writer/nonce authority, force LIVE_ACTIVE, or
+turn a failed broker read into success.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_position_convergence_v161")
+MARKER = "20260819-runtime-capital-position-convergence-v161"
+RELEASE_ID = "20260819-runtime-convergence-v161"
+_PATCH_ATTR = "_nija_runtime_capital_position_convergence_v161"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161_READY"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_POSITION_MONITOR_STARTED = False
+_ORPHANED_FLIGHTS: dict[str, list[Any]] = {}
+
+
+def _guard_module() -> ModuleType:
+    return importlib.import_module("bot.capital_refresh_stall_guard_v35")
+
+
+def _v108_module() -> ModuleType:
+    return importlib.import_module("bot.platform_position_sync_v108_patch")
+
+
+def _fetch_budget_seconds() -> float:
+    try:
+        v78 = importlib.import_module("bot.capital_refresh_live_continuity_v78_patch")
+        getter = getattr(v78, "fetch_budget_seconds", None)
+        if callable(getter):
+            return max(5.0, float(getter()))
+    except Exception:
+        pass
+    try:
+        ttl = float(getattr(_guard_module(), "_freshness_ttl_seconds")())
+    except Exception:
+        ttl = 90.0
+    return max(5.0, ttl - 30.0)
+
+
+def _stale_flight_after_seconds(broker_id: str) -> float:
+    guard = _guard_module()
+    budget = _fetch_budget_seconds()
+    try:
+        broker_timeout = float(guard._broker_timeout_seconds(str(broker_id)))
+    except Exception:
+        broker_timeout = budget
+    raw = str(os.environ.get("NIJA_CAPITAL_STALE_FLIGHT_AFTER_S", "") or "").strip()
+    if raw:
+        try:
+            requested = float(raw)
+        except (TypeError, ValueError):
+            requested = budget - 5.0
+    else:
+        requested = budget - 5.0
+    ceiling = max(2.0, min(broker_timeout, max(2.0, budget - 1.0)))
+    return max(2.0, min(requested, ceiling))
+
+
+def _max_orphaned_flights() -> int:
+    try:
+        value = int(float(os.environ.get("NIJA_CAPITAL_MAX_ORPHANED_FLIGHTS_PER_BROKER", "2") or 2))
+    except (TypeError, ValueError):
+        value = 2
+    return max(1, min(value, 4))
+
+
+def _wall_timestamp(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            result = value.timestamp()
+        elif hasattr(value, "timestamp") and callable(value.timestamp):
+            result = float(value.timestamp())
+        else:
+            result = float(value)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+    return result if math.isfinite(result) and result > 0.0 else None
+
+
+def _seed_fresh_broker_observation(guard: ModuleType, broker_id: str, broker: Any) -> bool:
+    """Seed v35 fallback state from a broker-owned, fresh timestamped balance."""
+    bid = str(broker_id).strip().lower()
+    if broker is None or not bool(getattr(broker, "connected", True)):
+        return False
+
+    raw = getattr(broker, "_last_known_balance", None)
+    scalar_fn = getattr(guard, "_coerce_scalar", None)
+    if not callable(scalar_fn):
+        return False
+    scalar = scalar_fn(raw)
+    if scalar is None or float(scalar) <= 0.0:
+        return False
+
+    observed_epoch = _wall_timestamp(getattr(broker, "_balance_last_updated", None))
+    getter = getattr(broker, "get_balance_fetch_timestamp", None)
+    if observed_epoch is None and callable(getter):
+        try:
+            observed_epoch = _wall_timestamp(getter())
+        except Exception:
+            observed_epoch = None
+    if observed_epoch is None:
+        return False
+
+    now_epoch = time.time()
+    age_s = max(0.0, now_epoch - observed_epoch)
+    try:
+        ttl_s = float(guard._freshness_ttl_seconds())
+    except Exception:
+        ttl_s = 90.0
+    if age_s > ttl_s:
+        return False
+
+    observed_mono = max(0.0, time.monotonic() - age_s)
+    observations = getattr(guard, "_OBSERVATIONS", None)
+    observation_cls = getattr(guard, "_Observation", None)
+    lock = getattr(guard, "_OBSERVATION_LOCK", None)
+    sequence_map = getattr(guard, "_BROKER_SEQUENCE", {})
+    if not isinstance(observations, dict) or observation_cls is None:
+        return False
+    sequence = int(sequence_map.get(bid, 0) or 0)
+    try:
+        observation = observation_cls(
+            value=float(scalar),
+            observed_monotonic=observed_mono,
+            observed_epoch=observed_epoch,
+            sequence=sequence,
+        )
+    except TypeError:
+        observation = observation_cls(float(scalar), observed_mono, observed_epoch, sequence)
+
+    def _store() -> bool:
+        previous = observations.get(bid)
+        previous_mono = float(getattr(previous, "observed_monotonic", 0.0) or 0.0)
+        if previous is None or observed_mono >= previous_mono:
+            observations[bid] = observation
+            return True
+        return False
+
+    stored = _store() if lock is None else False
+    if lock is not None:
+        with lock:
+            stored = _store()
+    if stored:
+        LOGGER.info(
+            "CAPITAL_V161_BROKER_CACHE_SEEDED marker=%s broker=%s balance=%.8f age_s=%.2f "
+            "source=broker_timestamped_last_known freshness_extended=false",
+            MARKER,
+            bid,
+            float(scalar),
+            age_s,
+        )
+    return stored
+
+
+def _prune_orphans(broker_id: str) -> list[Any]:
+    bid = str(broker_id).strip().lower()
+    alive: list[Any] = []
+    for flight in list(_ORPHANED_FLIGHTS.get(bid, [])):
+        thread = getattr(flight, "thread", None)
+        is_alive = getattr(thread, "is_alive", None)
+        if callable(is_alive) and bool(is_alive()):
+            alive.append(flight)
+    _ORPHANED_FLIGHTS[bid] = alive
+    return alive
+
+
+def _supersede_stale_guard_flights(guard: ModuleType, broker_map: dict[str, Any]) -> None:
+    in_flight = getattr(guard, "_IN_FLIGHT", None)
+    in_flight_lock = getattr(guard, "_IN_FLIGHT_LOCK", None)
+    if not isinstance(in_flight, dict) or in_flight_lock is None:
+        return
+    now = time.monotonic()
+    with in_flight_lock:
+        for broker_id in broker_map:
+            bid = str(broker_id).strip().lower()
+            flight = in_flight.get(bid)
+            if flight is None:
+                continue
+            thread = getattr(flight, "thread", None)
+            is_alive = getattr(thread, "is_alive", None)
+            if not callable(is_alive) or not bool(is_alive()):
+                continue
+            try:
+                age_s = max(0.0, now - float(getattr(flight, "started_monotonic", now) or now))
+            except (TypeError, ValueError):
+                age_s = 0.0
+            stale_after_s = _stale_flight_after_seconds(bid)
+            if age_s < stale_after_s:
+                continue
+            orphans = _prune_orphans(bid)
+            if len(orphans) >= _max_orphaned_flights():
+                LOGGER.warning(
+                    "CAPITAL_V161_STALE_FLIGHT_ROTATION_CAPPED marker=%s broker=%s age_s=%.2f "
+                    "stale_after_s=%.2f live_orphans=%d max_orphans=%d current_reused=true",
+                    MARKER,
+                    bid,
+                    age_s,
+                    stale_after_s,
+                    len(orphans),
+                    _max_orphaned_flights(),
+                )
+                continue
+            if in_flight.get(bid) is not flight:
+                continue
+            in_flight.pop(bid, None)
+            orphans.append(flight)
+            _ORPHANED_FLIGHTS[bid] = orphans
+            LOGGER.critical(
+                "CAPITAL_V161_STALE_FLIGHT_SUPERSEDED marker=%s broker=%s sequence=%s age_s=%.2f "
+                "stale_after_s=%.2f live_orphans=%d late_result_sequence_guard=true "
+                "new_fetch_allowed=true freshness_extended=false",
+                MARKER,
+                bid,
+                getattr(flight, "sequence", "unknown"),
+                age_s,
+                stale_after_s,
+                len(orphans),
+            )
+
+
+def _patch_capital_batch() -> bool:
+    guard = _guard_module()
+    batch_cls = getattr(guard, "_BalanceFetchBatch", None)
+    if not isinstance(batch_cls, type):
+        return False
+    current = getattr(batch_cls, "__init__", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def init_v161(self: Any, broker_map: dict[str, Any]) -> None:
+        live_map = {
+            str(broker_id).strip().lower(): broker
+            for broker_id, broker in dict(broker_map or {}).items()
+            if broker is not None
+        }
+        for bid, broker in live_map.items():
+            try:
+                _seed_fresh_broker_observation(guard, bid, broker)
+            except Exception as exc:
+                LOGGER.debug(
+                    "CAPITAL_V161_CACHE_SEED_ERROR marker=%s broker=%s error=%s:%s",
+                    MARKER,
+                    bid,
+                    type(exc).__name__,
+                    exc,
+                )
+        _supersede_stale_guard_flights(guard, live_map)
+        original(self, broker_map)
+
+    setattr(init_v161, _PATCH_ATTR, True)
+    setattr(init_v161, "__wrapped__", original)
+    batch_cls.__init__ = init_v161
+    return True
+
+
+def _startup_sync_module() -> ModuleType:
+    try:
+        return importlib.import_module("bot.startup_position_sync")
+    except ImportError:
+        return importlib.import_module("startup_position_sync")
+
+
+def _position_worker_v161(
+    v108: ModuleType,
+    manager: Any,
+    broker_name: str,
+    broker: Any,
+    key: tuple[int, int],
+    trigger: str,
+) -> None:
+    try:
+        sync_module = _startup_sync_module()
+        get_eps = getattr(sync_module, "_get_entry_price_store", None)
+        eps = get_eps() if callable(get_eps) else None
+        adopt = getattr(sync_module, "_adopt_broker_positions", None)
+        if not callable(adopt):
+            raise RuntimeError("startup position-sync adopter unavailable")
+
+        max_attempts, base_delay_s, max_delay_s = v108._retry_policy()
+        LOGGER.critical(
+            "POSITION_SYNC_V161_START marker=%s broker=%s trigger=%s authoritative_fetch=true "
+            "exception_retry=true max_attempts=%d synthetic_empty_snapshot=false",
+            MARKER,
+            broker_name,
+            trigger,
+            max_attempts,
+        )
+        for attempt in range(1, max_attempts + 1):
+            attempt_error: BaseException | None = None
+            try:
+                adopt(broker, f"platform:{broker_name}", eps)
+            except Exception as exc:
+                attempt_error = exc
+                setattr(broker, "_startup_position_sync_adopted", False)
+                setattr(broker, "_startup_position_sync_fetch_ok", False)
+                setattr(broker, "_startup_position_sync_error", f"{type(exc).__name__}:{exc}")
+                LOGGER.warning(
+                    "POSITION_SYNC_V161_ATTEMPT_FAILED marker=%s broker=%s trigger=%s attempt=%d "
+                    "error=%s:%s retryable=true trading_fail_closed=true",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    attempt,
+                    type(exc).__name__,
+                    exc,
+                )
+
+            synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None)
+            error = getattr(broker, "_startup_position_sync_error", None)
+            v108._publish_readiness(
+                manager,
+                source=f"v161:{trigger}:{broker_name}:attempt_{attempt}",
+            )
+            if synced:
+                LOGGER.critical(
+                    "POSITION_SYNC_V161_COMPLETE marker=%s broker=%s trigger=%s attempt=%d "
+                    "synced=true fetch_ok=%s error=%s",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    attempt,
+                    fetch_ok,
+                    error,
+                )
+                break
+
+            if attempt >= max_attempts:
+                LOGGER.warning(
+                    "POSITION_SYNC_V161_RETRIES_EXHAUSTED marker=%s broker=%s trigger=%s attempts=%d "
+                    "synced=false fetch_ok=%s error=%s last_attempt_exception=%s trading_fail_closed=true",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    max_attempts,
+                    fetch_ok,
+                    error,
+                    type(attempt_error).__name__ if attempt_error is not None else "none",
+                )
+                break
+
+            delay_s = min(max_delay_s, base_delay_s * (2 ** (attempt - 1)))
+            LOGGER.warning(
+                "POSITION_SYNC_V161_RETRY marker=%s broker=%s trigger=%s attempt=%d next_attempt=%d "
+                "delay_s=%.2f synced=false fetch_ok=%s error=%s trading_fail_closed=true",
+                MARKER,
+                broker_name,
+                trigger,
+                attempt,
+                attempt + 1,
+                delay_s,
+                fetch_ok,
+                error,
+            )
+            time.sleep(delay_s)
+    except BaseException as exc:
+        try:
+            setattr(broker, "_startup_position_sync_adopted", False)
+            setattr(broker, "_startup_position_sync_fetch_ok", False)
+            setattr(broker, "_startup_position_sync_error", f"{type(exc).__name__}:{exc}")
+        except Exception:
+            pass
+        LOGGER.warning(
+            "POSITION_SYNC_V161_FAILED marker=%s broker=%s trigger=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            broker_name,
+            trigger,
+            type(exc).__name__,
+            exc,
+        )
+    finally:
+        try:
+            v108._publish_readiness(manager, source=f"v161:{trigger}:{broker_name}:final")
+        except Exception:
+            pass
+        lock = getattr(v108, "_LOCK", None)
+        active = getattr(v108, "_ACTIVE", None)
+        if lock is not None and isinstance(active, set):
+            with lock:
+                active.discard(key)
+
+
+def _patch_position_worker() -> bool:
+    v108 = _v108_module()
+    current = getattr(v108, "_worker", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def worker_v161(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
+        _position_worker_v161(v108, manager, broker_name, broker, key, trigger)
+
+    setattr(worker_v161, _PATCH_ATTR, True)
+    setattr(worker_v161, "__wrapped__", current)
+    v108._worker = worker_v161
+    return True
+
+
+def _canonical_manager() -> Any:
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        getter = getattr(module, "get_broker_manager", None)
+        if callable(getter):
+            try:
+                manager = getter()
+                if manager is not None:
+                    return manager
+            except Exception:
+                pass
+        manager = getattr(module, "multi_account_broker_manager", None) or getattr(module, "_manager", None)
+        if manager is not None:
+            return manager
+    return None
+
+
+def _position_monitor_interval_seconds() -> float:
+    try:
+        value = float(os.environ.get("NIJA_POSITION_SYNC_CONVERGENCE_INTERVAL_S", "5.0") or 5.0)
+    except (TypeError, ValueError):
+        value = 5.0
+    return max(1.0, min(value, 30.0))
+
+
+def _position_monitor_iteration() -> tuple[int, bool]:
+    manager = _canonical_manager()
+    if manager is None:
+        return 0, False
+    v108 = _v108_module()
+    started = int(v108.dispatch_platform_position_sync(manager, trigger="v161_monitor") or 0)
+    try:
+        v108._publish_readiness(manager, source="v161_monitor_tick")
+        published = True
+    except Exception as exc:
+        LOGGER.warning(
+            "POSITION_SYNC_V161_MONITOR_PUBLISH_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        published = False
+    return started, published
+
+
+def _position_monitor() -> None:
+    while True:
+        try:
+            started, published = _position_monitor_iteration()
+            LOGGER.debug(
+                "POSITION_SYNC_V161_MONITOR_TICK marker=%s workers_started=%d readiness_published=%s",
+                MARKER,
+                started,
+                str(published).lower(),
+            )
+        except Exception as exc:
+            LOGGER.warning(
+                "POSITION_SYNC_V161_MONITOR_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(_position_monitor_interval_seconds())
+
+
+def _start_position_monitor() -> bool:
+    global _POSITION_MONITOR_STARTED
+    with _LOCK:
+        if _POSITION_MONITOR_STARTED:
+            return True
+        thread = threading.Thread(
+            target=_position_monitor,
+            name="RuntimeCapitalPositionConvergenceV161",
+            daemon=True,
+        )
+        thread.start()
+        _POSITION_MONITOR_STARTED = True
+        LOGGER.critical(
+            "POSITION_SYNC_V161_MONITOR_STARTED marker=%s interval_s=%.1f "
+            "capital_refresh_dependency=false authoritative_adopter_only=true",
+            MARKER,
+            _position_monitor_interval_seconds(),
+        )
+        return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    except Exception:
+        return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["runtime_capital_position_convergence_v161"] = _READY_FLAG
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        capital_ok = _patch_capital_batch()
+        position_ok = _patch_position_worker()
+        manifest_ok = _patch_release_manifest()
+        if not (capital_ok and position_ok and manifest_ok):
+            os.environ[_READY_FLAG] = "0"
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161_FAILED marker=%s capital_ok=%s "
+                "position_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                capital_ok,
+                position_ok,
+                manifest_ok,
+            )
+            return False
+        _start_position_monitor()
+        os.environ[_READY_FLAG] = "1"
+        _INSTALLED = True
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161 marker=%s ready=true "
+            "capital_stale_after_s=%.1f fetch_budget_s=%.1f max_orphans=%d "
+            "position_exception_retry=true position_monitor=true freshness_extended=false "
+            "publication_expiry_extended=false safety_gates_bypassed=false",
+            MARKER,
+            _stale_flight_after_seconds("kraken"),
+            _fetch_budget_seconds(),
+            _max_orphaned_flights(),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_patch_capital_batch",
+    "_patch_position_worker",
+    "_position_worker_v161",
+    "_position_monitor_iteration",
+    "_seed_fresh_broker_observation",
+    "_stale_flight_after_seconds",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -7,7 +7,8 @@ trade independently. This guard continuously restores the canonical alias, sets
 the authority broker threshold from the active readiness policy, installs the
 fail-closed v154 pre-authority structural gate repair, the v155 same-lease nonce
 maturity verifier, the v157 post-activation runtime-quality convergence repair,
-and the v158 bounded capital-pipeline publication-margin repair.
+the v158 bounded capital-pipeline publication-margin repair, and the v161
+capital/position liveness convergence repair.
 """
 from __future__ import annotations
 
@@ -158,6 +159,22 @@ def _install_v158_capital_margin() -> bool:
         return False
 
 
+def _install_v161_capital_position_convergence() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
+        install_fn = getattr(module, "install", None)
+        if not callable(install_fn):
+            raise RuntimeError("v161_install_missing")
+        return bool(install_fn())
+    except Exception as exc:
+        logger.error(
+            "RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -166,6 +183,7 @@ def _iteration() -> bool:
     v155_installed = _install_v155_nonce_maturity()
     v157_installed = _install_v157_runtime_quality()
     v158_installed = _install_v158_capital_margin()
+    v161_installed = _install_v161_capital_position_convergence()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -175,7 +193,8 @@ def _iteration() -> bool:
             _ALIAS,
         )
     logger.debug(
-        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s",
+        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
+        "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s v161_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -184,8 +203,15 @@ def _iteration() -> bool:
         str(v155_installed).lower(),
         str(v157_installed).lower(),
         str(v158_installed).lower(),
+        str(v161_installed).lower(),
     )
-    return bool(v154_installed and v155_installed and v157_installed and v158_installed)
+    return bool(
+        v154_installed
+        and v155_installed
+        and v157_installed
+        and v158_installed
+        and v161_installed
+    )
 
 
 def _watchdog() -> None:
@@ -209,7 +235,9 @@ def install() -> bool:
                 daemon=True,
             ).start()
         logger.critical(
-            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true v158_capital_margin=true",
+            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d "
+            "alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true "
+            "v158_capital_margin=true v161_capital_position_convergence=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -228,5 +256,6 @@ __all__ = [
     "_install_v155_nonce_maturity",
     "_install_v157_runtime_quality",
     "_install_v158_capital_margin",
+    "_install_v161_capital_position_convergence",
     "_iteration",
 ]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -7,8 +7,9 @@ trade independently. This guard continuously restores the canonical alias, sets
 the authority broker threshold from the active readiness policy, installs the
 fail-closed v154 pre-authority structural gate repair, the v155 same-lease nonce
 maturity verifier, the v157 post-activation runtime-quality convergence repair,
-the v158 bounded capital-pipeline publication-margin repair, and the v161
-capital/position liveness convergence repair.
+the v158 bounded capital-pipeline publication-margin repair, the v161
+capital/position liveness convergence repair, and the v162 retired-observation
+fence.
 """
 from __future__ import annotations
 
@@ -175,6 +176,22 @@ def _install_v161_capital_position_convergence() -> bool:
         return False
 
 
+def _install_v162_late_observation_fence() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_capital_late_observation_fence_v162_patch")
+        install_fn = getattr(module, "install", None)
+        if not callable(install_fn):
+            raise RuntimeError("v162_install_missing")
+        return bool(install_fn())
+    except Exception as exc:
+        logger.error(
+            "RUNTIME_CAPITAL_LATE_OBSERVATION_FENCE_V162_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -184,6 +201,7 @@ def _iteration() -> bool:
     v157_installed = _install_v157_runtime_quality()
     v158_installed = _install_v158_capital_margin()
     v161_installed = _install_v161_capital_position_convergence()
+    v162_installed = _install_v162_late_observation_fence()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -194,7 +212,8 @@ def _iteration() -> bool:
         )
     logger.debug(
         "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
-        "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s v161_installed=%s",
+        "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s "
+        "v161_installed=%s v162_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -204,6 +223,7 @@ def _iteration() -> bool:
         str(v157_installed).lower(),
         str(v158_installed).lower(),
         str(v161_installed).lower(),
+        str(v162_installed).lower(),
     )
     return bool(
         v154_installed
@@ -211,6 +231,7 @@ def _iteration() -> bool:
         and v157_installed
         and v158_installed
         and v161_installed
+        and v162_installed
     )
 
 
@@ -237,7 +258,8 @@ def install() -> bool:
         logger.critical(
             "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d "
             "alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true "
-            "v158_capital_margin=true v161_capital_position_convergence=true",
+            "v158_capital_margin=true v161_capital_position_convergence=true "
+            "v162_late_observation_fence=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -257,5 +279,6 @@ __all__ = [
     "_install_v157_runtime_quality",
     "_install_v158_capital_margin",
     "_install_v161_capital_position_convergence",
+    "_install_v162_late_observation_fence",
     "_iteration",
 ]

--- a/tests/test_runtime_capital_late_observation_fence_v162.py
+++ b/tests/test_runtime_capital_late_observation_fence_v162.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import namedtuple
+from types import SimpleNamespace
+
+import bot.runtime_capital_late_observation_fence_v162_patch as v162
+
+
+Observation = namedtuple(
+    "Observation",
+    "value observed_monotonic observed_epoch sequence",
+)
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
+def test_fence_preserves_authoritative_value_and_advances_sequence():
+    previous = Observation(242.0, 100.0, 200.0, 3)
+    guard = SimpleNamespace(
+        _BROKER_SEQUENCE={"kraken": 3},
+        _OBSERVATIONS={"kraken": previous},
+        _OBSERVATION_LOCK=threading.Lock(),
+        _Observation=Observation,
+    )
+
+    fence_sequence = v162._fence_observation(guard, "kraken", 3)
+
+    assert fence_sequence == 4
+    assert guard._BROKER_SEQUENCE["kraken"] == 4
+    fenced = guard._OBSERVATIONS["kraken"]
+    assert fenced.value == 242.0
+    assert fenced.observed_monotonic == 100.0
+    assert fenced.observed_epoch == 200.0
+    assert fenced.sequence == 4
+
+
+def test_fence_without_prior_observation_is_not_fresh_fallback():
+    guard = SimpleNamespace(
+        _BROKER_SEQUENCE={"kraken": 7},
+        _OBSERVATIONS={},
+        _OBSERVATION_LOCK=threading.Lock(),
+        _Observation=Observation,
+    )
+
+    fence_sequence = v162._fence_observation(guard, "kraken", 7)
+
+    assert fence_sequence == 8
+    tombstone = guard._OBSERVATIONS["kraken"]
+    assert tombstone.value == 0.0
+    assert tombstone.observed_monotonic == 0.0
+    assert tombstone.observed_epoch == 0.0
+    assert tombstone.sequence == 8
+
+
+def test_supersede_fences_old_worker_before_allowing_new_fetch(monkeypatch):
+    flight = SimpleNamespace(
+        thread=_AliveThread(),
+        sequence=5,
+        started_monotonic=time.monotonic() - 60.0,
+        timeout_s=75.0,
+    )
+    previous = Observation(242.0, time.monotonic() - 10.0, time.time() - 10.0, 5)
+    guard = SimpleNamespace(
+        _IN_FLIGHT={"kraken": flight},
+        _IN_FLIGHT_LOCK=threading.Lock(),
+        _BROKER_SEQUENCE={"kraken": 5},
+        _OBSERVATIONS={"kraken": previous},
+        _OBSERVATION_LOCK=threading.Lock(),
+        _Observation=Observation,
+    )
+    fake_v161 = SimpleNamespace(
+        _stale_flight_after_seconds=lambda broker_id: 45.0,
+        _prune_orphans=lambda broker_id: [],
+        _max_orphaned_flights=lambda: 2,
+        _ORPHANED_FLIGHTS={},
+    )
+    monkeypatch.setattr(v162, "_v161", lambda: fake_v161)
+
+    v162._supersede_with_observation_fence(guard, {"kraken": object()})
+
+    assert "kraken" not in guard._IN_FLIGHT
+    assert guard._BROKER_SEQUENCE["kraken"] == 6
+    assert guard._OBSERVATIONS["kraken"].value == 242.0
+    assert guard._OBSERVATIONS["kraken"].sequence == 6
+    assert fake_v161._ORPHANED_FLIGHTS["kraken"] == [flight]
+
+
+def test_old_retired_sequence_cannot_replace_fenced_observation():
+    # Mirrors v35's existing update condition:
+    # previous is None or broker_seq >= previous.sequence.
+    fenced = Observation(242.0, 100.0, 200.0, 6)
+    retired_sequence = 5
+    assert retired_sequence >= fenced.sequence is False

--- a/tests/test_runtime_capital_position_convergence_v161.py
+++ b/tests/test_runtime_capital_position_convergence_v161.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from types import SimpleNamespace
+
+import bot.runtime_capital_position_convergence_v161_patch as v161
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
+class _Broker:
+    def __init__(self, balance: float = 100.0, age_s: float = 5.0):
+        self.connected = True
+        self._last_known_balance = balance
+        self._balance_last_updated = time.time() - age_s
+        self._startup_position_sync_adopted = False
+        self._startup_position_sync_fetch_ok = None
+        self._startup_position_sync_error = None
+
+
+def test_stale_flight_threshold_stays_inside_fetch_budget(monkeypatch):
+    guard = SimpleNamespace(_broker_timeout_seconds=lambda broker_id: 75.0)
+    monkeypatch.setattr(v161, "_guard_module", lambda: guard)
+    monkeypatch.setattr(v161, "_fetch_budget_seconds", lambda: 50.0)
+    monkeypatch.delenv("NIJA_CAPITAL_STALE_FLIGHT_AFTER_S", raising=False)
+
+    assert v161._stale_flight_after_seconds("kraken") == 45.0
+
+
+def test_fresh_broker_owned_balance_seeds_guard_but_stale_does_not(monkeypatch):
+    observations = {}
+    lock = threading.Lock()
+
+    class Observation:
+        def __init__(self, value, observed_monotonic, observed_epoch, sequence):
+            self.value = value
+            self.observed_monotonic = observed_monotonic
+            self.observed_epoch = observed_epoch
+            self.sequence = sequence
+
+    guard = SimpleNamespace(
+        _coerce_scalar=lambda value: float(value),
+        _freshness_ttl_seconds=lambda: 90.0,
+        _OBSERVATIONS=observations,
+        _OBSERVATION_LOCK=lock,
+        _BROKER_SEQUENCE={"kraken": 7},
+        _Observation=Observation,
+    )
+
+    fresh = _Broker(242.0, age_s=10.0)
+    assert v161._seed_fresh_broker_observation(guard, "kraken", fresh) is True
+    assert observations["kraken"].value == 242.0
+    assert observations["kraken"].sequence == 7
+
+    observations.clear()
+    stale = _Broker(242.0, age_s=120.0)
+    assert v161._seed_fresh_broker_observation(guard, "kraken", stale) is False
+    assert observations == {}
+
+
+def test_stale_balance_flight_is_rotated_and_orphan_count_is_bounded(monkeypatch):
+    flight = SimpleNamespace(
+        thread=_AliveThread(),
+        result_queue=queue.Queue(maxsize=1),
+        sequence=3,
+        started_monotonic=time.monotonic() - 60.0,
+        timeout_s=75.0,
+    )
+    guard = SimpleNamespace(
+        _IN_FLIGHT={"kraken": flight},
+        _IN_FLIGHT_LOCK=threading.Lock(),
+    )
+    monkeypatch.setattr(v161, "_stale_flight_after_seconds", lambda broker_id: 45.0)
+    monkeypatch.setattr(v161, "_max_orphaned_flights", lambda: 2)
+    v161._ORPHANED_FLIGHTS.clear()
+
+    v161._supersede_stale_guard_flights(guard, {"kraken": object()})
+
+    assert "kraken" not in guard._IN_FLIGHT
+    assert v161._ORPHANED_FLIGHTS["kraken"] == [flight]
+
+    # With two still-alive orphans, the current request is retained rather than
+    # spawning an unbounded third abandoned worker.
+    second = SimpleNamespace(thread=_AliveThread())
+    v161._ORPHANED_FLIGHTS["kraken"] = [flight, second]
+    current = SimpleNamespace(
+        thread=_AliveThread(),
+        sequence=4,
+        started_monotonic=time.monotonic() - 60.0,
+        timeout_s=75.0,
+    )
+    guard._IN_FLIGHT["kraken"] = current
+    v161._supersede_stale_guard_flights(guard, {"kraken": object()})
+    assert guard._IN_FLIGHT["kraken"] is current
+
+
+def test_position_worker_retries_timeout_and_only_becomes_ready_after_real_success(monkeypatch):
+    broker = _Broker()
+    calls = []
+    readiness = []
+    active = set()
+    key = (11, 22)
+    active.add(key)
+
+    def adopt(broker_arg, broker_name, eps):
+        calls.append(broker_name)
+        if len(calls) < 3:
+            raise TimeoutError("slow position snapshot")
+        broker_arg._startup_position_sync_adopted = True
+        broker_arg._startup_position_sync_fetch_ok = True
+        broker_arg._startup_position_sync_error = None
+        return 0
+
+    sync_module = SimpleNamespace(
+        _get_entry_price_store=lambda: None,
+        _adopt_broker_positions=adopt,
+    )
+    fake_v108 = SimpleNamespace(
+        _retry_policy=lambda: (4, 0.01, 0.01),
+        _publish_readiness=lambda manager, source: readiness.append(
+            (source, broker._startup_position_sync_adopted)
+        ),
+        _LOCK=threading.RLock(),
+        _ACTIVE=active,
+    )
+    monkeypatch.setattr(v161, "_startup_sync_module", lambda: sync_module)
+    monkeypatch.setattr(v161.time, "sleep", lambda delay: None)
+
+    v161._position_worker_v161(fake_v108, object(), "kraken", broker, key, "test")
+
+    assert calls == ["platform:kraken"] * 3
+    assert readiness[0][1] is False
+    assert readiness[1][1] is False
+    assert readiness[2][1] is True
+    assert readiness[-1][1] is True
+    assert broker._startup_position_sync_adopted is True
+    assert key not in active
+
+
+def test_monitor_dispatches_position_sync_independent_of_capital_refresh(monkeypatch):
+    manager = object()
+    events = []
+    fake_v108 = SimpleNamespace(
+        dispatch_platform_position_sync=lambda mgr, trigger: events.append(("dispatch", trigger)) or 1,
+        _publish_readiness=lambda mgr, source: events.append(("publish", source)),
+    )
+    monkeypatch.setattr(v161, "_canonical_manager", lambda: manager)
+    monkeypatch.setattr(v161, "_v108_module", lambda: fake_v108)
+
+    started, published = v161._position_monitor_iteration()
+
+    assert started == 1
+    assert published is True
+    assert events == [
+        ("dispatch", "v161_monitor"),
+        ("publish", "v161_monitor_tick"),
+    ]
+
+
+def test_release_manifest_attests_v161(monkeypatch):
+    required = {}
+    fake_manifest = SimpleNamespace(_REQUIRED_FLAGS=required)
+    real_import = v161.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.runtime_release_manifest_patch":
+            return fake_manifest
+        return real_import(name)
+
+    monkeypatch.setattr(v161.importlib, "import_module", fake_import)
+    assert v161._patch_release_manifest() is True
+    assert required["runtime_capital_position_convergence_v161"] == v161._READY_FLAG


### PR DESCRIPTION
## Summary
- supersede stale broker balance flights before they consume the full synchronous capital publication budget
- seed fallback observations only from fresh broker-owned timestamped balances
- fence retired worker observations so a late lower-generation Kraken response cannot become newly-fresh fallback state
- retry bounded platform position-sync exceptions instead of abandoning reconciliation after the first timeout
- add an independent periodic platform position convergence tick
- install v161/v162 continuously from the post-import convergence watchdog
- keep capital freshness, publication expiry, kill switch, writer/nonce, risk, and execution gates unchanged

## Production failures addressed
- repeated 80s v142 coordinator rollovers with stale Kraken balance workers surviving generations
- CapitalAuthority remaining at 2/3 brokers while MABM reports all 3 viable
- canonical position_sync_ready remaining false and STARTUP_RECONCILIATION staying PENDING

## Validation
- v161 module compiles locally
- synthetic harness proves 50s fetch budget => 45s stale-flight rotation
- fresh timestamped balance seeds fallback while >90s stale balance is rejected
- timed-out position sync remains false through failed attempts and becomes true only after an authoritative successful retry
- source audit confirmed v35 late workers are sequence-controlled; v162 advances the observation fence before rotation so retired responses cannot refresh the global fallback cache
- dedicated v161 and v162 unit coverage added

This PR deliberately does not bypass readiness or manufacture a trade. Production 99/100 certification still requires post-deploy evidence of stable 3/3 authoritative capital, position_sync_ready=true, LIVE_ACTIVE dispatch, and no recurring v142 timeout.