### PR TITLE
Fix Kraken capital observation admission liveness

### DIFF
--- a/bot/runtime_kraken_capital_observation_admission_v174_patch.py
+++ b/bot/runtime_kraken_capital_observation_admission_v174_patch.py
@@ -1,0 +1,244 @@
+"""Admit fresh Kraken capital observations without re-waiting the full runtime budget.
+
+Production on 2026-08-21 showed a remaining liveness gap after v173: Kraken could
+finish a genuine platform balance read and leave a fresh, sequence-fenced v35
+observation, while the next proactive publication cycle still waited the full
+30-second synchronous fetch budget before consulting that same observation.
+During that wait the last canonical publication remained 2/3 and execution
+correctly stayed fail closed.
+
+v174 changes only the timing of an already-authorized fallback decision:
+
+* only proactive runtime publication refreshes are eligible;
+* only the canonical ``kraken`` broker is eligible;
+* only a positive v35 observation that is still inside both the canonical
+  freshness TTL and a stricter proactive cache-admission age may fast-path;
+* the existing v37 ``_handle_failure`` path performs the actual admission, so
+  fallback provenance, observation timestamp, sequence fencing, and v166
+  computed-at capping remain authoritative;
+* the live Kraken balance worker is not cancelled. It continues asynchronously
+  and may refresh the observation for a later cycle.
+
+This patch does not extend freshness/publication expiry, accept a partial
+snapshot, fabricate capital, bypass v162 sequence fencing, change risk limits,
+force activation/trading, or grant writer/nonce/execution authority.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import math
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.runtime_kraken_capital_observation_admission_v174")
+MARKER = "20260821-runtime-kraken-capital-observation-admission-v174"
+_READY_FLAG = "NIJA_RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174_READY"
+_PATCH_ATTR = "_nija_runtime_kraken_capital_observation_admission_v174"
+_LOCK = threading.RLock()
+_DEFAULT_MAX_AGE_S = 30.0
+
+
+def _guard() -> Any:
+    return importlib.import_module("bot.capital_refresh_stall_guard_v35")
+
+
+def _v166() -> Any:
+    return importlib.import_module("bot.runtime_capital_refresh_ownership_v166_patch")
+
+
+def _is_proactive_trigger() -> bool:
+    try:
+        checker = getattr(_v166(), "_is_proactive_trigger", None)
+        return bool(checker()) if callable(checker) else False
+    except Exception:
+        return False
+
+
+def _freshness_ttl_seconds(guard: Any | None = None) -> float:
+    target = guard if guard is not None else _guard()
+    try:
+        getter = getattr(target, "_freshness_ttl_seconds", None)
+        if callable(getter):
+            return max(5.0, float(getter()))
+    except Exception:
+        pass
+    return 90.0
+
+
+def _max_admission_age_seconds(guard: Any | None = None) -> float:
+    """Use a stricter-than-TTL age for the no-wait admission fast path."""
+    ttl_s = _freshness_ttl_seconds(guard)
+    try:
+        proactive_budget = float(_v166()._proactive_fetch_budget_seconds())
+    except Exception:
+        proactive_budget = _DEFAULT_MAX_AGE_S
+    try:
+        requested = float(
+            os.environ.get(
+                "NIJA_KRAKEN_CAPITAL_OBSERVATION_FASTPATH_MAX_AGE_S",
+                str(_DEFAULT_MAX_AGE_S),
+            )
+            or _DEFAULT_MAX_AGE_S
+        )
+    except (TypeError, ValueError):
+        requested = _DEFAULT_MAX_AGE_S
+    return max(1.0, min(requested, proactive_budget, ttl_s))
+
+
+def _coerce_positive(value: Any) -> Optional[float]:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(result) or result <= 0.0:
+        return None
+    return result
+
+
+def _read_fresh_observation(
+    guard: Any,
+    broker_id: str,
+    *,
+    now_mono: float | None = None,
+) -> tuple[Any | None, float]:
+    """Return a positive, sequence-fenced v35 observation inside fast-path age."""
+    bid = str(broker_id or "").strip().lower()
+    if bid != "kraken":
+        return None, float("inf")
+
+    observations = getattr(guard, "_OBSERVATIONS", None)
+    lock = getattr(guard, "_OBSERVATION_LOCK", None)
+    if not isinstance(observations, dict):
+        return None, float("inf")
+
+    def read() -> Any:
+        return observations.get(bid)
+
+    if lock is None:
+        observation = read()
+    else:
+        with lock:
+            observation = read()
+    if observation is None:
+        return None, float("inf")
+
+    value = _coerce_positive(getattr(observation, "value", None))
+    try:
+        observed_mono = float(getattr(observation, "observed_monotonic", 0.0) or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        observed_mono = 0.0
+    if value is None or observed_mono <= 0.0:
+        return None, float("inf")
+
+    now = time.monotonic() if now_mono is None else float(now_mono)
+    age_s = max(0.0, now - observed_mono)
+    if age_s > _max_admission_age_seconds(guard):
+        return None, age_s
+    return observation, age_s
+
+
+def _patch_batch_result() -> bool:
+    guard = _guard()
+    batch_cls = getattr(guard, "_BalanceFetchBatch", None)
+    if not isinstance(batch_cls, type):
+        return False
+    current = getattr(batch_cls, "result_for", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    if not callable(getattr(batch_cls, "_handle_failure", None)):
+        return False
+
+    original = current
+
+    @wraps(original)
+    def result_for_v174(self: Any, broker_id: str, broker: Any) -> Any:
+        bid = str(broker_id or "").strip().lower()
+        if bid == "kraken" and _is_proactive_trigger():
+            resolved = getattr(self, "_nija_v37_resolved", {})
+            if bid not in resolved:
+                observation, age_s = _read_fresh_observation(guard, bid)
+                if observation is not None:
+                    value = self._handle_failure(
+                        bid,
+                        "v174_proactive_fresh_observation",
+                    )
+                    scalar = _coerce_positive(value)
+                    if scalar is not None:
+                        LOGGER.critical(
+                            "CAPITAL_V174_KRAKEN_OBSERVATION_ADMITTED marker=%s broker=kraken "
+                            "balance=%.8f age_s=%.2f sequence=%s proactive=true "
+                            "synchronous_wait_bypassed=true source=v35_fenced_observation "
+                            "fallback_timestamp_preserved=true freshness_extended=false "
+                            "partial_aggregation_gate_unchanged=true safety_gates_bypassed=false",
+                            MARKER,
+                            scalar,
+                            age_s,
+                            getattr(observation, "sequence", "unknown"),
+                        )
+                        return value
+        return original(self, broker_id, broker)
+
+    setattr(result_for_v174, _PATCH_ATTR, True)
+    setattr(result_for_v174, "__wrapped__", original)
+    batch_cls.result_for = result_for_v174
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_kraken_capital_observation_admission_v174"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        batch_ok = _patch_batch_result()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(batch_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174_FAILED marker=%s "
+                "batch_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(batch_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+
+        LOGGER.critical(
+            "RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174 marker=%s ready=true "
+            "proactive_kraken_only=true max_fastpath_age_s=%.1f "
+            "v37_fallback_authoritative=true v162_sequence_fence_preserved=true "
+            "fallback_timestamp_preserved=true freshness_extended=false "
+            "partial_aggregation_gate_unchanged=true forced_trade=false safety_gates_bypassed=false",
+            MARKER,
+            _max_admission_age_seconds(),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_max_admission_age_seconds",
+    "_read_fresh_observation",
+    "_patch_batch_result",
+]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -14,9 +14,11 @@ ORDER/FILL proof and fresh broker-owned observations are seeded immediately
 before canonical publication augmentation. v170 then makes accepted capital
 publication/readiness monotonic, v171 reasserts the bounded concurrent
 market-data path used by Phase 3, v172 aligns the finite post-core activation
-wait with the longer capital convergence budget without changing any gate, and
-v173 keeps Kraken's post-Balance valuation tail from self-amplifying stale
-balance flights while preserving all freshness/completeness fences.
+wait with the longer capital convergence budget without changing any gate, v173
+keeps Kraken's post-Balance valuation tail from self-amplifying stale balance
+flights, and v174 admits an already-fresh, sequence-fenced Kraken observation
+without re-waiting the full proactive budget while preserving all freshness and
+completeness fences.
 """
 from __future__ import annotations
 
