### PR TITLE
Restore v142 canonical generation context in v181

### DIFF
--- a/bot/runtime_capital_generation_context_v181_patch.py
+++ b/bot/runtime_capital_generation_context_v181_patch.py
@@ -160,6 +160,7 @@ def _patch_publication_context() -> bool:
             else:
                 setattr(local, "refresh_generation", previous)
 
+    publish_snapshot_v181.__name__ = "publish_snapshot_v181"
     setattr(publish_snapshot_v181, _PATCH_ATTR, True)
     setattr(publish_snapshot_v181, "__wrapped__", original)
     cls.publish_snapshot = publish_snapshot_v181

--- a/bot/runtime_capital_generation_context_v181_patch.py
+++ b/bot/runtime_capital_generation_context_v181_patch.py
@@ -1,0 +1,219 @@
+"""Restore canonical v142 generation context without weakening rollover fencing.
+
+Production on 2026-08-21 showed a complete three-broker proactive refresh reach
+CapitalAuthority after a v142 coordinator rollover, but the publication arrived
+at the v142 fence with no thread-local generation tag and was rejected as
+``UNTAGGED_AFTER_ROLLOVER``.  The broker aggregation itself was complete and the
+current canonical coordinator worker was still the owner.
+
+v181 repairs only that handoff.  When the exact v142 publication wrapper is in
+the active call chain, an authorized publication may temporarily recover the
+wrapper owner's generation context only if the current thread is exactly the
+canonical manager's current coordinator worker, that worker is still in-flight,
+its generation equals v142's active generation, and it has not timed out.
+Retired, detached, unknown, and unauthorized publishers remain fenced.
+
+No capital value, freshness timestamp, publication expiry, writer/nonce/risk
+state, kill switch, activation state, or execution permission is changed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_generation_context_v181")
+MARKER = "20260821-runtime-capital-generation-context-v181"
+RELEASE_ID = "20260821-runtime-convergence-v181"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_GENERATION_CONTEXT_V181_READY"
+_PATCH_ATTR = "_nija_runtime_capital_generation_context_v181"
+_LOCK = threading.RLock()
+_MISSING = object()
+
+
+def _find_v142_publication_wrapper(callable_obj: Any) -> Any:
+    """Return the exact v142 publish wrapper from a wrapped call chain."""
+    seen: set[int] = set()
+    current = callable_obj
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return None
+        seen.add(id(current))
+        if (
+            str(getattr(current, "__name__", "")) == "publish_snapshot_v142"
+            and bool(getattr(current, "_nija_capital_publication_liveness_v142", False))
+        ):
+            return current
+        current = getattr(current, "__wrapped__", None)
+    return None
+
+
+def _canonical_generation_from_v142_wrapper(wrapper: Any) -> tuple[int | None, str, Any]:
+    """Prove the current thread is the live canonical v142 coordinator worker."""
+    if not callable(wrapper):
+        return None, "v142_wrapper_missing", None
+    owner = getattr(wrapper, "__globals__", {}) or {}
+    local = owner.get("_LOCAL")
+    generation_state = owner.get("_generation_state")
+    canonical_manager = owner.get("_canonical_manager")
+    if local is None or not callable(generation_state) or not callable(canonical_manager):
+        return None, "v142_owner_context_missing", local
+    if getattr(local, "refresh_generation", None) is not None:
+        return None, "generation_already_present", local
+
+    try:
+        active, rolled = generation_state()
+        active = int(active or 0)
+    except Exception:
+        return None, "generation_state_unavailable", local
+    if not bool(rolled) or active <= 0:
+        return None, "rollover_not_active", local
+
+    try:
+        manager = canonical_manager()
+    except Exception:
+        manager = None
+    coordinator = getattr(manager, "_capital_coordinator", None) if manager is not None else None
+    if coordinator is None:
+        return None, "canonical_coordinator_missing", local
+
+    worker = getattr(coordinator, "_nija_v142_flight_thread", None)
+    if worker is not threading.current_thread():
+        return None, "not_current_canonical_worker", local
+    if not bool(getattr(coordinator, "_in_flight", False)):
+        return None, "canonical_worker_not_in_flight", local
+    if bool(getattr(coordinator, "_nija_v142_flight_timed_out", False)):
+        return None, "canonical_worker_timed_out", local
+
+    try:
+        generation = int(getattr(coordinator, "_nija_v142_flight_generation", 0) or 0)
+    except (TypeError, ValueError):
+        generation = 0
+    if generation <= 0:
+        return None, "canonical_generation_missing", local
+    if generation != active:
+        return None, f"canonical_generation_not_active:{generation}!={active}", local
+    return generation, "current_canonical_worker", local
+
+
+def _patch_publication_context() -> bool:
+    """Wrap CapitalAuthority publication and restore only proven v142 context."""
+    try:
+        v142 = importlib.import_module("bot.capital_publication_liveness_v142_patch")
+        ensure_fence = getattr(v142, "_patch_publication_generation_fence", None)
+        if not callable(ensure_fence) or not bool(ensure_fence()):
+            return False
+        ca = importlib.import_module("bot.capital_authority")
+        cls = getattr(ca, "CapitalAuthority", None)
+    except Exception:
+        return False
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "publish_snapshot", None)
+    if not callable(current):
+        return False
+    if (
+        str(getattr(current, "__name__", "")) == "publish_snapshot_v181"
+        and bool(getattr(current, _PATCH_ATTR, False))
+    ):
+        return True
+
+    v142_wrapper = _find_v142_publication_wrapper(current)
+    if not callable(v142_wrapper):
+        return False
+    original = current
+
+    @wraps(original)
+    def publish_snapshot_v181(self: Any, snapshot: Any, writer_id: str) -> bool:
+        authorized = str(writer_id or "") == str(
+            getattr(self, "_AUTHORIZED_WRITER_ID", "mabm_capital_refresh_coordinator")
+        )
+        if not authorized:
+            return bool(original(self, snapshot, writer_id))
+
+        generation, reason, local = _canonical_generation_from_v142_wrapper(v142_wrapper)
+        if generation is None or local is None:
+            return bool(original(self, snapshot, writer_id))
+
+        previous = getattr(local, "refresh_generation", _MISSING)
+        setattr(local, "refresh_generation", generation)
+        LOGGER.critical(
+            "CAPITAL_V181_CANONICAL_WORKER_GENERATION_RESTORED marker=%s generation=%d "
+            "reason=%s canonical_worker_only=true retired_workers_rejected=true "
+            "publication_expiry_extended=false freshness_extended=false safety_gates_bypassed=false",
+            MARKER,
+            generation,
+            reason,
+        )
+        try:
+            return bool(original(self, snapshot, writer_id))
+        finally:
+            if previous is _MISSING:
+                try:
+                    delattr(local, "refresh_generation")
+                except AttributeError:
+                    pass
+            else:
+                setattr(local, "refresh_generation", previous)
+
+    setattr(publish_snapshot_v181, _PATCH_ATTR, True)
+    setattr(publish_snapshot_v181, "__wrapped__", original)
+    cls.publish_snapshot = publish_snapshot_v181
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_generation_context_v181"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        publication_ok = _patch_publication_context()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(publication_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_CAPITAL_GENERATION_CONTEXT_V181_FAILED marker=%s publication_ok=%s "
+                "manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(publication_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_GENERATION_CONTEXT_V181 marker=%s ready=true "
+            "canonical_worker_generation_recovery=true retired_worker_fence_preserved=true "
+            "unknown_worker_fence_preserved=true freshness_extended=false "
+            "publication_expiry_extended=false forced_trade=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_find_v142_publication_wrapper",
+    "_canonical_generation_from_v142_wrapper",
+    "_patch_publication_context",
+    "_patch_release_manifest",
+]

--- a/bot/runtime_capital_reactivation_v176_patch.py
+++ b/bot/runtime_capital_reactivation_v176_patch.py
@@ -14,12 +14,14 @@ false proof is still revoked and LIVE state still fails closed. No freshness
 TTL, capital value, safety gate, signal threshold, nonce rule, kill switch, or
 execution permission is altered.
 
-The 2026-08-21 follow-ups install v179, v178, and v180 before the coordinator
-wrapper. v179 converges bootstrap-seed generation identity plus the canonical
-hydration event invariant; v178 repairs only the exact same-canonical-publication
-status-poisoning case for ``snapshot_not_newer``; v180 prevents a private direct
-refresh fallback from replacing a previously complete canonical broker set after
-bootstrap. None of these patches broadens freshness or activation policy.
+The 2026-08-21 follow-ups install v179, v178, v180, and v181 before the
+coordinator wrapper. v179 converges bootstrap-seed generation identity plus the
+canonical hydration event invariant; v178 repairs only the exact
+same-canonical-publication status-poisoning case for ``snapshot_not_newer``;
+v180 prevents a private direct refresh fallback from replacing a previously
+complete canonical broker set after bootstrap; v181 restores v142 generation
+context only for the exact current canonical coordinator worker after rollover.
+None of these patches broadens freshness or activation policy.
 """
 from __future__ import annotations
 
