### PR TITLE
Reject incomplete registered bootstrap capital fallback v180

### DIFF
--- a/bot/runtime_capital_direct_refresh_downgrade_v180_patch.py
+++ b/bot/runtime_capital_direct_refresh_downgrade_v180_patch.py
@@ -1,26 +1,29 @@
-"""Prevent post-bootstrap direct fallback from downgrading canonical capital.
+"""Prevent private direct fallback from downgrading canonical capital.
 
-Production on 2026-08-21 proved a runtime-only capital split after the canonical
-coordinator had already established complete three-broker state. During a
-coordinator rollover/in-flight gap, ``MultiAccountBrokerManager`` may fall back
-to ``CapitalAuthority.refresh(..., _bypass_startup_lock=True)``. Base
-``CapitalAuthority.refresh`` replaces the complete internal balance map with the
-results of that direct refresh and stamps ``last_updated`` to now. A slow or
-failed Kraken read can therefore replace a complete 3/3 state with 2/3 before
-v170 correctly rejects the partial publication.
+Production on 2026-08-21 proved two runtime-only failure modes around
+``MultiAccountBrokerManager``'s coordinator-unavailable fallback to
+``CapitalAuthority.refresh(..., _bypass_startup_lock=True)``:
 
-v180 restores single-writer ownership after bootstrap:
+* after a complete canonical broker set exists, a later private fallback can
+  become a second writer and replace 3/3 capital with a partial map; and
+* after broker registration is finalized, the *first* private fallback can
+  arrive with only 2/3 expected broker inputs and seed an incomplete canonical
+  CapitalAuthority state before the coordinator publishes a complete snapshot.
 
-* the call must use the private ``_bypass_startup_lock`` fallback flag;
+v180 enforces the private-fallback boundary without weakening bootstrap:
+
+* the call must use the private ``_bypass_startup_lock`` flag;
 * broker registration must already be finalized;
-* CapitalAuthority must already hold at least ``expected_brokers`` entries;
-* once that complete canonical state exists, any later private bypass refresh is
-  suppressed and the canonical coordinator remains the only runtime writer.
+* if CapitalAuthority already holds a complete canonical set, every later
+  private fallback is suppressed so the coordinator remains the only writer;
+* if CapitalAuthority is still incomplete, an incomplete private input map is
+  suppressed, but a complete expected-broker input map remains allowed to build
+  the initial bootstrap snapshot.
 
