### PR TITLE
Repair v181 wrapper identity and platform fetch proof v182

### DIFF
--- a/bot/runtime_capital_generation_context_v181_patch.py
+++ b/bot/runtime_capital_generation_context_v181_patch.py
@@ -30,8 +30,30 @@ MARKER = "20260821-runtime-capital-generation-context-v181"
 RELEASE_ID = "20260821-runtime-convergence-v181"
 _READY_FLAG = "NIJA_RUNTIME_CAPITAL_GENERATION_CONTEXT_V181_READY"
 _PATCH_ATTR = "_nija_runtime_capital_generation_context_v181"
+_V142_PATCH_ATTR = "_nija_capital_publication_liveness_v142"
+_V142_MARKER = "20260818-capital-publication-liveness-v142"
+_V142_MODULE_NAMES = {
+    "bot.capital_publication_liveness_v142_patch",
+    "capital_publication_liveness_v142_patch",
+}
 _LOCK = threading.RLock()
 _MISSING = object()
+
+
+def _is_exact_v142_publication_wrapper(candidate: Any) -> bool:
+    """Identify v142 by function-owner globals, not a wraps-copied name/marker."""
+    if not callable(candidate) or not bool(getattr(candidate, _V142_PATCH_ATTR, False)):
+        return False
+    owner = getattr(candidate, "__globals__", {}) or {}
+    if str(owner.get("__name__", "")) not in _V142_MODULE_NAMES:
+        return False
+    if str(owner.get("MARKER", "")) != _V142_MARKER:
+        return False
+    return bool(
+        owner.get("_LOCAL") is not None
+        and callable(owner.get("_generation_state"))
+        and callable(owner.get("_canonical_manager"))
+    )
 
 
 def _find_v142_publication_wrapper(callable_obj: Any) -> Any:
@@ -42,10 +64,7 @@ def _find_v142_publication_wrapper(callable_obj: Any) -> Any:
         if not callable(current) or id(current) in seen:
             return None
         seen.add(id(current))
-        if (
-            str(getattr(current, "__name__", "")) == "publish_snapshot_v142"
-            and bool(getattr(current, "_nija_capital_publication_liveness_v142", False))
-        ):
+        if _is_exact_v142_publication_wrapper(current):
             return current
         current = getattr(current, "__wrapped__", None)
     return None
