### PR TITLE
Fix runtime activation convergence v163

### DIFF
--- a/bot/runtime_activation_convergence_v163_patch.py
+++ b/bot/runtime_activation_convergence_v163_patch.py
@@ -1,0 +1,392 @@
+"""Runtime activation convergence repair v163.
+
+Production deployment 4efea093 on 2026-08-19 proved that v161/v162 repaired the
+capital-liveness path, but exposed two final activation-liveness defects:
+
+* v108/v161 considered ``_startup_position_sync_adopted`` sufficient to stop
+  redispatching a platform broker. v146 correctly requires the independent
+  ``_startup_position_sync_fetch_ok is True`` proof, so a broker could be
+  reported ready by v96 while v146 revoked the same snapshot as unproven;
+* a same-owner/same-token Redis nonce lease that was merely finishing its
+  configured 30-second maturity window was counted as ``nonce_drift`` by the
+  execution circuit breaker. Three expected startup deferrals could therefore
+  permanently trip the breaker before the lease became mature. v155 also used a
+  two-second final wait cap, while production reached the final check only
+  2.31 seconds short of the full requirement.
+
+v163 converges those paths without weakening their safety contracts:
+
+* position reconciliation remains pending until BOTH the adopted marker and the
+  authoritative fetch proof are true; missing fetch proof is redispatched by the
+  existing bounded single-flight worker;
+* the v161 worker only completes when both proofs are true;
+* the final nonce maturity re-check may wait at most five seconds, but still
+  requires the full configured stability duration and the exact same lease
+  token/owner before succeeding;
+* expected same-lease maturity deferrals are not counted as nonce-drift circuit
+  breaker anomalies. Real nonce failures, token/owner changes, stability
+  regression, Redis failures, and every other anomaly remain unchanged;
+* once the full nonce gate later succeeds, a breaker that was tripped solely by
+  the historical transient-maturity classification is cleared. No unrelated
+  breaker reason is reset.
+
+No position, capital, nonce, writer, risk, kill-switch, or trading readiness is
+fabricated.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_activation_convergence_v163")
+MARKER = "20260819-runtime-activation-convergence-v163"
+_READY_FLAG = "NIJA_RUNTIME_ACTIVATION_CONVERGENCE_V163_READY"
+_PATCH_ATTR = "_nija_runtime_activation_convergence_v163"
+_LOCK = threading.RLock()
+
+
+def _v108() -> ModuleType:
+    return importlib.import_module("bot.platform_position_sync_v108_patch")
+
+
+def _v161() -> ModuleType:
+    return importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
+
+
+def _tsm() -> ModuleType:
+    return importlib.import_module("bot.trading_state_machine")
+
+
+def _v155() -> ModuleType:
+    return importlib.import_module("bot.nonce_lease_maturity_v155_patch")
+
+
+def _connected_platform_brokers_requiring_proof(manager: Any) -> list[tuple[str, Any]]:
+    """Return connected platform brokers lacking either authoritative sync proof."""
+    v108 = _v108()
+    found: list[tuple[str, Any]] = []
+    try:
+        platform = getattr(manager, "platform_brokers", {}) or {}
+        if callable(platform):
+            platform = platform()
+        for broker_type, broker in dict(platform or {}).items():
+            if broker is None or not bool(getattr(broker, "connected", False)):
+                continue
+            adopted = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
+            if adopted and fetch_ok:
+                continue
+            broker_name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+            found.append((broker_name, broker))
+    except Exception as exc:
+        LOGGER.warning(
+            "POSITION_SYNC_V163_DISCOVERY_FAILED marker=%s error=%s:%s fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+    return found
+
+
+def _position_worker_v163(
+    manager: Any,
+    broker_name: str,
+    broker: Any,
+    key: tuple[int, int],
+    trigger: str,
+) -> None:
+    """Run authoritative v161 reconciliation until both sync proofs converge."""
+    v108 = _v108()
+    v161 = _v161()
+    try:
+        sync_module = v161._startup_sync_module()
+        get_eps = getattr(sync_module, "_get_entry_price_store", None)
+        eps = get_eps() if callable(get_eps) else None
+        adopt = getattr(sync_module, "_adopt_broker_positions", None)
+        if not callable(adopt):
+            raise RuntimeError("startup position-sync adopter unavailable")
+
+        max_attempts, base_delay_s, max_delay_s = v108._retry_policy()
+        LOGGER.critical(
+            "POSITION_SYNC_V163_START marker=%s broker=%s trigger=%s max_attempts=%d "
+            "adopted_and_fetch_proof_required=true synthetic_success=false",
+            MARKER,
+            broker_name,
+            trigger,
+            max_attempts,
+        )
+        for attempt in range(1, max_attempts + 1):
+            attempt_error: BaseException | None = None
+            try:
+                adopt(broker, f"platform:{broker_name}", eps)
+            except Exception as exc:
+                attempt_error = exc
+                setattr(broker, "_startup_position_sync_adopted", False)
+                setattr(broker, "_startup_position_sync_fetch_ok", False)
+                setattr(broker, "_startup_position_sync_error", f"{type(exc).__name__}:{exc}")
+
+            adopted = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
+            error = getattr(broker, "_startup_position_sync_error", None)
+            v108._publish_readiness(
+                manager,
+                source=f"v163:{trigger}:{broker_name}:attempt_{attempt}",
+            )
+            if adopted and fetch_ok:
+                LOGGER.critical(
+                    "POSITION_SYNC_V163_COMPLETE marker=%s broker=%s trigger=%s attempt=%d "
+                    "adopted=true fetch_ok=true error=%s",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    attempt,
+                    error,
+                )
+                return
+
+            if attempt >= max_attempts:
+                LOGGER.warning(
+                    "POSITION_SYNC_V163_RETRIES_EXHAUSTED marker=%s broker=%s trigger=%s attempts=%d "
+                    "adopted=%s fetch_ok=%s error=%s last_exception=%s trading_fail_closed=true",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    max_attempts,
+                    str(adopted).lower(),
+                    str(fetch_ok).lower(),
+                    error,
+                    type(attempt_error).__name__ if attempt_error is not None else "none",
+                )
+                return
+
+            delay_s = min(max_delay_s, base_delay_s * (2 ** (attempt - 1)))
+            LOGGER.warning(
+                "POSITION_SYNC_V163_RETRY marker=%s broker=%s trigger=%s attempt=%d next_attempt=%d "
+                "delay_s=%.2f adopted=%s fetch_ok=%s error=%s trading_fail_closed=true",
+                MARKER,
+                broker_name,
+                trigger,
+                attempt,
+                attempt + 1,
+                delay_s,
+                str(adopted).lower(),
+                str(fetch_ok).lower(),
+                error,
+            )
+            time.sleep(delay_s)
+    except BaseException as exc:
+        try:
+            setattr(broker, "_startup_position_sync_adopted", False)
+            setattr(broker, "_startup_position_sync_fetch_ok", False)
+            setattr(broker, "_startup_position_sync_error", f"{type(exc).__name__}:{exc}")
+        except Exception:
+            pass
+        LOGGER.warning(
+            "POSITION_SYNC_V163_FAILED marker=%s broker=%s trigger=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            broker_name,
+            trigger,
+            type(exc).__name__,
+            exc,
+        )
+    finally:
+        try:
+            v108._publish_readiness(manager, source=f"v163:{trigger}:{broker_name}:final")
+        except Exception:
+            pass
+        active = getattr(v108, "_ACTIVE", None)
+        lock = getattr(v108, "_LOCK", None)
+        if isinstance(active, set) and lock is not None:
+            with lock:
+                active.discard(key)
+
+
+def _patch_position_sync() -> bool:
+    v108 = _v108()
+    current_discovery = getattr(v108, "_connected_unsynced_platform_brokers", None)
+    current_worker = getattr(v108, "_worker", None)
+    if not callable(current_discovery) or not callable(current_worker):
+        return False
+
+    if not bool(getattr(current_discovery, _PATCH_ATTR, False)):
+        @wraps(current_discovery)
+        def discovery_v163(manager: Any) -> list[tuple[str, Any]]:
+            return _connected_platform_brokers_requiring_proof(manager)
+
+        setattr(discovery_v163, _PATCH_ATTR, True)
+        setattr(discovery_v163, "__wrapped__", current_discovery)
+        v108._connected_unsynced_platform_brokers = discovery_v163
+
+    if not bool(getattr(current_worker, _PATCH_ATTR, False)):
+        @wraps(current_worker)
+        def worker_v163(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
+            _position_worker_v163(manager, broker_name, broker, key, trigger)
+
+        setattr(worker_v163, _PATCH_ATTR, True)
+        setattr(worker_v163, "__wrapped__", current_worker)
+        v108._worker = worker_v163
+    return True
+
+
+def _transient_nonce_maturity(detail: str) -> bool:
+    text = str(detail or "").lower()
+    return (
+        "nonce lease unstable" in text
+        and "lease_identity_changed" not in text
+        and "stability_regressed" not in text
+        and "hard fail" not in text
+        and "redis" not in text.split("nonce lease unstable", 1)[0]
+    )
+
+
+def _clear_historical_maturity_breaker(tsm: ModuleType) -> bool:
+    """Clear only a breaker tripped solely by transient nonce lease immaturity."""
+    lock = getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_LOCK", None)
+    counts = getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_COUNTS", None)
+    reason = str(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_REASON", "") or "")
+    tripped = bool(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_TRIPPED", False))
+    if not tripped or not _transient_nonce_maturity(reason):
+        return False
+    if lock is None or not isinstance(counts, dict):
+        return False
+    with lock:
+        current_reason = str(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_REASON", "") or "")
+        if not bool(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_TRIPPED", False)):
+            return False
+        if not _transient_nonce_maturity(current_reason):
+            return False
+        counts.pop("nonce_drift", None)
+        setattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_TRIPPED", False)
+        setattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_REASON", "")
+    LOGGER.critical(
+        "NONCE_V163_TRANSIENT_MATURITY_BREAKER_CLEARED marker=%s full_nonce_gate_verified=true "
+        "unrelated_breakers_unchanged=true",
+        MARKER,
+    )
+    return True
+
+
+def _patch_nonce_convergence() -> bool:
+    tsm = _tsm()
+    v155 = _v155()
+
+    current_cap = getattr(v155, "_final_wait_cap_s", None)
+    if not callable(current_cap):
+        return False
+    if not bool(getattr(current_cap, _PATCH_ATTR, False)):
+        original_cap = current_cap
+
+        @wraps(original_cap)
+        def final_wait_cap_v163() -> float:
+            # Preserve any operator value above five seconds only up to v155's
+            # own safety ceiling; lift the historical two-second default/limit
+            # just enough to finish the observed same-lease maturity edge.
+            try:
+                original_value = float(original_cap())
+            except Exception:
+                original_value = 2.0
+            return min(5.0, max(original_value, 5.0))
+
+        setattr(final_wait_cap_v163, _PATCH_ATTR, True)
+        setattr(final_wait_cap_v163, "__wrapped__", original_cap)
+        v155._final_wait_cap_s = final_wait_cap_v163
+
+    current_record = getattr(tsm, "_record_execution_anomaly", None)
+    if not callable(current_record):
+        return False
+    if not bool(getattr(current_record, _PATCH_ATTR, False)):
+        original_record = current_record
+
+        @wraps(original_record)
+        def record_v163(kind: str, detail: str = "") -> None:
+            if str(kind) == "nonce_drift" and _transient_nonce_maturity(detail):
+                LOGGER.warning(
+                    "NONCE_V163_MATURITY_DEFERRAL_NOT_COUNTED marker=%s detail=%s "
+                    "activation_still_fail_closed=true circuit_breaker_bypass=false",
+                    MARKER,
+                    detail,
+                )
+                return
+            original_record(kind, detail)
+
+        setattr(record_v163, _PATCH_ATTR, True)
+        setattr(record_v163, "__wrapped__", original_record)
+        tsm._record_execution_anomaly = record_v163
+
+    current_gate = getattr(tsm, "_nonce_writer_lease_gate", None)
+    if not callable(current_gate):
+        return False
+    if not bool(getattr(current_gate, _PATCH_ATTR, False)):
+        original_gate = current_gate
+
+        @wraps(original_gate)
+        def gate_v163() -> tuple[bool, str]:
+            ok, err = original_gate()
+            if ok:
+                _clear_historical_maturity_breaker(tsm)
+            return bool(ok), str(err or "")
+
+        setattr(gate_v163, _PATCH_ATTR, True)
+        setattr(gate_v163, "__wrapped__", original_gate)
+        tsm._nonce_writer_lease_gate = gate_v163
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_activation_convergence_v163"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        position_ok = _patch_position_sync()
+        nonce_ok = _patch_nonce_convergence()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(position_ok and nonce_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_ACTIVATION_CONVERGENCE_V163_FAILED marker=%s position_ok=%s nonce_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(position_ok).lower(),
+                str(nonce_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_ACTIVATION_CONVERGENCE_V163 marker=%s ready=true "
+            "position_adopted_and_fetch_proof=true nonce_maturity_wait_cap_s=5.0 "
+            "transient_maturity_not_counted_as_nonce_drift=true historical_maturity_breaker_self_heal=true "
+            "stability_requirement_preserved=true safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_connected_platform_brokers_requiring_proof",
+    "_position_worker_v163",
+    "_transient_nonce_maturity",
+    "_clear_historical_maturity_breaker",
+]

--- a/bot/runtime_activation_convergence_v163_patch.py
+++ b/bot/runtime_activation_convergence_v163_patch.py
@@ -1,37 +1,16 @@
-"""Runtime activation convergence repair v163.
+"""Converge platform position proof and nonce-lease activation liveness.
 
-Production deployment 4efea093 on 2026-08-19 proved that v161/v162 repaired the
-capital-liveness path, but exposed two final activation-liveness defects:
+v163 keeps all existing fail-closed requirements, but removes two startup
+liveness contradictions observed on 2026-08-19:
 
-* v108/v161 considered ``_startup_position_sync_adopted`` sufficient to stop
-  redispatching a platform broker. v146 correctly requires the independent
-  ``_startup_position_sync_fetch_ok is True`` proof, so a broker could be
-  reported ready by v96 while v146 revoked the same snapshot as unproven;
-* a same-owner/same-token Redis nonce lease that was merely finishing its
-  configured 30-second maturity window was counted as ``nonce_drift`` by the
-  execution circuit breaker. Three expected startup deferrals could therefore
-  permanently trip the breaker before the lease became mature. v155 also used a
-  two-second final wait cap, while production reached the final check only
-  2.31 seconds short of the full requirement.
+* a platform broker is not position-ready until both the adopted marker and the
+  independent authoritative-fetch proof are true;
+* a same-owner/same-token lease that is merely completing its configured
+  stability window remains an activation deferral, not a nonce-drift anomaly.
 
-v163 converges those paths without weakening their safety contracts:
-
-* position reconciliation remains pending until BOTH the adopted marker and the
-  authoritative fetch proof are true; missing fetch proof is redispatched by the
-  existing bounded single-flight worker;
-* the v161 worker only completes when both proofs are true;
-* the final nonce maturity re-check may wait at most five seconds, but still
-  requires the full configured stability duration and the exact same lease
-  token/owner before succeeding;
-* expected same-lease maturity deferrals are not counted as nonce-drift circuit
-  breaker anomalies. Real nonce failures, token/owner changes, stability
-  regression, Redis failures, and every other anomaly remain unchanged;
-* once the full nonce gate later succeeds, a breaker that was tripped solely by
-  the historical transient-maturity classification is cleared. No unrelated
-  breaker reason is reset.
-
-No position, capital, nonce, writer, risk, kill-switch, or trading readiness is
-fabricated.
+The full nonce stability duration, lease identity, Redis/writer authority,
+position fetch proof, circuit breakers for real faults, and every trading/risk
+safety gate remain required.
 """
 from __future__ import annotations
 
