### PR TITLE
Fix runtime capital publication scheduling v165

### DIFF
--- a/bot/runtime_capital_publication_scheduling_v165_patch.py
+++ b/bot/runtime_capital_publication_scheduling_v165_patch.py
@@ -1,0 +1,162 @@
+"""Converge proactive capital-publication scheduling with the effective pipeline deadline.
+
+Production after v164 proved three-broker position sync, LIVE_ACTIVE, writer/core
+registration, and live trade-cycle execution. It also exposed a remaining timing
+contradiction: v137 computed pre-expiry headroom from the 50s broker-fetch budget,
+while v158 correctly owns an 80s total runtime coordinator deadline inside the
+90s immutable publication TTL. A refresh could therefore be legitimately in
+flight when the older publication expired, briefly revoking otherwise fresh
+3/3 capital.
+
+v165 repairs scheduling only:
+* v137 headroom is derived from the effective v142/v158 total pipeline deadline
+  plus watchdog cadence, not merely the broker-fetch budget;
+* the resulting headroom is still capped strictly inside the existing canonical
+  freshness TTL, so publication expiry is never extended;
+* no balance, readiness, writer/nonce authority, kill switch, risk decision,
+  activation state, or order permission is synthesized.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_publication_scheduling_v165")
+MARKER = "20260819-runtime-capital-publication-scheduling-v165"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_PUBLICATION_SCHEDULING_V165_READY"
+_PATCH_ATTR = "_nija_runtime_capital_publication_scheduling_v165"
+_LOCK = threading.RLock()
+
+
+def _v137() -> Any:
+    return importlib.import_module("bot.capital_publication_deadline_v137_patch")
+
+
+def _v142() -> Any:
+    return importlib.import_module("bot.capital_publication_liveness_v142_patch")
+
+
+def _effective_pipeline_deadline_seconds() -> float:
+    v142 = _v142()
+    getter = getattr(v142, "_runtime_pipeline_deadline_seconds", None)
+    if not callable(getter):
+        raise RuntimeError("runtime_pipeline_deadline_getter_missing")
+    return max(10.0, float(getter()))
+
+
+def _freshness_ttl_seconds() -> float:
+    v137 = _v137()
+    getter = getattr(v137, "_freshness_ttl_seconds", None)
+    if not callable(getter):
+        raise RuntimeError("freshness_ttl_getter_missing")
+    return max(10.0, float(getter()))
+
+
+def _watchdog_cadence_seconds(manager: Any) -> float:
+    try:
+        value = float(getattr(manager, "capital_watchdog_interval_s", 10.0) or 10.0)
+    except (TypeError, ValueError):
+        value = 10.0
+    return max(1.0, min(10.0, value))
+
+
+def _required_headroom_seconds(manager: Any) -> float:
+    """Reserve enough validity for one worst-case coordinator run plus cadence."""
+    ttl_s = _freshness_ttl_seconds()
+    deadline_s = _effective_pipeline_deadline_seconds()
+    cadence_s = _watchdog_cadence_seconds(manager)
+    # Five seconds of immutable-validity margin remains non-negotiable. This
+    # moves the refresh earlier; it never broadens publication lifetime.
+    ceiling = max(5.0, ttl_s - 5.0)
+    requested = deadline_s + cadence_s
+    return max(5.0, min(requested, ceiling))
+
+
+def _patch_v137_headroom() -> bool:
+    v137 = _v137()
+    current = getattr(v137, "_refresh_headroom_seconds", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def headroom_v165(manager: Any) -> float:
+        return _required_headroom_seconds(manager)
+
+    setattr(headroom_v165, _PATCH_ATTR, True)
+    setattr(headroom_v165, "__wrapped__", original)
+    v137._refresh_headroom_seconds = headroom_v165
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_publication_scheduling_v165"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        headroom_ok = _patch_v137_headroom()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(headroom_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_PUBLICATION_SCHEDULING_V165_FAILED marker=%s "
+                "headroom_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(headroom_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        ttl_s = _freshness_ttl_seconds()
+        deadline_s = _effective_pipeline_deadline_seconds()
+        # Use a representative manager cadence only for telemetry if canonical
+        # manager lookup is unavailable during very early install.
+        try:
+            mabm = importlib.import_module("bot.multi_account_broker_manager")
+            getter = getattr(mabm, "get_broker_manager", None)
+            manager = getter() if callable(getter) else None
+        except Exception:
+            manager = None
+        cadence_s = _watchdog_cadence_seconds(manager)
+        headroom_s = _required_headroom_seconds(manager)
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_PUBLICATION_SCHEDULING_V165 marker=%s ready=true "
+            "freshness_ttl_s=%.1f effective_pipeline_deadline_s=%.1f watchdog_cadence_s=%.1f "
+            "refresh_headroom_s=%.1f publication_expiry_extended=false safety_gates_bypassed=false",
+            MARKER,
+            ttl_s,
+            deadline_s,
+            cadence_s,
+            headroom_s,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_effective_pipeline_deadline_seconds",
+    "_freshness_ttl_seconds",
+    "_watchdog_cadence_seconds",
+    "_required_headroom_seconds",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -9,8 +9,9 @@ fail-closed v154 pre-authority structural gate repair, the v155 same-lease nonce
 maturity verifier, the v157 post-activation runtime-quality convergence repair,
 the v158 bounded capital-pipeline publication-margin repair, the v161
 capital/position liveness convergence repair, the v162 retired-observation
-fence, the v163 activation proof convergence repair, and the v164 canonical
-capital publication/worker-liveness repair.
+fence, the v163 activation proof convergence repair, the v164 canonical
+capital publication/worker-liveness repair, and the v165 proactive publication
+scheduler convergence repair.
 """
 from __future__ import annotations
 