@@ -213,6 +232,7 @@ __all__ = [
     "RELEASE_ID",
     "install",
     "install_import_hook",
+    "_is_exact_v142_publication_wrapper",
     "_find_v142_publication_wrapper",
     "_canonical_generation_from_v142_wrapper",
     "_patch_publication_context",

--- a/bot/runtime_capital_reactivation_v176_patch.py
+++ b/bot/runtime_capital_reactivation_v176_patch.py
@@ -14,14 +14,16 @@ false proof is still revoked and LIVE state still fails closed. No freshness
 TTL, capital value, safety gate, signal threshold, nonce rule, kill switch, or
 execution permission is altered.
 
-The 2026-08-21 follow-ups install v179, v178, v180, and v181 before the
+The 2026-08-21 follow-ups install v179, v178, v180, v181, and v182 before the
 coordinator wrapper. v179 converges bootstrap-seed generation identity plus the
 canonical hydration event invariant; v178 repairs only the exact
 same-canonical-publication status-poisoning case for ``snapshot_not_newer``;
 v180 prevents a private direct refresh fallback from replacing a previously
 complete canonical broker set after bootstrap; v181 restores v142 generation
-context only for the exact current canonical coordinator worker after rollover.
-None of these patches broadens freshness or activation policy.
+context only for the exact current canonical coordinator worker after rollover;
+v182 reasserts the exact v98 authoritative position-fetch proof wrapper and
+requires both adoption and fetch proof for platform position convergence. None
+of these patches broadens freshness or activation policy.
 """
 from __future__ import annotations
 
@@ -166,6 +168,13 @@ def _install_v181_generation_context() -> bool:
     )
 
 
+def _install_v182_position_fetch_proof() -> bool:
+    return _install_named(
+        "bot.runtime_position_fetch_proof_v182_patch",
+        "RUNTIME_POSITION_FETCH_PROOF_V182",
+    )
+
+
 def _patch_coordinator() -> bool:
     try:
         module = importlib.import_module("bot.capital_flow_state_machine")
@@ -212,21 +221,30 @@ def install() -> bool:
         v178_ok = _install_v178_publication_identity()
         v180_ok = _install_v180_direct_refresh_downgrade()
         v181_ok = _install_v181_generation_context()
+        v182_ok = _install_v182_position_fetch_proof()
         coordinator_ok = _patch_coordinator()
         manifest_ok = _patch_release_manifest()
         ready = bool(
-            v179_ok and v178_ok and v180_ok and v181_ok and coordinator_ok and manifest_ok
+            v179_ok
+            and v178_ok
+            and v180_ok
+            and v181_ok
+            and v182_ok
+            and coordinator_ok
+            and manifest_ok
         )
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_CAPITAL_REACTIVATION_V176_FAILED marker=%s v179_ok=%s v178_ok=%s "
-                "v180_ok=%s v181_ok=%s coordinator_ok=%s manifest_ok=%s trading_fail_closed=true",
+                "v180_ok=%s v181_ok=%s v182_ok=%s coordinator_ok=%s manifest_ok=%s "
+                "trading_fail_closed=true",
                 MARKER,
                 str(v179_ok).lower(),
                 str(v178_ok).lower(),
                 str(v180_ok).lower(),
                 str(v181_ok).lower(),
+                str(v182_ok).lower(),
                 str(coordinator_ok).lower(),
                 str(manifest_ok).lower(),
             )
@@ -235,9 +253,9 @@ def install() -> bool:
             "RUNTIME_CAPITAL_REACTIVATION_V176 marker=%s ready=true "
             "v179_bootstrap_capital_publication=true v178_publication_identity=true "
             "v180_direct_refresh_downgrade=true v181_generation_context=true "
-            "post_publication_proof_recheck=true canonical_commit_only=true "
-            "v133_fail_closed_preserved=true freshness_ttl_unchanged=true "
-            "forced_activation=false safety_gates_bypassed=false",
+            "v182_position_fetch_proof=true post_publication_proof_recheck=true "
+            "canonical_commit_only=true v133_fail_closed_preserved=true "
+            "freshness_ttl_unchanged=true forced_activation=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -258,5 +276,6 @@ __all__ = [
     "_install_v178_publication_identity",
     "_install_v180_direct_refresh_downgrade",
     "_install_v181_generation_context",
+    "_install_v182_position_fetch_proof",
     "_patch_coordinator",
 ]

--- a/bot/runtime_position_fetch_proof_v182_patch.py
+++ b/bot/runtime_position_fetch_proof_v182_patch.py
@@ -1,0 +1,301 @@
+"""Reassert authoritative platform position-fetch proof after wrapper churn.
+
+Production on 2026-08-21 showed v96 reporting adopted platform position snapshots
+while v146 correctly rejected readiness because one or more brokers lacked the
+independent ``_startup_position_sync_fetch_ok`` proof.  The startup adopter is
+heavily wrapped and several wrappers use ``functools.wraps``; copied marker
+attributes can therefore make a later installer believe the v98 fetch-proof
+wrapper is present even when the exact v98 wrapper is no longer in the active
+call chain.
+
+v182 repairs only that wrapper/proof handoff.  It identifies the exact v98
+wrapper by its function-owner globals, reasserts it on the canonical startup
+adopter when missing, makes platform discovery require both adoption and fetch
+proof, and fail-closes a worker that returns adopted without fetch proof.
+
+No position, connectivity, capital, writer/nonce authority, kill switch, risk
+state, activation state, or execution permission is fabricated or promoted.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_position_fetch_proof_v182")
+MARKER = "20260821-runtime-position-fetch-proof-v182"
+RELEASE_ID = "20260821-runtime-convergence-v182"
+_READY_FLAG = "NIJA_RUNTIME_POSITION_FETCH_PROOF_V182_READY"
+_PATCH_ATTR = "_nija_runtime_position_fetch_proof_v182"
+_V98_PATCH_ATTR = "_nija_position_sync_failure_truth_v98"
+_V98_MARKER = "20260815-position-sync-failure-truth-v98"
+_V98_MODULE_NAMES = {
+    "bot.position_sync_failure_truth_v98_patch",
+    "position_sync_failure_truth_v98_patch",
+}
+_LOCK = threading.RLock()
+
+
+def _chain_has_exact_v98_wrapper(callable_obj: Any) -> bool:
+    """Prove the actual v98 owner is in the chain; ignore wraps-copied markers."""
+    seen: set[int] = set()
+    current = callable_obj
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, _V98_PATCH_ATTR, False)):
+            owner = getattr(current, "__globals__", {}) or {}
+            if (
+                str(owner.get("__name__", "")) in _V98_MODULE_NAMES
+                and str(owner.get("MARKER", "")) == _V98_MARKER
+            ):
+                return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
+def _chain_has_exact_v182_wrapper(callable_obj: Any, expected_name: str) -> bool:
+    seen: set[int] = set()
+    current = callable_obj
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if bool(getattr(current, _PATCH_ATTR, False)):
+            owner = getattr(current, "__globals__", {}) or {}
+            if owner.get("MARKER") == MARKER and str(getattr(current, "__name__", "")) == expected_name:
+                return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
+def _startup_sync_module() -> ModuleType:
+    try:
+        return importlib.import_module("bot.startup_position_sync")
+    except ImportError:
+        return importlib.import_module("startup_position_sync")
+
+
+def _v98_module() -> ModuleType:
+    try:
+        return importlib.import_module("bot.position_sync_failure_truth_v98_patch")
+    except ImportError:
+        return importlib.import_module("position_sync_failure_truth_v98_patch")
+
+
+def _v108_module() -> ModuleType:
+    return importlib.import_module("bot.platform_position_sync_v108_patch")
+
+
+def _reassert_v98_adopter() -> tuple[bool, str]:
+    """Ensure the canonical adopter contains the exact v98 fetch-proof wrapper."""
+    try:
+        sync_module = _startup_sync_module()
+        v98 = _v98_module()
+        current = getattr(sync_module, "_adopt_broker_positions", None)
+        if not callable(current):
+            return False, "canonical_adopter_missing"
+        if _chain_has_exact_v98_wrapper(current):
+            return True, "exact_v98_already_present"
+
+        marker = str(getattr(v98, "_ADOPT_ATTR", _V98_PATCH_ATTR) or _V98_PATCH_ATTR)
+        if bool(getattr(current, marker, False)):
+            try:
+                delattr(current, marker)
+            except Exception:
+                return False, "copied_v98_marker_not_clearable"
+
+        patcher = getattr(v98, "_patch_startup_sync", None)
+        if not callable(patcher) or not bool(patcher(sync_module)):
+            return False, "v98_repatch_failed"
+        updated = getattr(sync_module, "_adopt_broker_positions", None)
+        if not _chain_has_exact_v98_wrapper(updated):
+            return False, "exact_v98_not_in_chain_after_repatch"
+        LOGGER.critical(
+            "POSITION_FETCH_PROOF_V182_V98_REASSERTED marker=%s exact_owner=true "
+            "copied_marker_false_positive_blocked=true synthetic_success=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True, "v98_reasserted"
+    except Exception as exc:
+        return False, f"v98_reassert_error:{type(exc).__name__}:{exc}"
+
+
+def _connected_platform_brokers_requiring_proof(manager: Any) -> list[tuple[str, Any]]:
+    """Return connected platform brokers missing adoption OR fetch proof."""
+    found: list[tuple[str, Any]] = []
+    try:
+        platform = getattr(manager, "platform_brokers", {}) or {}
+        if callable(platform):
+            platform = platform()
+        for broker_type, broker in dict(platform or {}).items():
+            if broker is None or not bool(getattr(broker, "connected", False)):
+                continue
+            adopted = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
+            if adopted and fetch_ok:
+                continue
+            name = str(getattr(broker_type, "value", broker_type) or "unknown").lower()
+            found.append((name, broker))
+    except Exception as exc:
+        LOGGER.warning(
+            "POSITION_FETCH_PROOF_V182_DISCOVERY_FAILED marker=%s error=%s:%s fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+    return found
+
+
+def _patch_discovery() -> bool:
+    try:
+        v108 = _v108_module()
+        current = getattr(v108, "_connected_unsynced_platform_brokers", None)
+        if not callable(current):
+            return False
+        if _chain_has_exact_v182_wrapper(current, "discovery_v182"):
+            return True
+        original = current
+
+        @wraps(original)
+        def discovery_v182(manager: Any) -> list[tuple[str, Any]]:
+            return _connected_platform_brokers_requiring_proof(manager)
+
+        discovery_v182.__name__ = "discovery_v182"
+        setattr(discovery_v182, _PATCH_ATTR, True)
+        setattr(discovery_v182, "__wrapped__", original)
+        v108._connected_unsynced_platform_brokers = discovery_v182
+        return True
+    except Exception:
+        return False
+
+
+def _publish_fail_closed(v108: ModuleType, manager: Any, broker_name: str, broker: Any, key: tuple[int, int], reason: str) -> None:
+    try:
+        setattr(broker, "_startup_position_sync_adopted", False)
+        setattr(broker, "_startup_position_sync_fetch_ok", False)
+        setattr(broker, "_startup_position_sync_error", reason)
+    except Exception:
+        pass
+    try:
+        v108._publish_readiness(manager, source=f"v182:{broker_name}:{reason}")
+    except Exception:
+        pass
+    active = getattr(v108, "_ACTIVE", None)
+    lock = getattr(v108, "_LOCK", None)
+    if isinstance(active, set) and lock is not None:
+        with lock:
+            active.discard(key)
+
+
+def _patch_worker() -> bool:
+    try:
+        v108 = _v108_module()
+        current = getattr(v108, "_worker", None)
+        if not callable(current):
+            return False
+        if _chain_has_exact_v182_wrapper(current, "worker_v182"):
+            return True
+        original = current
+
+        @wraps(original)
+        def worker_v182(manager: Any, broker_name: str, broker: Any, key: tuple[int, int], trigger: str) -> None:
+            proof_ok, detail = _reassert_v98_adopter()
+            if not proof_ok:
+                reason = f"v98_fetch_proof_wrapper_unavailable:{detail}"
+                LOGGER.critical(
+                    "POSITION_FETCH_PROOF_V182_WORKER_BLOCKED marker=%s broker=%s trigger=%s "
+                    "reason=%s trading_fail_closed=true synthetic_success=false",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                    reason,
+                )
+                _publish_fail_closed(v108, manager, broker_name, broker, key, reason)
+                return
+
+            original(manager, broker_name, broker, key, trigger)
+            adopted = bool(getattr(broker, "_startup_position_sync_adopted", False))
+            fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
+            if adopted and not fetch_ok:
+                reason = "adopted_without_authoritative_fetch_proof"
+                LOGGER.critical(
+                    "POSITION_FETCH_PROOF_V182_POSTCHECK_REVOKED marker=%s broker=%s trigger=%s "
+                    "adopted=true fetch_ok=false trading_fail_closed=true synthetic_success=false",
+                    MARKER,
+                    broker_name,
+                    trigger,
+                )
+                _publish_fail_closed(v108, manager, broker_name, broker, key, reason)
+
+        worker_v182.__name__ = "worker_v182"
+        setattr(worker_v182, _PATCH_ATTR, True)
+        setattr(worker_v182, "__wrapped__", original)
+        v108._worker = worker_v182
+        return True
+    except Exception:
+        return False
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_position_fetch_proof_v182"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        v98_ok, v98_detail = _reassert_v98_adopter()
+        discovery_ok = _patch_discovery()
+        worker_ok = _patch_worker()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(v98_ok and discovery_ok and worker_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_POSITION_FETCH_PROOF_V182_FAILED marker=%s v98_ok=%s v98_detail=%s "
+                "discovery_ok=%s worker_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(v98_ok).lower(),
+                v98_detail,
+                str(discovery_ok).lower(),
+                str(worker_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_POSITION_FETCH_PROOF_V182 marker=%s ready=true exact_v98_owner_required=true "
+            "adopted_and_fetch_proof_required=true copied_marker_false_positive_blocked=true "
+            "synthetic_success=false forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_chain_has_exact_v98_wrapper",
+    "_reassert_v98_adopter",
+    "_connected_platform_brokers_requiring_proof",
+    "_patch_discovery",
+    "_patch_worker",
+    "_patch_release_manifest",
+]

--- a/tests/test_runtime_convergence_v176_v177.py
+++ b/tests/test_runtime_convergence_v176_v177.py
@@ -51,3 +51,16 @@ def test_v176_never_rearms_stale_publication(monkeypatch):
     active, reason = v176._rearm_after_publication("test")
     assert active is False
     assert reason == "publication_stale"
+
+
+def test_v176_installs_v182_position_fetch_proof(monkeypatch):
+    fake_v182 = types.SimpleNamespace(install=lambda: True)
+    original_import = v176.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.runtime_position_fetch_proof_v182_patch":
+            return fake_v182
+        return original_import(name)
+
+    monkeypatch.setattr(v176.importlib, "import_module", fake_import)
+    assert v176._install_v182_position_fetch_proof() is True

--- a/tests/test_runtime_position_fetch_proof_v182.py
+++ b/tests/test_runtime_position_fetch_proof_v182.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import threading
+from types import ModuleType, SimpleNamespace
+
+import bot.runtime_position_fetch_proof_v182_patch as v182
+
+
+class BrokerType:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class Broker:
+    def __init__(self, *, connected=True, adopted=False, fetch_ok=None):
+        self.connected = connected
+        self._startup_position_sync_adopted = adopted
+        self._startup_position_sync_fetch_ok = fetch_ok
+        self._startup_position_sync_error = None
+
+
+def test_exact_v98_detection_ignores_wraps_copied_marker():
+    def unrelated_wrapper(*args, **kwargs):
+        return None
+
+    setattr(unrelated_wrapper, "_nija_position_sync_failure_truth_v98", True)
+    assert v182._chain_has_exact_v98_wrapper(unrelated_wrapper) is False
+
+
+def test_reassert_v98_clears_copied_marker_and_installs_exact_owner(monkeypatch):
+    sync = ModuleType("bot.startup_position_sync")
+
+    def base_adopt(broker, broker_name, eps):
+        broker._startup_position_sync_adopted = True
+        return 0
+
+    setattr(base_adopt, "_nija_position_sync_failure_truth_v98", True)
+    sync._adopt_broker_positions = base_adopt
+
+    fake_v98 = ModuleType("bot.position_sync_failure_truth_v98_patch")
+    fake_v98.MARKER = "20260815-position-sync-failure-truth-v98"
+    fake_v98._ADOPT_ATTR = "_nija_position_sync_failure_truth_v98"
+    exec(
+        """
+from functools import wraps
+
+def _patch_startup_sync(module):
+    current = module._adopt_broker_positions
+    if getattr(current, _ADOPT_ATTR, False):
+        return True
+    original = current
+    @wraps(original)
+    def adopt_broker_positions_v98(broker, broker_name, eps):
+        broker._startup_position_sync_adopted = False
+        broker._startup_position_sync_fetch_ok = None
+        result = int(original(broker, broker_name, eps) or 0)
+        if getattr(broker, '_startup_position_sync_adopted', False):
+            broker._startup_position_sync_fetch_ok = True
+        return result
+    setattr(adopt_broker_positions_v98, _ADOPT_ATTR, True)
+    setattr(adopt_broker_positions_v98, '__wrapped__', original)
+    module._adopt_broker_positions = adopt_broker_positions_v98
+    return True
+""",
+        fake_v98.__dict__,
+    )
+
+    monkeypatch.setattr(v182, "_startup_sync_module", lambda: sync)
+    monkeypatch.setattr(v182, "_v98_module", lambda: fake_v98)
+
+    ok, detail = v182._reassert_v98_adopter()
+    assert ok is True
+    assert detail == "v98_reasserted"
+    assert v182._chain_has_exact_v98_wrapper(sync._adopt_broker_positions) is True
+
+    broker = Broker(adopted=True, fetch_ok=None)
+    sync._adopt_broker_positions(broker, "platform:coinbase", None)
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_fetch_ok is True
+
+
+def test_discovery_requires_adoption_and_authoritative_fetch_proof():
+    coinbase = Broker(adopted=True, fetch_ok=None)
+    okx = Broker(adopted=True, fetch_ok=True)
+    kraken = Broker(connected=False, adopted=False, fetch_ok=False)
+    manager = SimpleNamespace(
+        platform_brokers={
+            BrokerType("coinbase"): coinbase,
+            BrokerType("okx"): okx,
+            BrokerType("kraken"): kraken,
+        }
+    )
+
+    pending = v182._connected_platform_brokers_requiring_proof(manager)
+    assert pending == [("coinbase", coinbase)]
+
+
+def test_worker_revokes_adopted_without_fetch_proof(monkeypatch):
+    published: list[str] = []
+    active: set[tuple[int, int]] = set()
+
+    def unsafe_legacy_worker(manager, broker_name, broker, key, trigger):
+        broker._startup_position_sync_adopted = True
+        broker._startup_position_sync_fetch_ok = None
+        active.discard(key)
+
+    fake_v108 = SimpleNamespace(
+        _worker=unsafe_legacy_worker,
+        _ACTIVE=active,
+        _LOCK=threading.RLock(),
+        _publish_readiness=lambda manager, source: published.append(source),
+    )
+    monkeypatch.setattr(v182, "_v108_module", lambda: fake_v108)
+    monkeypatch.setattr(v182, "_reassert_v98_adopter", lambda: (True, "exact_v98_already_present"))
+
+    assert v182._patch_worker() is True
+
+    broker = Broker(adopted=False, fetch_ok=None)
+    manager = object()
+    key = (id(manager), id(broker))
+    active.add(key)
+    fake_v108._worker(manager, "coinbase", broker, key, "test")
+
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert broker._startup_position_sync_error == "adopted_without_authoritative_fetch_proof"
+    assert key not in active
+    assert any("adopted_without_authoritative_fetch_proof" in source for source in published)
+
+
+def test_worker_blocks_when_exact_v98_cannot_be_proven(monkeypatch):
+    calls: list[str] = []
+    published: list[str] = []
+    active: set[tuple[int, int]] = set()
+
+    def original_worker(manager, broker_name, broker, key, trigger):
+        calls.append(broker_name)
+
+    fake_v108 = SimpleNamespace(
+        _worker=original_worker,
+        _ACTIVE=active,
+        _LOCK=threading.RLock(),
+        _publish_readiness=lambda manager, source: published.append(source),
+    )
+    monkeypatch.setattr(v182, "_v108_module", lambda: fake_v108)
+    monkeypatch.setattr(v182, "_reassert_v98_adopter", lambda: (False, "exact_v98_not_in_chain_after_repatch"))
+
+    assert v182._patch_worker() is True
+
+    broker = Broker(adopted=True, fetch_ok=True)
+    manager = object()
+    key = (id(manager), id(broker))
+    active.add(key)
+    fake_v108._worker(manager, "okx", broker, key, "test")
+
+    assert calls == []
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert "v98_fetch_proof_wrapper_unavailable" in broker._startup_position_sync_error
+    assert key not in active
+
+
+def test_release_manifest_attests_v182(monkeypatch):
+    required = {}
+    fake_manifest = SimpleNamespace(_REQUIRED_FLAGS=required)
+    real_import = v182.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.runtime_release_manifest_patch":
+            return fake_manifest
+        return real_import(name)
+
+    monkeypatch.setattr(v182.importlib, "import_module", fake_import)
+    assert v182._patch_release_manifest() is True
+    assert required["runtime_position_fetch_proof_v182"] == (
+        "NIJA_RUNTIME_POSITION_FETCH_PROOF_V182_READY"
+    )


### PR DESCRIPTION
Production deployment `20a40012bb60a12fe948714cf0d1591316ec658b` exposed two fail-closed convergence defects:

1. v181 searched for a v142 wrapper by function name even though `functools.wraps` preserves the wrapped function name, causing `publication_ok=false` and the release manifest to stay unready.
2. Position-sync could report adopted snapshots while v146 correctly rejected the broker because the independent authoritative fetch proof was absent. Copied wrapper markers can make v98's idempotence guard believe the exact v98 owner is installed when it is not.

This PR:
- identifies the exact v142 wrapper from its function-owner globals rather than a wraps-copied name;
- adds v182 to verify/reassert the exact v98 authoritative-fetch wrapper;
- requires both adoption and fetch proof in the v182 platform discovery path;
- revokes any adopted-without-fetch-proof result rather than promoting readiness;
- integrates v182 into v176 release readiness;
- adds focused regression coverage.

Safety invariants preserved: no capital/freshness/expiry extension, no fabricated position/connectivity proof, no writer/nonce/risk/kill-switch bypass, no forced activation/trade, and v169 execution provenance remains unchanged.