@@ -68,8 +47,7 @@ def _v155() -> ModuleType:
 
 
 def _connected_platform_brokers_requiring_proof(manager: Any) -> list[tuple[str, Any]]:
-    """Return connected platform brokers lacking either authoritative sync proof."""
-    v108 = _v108()
+    """Find connected platform brokers missing either authoritative sync proof."""
     found: list[tuple[str, Any]] = []
     try:
         platform = getattr(manager, "platform_brokers", {}) or {}
@@ -82,8 +60,8 @@ def _connected_platform_brokers_requiring_proof(manager: Any) -> list[tuple[str,
             fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
             if adopted and fetch_ok:
                 continue
-            broker_name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
-            found.append((broker_name, broker))
+            name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+            found.append((name, broker))
     except Exception as exc:
         LOGGER.warning(
             "POSITION_SYNC_V163_DISCOVERY_FAILED marker=%s error=%s:%s fail_closed=true",
@@ -101,7 +79,7 @@ def _position_worker_v163(
     key: tuple[int, int],
     trigger: str,
 ) -> None:
-    """Run authoritative v161 reconciliation until both sync proofs converge."""
+    """Retry authoritative adoption until BOTH adopted and fetch proof are true."""
     v108 = _v108()
     v161 = _v161()
     try:
@@ -111,7 +89,6 @@ def _position_worker_v163(
         adopt = getattr(sync_module, "_adopt_broker_positions", None)
         if not callable(adopt):
             raise RuntimeError("startup position-sync adopter unavailable")
-
         max_attempts, base_delay_s, max_delay_s = v108._retry_policy()
         LOGGER.critical(
             "POSITION_SYNC_V163_START marker=%s broker=%s trigger=%s max_attempts=%d "
@@ -134,10 +111,7 @@ def _position_worker_v163(
             adopted = bool(getattr(broker, "_startup_position_sync_adopted", False))
             fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
             error = getattr(broker, "_startup_position_sync_error", None)
-            v108._publish_readiness(
-                manager,
-                source=f"v163:{trigger}:{broker_name}:attempt_{attempt}",
-            )
+            v108._publish_readiness(manager, source=f"v163:{trigger}:{broker_name}:attempt_{attempt}")
             if adopted and fetch_ok:
                 LOGGER.critical(
                     "POSITION_SYNC_V163_COMPLETE marker=%s broker=%s trigger=%s attempt=%d "
@@ -149,7 +123,6 @@ def _position_worker_v163(
                     error,
                 )
                 return
-
             if attempt >= max_attempts:
                 LOGGER.warning(
                     "POSITION_SYNC_V163_RETRIES_EXHAUSTED marker=%s broker=%s trigger=%s attempts=%d "
@@ -164,21 +137,7 @@ def _position_worker_v163(
                     type(attempt_error).__name__ if attempt_error is not None else "none",
                 )
                 return
-
             delay_s = min(max_delay_s, base_delay_s * (2 ** (attempt - 1)))
-            LOGGER.warning(
-                "POSITION_SYNC_V163_RETRY marker=%s broker=%s trigger=%s attempt=%d next_attempt=%d "
-                "delay_s=%.2f adopted=%s fetch_ok=%s error=%s trading_fail_closed=true",
-                MARKER,
-                broker_name,
-                trigger,
-                attempt,
-                attempt + 1,
-                delay_s,
-                str(adopted).lower(),
-                str(fetch_ok).lower(),
-                error,
-            )
             time.sleep(delay_s)
     except BaseException as exc:
         try:
@@ -209,51 +168,57 @@ def _position_worker_v163(
 
 def _patch_position_sync() -> bool:
     v108 = _v108()
-    current_discovery = getattr(v108, "_connected_unsynced_platform_brokers", None)
-    current_worker = getattr(v108, "_worker", None)
-    if not callable(current_discovery) or not callable(current_worker):
+    discovery = getattr(v108, "_connected_unsynced_platform_brokers", None)
+    worker = getattr(v108, "_worker", None)
+    if not callable(discovery) or not callable(worker):
         return False
+    if not bool(getattr(discovery, _PATCH_ATTR, False)):
+        original_discovery = discovery
 
-    if not bool(getattr(current_discovery, _PATCH_ATTR, False)):
-        @wraps(current_discovery)
+        @wraps(original_discovery)
         def discovery_v163(manager: Any) -> list[tuple[str, Any]]:
             return _connected_platform_brokers_requiring_proof(manager)
 
         setattr(discovery_v163, _PATCH_ATTR, True)
-        setattr(discovery_v163, "__wrapped__", current_discovery)
+        setattr(discovery_v163, "__wrapped__", original_discovery)
         v108._connected_unsynced_platform_brokers = discovery_v163
+    if not bool(getattr(worker, _PATCH_ATTR, False)):
+        original_worker = worker
 
-    if not bool(getattr(current_worker, _PATCH_ATTR, False)):
-        @wraps(current_worker)
+        @wraps(original_worker)
         def worker_v163(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
             _position_worker_v163(manager, broker_name, broker, key, trigger)
 
         setattr(worker_v163, _PATCH_ATTR, True)
-        setattr(worker_v163, "__wrapped__", current_worker)
+        setattr(worker_v163, "__wrapped__", original_worker)
         v108._worker = worker_v163
     return True
 
 
 def _transient_nonce_maturity(detail: str) -> bool:
+    """True only for an ordinary same-lease maturity deferral."""
     text = str(detail or "").lower()
-    return (
-        "nonce lease unstable" in text
-        and "lease_identity_changed" not in text
-        and "stability_regressed" not in text
-        and "hard fail" not in text
-        and "redis" not in text.split("nonce lease unstable", 1)[0]
+    if "nonce lease unstable" not in text:
+        return False
+    hard_markers = (
+        "lease_identity_changed",
+        "stability_regressed",
+        "invalid_status",
+        "status_unavailable",
+        "incomplete_identity",
+        "final_verify_error",
     )
+    return not any(marker in text for marker in hard_markers)
 
 
 def _clear_historical_maturity_breaker(tsm: ModuleType) -> bool:
-    """Clear only a breaker tripped solely by transient nonce lease immaturity."""
+    """Clear only a breaker whose recorded reason is transient lease maturity."""
     lock = getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_LOCK", None)
     counts = getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_COUNTS", None)
     reason = str(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_REASON", "") or "")
-    tripped = bool(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_TRIPPED", False))
-    if not tripped or not _transient_nonce_maturity(reason):
+    if not bool(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_TRIPPED", False)):
         return False
-    if lock is None or not isinstance(counts, dict):
+    if not _transient_nonce_maturity(reason) or lock is None or not isinstance(counts, dict):
         return False
     with lock:
         current_reason = str(getattr(tsm, "_EXECUTION_CIRCUIT_BREAKER_REASON", "") or "")
@@ -275,40 +240,34 @@ def _clear_historical_maturity_breaker(tsm: ModuleType) -> bool:
 def _patch_nonce_convergence() -> bool:
     tsm = _tsm()
     v155 = _v155()
-
-    current_cap = getattr(v155, "_final_wait_cap_s", None)
-    if not callable(current_cap):
+    cap = getattr(v155, "_final_wait_cap_s", None)
+    record = getattr(tsm, "_record_execution_anomaly", None)
+    gate = getattr(tsm, "_nonce_writer_lease_gate", None)
+    if not callable(cap) or not callable(record) or not callable(gate):
         return False
-    if not bool(getattr(current_cap, _PATCH_ATTR, False)):
-        original_cap = current_cap
+
+    if not bool(getattr(cap, _PATCH_ATTR, False)):
+        original_cap = cap
 
         @wraps(original_cap)
         def final_wait_cap_v163() -> float:
-            # Preserve any operator value above five seconds only up to v155's
-            # own safety ceiling; lift the historical two-second default/limit
-            # just enough to finish the observed same-lease maturity edge.
-            try:
-                original_value = float(original_cap())
-            except Exception:
-                original_value = 2.0
-            return min(5.0, max(original_value, 5.0))
+            # v155 itself has a five-second safety ceiling. Raising the old
+            # two-second cap does not lower the configured maturity requirement.
+            return 5.0
 
         setattr(final_wait_cap_v163, _PATCH_ATTR, True)
         setattr(final_wait_cap_v163, "__wrapped__", original_cap)
         v155._final_wait_cap_s = final_wait_cap_v163
 
-    current_record = getattr(tsm, "_record_execution_anomaly", None)
-    if not callable(current_record):
-        return False
-    if not bool(getattr(current_record, _PATCH_ATTR, False)):
-        original_record = current_record
+    if not bool(getattr(record, _PATCH_ATTR, False)):
+        original_record = record
 
         @wraps(original_record)
         def record_v163(kind: str, detail: str = "") -> None:
             if str(kind) == "nonce_drift" and _transient_nonce_maturity(detail):
                 LOGGER.warning(
-                    "NONCE_V163_MATURITY_DEFERRAL_NOT_COUNTED marker=%s detail=%s "
-                    "activation_still_fail_closed=true circuit_breaker_bypass=false",
+                    "NONCE_V163_MATURITY_DEFERRAL_NOT_COUNTED marker=%s "
+                    "activation_still_fail_closed=true circuit_breaker_bypass=false detail=%s",
                     MARKER,
                     detail,
                 )
@@ -319,11 +278,8 @@ def _patch_nonce_convergence() -> bool:
         setattr(record_v163, "__wrapped__", original_record)
         tsm._record_execution_anomaly = record_v163
 
-    current_gate = getattr(tsm, "_nonce_writer_lease_gate", None)
-    if not callable(current_gate):
-        return False
-    if not bool(getattr(current_gate, _PATCH_ATTR, False)):
-        original_gate = current_gate
+    if not bool(getattr(gate, _PATCH_ATTR, False)):
+        original_gate = gate
 
         @wraps(original_gate)
         def gate_v163() -> tuple[bool, str]:

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -8,8 +8,8 @@ the authority broker threshold from the active readiness policy, installs the
 fail-closed v154 pre-authority structural gate repair, the v155 same-lease nonce
 maturity verifier, the v157 post-activation runtime-quality convergence repair,
 the v158 bounded capital-pipeline publication-margin repair, the v161
-capital/position liveness convergence repair, and the v162 retired-observation
-fence.
+capital/position liveness convergence repair, the v162 retired-observation
+fence, and the v163 activation proof convergence repair.
 """
 from __future__ import annotations
 
@@ -96,100 +96,77 @@ def _patch_quiescence_audit() -> bool:
     return True
 
 
-def _install_v154_recovery() -> bool:
+def _install_named(module_name: str, missing_reason: str, log_prefix: str) -> bool:
     try:
-        module = importlib.import_module("bot.runtime_execution_recovery_v154_patch")
+        module = importlib.import_module(module_name)
         install_fn = getattr(module, "install", None)
         if not callable(install_fn):
-            raise RuntimeError("v154_install_missing")
+            raise RuntimeError(missing_reason)
         return bool(install_fn())
     except Exception as exc:
         logger.error(
-            "RUNTIME_EXECUTION_RECOVERY_V154_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
+            "%s error=%s:%s trading_fail_closed=true",
+            log_prefix,
             type(exc).__name__,
             exc,
         )
         return False
+
+
+def _install_v154_recovery() -> bool:
+    return _install_named(
+        "bot.runtime_execution_recovery_v154_patch",
+        "v154_install_missing",
+        "RUNTIME_EXECUTION_RECOVERY_V154_INSTALL_ERROR",
+    )
 
 
 def _install_v155_nonce_maturity() -> bool:
-    try:
-        module = importlib.import_module("bot.nonce_lease_maturity_v155_patch")
-        install_fn = getattr(module, "install", None)
-        if not callable(install_fn):
-            raise RuntimeError("v155_install_missing")
-        return bool(install_fn())
-    except Exception as exc:
-        logger.error(
-            "NONCE_LEASE_MATURITY_V155_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
-            type(exc).__name__,
-            exc,
-        )
-        return False
+    return _install_named(
+        "bot.nonce_lease_maturity_v155_patch",
+        "v155_install_missing",
+        "NONCE_LEASE_MATURITY_V155_INSTALL_ERROR",
+    )
 
 
 def _install_v157_runtime_quality() -> bool:
-    try:
-        module = importlib.import_module("bot.runtime_quality_convergence_v157_patch")
-        install_fn = getattr(module, "install", None)
-        if not callable(install_fn):
-            raise RuntimeError("v157_install_missing")
-        return bool(install_fn())
-    except Exception as exc:
-        logger.error(
-            "RUNTIME_QUALITY_CONVERGENCE_V157_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
-            type(exc).__name__,
-            exc,
-        )
-        return False
+    return _install_named(
+        "bot.runtime_quality_convergence_v157_patch",
+        "v157_install_missing",
+        "RUNTIME_QUALITY_CONVERGENCE_V157_INSTALL_ERROR",
+    )
 
 
 def _install_v158_capital_margin() -> bool:
-    try:
-        module = importlib.import_module("bot.capital_pipeline_margin_v158_patch")
-        install_fn = getattr(module, "install", None)
-        if not callable(install_fn):
-            raise RuntimeError("v158_install_missing")
-        return bool(install_fn())
-    except Exception as exc:
-        logger.error(
-            "CAPITAL_PIPELINE_MARGIN_V158_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
-            type(exc).__name__,
-            exc,
-        )
-        return False
+    return _install_named(
+        "bot.capital_pipeline_margin_v158_patch",
+        "v158_install_missing",
+        "CAPITAL_PIPELINE_MARGIN_V158_INSTALL_ERROR",
+    )
 
 
 def _install_v161_capital_position_convergence() -> bool:
-    try:
-        module = importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
-        install_fn = getattr(module, "install", None)
-        if not callable(install_fn):
-            raise RuntimeError("v161_install_missing")
-        return bool(install_fn())
-    except Exception as exc:
-        logger.error(
-            "RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
-            type(exc).__name__,
-            exc,
-        )
-        return False
+    return _install_named(
+        "bot.runtime_capital_position_convergence_v161_patch",
+        "v161_install_missing",
+        "RUNTIME_CAPITAL_POSITION_CONVERGENCE_V161_INSTALL_ERROR",
+    )
 
 
 def _install_v162_late_observation_fence() -> bool:
-    try:
-        module = importlib.import_module("bot.runtime_capital_late_observation_fence_v162_patch")
-        install_fn = getattr(module, "install", None)
-        if not callable(install_fn):
-            raise RuntimeError("v162_install_missing")
-        return bool(install_fn())
-    except Exception as exc:
-        logger.error(
-            "RUNTIME_CAPITAL_LATE_OBSERVATION_FENCE_V162_INSTALL_ERROR error=%s:%s trading_fail_closed=true",
-            type(exc).__name__,
-            exc,
-        )
-        return False
+    return _install_named(
+        "bot.runtime_capital_late_observation_fence_v162_patch",
+        "v162_install_missing",
+        "RUNTIME_CAPITAL_LATE_OBSERVATION_FENCE_V162_INSTALL_ERROR",
+    )
+
+
+def _install_v163_activation_convergence() -> bool:
+    return _install_named(
+        "bot.runtime_activation_convergence_v163_patch",
+        "v163_install_missing",
+        "RUNTIME_ACTIVATION_CONVERGENCE_V163_INSTALL_ERROR",
+    )
 
 
 def _iteration() -> bool:
@@ -202,6 +179,7 @@ def _iteration() -> bool:
     v158_installed = _install_v158_capital_margin()
     v161_installed = _install_v161_capital_position_convergence()
     v162_installed = _install_v162_late_observation_fence()
+    v163_installed = _install_v163_activation_convergence()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -213,7 +191,7 @@ def _iteration() -> bool:
     logger.debug(
         "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
         "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s "
-        "v161_installed=%s v162_installed=%s",
+        "v161_installed=%s v162_installed=%s v163_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -224,6 +202,7 @@ def _iteration() -> bool:
         str(v158_installed).lower(),
         str(v161_installed).lower(),
         str(v162_installed).lower(),
+        str(v163_installed).lower(),
     )
     return bool(
         v154_installed
@@ -232,6 +211,7 @@ def _iteration() -> bool:
         and v158_installed
         and v161_installed
         and v162_installed
+        and v163_installed
     )
 
 
@@ -259,7 +239,7 @@ def install() -> bool:
             "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d "
             "alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true "
             "v158_capital_margin=true v161_capital_position_convergence=true "
-            "v162_late_observation_fence=true",
+            "v162_late_observation_fence=true v163_activation_convergence=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -280,5 +260,6 @@ __all__ = [
     "_install_v158_capital_margin",
     "_install_v161_capital_position_convergence",
     "_install_v162_late_observation_fence",
+    "_install_v163_activation_convergence",
     "_iteration",
 ]

--- a/tests/test_runtime_activation_convergence_v163.py
+++ b/tests/test_runtime_activation_convergence_v163.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import bot.runtime_activation_convergence_v163_patch as v163
+
+
+class BrokerType:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class Broker:
+    def __init__(self, *, connected=True, adopted=False, fetch_ok=None):
+        self.connected = connected
+        self._startup_position_sync_adopted = adopted
+        self._startup_position_sync_fetch_ok = fetch_ok
+        self._startup_position_sync_error = None
+
+
+class Manager:
+    def __init__(self, brokers):
+        self.platform_brokers = brokers
+
+
+def test_position_discovery_requires_fetch_proof_even_when_adopted(monkeypatch):
+    coinbase = Broker(adopted=True, fetch_ok=None)
+    okx = Broker(adopted=True, fetch_ok=True)
+    manager = Manager({BrokerType("coinbase"): coinbase, BrokerType("okx"): okx})
+
+    pending = v163._connected_platform_brokers_requiring_proof(manager)
+
+    assert pending == [("coinbase", coinbase)]
+
+
+def test_position_discovery_ignores_disconnected_broker(monkeypatch):
+    kraken = Broker(connected=False, adopted=False, fetch_ok=False)
+    manager = Manager({BrokerType("kraken"): kraken})
+    assert v163._connected_platform_brokers_requiring_proof(manager) == []
+
+
+def test_worker_does_not_finish_on_adopted_without_fetch_proof(monkeypatch):
+    broker = Broker(adopted=True, fetch_ok=False)
+    manager = Manager({BrokerType("coinbase"): broker})
+    calls = []
+    published = []
+
+    class FakeSync:
+        @staticmethod
+        def _get_entry_price_store():
+            return None
+
+        @staticmethod
+        def _adopt_broker_positions(broker_arg, name, eps):
+            calls.append(name)
+            broker_arg._startup_position_sync_adopted = True
+            if len(calls) == 1:
+                broker_arg._startup_position_sync_fetch_ok = False
+                broker_arg._startup_position_sync_error = "proof_missing"
+            else:
+                broker_arg._startup_position_sync_fetch_ok = True
+                broker_arg._startup_position_sync_error = None
+
+    fake_v108 = SimpleNamespace(
+        _retry_policy=lambda: (3, 0.01, 0.01),
+        _publish_readiness=lambda manager, source: published.append(source),
+        _ACTIVE=set(),
+        _LOCK=threading.RLock(),
+    )
+    fake_v161 = SimpleNamespace(_startup_sync_module=lambda: FakeSync)
+    monkeypatch.setattr(v163, "_v108", lambda: fake_v108)
+    monkeypatch.setattr(v163, "_v161", lambda: fake_v161)
+    monkeypatch.setattr(v163.time, "sleep", lambda _: None)
+
+    key = (id(manager), id(broker))
+    fake_v108._ACTIVE.add(key)
+    v163._position_worker_v163(manager, "coinbase", broker, key, "test")
+
+    assert calls == ["platform:coinbase", "platform:coinbase"]
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_fetch_ok is True
+    assert any(value.endswith("attempt_1") for value in published)
+    assert any(value.endswith("attempt_2") for value in published)
+    assert key not in fake_v108._ACTIVE
+
+
+def test_transient_nonce_maturity_is_distinct_from_real_nonce_faults():
+    assert v163._transient_nonce_maturity(
+        "LIVE TRADING BLOCKED: last_error=nonce lease unstable (stable_for=27.7s required=30.0s)"
+    ) is True
+    assert v163._transient_nonce_maturity("nonce too low") is False
+    assert v163._transient_nonce_maturity(
+        "nonce lease unstable; final_verify=lease_identity_changed"
+    ) is False
+    assert v163._transient_nonce_maturity(
+        "nonce lease unstable; final_verify=stability_regressed"
+    ) is False
+
+
+def test_clear_historical_breaker_only_for_transient_maturity():
+    tsm = SimpleNamespace(
+        _EXECUTION_CIRCUIT_BREAKER_LOCK=threading.Lock(),
+        _EXECUTION_CIRCUIT_BREAKER_COUNTS={"nonce_drift": 3, "rejected_orders": 1},
+        _EXECUTION_CIRCUIT_BREAKER_TRIPPED=True,
+        _EXECUTION_CIRCUIT_BREAKER_REASON=(
+            "nonce_drift threshold=3 detail=LIVE TRADING BLOCKED: "
+            "nonce lease unstable (stable_for=27.7s required=30.0s)"
+        ),
+    )
+
+    assert v163._clear_historical_maturity_breaker(tsm) is True
+    assert tsm._EXECUTION_CIRCUIT_BREAKER_TRIPPED is False
+    assert tsm._EXECUTION_CIRCUIT_BREAKER_REASON == ""
+    assert "nonce_drift" not in tsm._EXECUTION_CIRCUIT_BREAKER_COUNTS
+    assert tsm._EXECUTION_CIRCUIT_BREAKER_COUNTS["rejected_orders"] == 1
+
+
+def test_unrelated_breaker_is_not_cleared():
+    tsm = SimpleNamespace(
+        _EXECUTION_CIRCUIT_BREAKER_LOCK=threading.Lock(),
+        _EXECUTION_CIRCUIT_BREAKER_COUNTS={"nonce_drift": 3},
+        _EXECUTION_CIRCUIT_BREAKER_TRIPPED=True,
+        _EXECUTION_CIRCUIT_BREAKER_REASON="nonce_drift threshold=3 detail=nonce too low",
+    )
+    assert v163._clear_historical_maturity_breaker(tsm) is False
+    assert tsm._EXECUTION_CIRCUIT_BREAKER_TRIPPED is True


### PR DESCRIPTION
## Summary
- require both position adoption and authoritative fetch proof before platform position sync is considered complete
- redispatch adopted-but-unproven platform brokers so v96 and v146 converge on the same truth
- allow the final same-owner/same-token nonce maturity proof up to the existing 5s safety ceiling while preserving the full configured stability duration
- stop counting ordinary lease-maturity deferrals as nonce-drift circuit-breaker anomalies
- self-heal only a circuit breaker whose recorded reason is that historical transient maturity classification, and only after the full nonce gate later succeeds
- install v163 continuously from the runtime post-import convergence watchdog

## Production evidence addressed
Deployment 4efea093 showed capital proof accepted with 3 registered brokers and v161/v162 active, but activation remained LIVE_PENDING_CONFIRMATION because:
1. nonce lease was stable for 27.7s of required 30.0s while v155 final verify capped at 2.0s, and repeated expected deferrals tripped nonce_drift threshold=3;
2. v96 reported position sync ready for Coinbase/OKX from adopted markers while v146 correctly revoked readiness because Coinbase lacked independent fetch proof.

## Safety
No position, capital, nonce, writer, kill-switch, risk, or LIVE_ACTIVE state is fabricated. Token/owner changes, stability regression, Redis failures, real nonce errors, missing position fetch proof, and all existing fail-closed gates remain blocking.

## Validation
Dedicated tests cover adopted-without-fetch redispatch, dual-proof worker completion, transient maturity classification, selective historical breaker cleanup, and preservation of unrelated breaker faults.