### PR TITLE
Fix writer and position readiness convergence

### DIFF
--- a/bot/runtime_authority_position_convergence_v175_patch.py
+++ b/bot/runtime_authority_position_convergence_v175_patch.py
@@ -1,0 +1,264 @@
+"""Runtime authority/position convergence repair v175.
+
+Production after v174 showed two fail-closed liveness gaps:
+
+* strategy publication could wait on process-local writer token/generation aliases
+  even while the canonical EntrypointWriterAuthority still held an exact Redis
+  lease; and
+* the v161 position monitor could select an empty compatibility manager before a
+  populated canonical manager, publishing ``ready=false pending=[] status={}``.
+
+v175 repairs those gaps without creating authority or synthesizing readiness.
+Writer lineage is republished only after v77 proves exact current Redis ownership.
+Position monitoring selects the manager with the strongest live connected-broker
+view and still requires every connected broker to carry a real adopted startup
+position snapshot.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_authority_position_convergence_v175")
+MARKER = "20260821-runtime-authority-position-convergence-v175"
+RELEASE_ID = "20260821-runtime-convergence-v175"
+_READY_FLAG = "NIJA_RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175_READY"
+_PATCH_ATTR = "_nija_runtime_authority_position_convergence_v175"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _writer_env_complete() -> bool:
+    return bool(
+        str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+        and str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+    )
+
+
+def restore_writer_lineage_from_exact_owner(source: str = "runtime") -> tuple[bool, str]:
+    """Restore local writer aliases only from v77 exact-owner proof."""
+    if _writer_env_complete():
+        return True, "already_complete"
+    try:
+        v77 = importlib.import_module("bot.writer_authority_reconstitution_v77_patch")
+        proof, reason = v77.exact_owner_proof()
+        if proof is None:
+            LOGGER.warning(
+                "WRITER_V175_LINEAGE_RESTORE_BLOCKED marker=%s source=%s reason=%s "
+                "authority_synthesized=false trading_fail_closed=true",
+                MARKER,
+                source,
+                reason,
+            )
+            return False, str(reason)
+        ok, generation, detail = v77.publish_local_lineage(
+            proof,
+            f"v175:{source}",
+        )
+        complete = bool(ok and generation > 0 and _writer_env_complete())
+        if complete:
+            LOGGER.critical(
+                "WRITER_V175_LINEAGE_RESTORED marker=%s source=%s generation=%s "
+                "exact_owner=true redis_mutation=false token_fabricated=false",
+                MARKER,
+                source,
+                generation,
+            )
+            return True, str(detail)
+        return False, "v77_publication_incomplete"
+    except Exception as exc:
+        LOGGER.warning(
+            "WRITER_V175_LINEAGE_RESTORE_ERROR marker=%s source=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            source,
+            type(exc).__name__,
+            exc,
+        )
+        return False, f"{type(exc).__name__}:{exc}"
+
+
+def _patch_strategy_publication() -> bool:
+    try:
+        module = importlib.import_module("bot.strategy_publication_patch")
+    except Exception:
+        return False
+    current = getattr(module, "_ready", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def ready_v175():
+        ready, reason = original()
+        if ready or reason not in {"writer_token_missing", "writer_generation_missing"}:
+            return ready, reason
+        restored, detail = restore_writer_lineage_from_exact_owner(
+            f"strategy_publication:{reason}"
+        )
+        if not restored:
+            return False, reason
+        ready2, reason2 = original()
+        LOGGER.info(
+            "STRATEGY_V175_AUTHORITY_RECHECK marker=%s initial_reason=%s restored=true "
+            "ready=%s detail=%s authority_bypass=false",
+            MARKER,
+            reason,
+            str(bool(ready2)).lower(),
+            detail,
+        )
+        return ready2, reason2
+
+    setattr(ready_v175, _PATCH_ATTR, True)
+    setattr(ready_v175, "__wrapped__", original)
+    module._ready = ready_v175
+    return True
+
+
+def _candidate_managers() -> list[Any]:
+    candidates: list[Any] = []
+    seen: set[int] = set()
+    for name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            try:
+                module = importlib.import_module(name)
+            except Exception:
+                continue
+        getter = getattr(module, "get_broker_manager", None)
+        if callable(getter):
+            try:
+                value = getter()
+                if value is not None and id(value) not in seen:
+                    seen.add(id(value))
+                    candidates.append(value)
+            except Exception:
+                pass
+        for attr in ("multi_account_broker_manager", "_manager"):
+            value = getattr(module, attr, None)
+            if value is not None and id(value) not in seen:
+                seen.add(id(value))
+                candidates.append(value)
+    return candidates
+
+
+def _manager_connected_count(manager: Any) -> int:
+    try:
+        v95 = importlib.import_module("bot.position_sync_core_handoff_v95_patch")
+        connected = getattr(v95, "_connected_brokers", None)
+        if callable(connected):
+            return len(dict(connected(manager) or {}))
+    except Exception:
+        pass
+    return 0
+
+
+def canonical_manager_with_live_brokers() -> Any:
+    """Prefer the current manager carrying the largest connected-broker view."""
+    candidates = _candidate_managers()
+    if not candidates:
+        return None
+    ranked = sorted(
+        candidates,
+        key=lambda manager: _manager_connected_count(manager),
+        reverse=True,
+    )
+    winner = ranked[0]
+    LOGGER.debug(
+        "POSITION_SYNC_V175_MANAGER_SELECTED marker=%s candidates=%d connected=%d",
+        MARKER,
+        len(candidates),
+        _manager_connected_count(winner),
+    )
+    return winner
+
+
+def _patch_v161_manager_selection() -> bool:
+    try:
+        v161 = importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
+    except Exception:
+        return False
+    current = getattr(v161, "_canonical_manager", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def canonical_manager_v175():
+        selected = canonical_manager_with_live_brokers()
+        if selected is not None and _manager_connected_count(selected) > 0:
+            return selected
+        return original()
+
+    setattr(canonical_manager_v175, _PATCH_ATTR, True)
+    setattr(canonical_manager_v175, "__wrapped__", original)
+    v161._canonical_manager = canonical_manager_v175
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_authority_position_convergence_v175"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        strategy_ok = _patch_strategy_publication()
+        position_ok = _patch_v161_manager_selection()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(strategy_ok and position_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175_FAILED marker=%s "
+                "strategy_ok=%s position_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(strategy_ok).lower(),
+                str(position_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        _INSTALLED = True
+        LOGGER.critical(
+            "RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175 marker=%s ready=true "
+            "writer_exact_owner_only=true writer_token_fabricated=false redis_mutation=false "
+            "position_manager_live_broker_preference=true empty_status_promoted=false "
+            "position_snapshot_requirement_unchanged=true safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "restore_writer_lineage_from_exact_owner",
+    "canonical_manager_with_live_brokers",
+    "_manager_connected_count",
+    "_patch_strategy_publication",
+    "_patch_v161_manager_selection",
+]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -16,9 +16,11 @@ publication/readiness monotonic, v171 reasserts the bounded concurrent
 market-data path used by Phase 3, v172 aligns the finite post-core activation
 wait with the longer capital convergence budget without changing any gate, v173
 keeps Kraken's post-Balance valuation tail from self-amplifying stale balance
-flights, and v174 admits an already-fresh, sequence-fenced Kraken observation
-without re-waiting the full proactive budget while preserving all freshness and
-completeness fences.
+flights, v174 admits an already-fresh, sequence-fenced Kraken observation without
+re-waiting the full proactive budget, and v175 restores process-local writer
+lineage only from exact current Redis ownership while making the v161 position
+monitor prefer the populated canonical broker manager over empty compatibility
+aliases.
 """
 from __future__ import annotations
 
