### PR TITLE
Complete runtime refresh-demand v167 attestation

### DIFF
--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -10,8 +10,8 @@ maturity verifier, the v157 post-activation runtime-quality convergence repair,
 the v158 bounded capital-pipeline publication-margin repair, the v161
 capital/position liveness convergence repair, the v162 retired-observation
 fence, the v163 activation proof convergence repair, the v164 canonical
-capital publication/worker-liveness repair, and the v165 proactive publication
-scheduler convergence repair.
+capital publication/worker-liveness repair, the v165 proactive publication
+scheduler convergence repair, and the v167 runtime refresh-demand attestation.
 """
 from __future__ import annotations
 
@@ -187,6 +187,14 @@ def _install_v165_capital_publication_scheduling() -> bool:
     )
 
 
+def _install_v167_refresh_demand() -> bool:
+    return _install_named(
+        "bot.runtime_refresh_demand_v167_patch",
+        "v167_install_missing",
+        "RUNTIME_REFRESH_DEMAND_V167_INSTALL_ERROR",
+    )
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -200,6 +208,7 @@ def _iteration() -> bool:
     v163_installed = _install_v163_activation_convergence()
     v164_installed = _install_v164_capital_publication_liveness()
     v165_installed = _install_v165_capital_publication_scheduling()
+    v167_installed = _install_v167_refresh_demand()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -212,7 +221,7 @@ def _iteration() -> bool:
         "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
         "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s "
         "v161_installed=%s v162_installed=%s v163_installed=%s v164_installed=%s "
-        "v165_installed=%s",
+        "v165_installed=%s v167_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -226,6 +235,7 @@ def _iteration() -> bool:
         str(v163_installed).lower(),
         str(v164_installed).lower(),
         str(v165_installed).lower(),
+        str(v167_installed).lower(),
     )
     return bool(
         v154_installed
@@ -237,6 +247,7 @@ def _iteration() -> bool:
         and v163_installed
         and v164_installed
         and v165_installed
+        and v167_installed
     )
 
 
@@ -265,7 +276,8 @@ def install() -> bool:
             "alias_same=true v154_recovery=true v155_nonce_maturity=true v157_runtime_quality=true "
             "v158_capital_margin=true v161_capital_position_convergence=true "
             "v162_late_observation_fence=true v163_activation_convergence=true "
-            "v164_capital_publication_liveness=true v165_capital_publication_scheduling=true",
+            "v164_capital_publication_liveness=true v165_capital_publication_scheduling=true "
+            "v167_refresh_demand=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -289,5 +301,6 @@ __all__ = [
     "_install_v163_activation_convergence",
     "_install_v164_capital_publication_liveness",
     "_install_v165_capital_publication_scheduling",
+    "_install_v167_refresh_demand",
     "_iteration",
 ]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -3,6 +3,11 @@
 Attests the pre-bootstrap v32 refresh-demand repair and keeps it installed after
 late imports. Routine capital freshness belongs to v137 once that scheduler is
 available; genuine reconnect/recovery triggers retain authoritative refreshes.
+
+If the legacy periodic runtime-convergence path ever has to fall back because
+v137 is unavailable, classify that refresh as proactive for v166 timing so it
+uses the same bounded 30s fetch / 50s total runtime budget instead of reopening
+the older 80s coordinator path.
 """
 from __future__ import annotations
 
@@ -10,16 +15,22 @@ import importlib
 import logging
 import os
 import threading
+from functools import wraps
 from typing import Any
 
 LOGGER = logging.getLogger("nija.runtime_refresh_demand_v167")
 MARKER = "20260819-runtime-refresh-demand-v167"
 _READY_FLAG = "NIJA_RUNTIME_REFRESH_DEMAND_V167_READY"
+_PATCH_ATTR = "_nija_runtime_refresh_demand_v167"
 _LOCK = threading.RLock()
 
 
 def _v32() -> Any:
     return importlib.import_module("bot.runtime_execution_convergence_v32")
+
+
+def _v166() -> Any:
+    return importlib.import_module("bot.runtime_capital_refresh_ownership_v166_patch")
 
 
 def _verify_v32() -> bool:
@@ -35,6 +46,40 @@ def _verify_v32() -> bool:
         and callable(owner)
         and callable(startup)
     )
+
+
+def _patch_v166_periodic_fallback() -> bool:
+    """Keep any periodic fallback inside the proactive v166 runtime budget."""
+    try:
+        v166 = _v166()
+    except Exception:
+        return False
+    current = getattr(v166, "_is_proactive_trigger", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def proactive_v167(value: Any = None) -> bool:
+        if value is None:
+            try:
+                trigger = str(getattr(v166, "_trigger")() or "").strip().lower()
+            except Exception:
+                trigger = ""
+        else:
+            trigger = str(value or "").strip().lower()
+        if trigger == "periodic_runtime_convergence" or trigger.startswith(
+            "periodic_runtime_convergence:"
+        ):
+            return True
+        return bool(original(value))
+
+    setattr(proactive_v167, _PATCH_ATTR, True)
+    setattr(proactive_v167, "__wrapped__", original)
+    v166._is_proactive_trigger = proactive_v167
+    return True
 
 
 def _patch_release_manifest() -> bool:
@@ -64,22 +109,25 @@ def install() -> bool:
                 exc,
             )
         verified = _verify_v32()