-The suppressed fallback does not merge balances, mutate ``last_updated``, extend
-freshness/publication expiry, promote stale data, fabricate a broker balance,
-change writer/nonce/risk/kill-switch authority, or force activation/trading.
-Cold/bootstrap refreshes and ordinary non-bypass refreshes continue unchanged.
+Suppression does not merge balances, mutate ``last_updated``, extend freshness
+or publication expiry, promote stale data, fabricate a broker balance, change
+writer/nonce/risk/kill-switch authority, or force activation/trading.
+Pre-registration bootstrap and ordinary non-bypass refreshes remain unchanged.
 """
 from __future__ import annotations
 
@@ -102,6 +105,9 @@ def _should_suppress_direct_fallback(
     incoming = _incoming_keys(broker_map)
     covered = existing.intersection(incoming)
     missing = sorted(existing.difference(incoming))
+    registration_complete = _registration_complete(authority)
+    existing_complete = len(existing) >= expected
+    incoming_complete = len(incoming) >= expected
 
     metadata = {
         "expected": expected,
@@ -109,20 +115,22 @@ def _should_suppress_direct_fallback(
         "incoming": sorted(incoming),
         "covered": sorted(covered),
         "missing": missing,
-        "registration_complete": _registration_complete(authority),
+        "registration_complete": registration_complete,
         "bypass_startup_lock": bool(bypass_startup_lock),
+        "existing_complete": existing_complete,
+        "incoming_complete": incoming_complete,
     }
 
-    # The private bypass exists to build the initial bootstrap snapshot. Once a
-    # complete canonical broker set already exists after registration, allowing
-    # this fallback to run creates a second capital writer. Preserve the exact
-    # prior state and let the coordinator refresh it; if it expires meanwhile,
-    # normal freshness gates fail closed.
+    # The private bypass exists only to build the initial bootstrap snapshot.
+    # Once registration is finalized, it must never publish an incomplete input
+    # map. A complete bootstrap input remains allowed while CA itself is still
+    # incomplete. Once CA has a complete canonical set, every later private
+    # fallback is suppressed so the coordinator remains the sole runtime writer.
     suppress = bool(
         bypass_startup_lock
-        and metadata["registration_complete"]
+        and registration_complete
         and expected > 1
-        and len(existing) >= expected
+        and (existing_complete or not incoming_complete)
     )
     return suppress, metadata
 
@@ -159,19 +167,28 @@ def _patch_capital_authority() -> bool:
         )
         if suppress:
             last_updated = getattr(self, "last_updated", None)
+            reason = (
+                "prior_complete_state"
+                if metadata["existing_complete"]
+                else "registered_incomplete_input"
+            )
             LOGGER.critical(
-                "CAPITAL_V180_DIRECT_FALLBACK_SUPPRESSED marker=%s "
+                "CAPITAL_V180_DIRECT_FALLBACK_SUPPRESSED marker=%s reason=%s "
                 "incoming=%s existing=%s missing=%s covered=%d expected=%d "
+                "incoming_complete=%s existing_complete=%s "
                 "registration_complete=true bypass_startup_lock=true "
                 "last_updated=%s balances_mutated=false last_updated_mutated=false "
                 "freshness_extended=false publication_expiry_extended=false "
                 "stale_promoted=false trading_fail_closed=true",
                 MARKER,
+                reason,
                 metadata["incoming"],
                 metadata["existing"],
                 metadata["missing"],
                 len(metadata["covered"]),
                 int(metadata["expected"]),
+                str(metadata["incoming_complete"]).lower(),
+                str(metadata["existing_complete"]).lower(),
                 last_updated,
             )
             return None
@@ -221,8 +238,9 @@ def install() -> bool:
 
         LOGGER.critical(
             "RUNTIME_CAPITAL_DIRECT_REFRESH_DOWNGRADE_V180 marker=%s ready=true "
-            "private_fallback_only=true prior_complete_state_required=true "
-            "post_bootstrap_direct_fallback_suppressed=true cold_bootstrap_unchanged=true "
+            "private_fallback_only=true prior_complete_state_required=false "
+            "registered_incomplete_input_rejected=true complete_bootstrap_input_allowed=true "
+            "post_bootstrap_direct_fallback_suppressed=true pre_registration_bootstrap_unchanged=true "
             "canonical_coordinator_single_writer=true balances_mutated_on_reject=false "
             "last_updated_mutated_on_reject=false freshness_extended=false "
             "publication_expiry_extended=false stale_promoted=false forced_trade=false "

--- a/tests/test_runtime_capital_direct_refresh_downgrade_v180.py
+++ b/tests/test_runtime_capital_direct_refresh_downgrade_v180.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import importlib
 import threading
 from datetime import datetime, timezone
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 from bot import runtime_capital_direct_refresh_downgrade_v180_patch as patch
 
@@ -33,6 +34,8 @@ def test_complete_post_bootstrap_state_suppresses_private_partial_fallback() -> 
 
     assert suppress is True
     assert details["expected"] == 3
+    assert details["existing_complete"] is True
+    assert details["incoming_complete"] is False
     assert details["missing"] == ["kraken"]
 
 
@@ -48,25 +51,41 @@ def test_complete_post_bootstrap_state_also_suppresses_complete_private_fallback
     )
 
     assert suppress is True
+    assert details["existing_complete"] is True
+    assert details["incoming_complete"] is True
     assert details["missing"] == []
 
 
-def test_cold_or_incomplete_authority_keeps_bootstrap_fallback_available() -> None:
+def test_registered_incomplete_authority_rejects_private_partial_bootstrap_fallback() -> None:
     authority = _authority(balances={"coinbase": 95.12})
 
-    suppress, _ = patch._should_suppress_direct_fallback(
+    suppress, details = patch._should_suppress_direct_fallback(
         authority,
         {"coinbase": object(), "okx": object()},
         bypass_startup_lock=True,
     )
 
+    assert suppress is True
+    assert details["existing_complete"] is False
+    assert details["incoming_complete"] is False
+
+
+def test_registered_incomplete_authority_allows_complete_private_bootstrap_fallback() -> None:
+    authority = _authority(balances={"coinbase": 95.12})
+
+    suppress, details = patch._should_suppress_direct_fallback(
+        authority,
+        {"kraken": object(), "coinbase": object(), "okx": object()},
+        bypass_startup_lock=True,
+    )
+
     assert suppress is False
+    assert details["existing_complete"] is False
+    assert details["incoming_complete"] is True
 
 
 def test_non_bypass_refresh_is_outside_v180_scope() -> None:
-    authority = _authority(
-        balances={"kraken": 154.49, "coinbase": 95.12, "okx": 0.0}
-    )
+    authority = _authority(balances={"coinbase": 95.12})
 
     suppress, _ = patch._should_suppress_direct_fallback(
         authority,
@@ -77,11 +96,8 @@ def test_non_bypass_refresh_is_outside_v180_scope() -> None:
     assert suppress is False
 
 
-def test_registration_must_be_complete_before_runtime_suppression() -> None:
-    authority = _authority(
-        balances={"kraken": 154.49, "coinbase": 95.12, "okx": 0.0},
-        registered=False,
-    )
+def test_registration_incomplete_keeps_bootstrap_fallback_available() -> None:
+    authority = _authority(balances={"coinbase": 95.12}, registered=False)
 
     suppress, _ = patch._should_suppress_direct_fallback(
         authority,
@@ -90,6 +106,85 @@ def test_registration_must_be_complete_before_runtime_suppression() -> None:
     )
 
     assert suppress is False
+
+
+def test_actual_wrapper_does_not_call_base_for_registered_partial_input(monkeypatch) -> None:
+    calls = []
+
+    class CapitalAuthority:
+        def __init__(self) -> None:
+            self._broker_balances = {"coinbase": 95.12}
+            self._expected_brokers = 3
+            self._broker_registration_complete = threading.Event()
+            self._broker_registration_complete.set()
+            self._lock = threading.RLock()
+            self.last_updated = datetime(2026, 8, 21, 21, 0, tzinfo=timezone.utc)
+
+        def refresh(self, broker_map, open_exposure_usd=0.0, _bypass_startup_lock=False):
+            calls.append((broker_map, open_exposure_usd, _bypass_startup_lock))
+            self._broker_balances = {key: 1.0 for key in broker_map}
+
+    fake = ModuleType("bot.capital_authority")
+    fake.CapitalAuthority = CapitalAuthority
+    real_import = importlib.import_module
+    monkeypatch.setattr(
+        patch.importlib,
+        "import_module",
+        lambda name: fake if name == "bot.capital_authority" else real_import(name),
+    )
+
+    assert patch._patch_capital_authority() is True
+    authority = CapitalAuthority()
+    before = dict(authority._broker_balances)
+    before_updated = authority.last_updated
+
+    result = authority.refresh(
+        {"coinbase": object(), "okx": object()},
+        _bypass_startup_lock=True,
+    )
+
+    assert result is None
+    assert calls == []
+    assert authority._broker_balances == before
+    assert authority.last_updated == before_updated
+
+
+def test_actual_wrapper_allows_complete_first_bootstrap_input(monkeypatch) -> None:
+    calls = []
+
+    class CapitalAuthority:
+        def __init__(self) -> None:
+            self._broker_balances = {"coinbase": 95.12}
+            self._expected_brokers = 3
+            self._broker_registration_complete = threading.Event()
+            self._broker_registration_complete.set()
+            self._lock = threading.RLock()
+            self.last_updated = datetime(2026, 8, 21, 21, 0, tzinfo=timezone.utc)
+
+        def refresh(self, broker_map, open_exposure_usd=0.0, _bypass_startup_lock=False):
+            calls.append((tuple(sorted(broker_map)), open_exposure_usd, _bypass_startup_lock))
+            self._broker_balances = {key: 1.0 for key in broker_map}
+            return "base-called"
+
+    fake = ModuleType("bot.capital_authority")
+    fake.CapitalAuthority = CapitalAuthority
+    real_import = importlib.import_module
+    monkeypatch.setattr(
+        patch.importlib,
+        "import_module",
+        lambda name: fake if name == "bot.capital_authority" else real_import(name),
+    )
+
+    assert patch._patch_capital_authority() is True
+    authority = CapitalAuthority()
+    result = authority.refresh(
+        {"kraken": object(), "coinbase": object(), "okx": object()},
+        _bypass_startup_lock=True,
+    )
+
+    assert result == "base-called"
+    assert calls == [(("coinbase", "kraken", "okx"), 0.0, True)]
+    assert set(authority._broker_balances) == {"kraken", "coinbase", "okx"}
 
 
 def test_v180_exposes_no_freshness_or_execution_bypass_api() -> None:


### PR DESCRIPTION
## Summary
- extend v180 so a private `_bypass_startup_lock` CapitalAuthority fallback cannot seed an incomplete canonical snapshot after broker registration is finalized
- when three brokers are expected and CapitalAuthority is still incomplete, reject a private fallback whose input map is also incomplete
- continue allowing a genuine complete expected-broker input map to build the first bootstrap snapshot
- once a complete canonical state exists, continue suppressing every later private fallback so the coordinator remains the only runtime writer

## Production evidence
Deployment `1bd329e3efe72b22dc7aec6359d3f398810ceeb8` has healthy writer authority and 3/3 platform position sync, but CapitalAuthority still contains only Coinbase + OKX with `broker_count=2`, `expected_brokers=3`, and publication rejected as `incomplete_broker_aggregation:2/3`. The previous v180 rule required a prior complete canonical state before suppression, so it could not protect the first registered bootstrap state.

## Safety
- no capital fabrication or balance merge
- no user-account capital admitted into platform capital
- no freshness or publication-expiry extension
- no stale promotion
- no kill-switch, writer, nonce, risk, or execution-gate bypass
- incomplete state remains fail closed
- pre-registration bootstrap behavior remains unchanged

## Validation
- `py_compile` passed
- focused v180 regression suite: `9 passed`
- wrapper-level tests prove registered incomplete 2/3 private input does not call the base refresh or mutate balances/timestamp
- complete 3/3 first-bootstrap input still calls the base refresh normally
- diff limited to v180 patch + v180 regression tests