### PR TITLE
Fix runtime capital reactivation and Kraken Phase3 market data

### DIFF
--- a/bot/runtime_capital_reactivation_v176_patch.py
+++ b/bot/runtime_capital_reactivation_v176_patch.py
@@ -1,0 +1,190 @@
+"""Runtime capital reactivation convergence v176.
+
+Production evidence showed a successful complete capital publication could land
+milliseconds after v133 had revoked ``capital_ready`` and transitioned
+``LIVE_ACTIVE -> OFF``.  The next normal monitor tick eventually re-probes the
+same facts, but during that gap execution remains fail-closed even though the
+canonical CapitalAuthority already holds a fresh accepted snapshot.
+
+v176 closes only that synchronization gap.  It wraps the canonical
+``CapitalRefreshCoordinator.execute_refresh`` return path and, after a non-None
+accepted snapshot, asks the existing v16 proof collector/activation path to
+re-evaluate immediately.  v16's readiness writer is still owned by v133, so a
+false proof is still revoked and LIVE state still fails closed.  No freshness
+TTL, capital value, safety gate, signal threshold, nonce rule, kill switch, or
+execution permission is altered.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_reactivation_v176")
+MARKER = "20260821-runtime-capital-reactivation-v176"
+RELEASE_ID = "20260821-runtime-convergence-v176"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_REACTIVATION_V176_READY"
+_PATCH_ATTR = "_nija_runtime_capital_reactivation_v176"
+_LOCK = threading.RLock()
+
+
+def _publication_is_fresh() -> tuple[bool, str]:
+    try:
+        authority_mod = importlib.import_module("bot.capital_authority")
+        authority = authority_mod.get_capital_authority()
+        status_fn = getattr(authority, "get_snapshot_publication_status", None)
+        if callable(status_fn):
+            status = status_fn()
+            if status is None:
+                return False, "publication_status_missing"
+            if bool(getattr(status, "stale", True)):
+                return False, "publication_stale"
+        stale_fn = getattr(authority, "is_stale", None)
+        if callable(stale_fn) and bool(stale_fn()):
+            return False, "authority_stale"
+        real = 0.0
+        for attr in ("total_capital", "real_capital", "available_capital"):
+            try:
+                real = max(real, float(getattr(authority, attr, 0.0) or 0.0))
+            except Exception:
+                pass
+        for method_name in ("get_real_capital", "get_total_capital", "get_usable_capital"):
+            method = getattr(authority, method_name, None)
+            if callable(method):
+                try:
+                    real = max(real, float(method() or 0.0))
+                except Exception:
+                    pass
+        if real <= 0.0:
+            return False, "capital_not_positive"
+        return True, "fresh_positive_publication"
+    except Exception as exc:
+        return False, f"publication_probe_error:{type(exc).__name__}:{exc}"
+
+
+def _rearm_after_publication(trigger: str) -> tuple[bool, str]:
+    fresh, reason = _publication_is_fresh()
+    if not fresh:
+        LOGGER.warning(
+            "CAPITAL_V176_REARM_BLOCKED marker=%s trigger=%s reason=%s "
+            "trading_fail_closed=true freshness_extended=false stale_promoted=false",
+            MARKER,
+            trigger,
+            reason,
+        )
+        return False, reason
+    try:
+        v16 = importlib.import_module("preactivation_readiness_convergence_v16_patch")
+        attempt = getattr(v16, "_attempt_activation", None)
+        if not callable(attempt):
+            return False, "v16_attempt_activation_missing"
+        active, details = attempt()
+        pending = list(details.get("pending") or []) if isinstance(details, dict) else []
+        state_after = details.get("state_after") if isinstance(details, dict) else None
+        state_before = details.get("state_before") if isinstance(details, dict) else None
+        LOGGER.critical(
+            "CAPITAL_V176_POST_PUBLICATION_REARM marker=%s trigger=%s active=%s "
+            "pending=%s state_before=%s state_after=%s canonical_commit_only=true "
+            "force_activation=false freshness_extended=false stale_promoted=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            trigger,
+            str(bool(active)).lower(),
+            pending,
+            state_before,
+            state_after,
+        )
+        return bool(active), "active" if active else f"pending:{','.join(pending) or 'commit_not_active'}"
+    except Exception as exc:
+        LOGGER.warning(
+            "CAPITAL_V176_REARM_ERROR marker=%s trigger=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            trigger,
+            type(exc).__name__,
+            exc,
+        )
+        return False, f"{type(exc).__name__}:{exc}"
+
+
+def _patch_coordinator() -> bool:
+    try:
+        module = importlib.import_module("bot.capital_flow_state_machine")
+        cls = getattr(module, "CapitalRefreshCoordinator", None)
+        if not isinstance(cls, type):
+            return False
+        current = getattr(cls, "execute_refresh", None)
+        if not callable(current):
+            return False
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            return True
+        original = current
+
+        @wraps(original)
+        def execute_refresh_v176(self: Any, broker_map: Any, trigger: str = "coordinator", *args: Any, **kwargs: Any):
+            snapshot = original(self, broker_map, trigger, *args, **kwargs)
+            if snapshot is not None:
+                _rearm_after_publication(str(trigger or "coordinator"))
+            return snapshot
+
+        setattr(execute_refresh_v176, _PATCH_ATTR, True)
+        setattr(execute_refresh_v176, "__wrapped__", original)
+        cls.execute_refresh = execute_refresh_v176
+        return True
+    except Exception:
+        return False
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_reactivation_v176"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        coordinator_ok = _patch_coordinator()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(coordinator_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_REACTIVATION_V176_FAILED marker=%s coordinator_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(coordinator_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_REACTIVATION_V176 marker=%s ready=true "
+            "post_publication_proof_recheck=true canonical_commit_only=true "
+            "v133_fail_closed_preserved=true freshness_ttl_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_publication_is_fresh",
+    "_rearm_after_publication",
+    "_patch_coordinator",
+]

--- a/bot/runtime_market_data_source_convergence_v177_patch.py
+++ b/bot/runtime_market_data_source_convergence_v177_patch.py
@@ -1,0 +1,237 @@
+"""Runtime market-data source convergence v177.
+
+Production evidence showed the live core loop receiving a ``KrakenBroker`` while
+Phase 3 still produced Coinbase candle timeouts and 0/30 usable frames.  v171
+bounded the work, but the stability patch targeted ``KrakenBrokerAdapter`` while
+the multi-account runtime uses ``broker_manager.KrakenBroker``.
+
+v177 patches the canonical core-loop fetch surface instead of changing execution
+routing.  For a live Kraken broker it tries Kraken's public OHLC endpoint first,
+returns a normalized pandas DataFrame when at least the shared 50-candle minimum
+is available, and otherwise falls back to the already-installed fetch chain.
+The direct read is public, bounded, cached, and has no nonce/order side effects.
+Unknown Kraken pairs fail back to the existing broker logic; no signal, risk,
+capital, or order gate is relaxed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_market_data_source_convergence_v177")
+MARKER = "20260821-runtime-market-data-source-convergence-v177"
+RELEASE_ID = "20260821-runtime-convergence-v177"
+_READY_FLAG = "NIJA_RUNTIME_MARKET_DATA_SOURCE_CONVERGENCE_V177_READY"
+_PATCH_ATTR = "_nija_runtime_market_data_source_convergence_v177"
+_LOCK = threading.RLock()
+_CACHE_LOCK = threading.RLock()
+_CACHE: dict[tuple[str, str], tuple[float, Any]] = {}
+_MIN_CANDLES = 50
+
+
+def _broker_name(broker: Any) -> str:
+    for attr in ("broker_type", "name", "broker_name", "exchange", "exchange_name"):
+        try:
+            value = getattr(broker, attr, None)
+            raw = getattr(value, "value", value)
+            text = str(raw or "").strip().lower()
+            if "kraken" in text:
+                return "kraken"
+        except Exception:
+            pass
+    return "kraken" if "kraken" in type(broker).__name__.lower() else "unknown"
+
+
+def _normalize_symbol(symbol: Any) -> str:
+    raw = str(symbol or "").strip().upper().replace("/", "-").replace("_", "-")
+    if "-" in raw:
+        base, quote = raw.rsplit("-", 1)
+    else:
+        quote = ""
+        for candidate in ("USDT", "USDC", "USD", "EUR"):
+            if raw.endswith(candidate) and len(raw) > len(candidate):
+                base, quote = raw[: -len(candidate)], candidate
+                break
+        else:
+            return ""
+    if quote == "USDC" and str(os.environ.get("NIJA_MARKET_DATA_MAP_USDC_TO_USD", "true")).lower() in {"1", "true", "yes", "on"}:
+        quote = "USD"
+    if base == "BTC":
+        base = "XBT"
+    if quote not in {"USD", "USDT", "EUR"}:
+        return ""
+    return f"{base}{quote}"
+
+
+def _public_kraken_frame(symbol: Any, timeframe: str = "5m") -> Any:
+    pair = _normalize_symbol(symbol)
+    if not pair:
+        return None
+    cache_ttl = max(1.0, float(os.environ.get("NIJA_V177_OHLC_CACHE_TTL_S", "20") or 20))
+    key = (pair, str(timeframe or "5m").lower())
+    now = time.time()
+    with _CACHE_LOCK:
+        cached = _CACHE.get(key)
+        if cached and now - cached[0] <= cache_ttl:
+            return cached[1]
+
+    try:
+        requests = importlib.import_module("requests")
+        pd = importlib.import_module("pandas")
+    except Exception:
+        return None
+
+    interval_map = {"1m": 1, "5m": 5, "15m": 15, "30m": 30, "1h": 60, "4h": 240, "1d": 1440}
+    interval = interval_map.get(key[1], 5)
+    timeout_s = max(1.0, min(8.0, float(os.environ.get("NIJA_V177_KRAKEN_PUBLIC_TIMEOUT_S", "4") or 4)))
+    try:
+        response = requests.get(
+            "https://api.kraken.com/0/public/OHLC",
+            params={"pair": pair, "interval": interval},
+            timeout=timeout_s,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("error"):
+            return None
+        result = payload.get("result") or {}
+        rows = next((value for name, value in result.items() if name != "last" and isinstance(value, list)), None)
+        if not rows:
+            return None
+        rows = rows[-200:]
+        normalized = []
+        for row in rows:
+            try:
+                normalized.append(
+                    {
+                        "timestamp": int(float(row[0])),
+                        "open": float(row[1]),
+                        "high": float(row[2]),
+                        "low": float(row[3]),
+                        "close": float(row[4]),
+                        "volume": float(row[6] if len(row) > 6 else row[5]),
+                    }
+                )
+            except Exception:
+                continue
+        if len(normalized) < _MIN_CANDLES:
+            return None
+        frame = pd.DataFrame(normalized)
+        if len(frame) < _MIN_CANDLES or "volume" not in frame.columns:
+            return None
+        with _CACHE_LOCK:
+            _CACHE[key] = (time.time(), frame)
+        LOGGER.info(
+            "MARKET_DATA_V177_KRAKEN_PUBLIC_OK marker=%s symbol=%s pair=%s rows=%d timeout_s=%.1f",
+            MARKER,
+            symbol,
+            pair,
+            len(frame),
+            timeout_s,
+        )
+        return frame
+    except Exception as exc:
+        LOGGER.debug(
+            "MARKET_DATA_V177_KRAKEN_PUBLIC_MISS marker=%s symbol=%s pair=%s error=%s:%s",
+            MARKER,
+            symbol,
+            pair,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def _patch_core_loop() -> bool:
+    try:
+        core = importlib.import_module("bot.nija_core_loop")
+        cls = getattr(core, "NijaCoreLoop", None)
+        if not isinstance(cls, type):
+            return False
+        current = getattr(cls, "_fetch_df", None)
+        if not callable(current):
+            return False
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            return True
+        original = current
+
+        @wraps(original)
+        def fetch_df_v177(self: Any, broker: Any, symbol: Any, *args: Any, **kwargs: Any):
+            if _broker_name(broker) == "kraken":
+                timeframe = str(kwargs.get("timeframe") or "5m")
+                frame = _public_kraken_frame(symbol, timeframe)
+                if frame is not None:
+                    try:
+                        if len(frame) >= _MIN_CANDLES:
+                            return frame
+                    except Exception:
+                        pass
+            return original(self, broker, symbol, *args, **kwargs)
+
+        setattr(fetch_df_v177, _PATCH_ATTR, True)
+        setattr(fetch_df_v177, "__wrapped__", original)
+        cls._fetch_df = fetch_df_v177
+        return True
+    except Exception:
+        return False
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_market_data_source_convergence_v177"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        os.environ.setdefault("NIJA_V177_KRAKEN_PUBLIC_TIMEOUT_S", "4")
+        os.environ.setdefault("NIJA_V177_OHLC_CACHE_TTL_S", "20")
+        core_ok = _patch_core_loop()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(core_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_MARKET_DATA_SOURCE_CONVERGENCE_V177_FAILED marker=%s core_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(core_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_MARKET_DATA_SOURCE_CONVERGENCE_V177 marker=%s ready=true "
+            "live_kraken_public_ohlc_first=true min_candles=%d bounded_timeout=true cache=true "
+            "execution_routing_unchanged=true signal_thresholds_unchanged=true forced_trade=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            _MIN_CANDLES,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_broker_name",
+    "_normalize_symbol",
+    "_public_kraken_frame",
+    "_patch_core_loop",
+]

--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -17,10 +17,13 @@ market-data path used by Phase 3, v172 aligns the finite post-core activation
 wait with the longer capital convergence budget without changing any gate, v173
 keeps Kraken's post-Balance valuation tail from self-amplifying stale balance
 flights, v174 admits an already-fresh, sequence-fenced Kraken observation without
-re-waiting the full proactive budget, and v175 restores process-local writer
+re-waiting the full proactive budget, v175 restores process-local writer
 lineage only from exact current Redis ownership while making the v161 position
 monitor prefer the populated canonical broker manager over empty compatibility
-aliases.
+aliases, v176 immediately re-evaluates canonical activation after an accepted
+fresh capital publication, and v177 gives the live Kraken Phase-3 path a bounded
+public-OHLC-first source so a Kraken scan does not depend on a slow Coinbase
+candle fallback.
 """
 from __future__ import annotations
 
@@ -182,6 +185,20 @@ def _install_v175_authority_position_convergence() -> bool:
     )
 
 
+def _install_v176_capital_reactivation() -> bool:
+    return _install_named(
+        "bot.runtime_capital_reactivation_v176_patch",
+        "RUNTIME_CAPITAL_REACTIVATION_V176",
+    )
+
+
+def _install_v177_market_data_source_convergence() -> bool:
+    return _install_named(
+        "bot.runtime_market_data_source_convergence_v177_patch",
+        "RUNTIME_MARKET_DATA_SOURCE_CONVERGENCE_V177",
+    )
+
+
 def install() -> bool:
     with _LOCK:
         try:
@@ -207,6 +224,8 @@ def install() -> bool:
         v173_ok = _install_v173_kraken_capital_tail_liveness()
         v174_ok = _install_v174_kraken_capital_observation_admission()
         v175_ok = _install_v175_authority_position_convergence()
+        v176_ok = _install_v176_capital_reactivation()
+        v177_ok = _install_v177_market_data_source_convergence()
         ready = bool(
             verified
             and periodic_ok
@@ -219,13 +238,15 @@ def install() -> bool:
             and v173_ok
             and v174_ok
             and v175_ok
+            and v176_ok
+            and v177_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
                 "manifest_ok=%s v168_ok=%s v169_ok=%s v170_ok=%s v171_ok=%s v172_ok=%s "
-                "v173_ok=%s v174_ok=%s v175_ok=%s trading_fail_closed=true",
+                "v173_ok=%s v174_ok=%s v175_ok=%s v176_ok=%s v177_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
@@ -238,6 +259,8 @@ def install() -> bool:
                 str(v173_ok).lower(),
                 str(v174_ok).lower(),
                 str(v175_ok).lower(),
+                str(v176_ok).lower(),
+                str(v177_ok).lower(),
             )
             return False
         LOGGER.critical(
@@ -247,7 +270,8 @@ def install() -> bool:
             "v169_execution_capital_integrity=true v170_capital_monotonicity=true "
             "v171_market_data_concurrency=true v172_post_core_activation_budget=true "
             "v173_kraken_capital_tail_liveness=true v174_kraken_observation_admission=true "
-            "v175_authority_position_convergence=true publication_expiry_extended=false "
+            "v175_authority_position_convergence=true v176_capital_reactivation=true "
+            "v177_market_data_source_convergence=true publication_expiry_extended=false "
             "stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
@@ -272,4 +296,6 @@ __all__ = [
     "_install_v173_kraken_capital_tail_liveness",
     "_install_v174_kraken_capital_observation_admission",
     "_install_v175_authority_position_convergence",
+    "_install_v176_capital_reactivation",
+    "_install_v177_market_data_source_convergence",
 ]

--- a/tests/test_runtime_convergence_v176_v177.py
+++ b/tests/test_runtime_convergence_v176_v177.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import types
+
+import bot.runtime_capital_reactivation_v176_patch as v176
+import bot.runtime_market_data_source_convergence_v177_patch as v177
+
+
+def test_v177_normalizes_kraken_market_data_symbols():
+    assert v177._normalize_symbol("BTC-USD") == "XBTUSD"
+    assert v177._normalize_symbol("ETH/USDT") == "ETHUSDT"
+    assert v177._normalize_symbol("SOL_USDC") == "SOLUSD"
+    assert v177._normalize_symbol("broken") == ""
+
+
+def test_v177_recognizes_live_kraken_broker_class():
+    KrakenBroker = type("KrakenBroker", (), {})
+    CoinbaseBroker = type("CoinbaseBroker", (), {})
+    assert v177._broker_name(KrakenBroker()) == "kraken"
+    assert v177._broker_name(CoinbaseBroker()) == "unknown"
+
+
+def test_v176_rearm_uses_existing_proof_based_activation(monkeypatch):
+    monkeypatch.setattr(v176, "_publication_is_fresh", lambda: (True, "fresh"))
+
+    fake_v16 = types.SimpleNamespace(
+        _attempt_activation=lambda: (
+            True,
+            {
+                "pending": [],
+                "state_before": "OFF",
+                "state_after": "LIVE_ACTIVE",
+            },
+        )
+    )
+    original_import = v176.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "preactivation_readiness_convergence_v16_patch":
+            return fake_v16
+        return original_import(name)
+
+    monkeypatch.setattr(v176.importlib, "import_module", fake_import)
+    active, reason = v176._rearm_after_publication("test")
+    assert active is True
+    assert reason == "active"
+
+
+def test_v176_never_rearms_stale_publication(monkeypatch):
+    monkeypatch.setattr(v176, "_publication_is_fresh", lambda: (False, "publication_stale"))
+    active, reason = v176._rearm_after_publication("test")
+    assert active is False
+    assert reason == "publication_stale"


### PR DESCRIPTION
## What this fixes

Production logs from 2026-08-21 showed two remaining live-trading blockers:

1. A complete 3/3 capital snapshot ($342.13) could publish after v133 had already revoked `capital_ready`, leaving the canonical FSM OFF until a later monitor tick.
2. Phase3 was running with a live `KrakenBroker` but returned 0/30 usable candle frames while Coinbase candle fallbacks timed out.

## Changes

- **v176 capital reactivation convergence**
  - Hooks the canonical `CapitalRefreshCoordinator.execute_refresh` success path.
  - Re-runs the existing v16/v133 proof-based activation path immediately after a fresh positive publication.
  - Does not extend freshness TTL, promote stale data, force activation, or bypass safety gates.

- **v177 market-data source convergence**
  - Adds a bounded/cacheable Kraken public OHLC-first read at the canonical core-loop `_fetch_df` surface for live Kraken scans.
  - Preserves the existing fetch chain as fallback.
  - Does not alter execution routing, signal thresholds, risk gates, nonce rules, or order semantics.

- Wires v176/v177 into the existing v167 runtime convergence install chain.
- Adds focused regression tests for proof-based reactivation and Kraken symbol/source handling.

## Safety invariants preserved

- v133 fail-closed behavior remains authoritative.
- Canonical commit is still required for activation.
- No forced trades.
- No kill-switch, nonce, risk, capital TTL, or execution-authority bypasses.