+        periodic_ok = _patch_v166_periodic_fallback()
         manifest_ok = _patch_release_manifest()
-        ready = bool(verified and manifest_ok)
+        ready = bool(verified and periodic_ok and manifest_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
-                "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s manifest_ok=%s "
-                "trading_fail_closed=true",
+                "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
+                str(periodic_ok).lower(),
                 str(manifest_ok).lower(),
             )
             return False
         LOGGER.critical(
             "RUNTIME_REFRESH_DEMAND_V167 marker=%s ready=true startup_double_refresh_removed=true "
-            "monitor_initial_delay=true routine_refresh_owner=v137 recovery_refresh_preserved=true "
-            "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
+            "monitor_initial_delay=true routine_refresh_owner=v137 periodic_fallback_bounded=true "
+            "recovery_refresh_preserved=true publication_expiry_extended=false stale_promoted=false "
+            "safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -89,4 +137,10 @@ def install_import_hook() -> bool:
     return install()
 
 
-__all__ = ["MARKER", "install", "install_import_hook", "_verify_v32"]
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_verify_v32",
+    "_patch_v166_periodic_fallback",
+]

--- a/tests/test_runtime_refresh_demand_v167.py
+++ b/tests/test_runtime_refresh_demand_v167.py
@@ -59,3 +59,47 @@ def test_install_sets_v167_prebot_attestation(monkeypatch):
     monkeypatch.delenv("NIJA_RUNTIME_REFRESH_DEMAND_V167_PREBOT_READY", raising=False)
     assert module.install_import_hook() is True
     assert os.environ["NIJA_RUNTIME_REFRESH_DEMAND_V167_PREBOT_READY"] == "1"
+
+
+def test_v167_attestation_bounds_periodic_fallback(monkeypatch):
+    patch = importlib.import_module("bot.runtime_refresh_demand_v167_patch")
+    v166 = importlib.import_module("bot.runtime_capital_refresh_ownership_v166_patch")
+
+    original = v166._is_proactive_trigger
+    monkeypatch.setattr(v166, "_is_proactive_trigger", original)
+    assert patch._patch_v166_periodic_fallback() is True
+    assert v166._is_proactive_trigger("periodic_runtime_convergence") is True
+    assert v166._is_proactive_trigger("periodic_runtime_convergence:retry") is True
+    assert v166._is_proactive_trigger("publication_deadline_v137") is True
+
+
+def test_v167_install_registers_release_manifest(monkeypatch):
+    patch = importlib.import_module("bot.runtime_refresh_demand_v167_patch")
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    monkeypatch.setattr(manifest, "_REQUIRED_FLAGS", dict(manifest._REQUIRED_FLAGS))
+    monkeypatch.delenv("NIJA_RUNTIME_REFRESH_DEMAND_V167_READY", raising=False)
+
+    assert patch.install() is True
+    assert os.environ["NIJA_RUNTIME_REFRESH_DEMAND_V167_READY"] == "1"
+    assert manifest._REQUIRED_FLAGS["runtime_refresh_demand_v167"] == (
+        "NIJA_RUNTIME_REFRESH_DEMAND_V167_READY"
+    )
+
+
+def test_post_import_convergence_installs_v167(monkeypatch):
+    post = importlib.import_module("bot.runtime_post_import_convergence_patch")
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_install_named(module_name: str, missing_reason: str, log_prefix: str) -> bool:
+        calls.append((module_name, missing_reason, log_prefix))
+        return True
+
+    monkeypatch.setattr(post, "_install_named", fake_install_named)
+    assert post._install_v167_refresh_demand() is True
+    assert calls == [
+        (
+            "bot.runtime_refresh_demand_v167_patch",
+            "v167_install_missing",
+            "RUNTIME_REFRESH_DEMAND_V167_INSTALL_ERROR",
+        )
+    ]


### PR DESCRIPTION
Production on `b5eb183b977bbb2b08bd63aa3b757127fd030c70` shows writer authority, position sync, broker connectivity, v164/v165/v166 liveness, and a single open capital refresh lane, but the runtime release manifest still does not attest v167. This patch:

- installs `runtime_refresh_demand_v167_patch` from the required post-import convergence watchdog;
- registers `NIJA_RUNTIME_REFRESH_DEMAND_V167_READY` in the release manifest;
- classifies any `periodic_runtime_convergence` fallback as proactive so v166 keeps it inside the 30s fetch / 50s total runtime budget;
- adds focused tests for fallback classification, manifest registration, and post-import installation.

Safety is unchanged: no balance fabrication, TTL extension, stale promotion, writer/nonce grant, kill-switch change, risk loosening, forced LIVE state, or execution/order bypass.