@@ -164,6 +166,13 @@ def _install_v173_kraken_capital_tail_liveness() -> bool:
     )
 
 
+def _install_v174_kraken_capital_observation_admission() -> bool:
+    return _install_named(
+        "bot.runtime_kraken_capital_observation_admission_v174_patch",
+        "RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174",
+    )
+
+
 def install() -> bool:
     with _LOCK:
         try:
@@ -187,6 +196,7 @@ def install() -> bool:
         v171_ok = _install_v171_market_data_concurrency()
         v172_ok = _install_v172_post_core_activation_budget()
         v173_ok = _install_v173_kraken_capital_tail_liveness()
+        v174_ok = _install_v174_kraken_capital_observation_admission()
         ready = bool(
             verified
             and periodic_ok
@@ -197,13 +207,14 @@ def install() -> bool:
             and v171_ok
             and v172_ok
             and v173_ok
+            and v174_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
                 "manifest_ok=%s v168_ok=%s v169_ok=%s v170_ok=%s v171_ok=%s v172_ok=%s "
-                "v173_ok=%s trading_fail_closed=true",
+                "v173_ok=%s v174_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
@@ -214,6 +225,7 @@ def install() -> bool:
                 str(v171_ok).lower(),
                 str(v172_ok).lower(),
                 str(v173_ok).lower(),
+                str(v174_ok).lower(),
             )
             return False
         LOGGER.critical(
@@ -222,8 +234,8 @@ def install() -> bool:
             "recovery_refresh_preserved=true v168_generation_liveness=true "
             "v169_execution_capital_integrity=true v170_capital_monotonicity=true "
             "v171_market_data_concurrency=true v172_post_core_activation_budget=true "
-            "v173_kraken_capital_tail_liveness=true publication_expiry_extended=false "
-            "stale_promoted=false safety_gates_bypassed=false",
+            "v173_kraken_capital_tail_liveness=true v174_kraken_observation_admission=true "
+            "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -245,4 +257,5 @@ __all__ = [
     "_install_v171_market_data_concurrency",
     "_install_v172_post_core_activation_budget",
     "_install_v173_kraken_capital_tail_liveness",
+    "_install_v174_kraken_capital_observation_admission",
 ]