@@ -173,6 +175,13 @@ def _install_v174_kraken_capital_observation_admission() -> bool:
     )
 
 
+def _install_v175_authority_position_convergence() -> bool:
+    return _install_named(
+        "bot.runtime_authority_position_convergence_v175_patch",
+        "RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175",
+    )
+
+
 def install() -> bool:
     with _LOCK:
         try:
@@ -197,6 +206,7 @@ def install() -> bool:
         v172_ok = _install_v172_post_core_activation_budget()
         v173_ok = _install_v173_kraken_capital_tail_liveness()
         v174_ok = _install_v174_kraken_capital_observation_admission()
+        v175_ok = _install_v175_authority_position_convergence()
         ready = bool(
             verified
             and periodic_ok
@@ -208,13 +218,14 @@ def install() -> bool:
             and v172_ok
             and v173_ok
             and v174_ok
+            and v175_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
                 "manifest_ok=%s v168_ok=%s v169_ok=%s v170_ok=%s v171_ok=%s v172_ok=%s "
-                "v173_ok=%s v174_ok=%s trading_fail_closed=true",
+                "v173_ok=%s v174_ok=%s v175_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
@@ -226,6 +237,7 @@ def install() -> bool:
                 str(v172_ok).lower(),
                 str(v173_ok).lower(),
                 str(v174_ok).lower(),
+                str(v175_ok).lower(),
             )
             return False
         LOGGER.critical(
@@ -235,7 +247,8 @@ def install() -> bool:
             "v169_execution_capital_integrity=true v170_capital_monotonicity=true "
             "v171_market_data_concurrency=true v172_post_core_activation_budget=true "
             "v173_kraken_capital_tail_liveness=true v174_kraken_observation_admission=true "
-            "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
+            "v175_authority_position_convergence=true publication_expiry_extended=false "
+            "stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -258,4 +271,5 @@ __all__ = [
     "_install_v172_post_core_activation_budget",
     "_install_v173_kraken_capital_tail_liveness",
     "_install_v174_kraken_capital_observation_admission",
+    "_install_v175_authority_position_convergence",
 ]

