### PR TITLE
Bound retired capital generations without starving refresh

### DIFF
--- a/bot/runtime_capital_generation_liveness_v168_patch.py
+++ b/bot/runtime_capital_generation_liveness_v168_patch.py
@@ -1,0 +1,313 @@
+"""Bound retired capital generations without starving the canonical refresh lane.
+
+Production after v167 proved the routine-demand and writer-ownership repairs, but
+v142/v164 still had one liveness contradiction: v142 generation-fences a timed
+out coordinator before requesting rollover, while v164 counts that retired
+physical daemon against the same two-thread capacity used for new canonical
+work. Two fenced daemons can therefore consume both slots forever and prevent a
+fresh CapitalAuthority publication even though they no longer have publication
+authority.
+
+v168 separates physical quarantine from canonical ownership:
+
+* at most two retired v142 runtime-refresh daemons may remain quarantined;
+* one additional canonical recovery lane may exist, for an absolute maximum of
+  three v142 runtime-refresh daemons;
+* a rollover may bypass v164's legacy two-thread physical cap only when the
+  coordinator being replaced is already generation-fenced and the absolute
+  three-thread ceiling has not been reached;
+* when three physical workers are alive, no fourth worker is permitted;
+* v142/v162 late-publication and late-observation fences remain authoritative.
+
+This patch does not extend capital freshness, promote stale observations,
+fabricate balances, change writer/nonce authority, clear kill switches, weaken
+risk/order gates, or force LIVE_ACTIVE.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import re
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_generation_liveness_v168")
+MARKER = "20260820-runtime-capital-generation-liveness-v168"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_GENERATION_LIVENESS_V168_READY"
+_PATCH_ATTR = "_nija_runtime_capital_generation_liveness_v168"
+_LOCK = threading.RLock()
+_THREAD_RE = re.compile(r"^capital-runtime-refresh-v142-g(?P<generation>[0-9]+)$")
+
+
+def _v142() -> Any:
+    return importlib.import_module("bot.capital_publication_liveness_v142_patch")
+
+
+def _v164() -> Any:
+    return importlib.import_module("bot.runtime_capital_publication_liveness_v164_patch")
+
+
+def _quarantine_limit() -> int:
+    raw = str(os.environ.get("NIJA_CAPITAL_RETIRED_GENERATION_QUARANTINE_MAX", "2") or "2").strip()
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        value = 2
+    # Production contract: enough room for the two already-observed retired
+    # generations, but never an unbounded daemon backlog.
+    return max(1, min(value, 2))
+
+
+def _absolute_runtime_thread_limit() -> int:
+    return _quarantine_limit() + 1
+
+
+def _thread_generation(thread: Any) -> int | None:
+    name = str(getattr(thread, "name", "") or "")
+    match = _THREAD_RE.match(name)
+    if match is None:
+        return None
+    try:
+        return int(match.group("generation"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _live_runtime_threads() -> list[Any]:
+    live: list[Any] = []
+    for thread in threading.enumerate():
+        generation = _thread_generation(thread)
+        if generation is None:
+            continue
+        alive = getattr(thread, "is_alive", None)
+        try:
+            if callable(alive) and bool(alive()):
+                live.append(thread)
+        except Exception:
+            continue
+    return live
+
+
+def _generation_state() -> tuple[int, bool]:
+    getter = getattr(_v142(), "_generation_state", None)
+    if not callable(getter):
+        return 0, False
+    try:
+        active, rolled = getter()
+        return int(active or 0), bool(rolled)
+    except Exception:
+        return 0, False
+
+
+def _coordinator_generation(coordinator: Any) -> int:
+    try:
+        return int(getattr(coordinator, "_nija_v142_flight_generation", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _capacity_snapshot(manager: Any = None) -> dict[str, Any]:
+    threads = _live_runtime_threads()
+    generations = [g for g in (_thread_generation(t) for t in threads) if g is not None]
+    active_generation, rolled = _generation_state()
+    coordinator = getattr(manager, "_capital_coordinator", None) if manager is not None else None
+    coordinator_generation = _coordinator_generation(coordinator)
+
+    retired = [g for g in generations if active_generation > 0 and g != active_generation]
+    active_physical = [g for g in generations if active_generation > 0 and g == active_generation]
+    if active_generation <= 0:
+        retired = []
+        active_physical = list(generations)
+
+    return {
+        "active_generation": active_generation,
+        "rollover_occurred": rolled,
+        "coordinator_generation": coordinator_generation,
+        "live_generations": sorted(generations),
+        "retired_generations": sorted(retired),
+        "active_physical_generations": sorted(active_physical),
+        "live_count": len(generations),
+        "retired_count": len(retired),
+        "quarantine_limit": _quarantine_limit(),
+        "absolute_limit": _absolute_runtime_thread_limit(),
+    }
+
+
+def _already_generation_fenced(coordinator: Any) -> bool:
+    generation = _coordinator_generation(coordinator)
+    if generation <= 0:
+        return False
+    active_generation, rolled = _generation_state()
+    return bool(rolled and active_generation > 0 and generation != active_generation)
+
+
+def _legacy_v142_rollover(current: Any) -> Any:
+    """Return the v142 rollover under the v164 containment wrapper when provable."""
+    wrapped = getattr(current, "__wrapped__", None)
+    if not callable(wrapped):
+        return None
+    # v164's wrapper directly wraps v142._rollover_coordinator. Do not peel
+    # arbitrary wrapper chains: bypassing anything else could discard a safety
+    # layer installed after v164.
+    v164_marker = str(getattr(_v164(), "_PATCH_ATTR", "_nija_runtime_capital_publication_liveness_v164"))
+    if not bool(getattr(current, v164_marker, False)):
+        return None
+    return wrapped
+
+
+def _patch_rollover_capacity() -> bool:
+    v142 = _v142()
+    current = getattr(v142, "_rollover_coordinator", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    legacy = _legacy_v142_rollover(current)
+    if not callable(legacy):
+        LOGGER.error(
+            "CAPITAL_V168_ROLLOVER_CHAIN_UNPROVEN marker=%s trading_fail_closed=true",
+            MARKER,
+        )
+        return False
+
+    @wraps(current)
+    def rollover_v168(
+        manager: Any,
+        *,
+        expected_old: Any = None,
+        reason: str,
+    ) -> Any:
+        old = getattr(manager, "_capital_coordinator", None)
+        if old is None or (expected_old is not None and old is not expected_old):
+            return current(manager, expected_old=expected_old, reason=reason)
+
+        capacity = _capacity_snapshot(manager)
+        fenced = _already_generation_fenced(old)
+        total = int(capacity["live_count"])
+        absolute = int(capacity["absolute_limit"])
+
+        # v142 retires the timed-out generation before invoking rollover. When
+        # that is proven and there is room below the absolute ceiling, bypass
+        # only v164's legacy two-physical-thread cap and invoke the underlying
+        # v142 swap. The new coordinator object itself starts no worker; v137's
+        # immediate retry may then occupy the one canonical recovery lane.
+        if fenced and total < absolute:
+            replacement = legacy(
+                manager,
+                expected_old=expected_old,
+                reason=reason,
+            )
+            LOGGER.critical(
+                "CAPITAL_V168_CANONICAL_LANE_RELEASED marker=%s reason=%s old_generation=%d "
+                "active_generation=%d live_generations=%s retired_alive=%d quarantine_limit=%d "
+                "absolute_limit=%d replacement=%s generation_fence_preserved=true "
+                "publication_expiry_extended=false trading_fail_closed_until_fresh=true",
+                MARKER,
+                reason,
+                _coordinator_generation(old),
+                int(capacity["active_generation"]),
+                capacity["live_generations"],
+                int(capacity["retired_count"]),
+                int(capacity["quarantine_limit"]),
+                absolute,
+                replacement is not None and replacement is not old,
+            )
+            return replacement
+
+        if fenced and total >= absolute:
+            LOGGER.critical(
+                "CAPITAL_V168_ABSOLUTE_THREAD_CAP marker=%s reason=%s live_generations=%s "
+                "retired_alive=%d absolute_limit=%d fourth_worker_blocked=true "
+                "generation_fence_preserved=true trading_fail_closed=true",
+                MARKER,
+                reason,
+                capacity["live_generations"],
+                int(capacity["retired_count"]),
+                absolute,
+            )
+
+        # For unproven/unretired ownership, preserve v164 exactly.
+        return current(manager, expected_old=expected_old, reason=reason)
+
+    setattr(rollover_v168, _PATCH_ATTR, True)
+    # Preserve v164 marker so its periodic installer does not re-wrap over v168.
+    v164_marker = str(getattr(_v164(), "_PATCH_ATTR", "_nija_runtime_capital_publication_liveness_v164"))
+    setattr(rollover_v168, v164_marker, True)
+    setattr(rollover_v168, "__wrapped__", current)
+    v142._rollover_coordinator = rollover_v168
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_generation_liveness_v168"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        rollover_ok = _patch_rollover_capacity()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(rollover_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_GENERATION_LIVENESS_V168_FAILED marker=%s rollover_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(rollover_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+
+        manager = None
+        try:
+            mabm = importlib.import_module("bot.multi_account_broker_manager")
+            getter = getattr(mabm, "get_broker_manager", None)
+            manager = getter() if callable(getter) else None
+        except Exception:
+            manager = None
+        capacity = _capacity_snapshot(manager)
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_GENERATION_LIVENESS_V168 marker=%s ready=true quarantine_limit=%d "
+            "canonical_recovery_lanes=1 absolute_runtime_thread_limit=%d live_generations=%s "
+            "retired_alive=%d active_physical=%d late_publication_fence_preserved=true "
+            "late_observation_fence_preserved=true publication_expiry_extended=false stale_promoted=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            int(capacity["quarantine_limit"]),
+            int(capacity["absolute_limit"]),
+            capacity["live_generations"],
+            int(capacity["retired_count"]),
+            len(capacity["active_physical_generations"]),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_quarantine_limit",
+    "_absolute_runtime_thread_limit",
+    "_thread_generation",
+    "_live_runtime_threads",
+    "_generation_state",
+    "_coordinator_generation",
+    "_capacity_snapshot",
+    "_already_generation_fenced",
+    "_patch_rollover_capacity",
+]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -7,7 +7,8 @@ available; genuine reconnect/recovery triggers retain authoritative refreshes.
 If the legacy periodic runtime-convergence path ever has to fall back because
 v137 is unavailable, classify that refresh as proactive for v166 timing so it
 uses the same bounded 30s fetch / 50s total runtime budget instead of reopening
-the older 80s coordinator path.
+the older 80s coordinator path. v168 is installed immediately afterward so
+retired physical v142 generations cannot starve the canonical recovery lane.
 """
 from __future__ import annotations
 