@@ -157,6 +159,13 @@ def _install_v180_direct_refresh_downgrade() -> bool:
     )
 
 
+def _install_v181_generation_context() -> bool:
+    return _install_named(
+        "bot.runtime_capital_generation_context_v181_patch",
+        "RUNTIME_CAPITAL_GENERATION_CONTEXT_V181",
+    )
+
+
 def _patch_coordinator() -> bool:
     try:
         module = importlib.import_module("bot.capital_flow_state_machine")
@@ -202,18 +211,22 @@ def install() -> bool:
         v179_ok = _install_v179_bootstrap_capital_publication()
         v178_ok = _install_v178_publication_identity()
         v180_ok = _install_v180_direct_refresh_downgrade()
+        v181_ok = _install_v181_generation_context()
         coordinator_ok = _patch_coordinator()
         manifest_ok = _patch_release_manifest()
-        ready = bool(v179_ok and v178_ok and v180_ok and coordinator_ok and manifest_ok)
+        ready = bool(
+            v179_ok and v178_ok and v180_ok and v181_ok and coordinator_ok and manifest_ok
+        )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_CAPITAL_REACTIVATION_V176_FAILED marker=%s v179_ok=%s v178_ok=%s "
-                "v180_ok=%s coordinator_ok=%s manifest_ok=%s trading_fail_closed=true",
+                "v180_ok=%s v181_ok=%s coordinator_ok=%s manifest_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(v179_ok).lower(),
                 str(v178_ok).lower(),
                 str(v180_ok).lower(),
