### PR TITLE
Fix runtime capital pipeline completion

### DIFF
--- a/bot/runtime_capital_pipeline_completion_v176_patch.py
+++ b/bot/runtime_capital_pipeline_completion_v176_patch.py
@@ -1,0 +1,337 @@
+"""Runtime capital pipeline completion convergence v176.
+
+Production after v175 proved LIVE_ACTIVE, writer authority, three-broker
+connectivity, and three-broker position readiness, but the proactive v137
+capital refresh path still exposed two liveness contradictions:
+
+* v166 correctly reduced proactive broker collection to a 30 second synchronous
+  budget and intended a 50 second total coordinator deadline, while v142 still
+  observed an 80 second deadline on the caller thread.  The worker thread had
+  the proactive trigger context, but the caller thread that evaluates the v142
+  total deadline did not reliably retain it through the accumulated wrapper
+  chain; and
+* CapitalAuthority performs best-effort warm-start persistence synchronously at
+  the end of an accepted publication.  Slow filesystem/fsync work can therefore
+  hold the coordinator open after capital has already been atomically accepted,
+  causing v142 to retire an otherwise successful generation.
+
+v176 closes those liveness gaps without changing capital truth.  It reasserts
+proactive trigger context around the effective coordinator entrypoint, caps the
+proactive v142 total deadline to v166's existing bounded deadline, and moves
+non-authoritative warm-start persistence off the live publication critical path
+with a single coalescing daemon worker.
+
+The patch does not extend freshness/publication expiry, accept partial capital,
+fabricate balances, promote stale data, force activation/trading, mutate writer
+or nonce authority, or bypass risk/execution/order gates.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_pipeline_completion_v176")
+MARKER = "20260821-runtime-capital-pipeline-completion-v176"
+RELEASE_ID = "20260821-runtime-convergence-v176"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176_READY"
+_PATCH_ATTR = "_nija_runtime_capital_pipeline_completion_v176"
+_LOCK = threading.RLock()
+_PERSIST_LOCK = threading.RLock()
+_PERSIST_RUNNING = False
+_PERSIST_PENDING = False
+_PERSIST_WORKER: threading.Thread | None = None
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in _TRUE
+
+
+def _live_runtime() -> bool:
+    return bool(
+        _truthy(os.environ.get("LIVE_CAPITAL_VERIFIED"))
+        and not _truthy(os.environ.get("DRY_RUN_MODE"))
+        and not _truthy(os.environ.get("PAPER_MODE"))
+    )
+
+
+def _flow() -> Any:
+    return importlib.import_module("bot.capital_flow_state_machine")
+
+
+def _v142() -> Any:
+    return importlib.import_module("bot.capital_publication_liveness_v142_patch")
+
+
+def _v166() -> Any:
+    return importlib.import_module("bot.runtime_capital_refresh_ownership_v166_patch")
+
+
+def _patch_proactive_deadline_context() -> bool:
+    """Keep proactive v137 work inside v166's existing total runtime budget."""
+    try:
+        v142 = _v142()
+        current = getattr(v142, "_runtime_pipeline_deadline_seconds", None)
+    except Exception:
+        return False
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def runtime_pipeline_deadline_v176() -> float:
+        base = max(10.0, float(original()))
+        try:
+            v166 = _v166()
+            proactive = bool(v166._is_proactive_trigger())
+            if not proactive:
+                return base
+            bounded = max(10.0, float(v166._proactive_pipeline_deadline_seconds()))
+            # Only shorten proactive work to the deadline v166 already owns.
+            # Never lengthen any stricter deadline installed elsewhere.
+            return min(base, bounded)
+        except Exception:
+            return base
+
+    setattr(runtime_pipeline_deadline_v176, _PATCH_ATTR, True)
+    setattr(runtime_pipeline_deadline_v176, "__wrapped__", original)
+    v142._runtime_pipeline_deadline_seconds = runtime_pipeline_deadline_v176
+    return True
+
+
+def _patch_execute_trigger_context() -> bool:
+    """Reassert v166 trigger context on the thread that owns v142's deadline wait."""
+    try:
+        flow = _flow()
+        cls = getattr(flow, "CapitalRefreshCoordinator", None)
+    except Exception:
+        return False
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "execute_refresh", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def execute_refresh_v176(
+        self: Any,
+        broker_map: dict[str, Any],
+        trigger: str = "coordinator",
+        open_exposure_usd: float = 0.0,
+    ) -> Any:
+        try:
+            v166 = _v166()
+            setter = getattr(v166, "_set_trigger", None)
+            restorer = getattr(v166, "_restore_trigger", None)
+        except Exception:
+            setter = None
+            restorer = None
+            v166 = None
+        if not callable(setter) or not callable(restorer):
+            return original(
+                self,
+                broker_map=broker_map,
+                trigger=trigger,
+                open_exposure_usd=open_exposure_usd,
+            )
+
+        previous = setter(trigger)
+        try:
+            proactive = bool(v166._is_proactive_trigger(trigger))
+            if proactive:
+                try:
+                    effective = float(_v142()._runtime_pipeline_deadline_seconds())
+                except Exception:
+                    effective = -1.0
+                LOGGER.info(
+                    "CAPITAL_V176_PROACTIVE_CALLER_CONTEXT marker=%s trigger=%s "
+                    "caller_context=true deadline_s=%.1f freshness_extended=false",
+                    MARKER,
+                    trigger,
+                    effective,
+                )
+            return original(
+                self,
+                broker_map=broker_map,
+                trigger=trigger,
+                open_exposure_usd=open_exposure_usd,
+            )
+        finally:
+            restorer(previous)
+
+    setattr(execute_refresh_v176, _PATCH_ATTR, True)
+    setattr(execute_refresh_v176, "__wrapped__", original)
+    cls.execute_refresh = execute_refresh_v176
+    return True
+
+
+def _patch_async_best_effort_persistence() -> bool:
+    """Keep warm-start disk persistence out of the live publication critical path."""
+    try:
+        ca = importlib.import_module("bot.capital_authority")
+        cls = getattr(ca, "CapitalAuthority", None)
+    except Exception:
+        return False
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_save_cached_state", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def save_cached_state_v176(self: Any) -> None:
+        global _PERSIST_RUNNING, _PERSIST_PENDING, _PERSIST_WORKER
+
+        # Preserve deterministic synchronous behavior outside the real live
+        # runtime (including unit tests and paper/dry-run environments).
+        if not _live_runtime():
+            original(self)
+            return
+
+        with _PERSIST_LOCK:
+            if _PERSIST_RUNNING:
+                _PERSIST_PENDING = True
+                LOGGER.debug(
+                    "CAPITAL_V176_PERSISTENCE_COALESCED marker=%s running=true",
+                    MARKER,
+                )
+                return
+            _PERSIST_RUNNING = True
+            _PERSIST_PENDING = False
+
+        def _worker() -> None:
+            global _PERSIST_RUNNING, _PERSIST_PENDING, _PERSIST_WORKER
+            while True:
+                started = time.monotonic()
+                try:
+                    original(self)
+                except BaseException as exc:
+                    # Persistence is explicitly best-effort in CapitalAuthority;
+                    # a disk failure must not mutate publication truth.
+                    LOGGER.warning(
+                        "CAPITAL_V176_PERSISTENCE_ERROR marker=%s error=%s:%s "
+                        "capital_publication_unchanged=true",
+                        MARKER,
+                        type(exc).__name__,
+                        exc,
+                    )
+                elapsed = max(0.0, time.monotonic() - started)
+                if elapsed >= 5.0:
+                    LOGGER.warning(
+                        "CAPITAL_V176_PERSISTENCE_SLOW marker=%s elapsed_s=%.2f "
+                        "publication_path_blocked=false",
+                        MARKER,
+                        elapsed,
+                    )
+                with _PERSIST_LOCK:
+                    if _PERSIST_PENDING:
+                        _PERSIST_PENDING = False
+                        continue
+                    _PERSIST_RUNNING = False
+                    _PERSIST_WORKER = None
+                    return
+
+        worker = threading.Thread(
+            target=_worker,
+            name="capital-state-persist-v176",
+            daemon=True,
+        )
+        with _PERSIST_LOCK:
+            _PERSIST_WORKER = worker
+        try:
+            worker.start()
+        except BaseException:
+            with _PERSIST_LOCK:
+                _PERSIST_RUNNING = False
+                _PERSIST_PENDING = False
+                _PERSIST_WORKER = None
+            raise
+        LOGGER.debug(
+            "CAPITAL_V176_PERSISTENCE_ASYNC marker=%s single_worker=true "
+            "publication_path_blocked=false",
+            MARKER,
+        )
+
+    setattr(save_cached_state_v176, _PATCH_ATTR, True)
+    setattr(save_cached_state_v176, "__wrapped__", original)
+    cls._save_cached_state = save_cached_state_v176
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_pipeline_completion_v176"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        deadline_ok = _patch_proactive_deadline_context()
+        context_ok = _patch_execute_trigger_context()
+        persistence_ok = _patch_async_best_effort_persistence()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(deadline_ok and context_ok and persistence_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176_FAILED marker=%s "
+                "deadline_ok=%s context_ok=%s persistence_ok=%s manifest_ok=%s "
+                "trading_fail_closed=true",
+                MARKER,
+                str(deadline_ok).lower(),
+                str(context_ok).lower(),
+                str(persistence_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+
+        try:
+            proactive_deadline = float(_v166()._proactive_pipeline_deadline_seconds())
+        except Exception:
+            proactive_deadline = -1.0
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176 marker=%s ready=true "
+            "proactive_caller_context=true proactive_pipeline_deadline_s=%.1f "
+            "best_effort_persistence_async=true persistence_single_worker=true "
+            "freshness_extended=false publication_expiry_extended=false "
+            "partial_aggregation_gate_unchanged=true stale_promoted=false forced_trade=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            proactive_deadline,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_patch_proactive_deadline_context",
+    "_patch_execute_trigger_context",
+    "_patch_async_best_effort_persistence",
+    "_live_runtime",
+]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -17,10 +17,12 @@ market-data path used by Phase 3, v172 aligns the finite post-core activation
 wait with the longer capital convergence budget without changing any gate, v173
 keeps Kraken's post-Balance valuation tail from self-amplifying stale balance
 flights, v174 admits an already-fresh, sequence-fenced Kraken observation without
-re-waiting the full proactive budget, and v175 restores process-local writer
+re-waiting the full proactive budget, v175 restores process-local writer
 lineage only from exact current Redis ownership while making the v161 position
 monitor prefer the populated canonical broker manager over empty compatibility
-aliases.
+aliases, and v176 keeps proactive caller-thread deadline context intact while
+moving best-effort capital-state persistence off the live publication critical
+path.
 """
 from __future__ import annotations
 
@@ -182,6 +184,13 @@ def _install_v175_authority_position_convergence() -> bool:
     )
 
 
+def _install_v176_capital_pipeline_completion() -> bool:
+    return _install_named(
+        "bot.runtime_capital_pipeline_completion_v176_patch",
+        "RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176",
+    )
+
+
 def install() -> bool:
     with _LOCK:
         try:
@@ -207,6 +216,7 @@ def install() -> bool:
         v173_ok = _install_v173_kraken_capital_tail_liveness()
         v174_ok = _install_v174_kraken_capital_observation_admission()
         v175_ok = _install_v175_authority_position_convergence()
+        v176_ok = _install_v176_capital_pipeline_completion()
         ready = bool(
             verified
             and periodic_ok
@@ -219,13 +229,14 @@ def install() -> bool:
             and v173_ok
             and v174_ok
             and v175_ok
+            and v176_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
                 "manifest_ok=%s v168_ok=%s v169_ok=%s v170_ok=%s v171_ok=%s v172_ok=%s "
-                "v173_ok=%s v174_ok=%s v175_ok=%s trading_fail_closed=true",
+                "v173_ok=%s v174_ok=%s v175_ok=%s v176_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
@@ -238,6 +249,7 @@ def install() -> bool:
                 str(v173_ok).lower(),
                 str(v174_ok).lower(),
                 str(v175_ok).lower(),
+                str(v176_ok).lower(),
             )
             return False
         LOGGER.critical(
@@ -247,8 +259,8 @@ def install() -> bool:
             "v169_execution_capital_integrity=true v170_capital_monotonicity=true "
             "v171_market_data_concurrency=true v172_post_core_activation_budget=true "
             "v173_kraken_capital_tail_liveness=true v174_kraken_observation_admission=true "
-            "v175_authority_position_convergence=true publication_expiry_extended=false "
-            "stale_promoted=false safety_gates_bypassed=false",
+            "v175_authority_position_convergence=true v176_capital_pipeline_completion=true "
+            "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -272,4 +284,5 @@ __all__ = [
     "_install_v173_kraken_capital_tail_liveness",
     "_install_v174_kraken_capital_observation_admission",
     "_install_v175_authority_position_convergence",
+    "_install_v176_capital_pipeline_completion",
 ]

--- a/tests/test_runtime_capital_pipeline_completion_v176.py
+++ b/tests/test_runtime_capital_pipeline_completion_v176.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import bot.runtime_capital_pipeline_completion_v176_patch as v176
+
+
+def test_proactive_deadline_uses_existing_v166_bound(monkeypatch):
+    fake_v142 = SimpleNamespace(_runtime_pipeline_deadline_seconds=lambda: 80.0)
+    fake_v166 = SimpleNamespace(
+        _is_proactive_trigger=lambda value=None: True,
+        _proactive_pipeline_deadline_seconds=lambda: 50.0,
+    )
+    monkeypatch.setattr(v176, "_v142", lambda: fake_v142)
+    monkeypatch.setattr(v176, "_v166", lambda: fake_v166)
+
+    assert v176._patch_proactive_deadline_context() is True
+    assert fake_v142._runtime_pipeline_deadline_seconds() == 50.0
+
+
+def test_non_proactive_deadline_preserves_existing_bound(monkeypatch):
+    fake_v142 = SimpleNamespace(_runtime_pipeline_deadline_seconds=lambda: 80.0)
+    fake_v166 = SimpleNamespace(
+        _is_proactive_trigger=lambda value=None: False,
+        _proactive_pipeline_deadline_seconds=lambda: 50.0,
+    )
+    monkeypatch.setattr(v176, "_v142", lambda: fake_v142)
+    monkeypatch.setattr(v176, "_v166", lambda: fake_v166)
+
+    assert v176._patch_proactive_deadline_context() is True
+    assert fake_v142._runtime_pipeline_deadline_seconds() == 80.0
+
+
+def test_execute_wrapper_sets_and_restores_caller_context(monkeypatch):
+    context = {"trigger": "before"}
+    observed: list[str] = []
+
+    def set_trigger(value):
+        previous = context["trigger"]
+        context["trigger"] = str(value)
+        return previous
+
+    def restore_trigger(previous):
+        context["trigger"] = previous
+
+    class Coordinator:
+        def execute_refresh(self, broker_map, trigger="coordinator", open_exposure_usd=0.0):
+            observed.append(context["trigger"])
+            return "ok"
+
+    fake_v166 = SimpleNamespace(
+        _set_trigger=set_trigger,
+        _restore_trigger=restore_trigger,
+        _is_proactive_trigger=lambda value=None: str(value or context["trigger"]).startswith(
+            "publication_deadline_v137"
+        ),
+    )
+    fake_v142 = SimpleNamespace(_runtime_pipeline_deadline_seconds=lambda: 50.0)
+    monkeypatch.setattr(v176, "_flow", lambda: SimpleNamespace(CapitalRefreshCoordinator=Coordinator))
+    monkeypatch.setattr(v176, "_v166", lambda: fake_v166)
+    monkeypatch.setattr(v176, "_v142", lambda: fake_v142)
+
+    assert v176._patch_execute_trigger_context() is True
+    coordinator = Coordinator()
+    result = coordinator.execute_refresh({}, trigger="publication_deadline_v137")
+
+    assert result == "ok"
+    assert observed == ["publication_deadline_v137"]
+    assert context["trigger"] == "before"
+
+
+def test_persistence_remains_synchronous_outside_live_runtime(monkeypatch):
+    calls: list[str] = []
+
+    class CapitalAuthority:
+        def _save_cached_state(self):
+            calls.append("saved")
+
+    real_import = v176.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.capital_authority":
+            return SimpleNamespace(CapitalAuthority=CapitalAuthority)
+        return real_import(name)
+
+    monkeypatch.setattr(v176.importlib, "import_module", fake_import)
+    monkeypatch.delenv("LIVE_CAPITAL_VERIFIED", raising=False)
+    monkeypatch.delenv("DRY_RUN_MODE", raising=False)
+    monkeypatch.delenv("PAPER_MODE", raising=False)
+
+    assert v176._patch_async_best_effort_persistence() is True
+    CapitalAuthority()._save_cached_state()
+    assert calls == ["saved"]
+
+
+def test_v176_source_preserves_fail_closed_contract():
+    source = Path(v176.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "accept_partial_snapshot(",
+        "extend_freshness(",
+        "force_activation(",
+        "grant_execution_authority(",
+        "force_trade(",
+    )
+    for token in forbidden:
+        assert token not in source
+
+    assert "partial_aggregation_gate_unchanged=true" in source
+    assert "freshness_extended=false" in source
+    assert "publication_expiry_extended=false" in source
+    assert "safety_gates_bypassed=false" in source

--- a/tests/test_runtime_refresh_demand_v167.py
+++ b/tests/test_runtime_refresh_demand_v167.py
@@ -122,6 +122,24 @@ def test_v167_install_chain_includes_v175(monkeypatch):
     ]
 
 
+def test_v167_install_chain_includes_v176(monkeypatch):
+    patch = importlib.import_module("bot.runtime_refresh_demand_v167_patch")
+    calls: list[tuple[str, str]] = []
+
+    def fake_install_named(module_name: str, label: str) -> bool:
+        calls.append((module_name, label))
+        return True
+
+    monkeypatch.setattr(patch, "_install_named", fake_install_named)
+    assert patch._install_v176_capital_pipeline_completion() is True
+    assert calls == [
+        (
+            "bot.runtime_capital_pipeline_completion_v176_patch",
+            "RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176",
+        )
+    ]
+
+
 def test_post_import_convergence_installs_v167(monkeypatch):
     post = importlib.import_module("bot.runtime_post_import_convergence_patch")
     calls: list[tuple[str, str, str]] = []


### PR DESCRIPTION
## Production evidence
The v175 deployment is healthy on the authority/position side: production is `LIVE_ACTIVE`, writer generation 4583 is renewing, Kraken/Coinbase/OKX are connected, and v96 reports all three platform position snapshots ready.

The remaining fail-closed liveness defect is now isolated to recurring capital publication. Production showed v166 advertising a proactive 50s total pipeline deadline while v142 still retired generation 266 at `deadline_s=80.0`, then rolled to generation 267. That proves the proactive trigger context is not reliably visible on the caller thread that evaluates v142's total deadline. CapitalAuthority also performs best-effort state-file persistence synchronously after an accepted publication, so slow filesystem/fsync work can unnecessarily hold the coordinator open after capital truth has already been atomically accepted.

## Fix — v176
Add runtime capital pipeline completion convergence:
- reassert v166 trigger context around the effective coordinator entrypoint on the caller thread;
- when that trigger is proactive `publication_deadline_v137` work, cap v142 to v166's already-existing bounded 50s proactive deadline rather than falling back to the 80s general runtime envelope;
- preserve stricter deadlines if another layer installs one;
- move CapitalAuthority's explicitly best-effort warm-start persistence off the real live publication critical path to one coalescing daemon worker;
- preserve synchronous persistence outside real live runtime for deterministic tests/paper mode;
- wire v176 into the existing v167 convergence chain and release manifest.

## Safety invariants unchanged
- complete broker aggregation remains required
- no capital freshness/TTL or publication-expiry extension
- no stale-to-fresh promotion
- no partial snapshot acceptance
- no balance fabrication
- no writer/nonce authority mutation
- no forced activation or trade
- no risk/execution/order gate bypass

## Expected production proof
- `RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176 ... ready=true ... proactive_pipeline_deadline_s=50.0`
- proactive calls emit `CAPITAL_V176_PROACTIVE_CALLER_CONTEXT ... deadline_s=50.0`
- recurring `publication_deadline_v137` refreshes no longer reach the legacy 80s v142 timeout
- 3/3 canonical publication remains current and capital readiness stays true
- existing LIVE_ACTIVE/writer/position readiness remains stable

Actual order/fill proof is still required separately before declaring active trading/100% production proof.