--- a/tests/test_runtime_kraken_capital_observation_admission_v174.py
+++ b/tests/test_runtime_kraken_capital_observation_admission_v174.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from bot import runtime_kraken_capital_observation_admission_v174_patch as patch
+
+
+def _guard_with_observation(*, value: float, observed_mono: float, sequence: int = 7):
+    observation = SimpleNamespace(
+        value=value,
+        observed_monotonic=observed_mono,
+        observed_epoch=1_787_278_000.0,
+        sequence=sequence,
+    )
+    return SimpleNamespace(
+        _OBSERVATIONS={"kraken": observation},
+        _OBSERVATION_LOCK=threading.Lock(),
+        _freshness_ttl_seconds=lambda: 90.0,
+    )
+
+
+def test_fresh_positive_kraken_observation_is_fastpath_eligible(monkeypatch) -> None:
+    guard = _guard_with_observation(value=245.93, observed_mono=990.0)
+    monkeypatch.setattr(patch, "_max_admission_age_seconds", lambda guard=None: 30.0)
+
+    observation, age_s = patch._read_fresh_observation(
+        guard,
+        "kraken",
+        now_mono=1000.0,
+    )
+
+    assert observation is guard._OBSERVATIONS["kraken"]
+    assert age_s == 10.0
+
+
+def test_stale_or_nonpositive_observation_is_not_fastpathed(monkeypatch) -> None:
+    monkeypatch.setattr(patch, "_max_admission_age_seconds", lambda guard=None: 30.0)
+
+    stale = _guard_with_observation(value=245.93, observed_mono=900.0)
+    observation, age_s = patch._read_fresh_observation(stale, "kraken", now_mono=1000.0)
+    assert observation is None
+    assert age_s == 100.0
+
+    zero = _guard_with_observation(value=0.0, observed_mono=999.0)
+    observation, _ = patch._read_fresh_observation(zero, "kraken", now_mono=1000.0)
+    assert observation is None
+
+
+def test_fastpath_uses_existing_v37_failure_handler_and_skips_wait(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeBatch:
+        def __init__(self):
+            self._nija_v37_resolved = {}
+
+        def _handle_failure(self, broker_id: str, reason: str) -> float:
+            calls.append((broker_id, reason))
+            self._nija_v37_resolved[broker_id] = 245.93
+            return 245.93
+
+        def result_for(self, broker_id: str, broker):
+            raise AssertionError("synchronous wait path must be bypassed")
+
+    guard = _guard_with_observation(value=245.93, observed_mono=999.0)
+    guard._BalanceFetchBatch = FakeBatch
+    monkeypatch.setattr(patch, "_guard", lambda: guard)
+    monkeypatch.setattr(patch, "_is_proactive_trigger", lambda: True)
+    monkeypatch.setattr(patch, "_max_admission_age_seconds", lambda guard=None: 30.0)
+    monkeypatch.setattr(patch.time, "monotonic", lambda: 1000.0)
+
+    assert patch._patch_batch_result() is True
+    batch = FakeBatch()
+    assert batch.result_for("kraken", object()) == 245.93
+    assert calls == [("kraken", "v174_proactive_fresh_observation")]
+
+
+def test_nonproactive_refresh_keeps_original_wait_path(monkeypatch) -> None:
+    class FakeBatch:
+        def _handle_failure(self, broker_id: str, reason: str) -> float:
+            return 245.93
+
+        def result_for(self, broker_id: str, broker):
+            return "original"
+
+    guard = _guard_with_observation(value=245.93, observed_mono=999.0)
+    guard._BalanceFetchBatch = FakeBatch
+    monkeypatch.setattr(patch, "_guard", lambda: guard)
+    monkeypatch.setattr(patch, "_is_proactive_trigger", lambda: False)
+
+    assert patch._patch_batch_result() is True
+    assert FakeBatch().result_for("kraken", object()) == "original"
+
+
+def test_fastpath_age_is_never_longer_than_proactive_budget_or_ttl(monkeypatch) -> None:
+    guard = SimpleNamespace(_freshness_ttl_seconds=lambda: 90.0)
+    fake_v166 = SimpleNamespace(_proactive_fetch_budget_seconds=lambda: 30.0)
+    monkeypatch.setattr(patch, "_v166", lambda: fake_v166)
+    monkeypatch.setenv("NIJA_KRAKEN_CAPITAL_OBSERVATION_FASTPATH_MAX_AGE_S", "300")
+    assert patch._max_admission_age_seconds(guard) == 30.0
+
+
+def test_patch_exposes_no_freshness_or_execution_bypass_api() -> None:
+    assert not hasattr(patch, "extend_freshness")
+    assert not hasattr(patch, "accept_partial_snapshot")
+    assert not hasattr(patch, "force_activation")
+    assert not hasattr(patch, "grant_execution_authority")

--- a/tests/test_runtime_refresh_demand_v167.py
+++ b/tests/test_runtime_refresh_demand_v167.py
@@ -86,6 +86,24 @@ def test_v167_install_registers_release_manifest(monkeypatch):
     )
 
 