@@ -94,6 +95,24 @@ def _patch_release_manifest() -> bool:
         return False
 
 
+def _install_v168_generation_liveness() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_capital_generation_liveness_v168_patch")
+        installer = getattr(module, "install", None)
+        if not callable(installer):
+            return False
+        return bool(installer())
+    except Exception as exc:
+        LOGGER.error(
+            "RUNTIME_CAPITAL_GENERATION_LIVENESS_V168_INSTALL_ERROR marker=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def install() -> bool:
     with _LOCK:
         try:
@@ -111,23 +130,25 @@ def install() -> bool:
         verified = _verify_v32()
         periodic_ok = _patch_v166_periodic_fallback()
         manifest_ok = _patch_release_manifest()
-        ready = bool(verified and periodic_ok and manifest_ok)
+        v168_ok = _install_v168_generation_liveness()
+        ready = bool(verified and periodic_ok and manifest_ok and v168_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
-                "manifest_ok=%s trading_fail_closed=true",
+                "manifest_ok=%s v168_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
                 str(manifest_ok).lower(),
+                str(v168_ok).lower(),
             )
             return False
         LOGGER.critical(
             "RUNTIME_REFRESH_DEMAND_V167 marker=%s ready=true startup_double_refresh_removed=true "
             "monitor_initial_delay=true routine_refresh_owner=v137 periodic_fallback_bounded=true "
-            "recovery_refresh_preserved=true publication_expiry_extended=false stale_promoted=false "
-            "safety_gates_bypassed=false",
+            "recovery_refresh_preserved=true v168_generation_liveness=true "
+            "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -143,4 +164,5 @@ __all__ = [
     "install_import_hook",
     "_verify_v32",
     "_patch_v166_periodic_fallback",
+    "_install_v168_generation_liveness",
 ]

--- a/tests/test_runtime_capital_generation_liveness_v168.py
+++ b/tests/test_runtime_capital_generation_liveness_v168.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import bot.runtime_capital_generation_liveness_v168_patch as v168
+
+
+class FakeThread:
+    def __init__(self, name: str, alive: bool = True):
+        self.name = name
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def test_quarantine_and_absolute_limits_are_strict(monkeypatch):
+    monkeypatch.setenv("NIJA_CAPITAL_RETIRED_GENERATION_QUARANTINE_MAX", "20")
+    assert v168._quarantine_limit() == 2
+    assert v168._absolute_runtime_thread_limit() == 3
+
+    monkeypatch.setenv("NIJA_CAPITAL_RETIRED_GENERATION_QUARANTINE_MAX", "0")
+    assert v168._quarantine_limit() == 1
+    assert v168._absolute_runtime_thread_limit() == 2
+
+
+def test_capacity_separates_two_retired_threads_from_empty_canonical_lane(monkeypatch):
+    monkeypatch.setattr(
+        v168.threading,
+        "enumerate",
+        lambda: [
+            FakeThread("capital-runtime-refresh-v142-g57"),
+            FakeThread("capital-runtime-refresh-v142-g59"),
+            FakeThread("TradingLoop"),
+        ],
+    )
+    fake_v142 = SimpleNamespace(_generation_state=lambda: (60, True))
+    monkeypatch.setattr(v168, "_v142", lambda: fake_v142)
+
+    manager = SimpleNamespace(
+        _capital_coordinator=SimpleNamespace(_nija_v142_flight_generation=59)
+    )
+    status = v168._capacity_snapshot(manager)
+
+    assert status["live_generations"] == [57, 59]
+    assert status["retired_generations"] == [57, 59]
+    assert status["active_physical_generations"] == []
+    assert status["retired_count"] == 2
+    assert status["absolute_limit"] == 3
+    assert v168._already_generation_fenced(manager._capital_coordinator) is True
+
+
+def _rollover_fixture(monkeypatch, *, live_generations: list[int], active_generation: int):
+    old = SimpleNamespace(_nija_v142_flight_generation=59)
+    replacement = SimpleNamespace(_nija_v142_flight_generation=0)
+    manager = SimpleNamespace(_capital_coordinator=old)
+    calls = {"v164": 0, "v142": 0}
+
+    def legacy(manager_arg, *, expected_old=None, reason: str):
+        calls["v142"] += 1
+        assert manager_arg is manager
+        assert expected_old is old
+        manager._capital_coordinator = replacement
+        return replacement
+
+    def v164_wrapper(manager_arg, *, expected_old=None, reason: str):
+        calls["v164"] += 1
+        return old
+
+    setattr(v164_wrapper, "_nija_runtime_capital_publication_liveness_v164", True)
+    setattr(v164_wrapper, "__wrapped__", legacy)
+
+    fake_v142 = SimpleNamespace(
+        _rollover_coordinator=v164_wrapper,
+        _generation_state=lambda: (active_generation, True),
+    )
+    fake_v164 = SimpleNamespace(
+        _PATCH_ATTR="_nija_runtime_capital_publication_liveness_v164"
+    )
+    monkeypatch.setattr(v168, "_v142", lambda: fake_v142)
+    monkeypatch.setattr(v168, "_v164", lambda: fake_v164)
+    monkeypatch.setattr(
+        v168.threading,
+        "enumerate",
+        lambda: [
+            FakeThread(f"capital-runtime-refresh-v142-g{generation}")
+            for generation in live_generations
+        ],
+    )
+    return fake_v142, manager, old, replacement, calls
+
+
+def test_two_retired_alive_generations_release_one_canonical_lane(monkeypatch):
+    fake_v142, manager, old, replacement, calls = _rollover_fixture(
+        monkeypatch,
+        live_generations=[57, 59],
+        active_generation=60,
+    )
+
+    assert v168._patch_rollover_capacity() is True
+    result = fake_v142._rollover_coordinator(
+        manager,
+        expected_old=old,
+        reason="coordinator_timeout_flag",
+    )
+
+    assert result is replacement
+    assert manager._capital_coordinator is replacement
+    assert calls == {"v164": 0, "v142": 1}
+
+
+def test_three_alive_generations_block_a_fourth_worker(monkeypatch):
+    fake_v142, manager, old, _replacement, calls = _rollover_fixture(
+        monkeypatch,
+        live_generations=[57, 59, 61],
+        active_generation=62,
+    )
+
+    assert v168._patch_rollover_capacity() is True
+    result = fake_v142._rollover_coordinator(
+        manager,
+        expected_old=old,
+        reason="coordinator_timeout_flag",
+    )
+
+    assert result is old
+    assert manager._capital_coordinator is old
+    assert calls == {"v164": 1, "v142": 0}
+
+
+def test_unfenced_current_generation_preserves_v164_policy(monkeypatch):
+    fake_v142, manager, old, _replacement, calls = _rollover_fixture(
+        monkeypatch,
+        live_generations=[59],
+        active_generation=59,
+    )
+
+    assert v168._patch_rollover_capacity() is True
+    result = fake_v142._rollover_coordinator(
+        manager,
+        expected_old=old,
+        reason="manual_probe",
+    )
+
+    assert result is old
+    assert calls == {"v164": 1, "v142": 0}
+
+
+def test_v167_installs_v168(monkeypatch):
+    import bot.runtime_refresh_demand_v167_patch as v167
+
+    fake_v168 = SimpleNamespace(install=lambda: True)
+    real_import = v167.importlib.import_module
+
+    def fake_import(name: str, *args, **kwargs):
+        if name == "bot.runtime_capital_generation_liveness_v168_patch":
+            return fake_v168
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(v167.importlib, "import_module", fake_import)
+    assert v167._install_v168_generation_liveness() is True


### PR DESCRIPTION
Production on `007bf8fd6e37f677fe477487d60b8d51e7aea512` proves v167 is installed and attested, but two generation-fenced v142 runtime-refresh daemon threads can still occupy v164's two physical slots for 200+ seconds. That leaves the canonical coordinator unable to roll over, the CapitalAuthority snapshot expires, and NIJA correctly fails closed.

This patch adds v168 generation-liveness convergence:

- separates retired physical daemon quarantine from canonical refresh ownership;
- permits one canonical recovery lane when up to two already-retired generations remain alive;
- enforces an absolute maximum of three v142 runtime-refresh threads (2 quarantined + 1 canonical), so a fourth worker is never spawned;
- bypasses only v164's legacy two-physical-thread cap, and only when the coordinator being replaced is already proven generation-fenced;
- preserves v142 late-publication fencing and v162 late-observation fencing;
- installs v168 from the existing v167 post-import convergence path and requires its release manifest flag;
- adds focused regression tests for the 2-retired→1-recovery case, absolute cap, and unfenced fail-closed behavior.

Safety is unchanged: no freshness/TTL extension, stale promotion, fabricated balances, writer/nonce grant, kill-switch clearing, risk loosening, forced LIVE state, or order-gate bypass.