@@ -178,6 +179,14 @@ def _install_v164_capital_publication_liveness() -> bool:
     )
 
 
+def _install_v165_capital_publication_scheduling() -> bool:
+    return _install_named(
+        "bot.runtime_capital_publication_scheduling_v165_patch",
+        "v165_install_missing",
+        "RUNTIME_CAPITAL_PUBLICATION_SCHEDULING_V165_INSTALL_ERROR",
+    )
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -190,6 +199,7 @@ def _iteration() -> bool:
     v162_installed = _install_v162_late_observation_fence()
     v163_installed = _install_v163_activation_convergence()
     v164_installed = _install_v164_capital_publication_liveness()
+    v165_installed = _install_v165_capital_publication_scheduling()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -201,7 +211,8 @@ def _iteration() -> bool:
     logger.debug(
         "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
         "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s "
-        "v161_installed=%s v162_installed=%s v163_installed=%s v164_installed=%s",
+        "v161_installed=%s v162_installed=%s v163_installed=%s v164_installed=%s "
+        "v165_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -214,6 +225,7 @@ def _iteration() -> bool:
         str(v162_installed).lower(),
         str(v163_installed).lower(),
         str(v164_installed).lower(),
+        str(v165_installed).lower(),
     )
     return bool(
         v154_installed
@@ -224,6 +236,7 @@ def _iteration() -> bool:
         and v162_installed
         and v163_installed
         and v164_installed
+        and v165_installed
     )
 
 
@@ -252,7 +265,7 @@ def install() -> bool:
             "alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true "
             "v158_capital_margin=true v161_capital_position_convergence=true "
             "v162_late_observation_fence=true v163_activation_convergence=true "
-            "v164_capital_publication_liveness=true",
+            "v164_capital_publication_liveness=true v165_capital_publication_scheduling=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -275,5 +288,6 @@ __all__ = [
     "_install_v162_late_observation_fence",
     "_install_v163_activation_convergence",
     "_install_v164_capital_publication_liveness",