+def test_v167_install_chain_includes_v174(monkeypatch):
+    patch = importlib.import_module("bot.runtime_refresh_demand_v167_patch")
+    calls: list[tuple[str, str]] = []
+
+    def fake_install_named(module_name: str, label: str) -> bool:
+        calls.append((module_name, label))
+        return True
+
+    monkeypatch.setattr(patch, "_install_named", fake_install_named)
+    assert patch._install_v174_kraken_capital_observation_admission() is True
+    assert calls == [
+        (
+            "bot.runtime_kraken_capital_observation_admission_v174_patch",
+            "RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174",
+        )
+    ]
+
+
 def test_post_import_convergence_installs_v167(monkeypatch):
     post = importlib.import_module("bot.runtime_post_import_convergence_patch")
     calls: list[tuple[str, str, str]] = []


### PR DESCRIPTION
## Production failure
Kraken PLATFORM can complete a genuine fresh balance/equity read while the canonical capital publication remains fail-closed at `incomplete_broker_aggregation:2/3`. The existing v35/v37 observation is sequence-fenced and freshness-checked, but a proactive publication cycle can still wait the full 30-second synchronous fetch budget before consulting that already-fresh observation.

## Fix
Add v174 Kraken capital observation admission:
- proactive runtime publication refreshes only
- canonical `kraken` broker only
- requires a positive v35 observation inside both canonical freshness TTL and a stricter proactive fast-path age
- delegates admission to existing v37 `_handle_failure`, preserving fallback provenance and exact observation timestamp
- preserves v162 sequence fencing and v166 computed-at capping
- leaves the live Kraken fetch running asynchronously
- wires v174 into the existing v167 -> v173 runtime convergence install chain

## Safety invariants unchanged
- no freshness/publication expiry extension
- no partial 2/3 acceptance
- no fabricated balances
- no writer/nonce/risk/order/execution bypass
- no forced activation or forced trade

## Validation
Targeted isolated regression harness: 6/6 tests passed.
Additional repository tests cover the v174 install chain and explicit absence of bypass APIs.

## Expected production proof after deployment
- `RUNTIME_KRAKEN_CAPITAL_OBSERVATION_ADMISSION_V174 ... ready=true`
- `CAPITAL_V174_KRAKEN_OBSERVATION_ADMITTED`
- canonical capital snapshot `valid_brokers=3`
- v170 complete 3/3 publication accepted
- `capital_ready=True`
- repeated v141 `incomplete_broker_aggregation:2/3` disappears
