### PR TITLE
Harden v169 execution proof against detached modules

### DIFF
--- a/bot/runtime_execution_capital_integrity_v169_patch.py
+++ b/bot/runtime_execution_capital_integrity_v169_patch.py
@@ -20,6 +20,11 @@ v169 keeps those domains separate:
   ``source=heartbeat_trade`` and ``proof_kind=execution_probe``;
 * ORDER_VERIFY/FILL_VERIFY are accepted only from that genuine execution-probe
   source.  Pre-v169 authority-generated FILL_VERIFY markers fail closed;
+* stale/detached module objects are patched too, so an older authority monitor
+  cannot keep writing execution proof after module-identity convergence removes
+  its import alias from ``sys.modules``;
+* target imports reassert the patch so late imports cannot silently restore the
+  legacy authority-to-execution marker bridge;
 * immediately before v43/v164 augmentation, connected platform brokers are
   offered to v161's existing timestamp/freshness-checked observation seeder.
   Stale or missing broker timestamps remain excluded.
@@ -30,20 +35,25 @@ kill switch, weaken nonce/writer authority, or bypass risk/order gates.
 """
 from __future__ import annotations
 
+import builtins
+import gc
 import importlib
 import json
 import logging
 import os
+import sys
 import threading
 import time
 from functools import wraps
 from pathlib import Path
-from typing import Any
+from types import ModuleType
+from typing import Any, Iterator
 
 LOGGER = logging.getLogger("nija.runtime_execution_capital_integrity_v169")
 MARKER = "20260820-runtime-execution-capital-integrity-v169"
 _READY_FLAG = "NIJA_RUNTIME_EXECUTION_CAPITAL_INTEGRITY_V169_READY"
 _PATCH_ATTR = "_nija_runtime_execution_capital_integrity_v169"
+_IMPORT_HOOK_ATTR = "_NIJA_RUNTIME_EXECUTION_CAPITAL_INTEGRITY_V169_IMPORT_HOOK"
 _LOCK = threading.RLock()
 
 _STAGE_ORDER = {"AUTH_VERIFY": 1, "ORDER_VERIFY": 2, "FILL_VERIFY": 3}
@@ -51,6 +61,12 @@ _EXECUTION_SOURCE = "heartbeat_trade"
 _EXECUTION_KIND = "execution_probe"
 _AUTHORITY_SOURCE = "authority_heartbeat"
 _AUTHORITY_KIND = "authority_liveness"
+_TARGET_IMPORT_SUFFIXES = (
+    "authority_heartbeat",
+    "heartbeat_authority_single_source_patch",
+    "trading_strategy",
+    "trading_state_machine",
+)
 
 
 def _authority_marker_path() -> Path:
@@ -73,7 +89,11 @@ def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
-def _write_authority_liveness_marker(*, epoch_ts: float | None = None, source: str = _AUTHORITY_SOURCE) -> None:
+def _write_authority_liveness_marker(
+    *,
+    epoch_ts: float | None = None,
+    source: str = _AUTHORITY_SOURCE,
+) -> None:
     """Publish authority liveness without mutating execution verification proof."""
     ts = float(epoch_ts if epoch_ts is not None else time.time())
     payload = {
@@ -90,107 +110,158 @@ def _write_authority_liveness_marker(*, epoch_ts: float | None = None, source: s
     _atomic_json_write(_authority_marker_path(), payload)
 
 
+def _module_candidates(*names: str) -> Iterator[ModuleType]:
+    """Yield live and detached module objects for one runtime surface.
+
+    Module-identity convergence can remove a duplicate alias from ``sys.modules``
+    while a background thread still references functions whose ``__globals__``
+    belong to that detached module object.  Inspecting GC-tracked modules closes
+    that gap without changing import identity or resurrecting an alias.
+    """
+    wanted = {str(name or "").strip() for name in names if str(name or "").strip()}
+    leaf_names = {name.rsplit(".", 1)[-1] for name in wanted}
+    seen: set[int] = set()
+
+    for name in names:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            yield module
+
+    if not seen and names:
+        try:
+            module = importlib.import_module(names[0])
+        except Exception:
+            module = None
+        if isinstance(module, ModuleType) and id(module) not in seen:
+            seen.add(id(module))
+            yield module
+
+    for obj in gc.get_objects():
+        try:
+            if not isinstance(obj, ModuleType) or id(obj) in seen:
+                continue
+            module_name = str(getattr(obj, "__name__", "") or "")
+            module_file = str(getattr(obj, "__file__", "") or "")
+            module_leaf = Path(module_file).stem if module_file else ""
+            if module_name not in wanted and module_leaf not in leaf_names:
+                continue
+            seen.add(id(obj))
+            yield obj
+        except Exception:
+            continue
+
+
 def _patch_authority_heartbeat_writer() -> bool:
-    try:
-        module = importlib.import_module("bot.authority_heartbeat")
-    except Exception:
-        return False
-    current = getattr(module, "_write_heartbeat_marker", None)
-    if not callable(current):
-        return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
-        return True
+    matched = False
+    for module in _module_candidates("bot.authority_heartbeat", "authority_heartbeat"):
+        current = getattr(module, "_write_heartbeat_marker", None)
+        if not callable(current):
+            continue
+        matched = True
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            if hasattr(module, "_DEFAULT_MARKER_STAGE"):
+                module._DEFAULT_MARKER_STAGE = "AUTH_VERIFY"
+            continue
 
-    @wraps(current)
-    def authority_only() -> None:
-        _write_authority_liveness_marker(source="authority_heartbeat")
-        LOGGER.info(
-            "EXECUTION_PROOF_V169_AUTHORITY_MARKER_ISOLATED marker=%s authority_path=%s "
-            "execution_marker_mutated=false stage=AUTH_VERIFY",
-            MARKER,
-            _authority_marker_path(),
-        )
+        @wraps(current)
+        def authority_only() -> None:
+            _write_authority_liveness_marker(source="authority_heartbeat")
+            LOGGER.info(
+                "EXECUTION_PROOF_V169_AUTHORITY_MARKER_ISOLATED marker=%s authority_path=%s "
+                "execution_marker_mutated=false stage=AUTH_VERIFY",
+                MARKER,
+                _authority_marker_path(),
+            )
 
-    setattr(authority_only, _PATCH_ATTR, True)
-    setattr(authority_only, "__wrapped__", current)
-    module._write_heartbeat_marker = authority_only
-    if hasattr(module, "_DEFAULT_MARKER_STAGE"):
-        module._DEFAULT_MARKER_STAGE = "AUTH_VERIFY"
-    return True
+        setattr(authority_only, _PATCH_ATTR, True)
+        setattr(authority_only, "__wrapped__", current)
+        module._write_heartbeat_marker = authority_only
+        if hasattr(module, "_DEFAULT_MARKER_STAGE"):
+            module._DEFAULT_MARKER_STAGE = "AUTH_VERIFY"
+    return matched
 
 
 def _patch_single_source_authority_writer() -> bool:
-    """Stop the legacy single-source bridge from writing execution proof."""
-    try:
-        module = importlib.import_module("bot.heartbeat_authority_single_source_patch")
-    except Exception:
-        return False
+    """Stop canonical and detached single-source bridges from writing execution proof."""
+    matched = False
+    for module in _module_candidates(
+        "bot.heartbeat_authority_single_source_patch",
+        "heartbeat_authority_single_source_patch",
+    ):
+        current = getattr(module, "_write_marker", None)
+        if not callable(current):
+            continue
+        matched = True
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            module._marker_path = _authority_marker_path
+            module._marker_stage = lambda: "AUTH_VERIFY"
+            continue
 
-    current = getattr(module, "_write_marker", None)
-    if not callable(current):
-        return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
-        return True
+        @wraps(current)
+        def authority_only(epoch_ts: float) -> None:
+            _write_authority_liveness_marker(
+                epoch_ts=float(epoch_ts),
+                source="heartbeat_authority_single_source",
+            )
 
-    @wraps(current)
-    def authority_only(epoch_ts: float) -> None:
-        _write_authority_liveness_marker(
-            epoch_ts=float(epoch_ts),
-            source="heartbeat_authority_single_source",
-        )
-
-    setattr(authority_only, _PATCH_ATTR, True)
-    setattr(authority_only, "__wrapped__", current)
-    module._write_marker = authority_only
-    module._marker_path = _authority_marker_path
-    module._marker_stage = lambda: "AUTH_VERIFY"
-    return True
+        setattr(authority_only, _PATCH_ATTR, True)
+        setattr(authority_only, "__wrapped__", current)
+        module._write_marker = authority_only
+        module._marker_path = _authority_marker_path
+        module._marker_stage = lambda: "AUTH_VERIFY"
+    return matched
 
 
 def _patch_trading_strategy_provenance() -> bool:
     """Tag genuine heartbeat-trade markers with unambiguous provenance."""
-    try:
-        module = importlib.import_module("bot.trading_strategy")
-    except Exception:
-        return False
-    cls = getattr(module, "TradingStrategy", None)
-    if not isinstance(cls, type):
-        return False
-    current = getattr(cls, "_persist_heartbeat_marker", None)
-    if not callable(current):
-        return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
-        return True
+    matched = False
+    for module in _module_candidates("bot.trading_strategy", "trading_strategy"):
+        cls = getattr(module, "TradingStrategy", None)
+        if not isinstance(cls, type):
+            continue
+        current = getattr(cls, "_persist_heartbeat_marker", None)
+        if not callable(current):
+            continue
+        matched = True
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            continue
 
-    @wraps(current)
-    def persist_v169(self: Any, *, stage: str, details: Any = None) -> None:
-        normalized = str(stage or "").strip().upper()
-        if normalized not in _STAGE_ORDER:
-            raise ValueError(f"invalid heartbeat execution stage: {normalized or 'missing'}")
-        current(self, stage=normalized, details=details)
-        path = _execution_marker_path()
-        raw = path.read_text(encoding="utf-8").strip()
-        payload = json.loads(raw) if raw.startswith("{") else {}
-        payload["stage"] = normalized
-        payload["source"] = _EXECUTION_SOURCE
-        payload["proof_kind"] = _EXECUTION_KIND
-        payload.setdefault("verified_at_epoch", time.time())
-        _atomic_json_write(path, payload)
-        LOGGER.critical(
-            "EXECUTION_PROOF_V169_RECORDED marker=%s stage=%s source=%s proof_kind=%s",
-            MARKER,
-            normalized,
-            _EXECUTION_SOURCE,
-            _EXECUTION_KIND,
-        )
+        def _make_persist_wrapper(original: Any) -> Any:
+            @wraps(original)
+            def persist_v169(self: Any, *, stage: str, details: Any = None) -> None:
+                normalized = str(stage or "").strip().upper()
+                if normalized not in _STAGE_ORDER:
+                    raise ValueError(f"invalid heartbeat execution stage: {normalized or 'missing'}")
+                original(self, stage=normalized, details=details)
+                path = _execution_marker_path()
+                raw = path.read_text(encoding="utf-8").strip()
+                payload = json.loads(raw) if raw.startswith("{") else {}
+                payload["stage"] = normalized
+                payload["source"] = _EXECUTION_SOURCE
+                payload["proof_kind"] = _EXECUTION_KIND
+                payload.setdefault("verified_at_epoch", time.time())
+                _atomic_json_write(path, payload)
+                LOGGER.critical(
+                    "EXECUTION_PROOF_V169_RECORDED marker=%s stage=%s source=%s proof_kind=%s",
+                    MARKER,
+                    normalized,
+                    _EXECUTION_SOURCE,
+                    _EXECUTION_KIND,
+                )
 
-    setattr(persist_v169, _PATCH_ATTR, True)
-    setattr(persist_v169, "__wrapped__", current)
-    cls._persist_heartbeat_marker = persist_v169
-    return True
+            setattr(persist_v169, _PATCH_ATTR, True)
+            setattr(persist_v169, "__wrapped__", original)
+            return persist_v169
+
+        cls._persist_heartbeat_marker = _make_persist_wrapper(current)
+    return matched
 
 
-def _execution_provenance_valid(payload: dict[str, Any], required_stage: str) -> tuple[bool, str]:
+def _execution_provenance_valid(
+    payload: dict[str, Any],
+    required_stage: str,
+) -> tuple[bool, str]:
     """Require genuine execution provenance for ORDER/FILL verification."""
     required = str(required_stage or "ORDER_VERIFY").strip().upper()
     if required not in _STAGE_ORDER:
@@ -209,51 +280,96 @@ def _execution_provenance_valid(payload: dict[str, Any], required_stage: str) ->
 
 
 def _patch_tsm_execution_provenance() -> bool:
-    try:
-        module = importlib.import_module("bot.trading_state_machine")
-    except Exception:
-        return False
-    current = getattr(module, "_heartbeat_verification_status", None)
-    if not callable(current):
-        return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
+    matched = False
+    for module in _module_candidates("bot.trading_state_machine", "trading_state_machine"):
+        current = getattr(module, "_heartbeat_verification_status", None)
+        if not callable(current):
+            continue
+        matched = True
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            continue
+
+        def _make_status_wrapper(original: Any) -> Any:
+            @wraps(original)
+            def status_v169() -> tuple[bool, str, dict[str, Any]]:
+                ok, reason, meta = original()
+                meta = dict(meta or {})
+                if not ok:
+                    return bool(ok), str(reason or ""), meta
+                try:
+                    path = _execution_marker_path()
+                    raw = path.read_text(encoding="utf-8").strip()
+                    payload = json.loads(raw) if raw.startswith("{") else {}
+                except Exception as exc:
+                    return False, f"execution_proof_read_failed:{type(exc).__name__}:{exc}", meta
+
+                required = str(meta.get("required_stage", "ORDER_VERIFY") or "ORDER_VERIFY")
+                provenance_ok, provenance_reason = _execution_provenance_valid(payload, required)
+                meta["source"] = str(payload.get("source", "") or "")
+                meta["proof_kind"] = str(payload.get("proof_kind", "") or "")
+                meta["v169_provenance"] = provenance_reason
+                if not provenance_ok:
+                    LOGGER.critical(
+                        "EXECUTION_PROOF_V169_REJECTED marker=%s required_stage=%s stage=%s source=%s "
+                        "proof_kind=%s reason=%s trading_fail_closed=true",
+                        MARKER,
+                        required,
+                        meta.get("stage", payload.get("stage", "unknown")),
+                        meta["source"] or "missing",
+                        meta["proof_kind"] or "missing",
+                        provenance_reason,
+                    )
+                    return False, provenance_reason, meta
+                return True, "", meta
+
+            setattr(status_v169, _PATCH_ATTR, True)
+            setattr(status_v169, "__wrapped__", original)
+            return status_v169
+
+        module._heartbeat_verification_status = _make_status_wrapper(current)
+    return matched
+
+
+def _patch_execution_surfaces() -> bool:
+    """Patch every execution/authority surface, including detached module objects."""
+    authority_ok = _patch_authority_heartbeat_writer()
+    single_source_ok = _patch_single_source_authority_writer()
+    strategy_ok = _patch_trading_strategy_provenance()
+    tsm_ok = _patch_tsm_execution_provenance()
+    return bool(authority_ok and single_source_ok and strategy_ok and tsm_ok)
+
+
+def _install_import_reassertion_hook() -> bool:
+    """Reassert v169 after late imports of execution/authority surfaces."""
+    if bool(getattr(builtins, _IMPORT_HOOK_ATTR, False)):
         return True
 
-    @wraps(current)
-    def status_v169() -> tuple[bool, str, dict[str, Any]]:
-        ok, reason, meta = current()
-        meta = dict(meta or {})
-        if not ok:
-            return bool(ok), str(reason or ""), meta
-        try:
-            path = _execution_marker_path()
-            raw = path.read_text(encoding="utf-8").strip()
-            payload = json.loads(raw) if raw.startswith("{") else {}
-        except Exception as exc:
-            return False, f"execution_proof_read_failed:{type(exc).__name__}:{exc}", meta
+    original_import = builtins.__import__
 
-        required = str(meta.get("required_stage", "ORDER_VERIFY") or "ORDER_VERIFY")
-        provenance_ok, provenance_reason = _execution_provenance_valid(payload, required)
-        meta["source"] = str(payload.get("source", "") or "")
-        meta["proof_kind"] = str(payload.get("proof_kind", "") or "")
-        meta["v169_provenance"] = provenance_reason
-        if not provenance_ok:
-            LOGGER.critical(
-                "EXECUTION_PROOF_V169_REJECTED marker=%s required_stage=%s stage=%s source=%s "
-                "proof_kind=%s reason=%s trading_fail_closed=true",
-                MARKER,
-                required,
-                meta.get("stage", payload.get("stage", "unknown")),
-                meta["source"] or "missing",
-                meta["proof_kind"] or "missing",
-                provenance_reason,
-            )
-            return False, provenance_reason, meta
-        return True, "", meta
+    def guarded_import(
+        name: str,
+        globals: Any = None,
+        locals: Any = None,
+        fromlist: Any = (),
+        level: int = 0,
+    ) -> Any:
+        module = original_import(name, globals, locals, fromlist, level)
+        if any(str(name or "").endswith(suffix) for suffix in _TARGET_IMPORT_SUFFIXES):
+            try:
+                _patch_execution_surfaces()
+            except Exception as exc:
+                LOGGER.error(
+                    "EXECUTION_PROOF_V169_IMPORT_REASSERT_FAILED marker=%s imported=%s error=%s:%s "
+                    "trading_fail_closed=true",
+                    MARKER,
+                    name,
+                    type(exc).__name__,
+                    exc,
+                )
+        return module
 
-    setattr(status_v169, _PATCH_ATTR, True)
-    setattr(status_v169, "__wrapped__", current)
-    module._heartbeat_verification_status = status_v169
+    builtins.__import__ = guarded_import
+    setattr(builtins, _IMPORT_HOOK_ATTR, True)
     return True
 
 
@@ -337,31 +453,19 @@ def _patch_release_manifest() -> bool:
 
 def install() -> bool:
     with _LOCK:
-        authority_ok = _patch_authority_heartbeat_writer()
-        single_source_ok = _patch_single_source_authority_writer()
-        strategy_ok = _patch_trading_strategy_provenance()
-        tsm_ok = _patch_tsm_execution_provenance()
+        surfaces_ok = _patch_execution_surfaces()
+        import_hook_ok = _install_import_reassertion_hook()
         capital_ok = _patch_v164_publish_preseed()
         manifest_ok = _patch_release_manifest()
-        ready = bool(
-            authority_ok
-            and single_source_ok
-            and strategy_ok
-            and tsm_ok
-            and capital_ok
-            and manifest_ok
-        )
+        ready = bool(surfaces_ok and import_hook_ok and capital_ok and manifest_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
-                "RUNTIME_EXECUTION_CAPITAL_INTEGRITY_V169_FAILED marker=%s authority_ok=%s "
-                "single_source_ok=%s strategy_ok=%s tsm_ok=%s capital_ok=%s manifest_ok=%s "
-                "trading_fail_closed=true",
+                "RUNTIME_EXECUTION_CAPITAL_INTEGRITY_V169_FAILED marker=%s surfaces_ok=%s "
+                "import_hook_ok=%s capital_ok=%s manifest_ok=%s trading_fail_closed=true",
                 MARKER,
-                str(authority_ok).lower(),
-                str(single_source_ok).lower(),
-                str(strategy_ok).lower(),
-                str(tsm_ok).lower(),
+                str(surfaces_ok).lower(),
+                str(import_hook_ok).lower(),
                 str(capital_ok).lower(),
                 str(manifest_ok).lower(),
             )
@@ -370,6 +474,7 @@ def install() -> bool:
         LOGGER.critical(
             "RUNTIME_EXECUTION_CAPITAL_INTEGRITY_V169 marker=%s ready=true "
             "authority_execution_marker_isolated=true execution_provenance_required=true "
+            "detached_module_repair=true import_reassertion=true "
             "prepublication_broker_timestamp_seed=true capital_thread_limit_unchanged=true "
             "freshness_extended=false publication_expiry_extended=false stale_promoted=false "
             "forced_trade=false safety_gates_bypassed=false",
@@ -389,6 +494,7 @@ __all__ = [
     "_authority_marker_path",
     "_execution_marker_path",
     "_write_authority_liveness_marker",
+    "_module_candidates",
     "_execution_provenance_valid",
     "_preseed_connected_platform_observations",
 ]

--- a/bot/tests/test_runtime_execution_capital_integrity_v169.py
+++ b/bot/tests/test_runtime_execution_capital_integrity_v169.py
@@ -59,6 +59,111 @@ def test_authority_marker_does_not_overwrite_execution_marker(monkeypatch, tmp_p
     assert payload["proof_kind"] == "authority_liveness"
 
 
+def test_detached_authority_module_is_repaired(monkeypatch, tmp_path: Path):
+    """A stale thread-owned module object must not keep writing execution proof."""
+    execution = tmp_path / "heartbeat_verified.flag"
+    authority = tmp_path / "authority_heartbeat.flag"
+    execution.write_text("sentinel", encoding="utf-8")
+    monkeypatch.setenv("HEARTBEAT_MARKER_PATH", str(execution))
+    monkeypatch.setenv("NIJA_AUTHORITY_LIVENESS_MARKER_PATH", str(authority))
+
+    detached = types.ModuleType("authority_heartbeat")
+    detached.__file__ = "/detached/authority_heartbeat.py"
+    detached._DEFAULT_MARKER_STAGE = "FILL_VERIFY"
+
+    def legacy_write() -> None:
+        execution.write_text(
+            json.dumps(
+                {
+                    "stage": "FILL_VERIFY",
+                    "source": "authority_heartbeat",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    detached._write_heartbeat_marker = legacy_write
+
+    assert any(
+        module is detached
+        for module in v169._module_candidates(
+            "bot.authority_heartbeat",
+            "authority_heartbeat",
+        )
+    )
+    assert v169._patch_authority_heartbeat_writer() is True
+
+    detached._write_heartbeat_marker()
+
+    assert execution.read_text(encoding="utf-8") == "sentinel"
+    payload = json.loads(authority.read_text(encoding="utf-8"))
+    assert payload["stage"] == "AUTH_VERIFY"
+    assert payload["proof_kind"] == "authority_liveness"
+    assert detached._DEFAULT_MARKER_STAGE == "AUTH_VERIFY"
+
+
+def test_detached_trading_strategy_gets_execution_provenance(monkeypatch, tmp_path: Path):
+    execution = tmp_path / "heartbeat_verified.flag"
+    monkeypatch.setenv("HEARTBEAT_MARKER_PATH", str(execution))
+
+    detached = types.ModuleType("trading_strategy")
+    detached.__file__ = "/detached/trading_strategy.py"
+
+    class TradingStrategy:
+        def _persist_heartbeat_marker(self, *, stage: str, details=None) -> None:
+            execution.write_text(
+                json.dumps(
+                    {
+                        "stage": stage,
+                        "verified_at_epoch": 1.0,
+                        "details": details or {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    detached.TradingStrategy = TradingStrategy
+
+    assert v169._patch_trading_strategy_provenance() is True
+    TradingStrategy()._persist_heartbeat_marker(stage="ORDER_VERIFY", details={"ok": True})
+
+    payload = json.loads(execution.read_text(encoding="utf-8"))
+    assert payload["source"] == "heartbeat_trade"
+    assert payload["proof_kind"] == "execution_probe"
+
+
+def test_detached_tsm_still_rejects_authority_execution_proof(monkeypatch, tmp_path: Path):
+    execution = tmp_path / "heartbeat_verified.flag"
+    monkeypatch.setenv("HEARTBEAT_MARKER_PATH", str(execution))
+    execution.write_text(
+        json.dumps(
+            {
+                "stage": "FILL_VERIFY",
+                "verified_at_epoch": 1.0,
+                "source": "authority_heartbeat",
+                "proof_kind": "authority_liveness",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    detached = types.ModuleType("trading_state_machine")
+    detached.__file__ = "/detached/trading_state_machine.py"
+
+    def heartbeat_status():
+        return True, "", {"required_stage": "ORDER_VERIFY", "stage": "FILL_VERIFY"}
+
+    detached._heartbeat_verification_status = heartbeat_status
+
+    assert v169._patch_tsm_execution_provenance() is True
+    ok, reason, meta = detached._heartbeat_verification_status()
+
+    assert ok is False
+    assert "execution_proof_source_invalid" in reason
+    assert meta["source"] == "authority_heartbeat"
+    assert meta["proof_kind"] == "authority_liveness"
+
+
 def test_prepublication_seed_uses_only_connected_platform_brokers(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Purpose

Harden runtime execution-proof integrity v169 against stale/detached module objects and late import/reload ordering that can otherwise allow authority-liveness writers to mutate the execution verification marker after module-identity convergence.

## Changes

- Patch live and GC-tracked detached authority, single-source heartbeat, TradingStrategy, and trading-state-machine module objects.
- Reassert v169 after late imports of execution/authority surfaces.
- Preserve genuine execution provenance as `source=heartbeat_trade` + `proof_kind=execution_probe`.
- Keep authority liveness isolated to the authority marker and `AUTH_VERIFY`.
- Keep ORDER/FILL provenance validation fail-closed.
- Add regressions for detached authority, strategy, and state-machine module objects.

## Risk Assessment

- Risk level: high (writer-authority / execution-safety runtime surface)
- No strategy entry/exit thresholds, sizing, confidence gates, volume gates, capital TTL, nonce policy, writer-lock policy, or broker order semantics are changed.
- No safety bypasses are added.

## Rollback Plan

Revert the two commits on this branch. The existing v169 behavior on `main` is restored; no data migration or persistent schema change is involved.

## Validation

- Focused local syntax validation passed for both changed Python files.
- Focused regression harness passed for detached authority writer isolation, genuine execution provenance, and fail-closed authority-liveness rejection.
- Branch diff is limited to:
  - `bot/runtime_execution_capital_integrity_v169_patch.py`
  - `bot/tests/test_runtime_execution_capital_integrity_v169.py`
- No unsafe bypass flags introduced.

### NIJA Safety Checks

- [x] `python -m py_compile` clean on changed `.py` files
- [x] No bypass flags committed
- [x] Authority-only heartbeat remains unable to satisfy ORDER/FILL execution proof
- [x] Risk/order gates remain unchanged
- [ ] CI checks passed
- [ ] Human review completed before merge