+                str(v181_ok).lower(),
                 str(coordinator_ok).lower(),
                 str(manifest_ok).lower(),
             )
@@ -221,9 +234,10 @@ def install() -> bool:
         LOGGER.critical(
             "RUNTIME_CAPITAL_REACTIVATION_V176 marker=%s ready=true "
             "v179_bootstrap_capital_publication=true v178_publication_identity=true "
-            "v180_direct_refresh_downgrade=true post_publication_proof_recheck=true "
-            "canonical_commit_only=true v133_fail_closed_preserved=true "
-            "freshness_ttl_unchanged=true forced_activation=false safety_gates_bypassed=false",
+            "v180_direct_refresh_downgrade=true v181_generation_context=true "
+            "post_publication_proof_recheck=true canonical_commit_only=true "
+            "v133_fail_closed_preserved=true freshness_ttl_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -243,5 +257,6 @@ __all__ = [
     "_install_v179_bootstrap_capital_publication",
     "_install_v178_publication_identity",
     "_install_v180_direct_refresh_downgrade",
+    "_install_v181_generation_context",
     "_patch_coordinator",
 ]

--- a/tests/test_runtime_capital_generation_context_v181.py
+++ b/tests/test_runtime_capital_generation_context_v181.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from bot import capital_authority as ca
+from bot import capital_publication_liveness_v142_patch as v142
+from bot import runtime_capital_generation_context_v181_patch as v181
+from bot import runtime_release_manifest_patch as manifest
+
+
+def _install_chain(monkeypatch):
+    calls: list[tuple[object, str]] = []
+
+    def base_publish(self, snapshot, writer_id):
+        calls.append((snapshot, writer_id))
+        return str(writer_id) == str(self._AUTHORIZED_WRITER_ID)
+
+    monkeypatch.setattr(ca.CapitalAuthority, "publish_snapshot", base_publish)
+    monkeypatch.setattr(v142, "_ACTIVE_GENERATION", 18)
+    monkeypatch.setattr(v142, "_NEXT_GENERATION", 18)
+    monkeypatch.setattr(v142, "_ROLLOVER_OCCURRED", True)
+    try:
+        delattr(v142._LOCAL, "refresh_generation")
+    except AttributeError:
+        pass
+
+    assert v142._patch_publication_generation_fence()
+    assert v181._patch_publication_context()
+    return calls
+
+
+def _authority():
+    authority = object.__new__(ca.CapitalAuthority)
+    authority._AUTHORIZED_WRITER_ID = "mabm_capital_refresh_coordinator"
+    return authority
+
+
+def test_current_canonical_worker_can_restore_missing_generation(monkeypatch) -> None:
+    calls = _install_chain(monkeypatch)
+    coordinator = SimpleNamespace(
+        _nija_v142_flight_thread=threading.current_thread(),
+        _nija_v142_flight_generation=18,
+        _nija_v142_flight_timed_out=False,
+        _in_flight=True,
+    )
+    monkeypatch.setattr(
+        v142,
+        "_canonical_manager",
+        lambda: SimpleNamespace(_capital_coordinator=coordinator),
+    )
+
+    authority = _authority()
+    snapshot = SimpleNamespace(real_capital=347.23)
+
+    assert authority.publish_snapshot(snapshot, "mabm_capital_refresh_coordinator") is True
+    assert calls == [(snapshot, "mabm_capital_refresh_coordinator")]
+    assert not hasattr(v142._LOCAL, "refresh_generation")
+
+
+def test_retired_generation_remains_rejected(monkeypatch) -> None:
+    calls = _install_chain(monkeypatch)
+    coordinator = SimpleNamespace(
+        _nija_v142_flight_thread=threading.current_thread(),
+        _nija_v142_flight_generation=17,
+        _nija_v142_flight_timed_out=False,
+        _in_flight=True,
+    )
+    monkeypatch.setattr(
+        v142,
+        "_canonical_manager",
+        lambda: SimpleNamespace(_capital_coordinator=coordinator),
+    )
+
+    assert _authority().publish_snapshot(
+        SimpleNamespace(), "mabm_capital_refresh_coordinator"
+    ) is False
+    assert calls == []
+
+
+def test_timed_out_current_generation_remains_rejected(monkeypatch) -> None:
+    calls = _install_chain(monkeypatch)
+    coordinator = SimpleNamespace(
+        _nija_v142_flight_thread=threading.current_thread(),
+        _nija_v142_flight_generation=18,
+        _nija_v142_flight_timed_out=True,
+        _in_flight=True,
+    )
+    monkeypatch.setattr(
+        v142,
+        "_canonical_manager",
+        lambda: SimpleNamespace(_capital_coordinator=coordinator),
+    )
+
+    assert _authority().publish_snapshot(
+        SimpleNamespace(), "mabm_capital_refresh_coordinator"
+    ) is False
+    assert calls == []
+
+
+def test_detached_or_unknown_worker_remains_rejected(monkeypatch) -> None:
+    calls = _install_chain(monkeypatch)
+    coordinator = SimpleNamespace(
+        _nija_v142_flight_thread=threading.Thread(target=lambda: None),
+        _nija_v142_flight_generation=18,
+        _nija_v142_flight_timed_out=False,
+        _in_flight=True,
+    )
+    monkeypatch.setattr(
+        v142,
+        "_canonical_manager",
+        lambda: SimpleNamespace(_capital_coordinator=coordinator),
+    )
+
+    assert _authority().publish_snapshot(
+        SimpleNamespace(), "mabm_capital_refresh_coordinator"
+    ) is False
+    assert calls == []
+
+
+def test_unauthorized_writer_is_not_promoted(monkeypatch) -> None:
+    calls = _install_chain(monkeypatch)
+    coordinator = SimpleNamespace(
+        _nija_v142_flight_thread=threading.current_thread(),
+        _nija_v142_flight_generation=18,
+        _nija_v142_flight_timed_out=False,
+        _in_flight=True,
+    )
+    monkeypatch.setattr(
+        v142,
+        "_canonical_manager",
+        lambda: SimpleNamespace(_capital_coordinator=coordinator),
+    )
+
+    snapshot = SimpleNamespace()
+    assert _authority().publish_snapshot(snapshot, "not-authorized") is False
+    assert calls == [(snapshot, "not-authorized")]
+    assert not hasattr(v142._LOCAL, "refresh_generation")
+
+
+def test_release_manifest_and_safety_environment_are_preserved(monkeypatch) -> None:
+    monkeypatch.setattr(manifest, "_REQUIRED_FLAGS", dict(manifest._REQUIRED_FLAGS))
+    monkeypatch.setenv("NIJA_EMERGENCY_STOP", "1")
+    monkeypatch.setenv("NIJA_NONCE_READY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+
+    assert v181._patch_release_manifest()
+    assert manifest._REQUIRED_FLAGS["runtime_capital_generation_context_v181"] == (
+        "NIJA_RUNTIME_CAPITAL_GENERATION_CONTEXT_V181_READY"
+    )
+    assert v181._find_v142_publication_wrapper(lambda: None) is None
+
+    assert __import__("os").environ["NIJA_EMERGENCY_STOP"] == "1"
+    assert __import__("os").environ["NIJA_NONCE_READY"] == "0"
+    assert __import__("os").environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"


### PR DESCRIPTION
Production evidence on deployment `3ddccccf98267c3325feb2db4a142a535fb23a2d` showed a complete three-broker proactive capital refresh (`included=['coinbase','kraken','okx']`, snapshot total ~$347.23) being rejected by v142 as `CAPITAL_PUBLICATION_V142_UNTAGGED_AFTER_ROLLOVER_REJECTED`, leaving publication expiry missing and activation fail-closed.

This PR adds v181 generation-context recovery. It restores v142's thread-local generation only when the publisher is provably the exact current canonical coordinator worker: same current worker thread, in flight, not timed out, and coordinator generation equals v142's active generation. Retired, detached, unknown, timed-out, and unauthorized publishers remain rejected by the existing v142 fence.

It wires v181 into the existing runtime capital-reactivation installer before the post-publication rearm and adds regression coverage for current canonical acceptance plus retired/timed-out/detached rejection and safety-environment preservation.

No freshness TTL, publication expiry, capital values, kill switch, writer/nonce authority, risk gates, v169 execution-proof rules, or activation policy are weakened. Position-sync fetch proof remains fail-closed.

Validation performed locally:
- `py_compile` passed for the new v181 module and updated v176 installer.
- Focused v181 safety self-test passed for current canonical acceptance and retired/timed-out/detached rejection.