### PR TITLE
Arm v180 before first startup capital refresh

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -148,18 +148,56 @@ def _install_canonical_import_shield_v123() -> bool:
         return False
 
 
+def _install_capital_v180_early(*, mode: str) -> bool:
+    """Arm only v180's CapitalAuthority guard before bot_main can refresh capital.
+
+    The full v180 installer also edits the release manifest, which belongs to the
+    later post-import convergence chain. At the entrypoint we need only the
+    idempotent CapitalAuthority.refresh wrapper so the first post-bootstrap
+    private fallback cannot become a second capital writer.
+    """
+    try:
+        module_name = "bot.runtime_capital_direct_refresh_downgrade_v180_patch"
+        module = _canonical_fast_import(module_name) if mode == "canonical_fast" else importlib.import_module(module_name)
+        patcher = getattr(module, "_patch_capital_authority", None)
+        if not callable(patcher) or patcher() is False:
+            raise RuntimeError("v180 capital authority patcher unavailable or returned false")
+        logger.critical(
+            "CAPITAL_V180_EARLY_ENTRYPOINT_READY source=bot_entrypoint mode=%s "
+            "before_bot_main=true release_manifest_deferred=true "
+            "freshness_extended=false safety_gates_unchanged=true",
+            mode,
+        )
+        return True
+    except Exception as exc:
+        logger.critical(
+            "CAPITAL_V180_EARLY_ENTRYPOINT_FAILED source=bot_entrypoint mode=%s "
+            "err=%s trading_fail_closed=true",
+            mode,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
+def _fail_closed_startup(reason: str) -> None:
+    os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
+    os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
+    raise RuntimeError(reason)
+
+
 if _canonical_fast_path_enabled():
     if not _install_canonical_import_shield_v123():
-        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
-        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
-        raise RuntimeError("canonical import shield failed; trading remains fail closed")
+        _fail_closed_startup("canonical import shield failed; trading remains fail closed")
+    if not _install_capital_v180_early(mode="canonical_fast"):
+        _fail_closed_startup("v180 early capital guard failed; trading remains fail closed")
     if not _install_guards(_FAST_PATH_INSTALLERS, mode="canonical_fast", optional_labels=_FAST_PATH_COMPAT_OPTIONAL_GUARDS):
-        os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"
-        os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"
-        raise RuntimeError("canonical fast-path safety guards failed; trading remains fail closed")
-    logger.critical("CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred import_shield_v123=true handoff=bot.bot_main", _FAST_PATH_MARKER)
+        _fail_closed_startup("canonical fast-path safety guards failed; trading remains fail closed")
+    logger.critical("CANONICAL_ENTRYPOINT_FAST_PATH_READY marker=%s import_loader=frozen_bootstrap package_hook_fanout=deferred import_shield_v123=true capital_v180_early=true handoff=bot.bot_main", _FAST_PATH_MARKER)
 else:
     logger.warning("BOT_ENTRYPOINT_LEGACY_COMPATIBILITY_PATH marker=%s canonical_fast_path=false", _FAST_PATH_MARKER)
+    if not _install_capital_v180_early(mode="legacy_compatibility"):
+        _fail_closed_startup("v180 early capital guard failed; trading remains fail closed")
     _install_guards(_LEGACY_INSTALLERS, mode="legacy_compatibility")
 
 from bot.bot_main import main

--- a/tests/test_runtime_capital_v180_early_entrypoint.py
+++ b/tests/test_runtime_capital_v180_early_entrypoint.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+def test_v180_guard_is_armed_before_fast_guard_bundle_and_bot_main() -> None:
+    source = (Path(__file__).parents[1] / "bot" / "bot.py").read_text(encoding="utf-8")
+    canonical = source.split("if _canonical_fast_path_enabled():", 1)[1].split("else:", 1)[0]
+
+    early_call = '_install_capital_v180_early(mode="canonical_fast")'
+    bundle_call = "_install_guards(_FAST_PATH_INSTALLERS"
+
+    assert "bot.runtime_capital_direct_refresh_downgrade_v180_patch" in source
+    assert "_patch_capital_authority" in source
+    assert "release_manifest_deferred=true" in source
+    assert early_call in canonical
+    assert bundle_call in canonical
+    assert canonical.index(early_call) < canonical.index(bundle_call)
+    assert source.index(early_call) < source.index("from bot.bot_main import main")
+
+
+def test_v180_early_guard_is_fail_closed() -> None:
+    source = (Path(__file__).parents[1] / "bot" / "bot.py").read_text(encoding="utf-8")
+
+    assert "CAPITAL_V180_EARLY_ENTRYPOINT_FAILED" in source
+    assert 'os.environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] = "0"' in source
+    assert 'os.environ["NIJA_RUNTIME_TRADING_STATE"] = "OFF"' in source
+    assert "v180 early capital guard failed; trading remains fail closed" in source


### PR DESCRIPTION
## Summary
- arm v180's CapitalAuthority guard in the canonical bot entrypoint before `bot_main` starts
- call only v180's lightweight `_patch_capital_authority()` early; defer release-manifest mutation to the normal late convergence chain
- fail closed if the early guard cannot install
- keep legacy compatibility path protected as well
- add regression tests proving v180 is armed before the fast guard bundle / `bot_main` and that installation failure disables runtime execution authority

## Production evidence
Deployment `68b99033c0cd4746441dd6ef7c1daff297009093` showed the 2/3 CapitalAuthority snapshot existed at 21:51:05, while v180 did not install until 21:51:27. v180 therefore worked as designed but arrived too late to prevent the first startup downgrade.

## Safety
- no capital fabrication or balance merge
- no freshness/publication-expiry extension
- no stale promotion
- no kill-switch, writer, nonce, risk, strategy, or execution-gate bypass
- startup remains fail closed if the early guard cannot be armed

## Validation
- `py_compile` passed for modified entrypoint and new test
- focused entrypoint ordering/fail-closed tests passed: `2 passed`
- diff limited to `bot/bot.py` and `tests/test_runtime_capital_v180_early_entrypoint.py`