--- a/tests/test_runtime_authority_position_convergence_v175.py
+++ b/tests/test_runtime_authority_position_convergence_v175.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+
+import bot.runtime_authority_position_convergence_v175_patch as v175
+
+
+def test_writer_restore_requires_exact_owner(monkeypatch):
+    monkeypatch.delenv("NIJA_WRITER_FENCING_TOKEN", raising=False)
+    monkeypatch.delenv("NIJA_WRITER_LEASE_GENERATION", raising=False)
+
+    fake_v77 = ModuleType("bot.writer_authority_reconstitution_v77_patch")
+    fake_v77.exact_owner_proof = lambda: (None, "redis_lock_owner_mismatch")
+    called = {"publish": False}
+
+    def publish_local_lineage(*args, **kwargs):
+        called["publish"] = True
+        raise AssertionError("must not publish without exact-owner proof")
+
+    fake_v77.publish_local_lineage = publish_local_lineage
+    monkeypatch.setitem(sys.modules, fake_v77.__name__, fake_v77)
+
+    ok, reason = v175.restore_writer_lineage_from_exact_owner("test")
+
+    assert ok is False
+    assert reason == "redis_lock_owner_mismatch"
+    assert called["publish"] is False
+    assert os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") == ""
+
+
+def test_writer_restore_republishes_proven_current_lineage(monkeypatch):
+    monkeypatch.delenv("NIJA_WRITER_FENCING_TOKEN", raising=False)
+    monkeypatch.delenv("NIJA_WRITER_LEASE_GENERATION", raising=False)
+
+    proof = {"generation": 91, "token": "proven-token", "runtime": object()}
+    fake_v77 = ModuleType("bot.writer_authority_reconstitution_v77_patch")
+    fake_v77.exact_owner_proof = lambda: (proof, "exact_runtime_redis_owner")
+
+    def publish_local_lineage(received, source):
+        assert received is proof
+        os.environ["NIJA_WRITER_FENCING_TOKEN"] = "proven-token"
+        os.environ["NIJA_WRITER_LEASE_GENERATION"] = "91"
+        return True, 91, "exact_owner_reconstituted"
+
+    fake_v77.publish_local_lineage = publish_local_lineage
+    monkeypatch.setitem(sys.modules, fake_v77.__name__, fake_v77)
+
+    ok, reason = v175.restore_writer_lineage_from_exact_owner("test")
+
+    assert ok is True
+    assert reason == "exact_owner_reconstituted"
+    assert os.environ["NIJA_WRITER_FENCING_TOKEN"] == "proven-token"
+    assert os.environ["NIJA_WRITER_LEASE_GENERATION"] == "91"
+
+
+def test_manager_selection_prefers_populated_connected_view(monkeypatch):
+    empty = SimpleNamespace(name="empty")
+    populated = SimpleNamespace(name="populated")
+
+    monkeypatch.setattr(v175, "_candidate_managers", lambda: [empty, populated])
+    monkeypatch.setattr(
+        v175,
+        "_manager_connected_count",
+        lambda manager: 0 if manager is empty else 3,
+    )
+
+    assert v175.canonical_manager_with_live_brokers() is populated
+
+
+def test_manager_selection_does_not_turn_empty_view_into_ready(monkeypatch):
+    empty = SimpleNamespace(name="empty")
+    monkeypatch.setattr(v175, "_candidate_managers", lambda: [empty])
+    monkeypatch.setattr(v175, "_manager_connected_count", lambda manager: 0)
+
+    assert v175.canonical_manager_with_live_brokers() is empty
+    assert v175._manager_connected_count(empty) == 0
+
+
+def test_v175_has_no_safety_bypass_api():
+    source = open(v175.__file__, "r", encoding="utf-8").read()
+    forbidden = (
+        "accept_partial_snapshot",
+        "extend_freshness",
+        "force_activation",
+        "grant_execution_authority",
+        "force_trade",
+    )
+    for token in forbidden:
+        assert token not in source