+    "_install_v165_capital_publication_scheduling",
     "_iteration",
 ]

--- a/tests/test_runtime_capital_publication_scheduling_v165.py
+++ b/tests/test_runtime_capital_publication_scheduling_v165.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import bot.runtime_capital_publication_scheduling_v165_patch as v165
+
+
+def test_headroom_uses_effective_pipeline_deadline_and_cadence(monkeypatch):
+    monkeypatch.setattr(v165, "_freshness_ttl_seconds", lambda: 90.0)
+    monkeypatch.setattr(v165, "_effective_pipeline_deadline_seconds", lambda: 80.0)
+    manager = SimpleNamespace(capital_watchdog_interval_s=10.0)
+
+    # 80s effective coordinator deadline + 10s cadence would equal the TTL,
+    # so preserve five seconds of immutable-validity margin and start at 85s.
+    assert v165._required_headroom_seconds(manager) == 85.0
+
+
+def test_headroom_does_not_overreserve_for_fast_pipeline(monkeypatch):
+    monkeypatch.setattr(v165, "_freshness_ttl_seconds", lambda: 90.0)
+    monkeypatch.setattr(v165, "_effective_pipeline_deadline_seconds", lambda: 40.0)
+    manager = SimpleNamespace(capital_watchdog_interval_s=5.0)
+
+    assert v165._required_headroom_seconds(manager) == 45.0
+
+
+def test_watchdog_cadence_is_bounded():
+    assert v165._watchdog_cadence_seconds(SimpleNamespace(capital_watchdog_interval_s=0.1)) == 1.0
+    assert v165._watchdog_cadence_seconds(SimpleNamespace(capital_watchdog_interval_s=30.0)) == 10.0
+
+
+def test_v137_headroom_patch_delegates_to_v165(monkeypatch):
+    class FakeV137:
+        @staticmethod
+        def _refresh_headroom_seconds(manager):
+            return 12.0
+
+    fake = FakeV137()
+    monkeypatch.setattr(v165, "_v137", lambda: fake)
+    monkeypatch.setattr(v165, "_required_headroom_seconds", lambda manager: 77.0)
+
+    assert v165._patch_v137_headroom() is True
+    assert fake._refresh_headroom_seconds(SimpleNamespace()) == 77.0
+    assert getattr(fake._refresh_headroom_seconds, v165._PATCH_ATTR, False) is True
+
+
+def test_headroom_never_extends_ttl(monkeypatch):
+    monkeypatch.setattr(v165, "_freshness_ttl_seconds", lambda: 60.0)
+    monkeypatch.setattr(v165, "_effective_pipeline_deadline_seconds", lambda: 55.0)
+    manager = SimpleNamespace(capital_watchdog_interval_s=10.0)
+
+    assert v165._required_headroom_seconds(manager) == 55.0


### PR DESCRIPTION
## Summary
- make v137 pre-expiry scheduling reserve the effective v142/v158 total coordinator deadline instead of only the broker-fetch budget
- preserve a five-second immutable-validity margin inside the existing 90s capital TTL
- install v165 through post-import convergence and require it in the runtime release manifest
- add deterministic tests for 80s/90s production timing, faster pipelines, cadence bounds, and TTL non-extension

## Production evidence
At 01:08:25 the runtime had fresh 3/3 capital and was executing a live trade cycle, but the CapitalAuthority publication status still carried an older expiry at 01:08:26.655. Seconds later v141/v136 correctly failed closed on `snapshot_expired` while a canonical refresh was in flight. v158 reports an 80s effective pipeline deadline, while v137 scheduled using the 50s fetch budget.

## Safety
- does not extend publication expiry or capital freshness TTL
- does not fabricate balances or position proof
- does not force LIVE_ACTIVE or execution
- does not alter writer/nonce authority, kill switches, risk gates, or order routing
- only starts canonical refresh work earlier so the existing immutable publication can be replaced before expiry