### PR TITLE
Fix v167 syntax and restore v176-v177 runtime chain

### DIFF
--- a/bot/runtime_refresh_demand_v167_patch.py
+++ b/bot/runtime_refresh_demand_v167_patch.py
@@ -20,13 +20,10 @@ flights, v174 admits an already-fresh, sequence-fenced Kraken observation withou
 re-waiting the full proactive budget, v175 restores process-local writer
 lineage only from exact current Redis ownership while making the v161 position
 monitor prefer the populated canonical broker manager over empty compatibility
-aliases, and v176 keeps proactive caller-thread deadline context intact while
-moving best-effort capital-state persistence off the live publication critical
-path.
-aliases, v176 immediately re-evaluates canonical activation after an accepted
-fresh capital publication, and v177 gives the live Kraken Phase-3 path a bounded
-public-OHLC-first source so a Kraken scan does not depend on a slow Coinbase
-candle fallback.
+aliases, v176 preserves proactive capital-pipeline completion and immediately
+re-evaluates canonical activation after an accepted fresh capital publication,
+and v177 gives the live Kraken Phase-3 path a bounded public-OHLC-first source
+so a Kraken scan does not depend on a slow Coinbase candle fallback.
 """
 from __future__ import annotations
 
@@ -192,6 +189,9 @@ def _install_v176_capital_pipeline_completion() -> bool:
     return _install_named(
         "bot.runtime_capital_pipeline_completion_v176_patch",
         "RUNTIME_CAPITAL_PIPELINE_COMPLETION_V176",
+    )
+
+
 def _install_v176_capital_reactivation() -> bool:
     return _install_named(
         "bot.runtime_capital_reactivation_v176_patch",
@@ -231,8 +231,8 @@ def install() -> bool:
         v173_ok = _install_v173_kraken_capital_tail_liveness()
         v174_ok = _install_v174_kraken_capital_observation_admission()
         v175_ok = _install_v175_authority_position_convergence()
-        v176_ok = _install_v176_capital_pipeline_completion()
-        v176_ok = _install_v176_capital_reactivation()
+        v176_pipeline_ok = _install_v176_capital_pipeline_completion()
+        v176_reactivation_ok = _install_v176_capital_reactivation()
         v177_ok = _install_v177_market_data_source_convergence()
         ready = bool(
             verified
@@ -246,7 +246,8 @@ def install() -> bool:
             and v173_ok
             and v174_ok
             and v175_ok
-            and v176_ok
+            and v176_pipeline_ok
+            and v176_reactivation_ok
             and v177_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
@@ -254,8 +255,8 @@ def install() -> bool:
             LOGGER.critical(
                 "RUNTIME_REFRESH_DEMAND_V167_FAILED marker=%s v32_verified=%s periodic_fallback_ok=%s "
                 "manifest_ok=%s v168_ok=%s v169_ok=%s v170_ok=%s v171_ok=%s v172_ok=%s "
-                "v173_ok=%s v174_ok=%s v175_ok=%s v176_ok=%s trading_fail_closed=true",
-                "v173_ok=%s v174_ok=%s v175_ok=%s v176_ok=%s v177_ok=%s trading_fail_closed=true",
+                "v173_ok=%s v174_ok=%s v175_ok=%s v176_pipeline_ok=%s "
+                "v176_reactivation_ok=%s v177_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(verified).lower(),
                 str(periodic_ok).lower(),
@@ -268,7 +269,8 @@ def install() -> bool:
                 str(v173_ok).lower(),
                 str(v174_ok).lower(),
                 str(v175_ok).lower(),
-                str(v176_ok).lower(),
+                str(v176_pipeline_ok).lower(),
+                str(v176_reactivation_ok).lower(),
                 str(v177_ok).lower(),
             )
             return False
@@ -280,10 +282,8 @@ def install() -> bool:
             "v171_market_data_concurrency=true v172_post_core_activation_budget=true "
             "v173_kraken_capital_tail_liveness=true v174_kraken_observation_admission=true "
             "v175_authority_position_convergence=true v176_capital_pipeline_completion=true "
+            "v176_capital_reactivation=true v177_market_data_source_convergence=true "
             "publication_expiry_extended=false stale_promoted=false safety_gates_bypassed=false",
-            "v175_authority_position_convergence=true v176_capital_reactivation=true "
-            "v177_market_data_source_convergence=true publication_expiry_extended=false "
-            "stale_promoted=false safety_gates_bypassed=false",
             MARKER,
         )
         return True


### PR DESCRIPTION
Production deployment `76c376f4cdb00ba9d4edfc5c5d1a7a8649d83a4c` fails to install `runtime_refresh_demand_v167_patch.py` with `SyntaxError: '(' was never closed` at line 192. The failure came from an interleaved merge of the pre-existing v176 capital-pipeline completion installer with the newer v176 capital-reactivation and v177 market-data convergence installers.

This repair:
- closes the broken `_install_v176_capital_pipeline_completion()` call;
- keeps both v176 patches as separate readiness checks (`v176_pipeline_ok` and `v176_reactivation_ok`);
- retains v177 market-data source convergence in the same deterministic install chain;
- fixes duplicated/misaligned failure and success logging arguments;
- preserves all fail-closed capital, writer, nonce, risk, kill-switch, and execution-authority behavior.

Local syntax validation: `python -m py_compile bot/runtime_refresh_demand_v167_patch.py` passes.