--- a/tests/test_runtime_refresh_demand_v167.py
+++ b/tests/test_runtime_refresh_demand_v167.py
@@ -104,6 +104,24 @@ def test_v167_install_chain_includes_v174(monkeypatch):
     ]
 
 
+def test_v167_install_chain_includes_v175(monkeypatch):
+    patch = importlib.import_module("bot.runtime_refresh_demand_v167_patch")
+    calls: list[tuple[str, str]] = []
+
+    def fake_install_named(module_name: str, label: str) -> bool:
+        calls.append((module_name, label))
+        return True
+
+    monkeypatch.setattr(patch, "_install_named", fake_install_named)
+    assert patch._install_v175_authority_position_convergence() is True
+    assert calls == [
+        (
+            "bot.runtime_authority_position_convergence_v175_patch",
+            "RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175",
+        )
+    ]
+
+
 def test_post_import_convergence_installs_v167(monkeypatch):
     post = importlib.import_module("bot.runtime_post_import_convergence_patch")
     calls: list[tuple[str, str, str]] = []


### PR DESCRIPTION
## Production blockers
After v174 deployed successfully, production still showed two concrete fail-closed liveness gaps:
- `STRATEGY_PUBLICATION_WAITING reason=writer_token_missing` even though canonical writer authority had previously proven an active lease.
- `POSITION_SYNC_V96_READINESS ... ready=false pending=[] status={}` from the v161 monitor, consistent with selecting an empty compatibility manager instead of the populated canonical broker manager.

The broker-local readiness contract was also reviewed. Its `policy=optional;required_ready=0` state is intentional telemetry and is not changed by this PR.

## Fix
Add v175 runtime authority/position convergence:
- when strategy publication is blocked only by a missing local writer token/generation alias, consult existing v77 exact-owner proof;
- republish local writer lineage only if the canonical EntrypointWriterAuthority and Redis prove exact current lock ownership, matching generation, fencing token, and positive TTL;
- do not reacquire, fabricate, or bypass writer authority in the strategy publication path;
- make the v161 position monitor prefer the manager carrying the strongest live connected-broker view over empty compatibility aliases;
- preserve the existing v95 requirement that every connected broker has a real adopted startup position snapshot before position readiness becomes true;
- wire v175 into the existing v167 runtime convergence chain and release manifest.

## Safety invariants unchanged
- no token fabrication
- no Redis lock mutation in v175 writer restoration
- no empty position status promoted to ready
- no partial capital acceptance
- no freshness extension/stale promotion
- no forced activation/trading
- no writer/nonce/risk/order/execution gate bypass

## Expected production proof
- `RUNTIME_AUTHORITY_POSITION_CONVERGENCE_V175 ... ready=true`
- if local writer aliases are missing while exact owner proof is valid: `WRITER_V175_LINEAGE_RESTORED ... exact_owner=true`
- strategy publication no longer remains stuck on `writer_token_missing`
- `POSITION_SYNC_V96_READINESS ... status={'platform:kraken': true, 'platform:coinbase': true, 'platform:okx': true} ready=true` once real snapshots exist
- v174 can then exercise on a proactive refresh if needed
- canonical capital publication reaches accepted 3/3 and current execution readiness can converge without weakening any safety gate
