### PR TITLE
Bound Kraken capital refresh valuation v183

### DIFF
--- a/bot/runtime_capital_reactivation_v176_patch.py
+++ b/bot/runtime_capital_reactivation_v176_patch.py
@@ -14,16 +14,18 @@ false proof is still revoked and LIVE state still fails closed. No freshness
 TTL, capital value, safety gate, signal threshold, nonce rule, kill switch, or
 execution permission is altered.
 
-The 2026-08-21 follow-ups install v179, v178, v180, v181, and v182 before the
-coordinator wrapper. v179 converges bootstrap-seed generation identity plus the
-canonical hydration event invariant; v178 repairs only the exact
+The 2026-08-21/22 follow-ups install v179, v178, v180, v181, v182, and v183 before
+the coordinator wrapper. v179 converges bootstrap-seed generation identity plus
+the canonical hydration event invariant; v178 repairs only the exact
 same-canonical-publication status-poisoning case for ``snapshot_not_newer``;
 v180 prevents a private direct refresh fallback from replacing a previously
 complete canonical broker set after bootstrap; v181 restores v142 generation
 context only for the exact current canonical coordinator worker after rollover;
 v182 reasserts the exact v98 authoritative position-fetch proof wrapper and
-requires both adoption and fetch proof for platform position convergence. None
-of these patches broadens freshness or activation policy.
+requires both adoption and fetch proof for platform position convergence; v183
+keeps Kraken capital-refresh asset valuation cache-only so the existing bounded
+Balance + TradeBalance path can finish inside the proactive pipeline budget.
+None of these patches broadens freshness or activation policy.
 """
 from __future__ import annotations
 
@@ -175,6 +177,13 @@ def _install_v182_position_fetch_proof() -> bool:
     )
 
 
+def _install_v183_kraken_capital_balance_liveness() -> bool:
+    return _install_named(
+        "bot.runtime_kraken_capital_balance_liveness_v183_patch",
+        "RUNTIME_KRAKEN_CAPITAL_BALANCE_LIVENESS_V183",
+    )
+
+
 def _patch_coordinator() -> bool:
     try:
         module = importlib.import_module("bot.capital_flow_state_machine")
@@ -222,6 +231,7 @@ def install() -> bool:
         v180_ok = _install_v180_direct_refresh_downgrade()
         v181_ok = _install_v181_generation_context()
         v182_ok = _install_v182_position_fetch_proof()
+        v183_ok = _install_v183_kraken_capital_balance_liveness()
         coordinator_ok = _patch_coordinator()
         manifest_ok = _patch_release_manifest()
         ready = bool(
@@ -230,6 +240,7 @@ def install() -> bool:
             and v180_ok
             and v181_ok
             and v182_ok
+            and v183_ok
             and coordinator_ok
             and manifest_ok
         )
@@ -237,7 +248,7 @@ def install() -> bool:
         if not ready:
             LOGGER.critical(
                 "RUNTIME_CAPITAL_REACTIVATION_V176_FAILED marker=%s v179_ok=%s v178_ok=%s "
-                "v180_ok=%s v181_ok=%s v182_ok=%s coordinator_ok=%s manifest_ok=%s "
+                "v180_ok=%s v181_ok=%s v182_ok=%s v183_ok=%s coordinator_ok=%s manifest_ok=%s "
                 "trading_fail_closed=true",
                 MARKER,
                 str(v179_ok).lower(),
@@ -245,6 +256,7 @@ def install() -> bool:
                 str(v180_ok).lower(),
                 str(v181_ok).lower(),
                 str(v182_ok).lower(),
+                str(v183_ok).lower(),
                 str(coordinator_ok).lower(),
                 str(manifest_ok).lower(),
             )
@@ -253,9 +265,10 @@ def install() -> bool:
             "RUNTIME_CAPITAL_REACTIVATION_V176 marker=%s ready=true "
             "v179_bootstrap_capital_publication=true v178_publication_identity=true "
             "v180_direct_refresh_downgrade=true v181_generation_context=true "
-            "v182_position_fetch_proof=true post_publication_proof_recheck=true "
-            "canonical_commit_only=true v133_fail_closed_preserved=true "
-            "freshness_ttl_unchanged=true forced_activation=false safety_gates_bypassed=false",
+            "v182_position_fetch_proof=true v183_kraken_capital_balance_liveness=true "
+            "post_publication_proof_recheck=true canonical_commit_only=true "
+            "v133_fail_closed_preserved=true freshness_ttl_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -277,5 +290,6 @@ __all__ = [
     "_install_v180_direct_refresh_downgrade",
     "_install_v181_generation_context",
     "_install_v182_position_fetch_proof",
+    "_install_v183_kraken_capital_balance_liveness",
     "_patch_coordinator",
 ]

--- a/bot/runtime_kraken_capital_balance_liveness_v183_patch.py
+++ b/bot/runtime_kraken_capital_balance_liveness_v183_patch.py
@@ -1,0 +1,190 @@
+"""Bound Kraken capital-refresh valuation without weakening capital truth.
+
+Production on 2026-08-22 showed PLATFORM Kraken connected and position-synced,
+but the canonical capital refresh repeatedly excluded Kraken after the 30 second
+batch budget expired.  ``KrakenBroker.get_account_balance`` performs a private
+``Balance`` read, then values every non-fiat holding through public ticker / emergency
+resolution, and finally performs a private ``TradeBalance`` read.  On a cold price
+cache, several serial public lookups can consume the whole capital-refresh budget
+before the broker returns even though Kraken's own equivalent-balance (``eb``)
+would provide an authoritative full-equity floor.
+
+v183 changes only the capital-balance call context:
+* normal market-price calls are unchanged;
+* while ``get_account_balance`` is running, asset USD lookup is cache-only;
+* stablecoin fallback semantics stay unchanged;
+* the existing bounded authenticated ``TradeBalance`` call remains authoritative;
+* ``total_funds`` remains the existing max(local valuation, Kraken ``eb``);
+* if Balance / TradeBalance cannot provide usable capital, the broker remains
+  excluded and the 3/3 publication gate remains fail closed.
+
+No freshness TTL, publication expiry, broker count, writer/nonce/risk state,
+kill switch, activation state, execution permission, signal threshold, or trade
+routing is modified.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.runtime_kraken_capital_balance_liveness_v183")
+MARKER = "20260822-runtime-kraken-capital-balance-liveness-v183"
+RELEASE_ID = "20260822-runtime-convergence-v183"
+_READY_FLAG = "NIJA_RUNTIME_KRAKEN_CAPITAL_BALANCE_LIVENESS_V183_READY"
+_BALANCE_ATTR = "_nija_runtime_kraken_capital_balance_liveness_v183_balance"
+_PRICE_ATTR = "_nija_runtime_kraken_capital_balance_liveness_v183_price"
+_LOCK = threading.RLock()
+_LOCAL = threading.local()
+
+
+def _positive_float(value: Any) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed > 0.0 else None
+
+
+def _cached_asset_price(instance: Any, symbol: str) -> Optional[float]:
+    """Return broker-owned cached USD/USDT price without network I/O."""
+    v173 = importlib.import_module("bot.runtime_kraken_capital_tail_liveness_v173_patch")
+    cached = getattr(v173, "_cached_pair_price", None)
+    if callable(cached):
+        try:
+            return _positive_float(cached(instance, str(symbol or "").upper()))
+        except Exception:
+            return None
+    return None
+
+
+def _in_capital_balance_context(instance: Any) -> bool:
+    return getattr(_LOCAL, "broker", None) is instance and bool(
+        getattr(_LOCAL, "active", False)
+    )
+
+
+def _patch_kraken_balance_context() -> bool:
+    broker_module = importlib.import_module("bot.broker_manager")
+    broker_cls = getattr(broker_module, "KrakenBroker", None)
+    if not isinstance(broker_cls, type):
+        return False
+
+    current_balance = getattr(broker_cls, "get_account_balance", None)
+    current_price = getattr(broker_cls, "_get_asset_usd_price", None)
+    if not callable(current_balance) or not callable(current_price):
+        return False
+
+    balance_exact = (
+        bool(getattr(current_balance, _BALANCE_ATTR, False))
+        and str(getattr(current_balance, "__name__", "")) == "get_account_balance_v183"
+        and getattr(current_balance, "__globals__", {}).get("MARKER") == MARKER
+    )
+    price_exact = (
+        bool(getattr(current_price, _PRICE_ATTR, False))
+        and str(getattr(current_price, "__name__", "")) == "asset_price_v183"
+        and getattr(current_price, "__globals__", {}).get("MARKER") == MARKER
+    )
+
+    if not price_exact:
+        original_price = current_price
+
+        @wraps(original_price)
+        def asset_price_v183(self: Any, symbol: str):
+            if _in_capital_balance_context(self):
+                price = _cached_asset_price(self, symbol)
+                if price is None:
+                    LOGGER.debug(
+                        "KRAKEN_CAPITAL_V183_CACHE_MISS marker=%s account=%s asset=%s "
+                        "network_lookup=false confidence_not_promoted=true",
+                        MARKER,
+                        getattr(self, "account_identifier", "unknown"),
+                        symbol,
+                    )
+                    return 0.0
+                return price
+            return original_price(self, symbol)
+
+        asset_price_v183.__name__ = "asset_price_v183"
+        setattr(asset_price_v183, _PRICE_ATTR, True)
+        setattr(asset_price_v183, "__wrapped__", original_price)
+        broker_cls._get_asset_usd_price = asset_price_v183
+
+    if not balance_exact:
+        original_balance = current_balance
+
+        @wraps(original_balance)
+        def get_account_balance_v183(self: Any, *args: Any, **kwargs: Any):
+            previous_active = getattr(_LOCAL, "active", False)
+            previous_broker = getattr(_LOCAL, "broker", None)
+            _LOCAL.active = True
+            _LOCAL.broker = self
+            try:
+                return original_balance(self, *args, **kwargs)
+            finally:
+                _LOCAL.active = previous_active
+                _LOCAL.broker = previous_broker
+
+        get_account_balance_v183.__name__ = "get_account_balance_v183"
+        setattr(get_account_balance_v183, _BALANCE_ATTR, True)
+        setattr(get_account_balance_v183, "__wrapped__", original_balance)
+        broker_cls.get_account_balance = get_account_balance_v183
+
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_kraken_capital_balance_liveness_v183"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        balance_ok = _patch_kraken_balance_context()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(balance_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_KRAKEN_CAPITAL_BALANCE_LIVENESS_V183_FAILED marker=%s "
+                "balance_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(balance_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_KRAKEN_CAPITAL_BALANCE_LIVENESS_V183 marker=%s ready=true "
+            "capital_asset_pricing_cache_only=true normal_market_pricing_unchanged=true "
+            "tradebalance_equity_authority_preserved=true partial_aggregation_gate_unchanged=true "
+            "freshness_extended=false publication_expiry_extended=false forced_activation=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_cached_asset_price",
+    "_in_capital_balance_context",
+    "_patch_kraken_balance_context",
+    "_patch_release_manifest",
+]

--- a/tests/test_runtime_convergence_v176_v177.py
+++ b/tests/test_runtime_convergence_v176_v177.py
@@ -64,3 +64,16 @@ def test_v176_installs_v182_position_fetch_proof(monkeypatch):
 
     monkeypatch.setattr(v176.importlib, "import_module", fake_import)
     assert v176._install_v182_position_fetch_proof() is True
+
+
+def test_v176_installs_v183_kraken_capital_balance_liveness(monkeypatch):
+    fake_v183 = types.SimpleNamespace(install=lambda: True)
+    original_import = v176.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.runtime_kraken_capital_balance_liveness_v183_patch":
+            return fake_v183
+        return original_import(name)
+
+    monkeypatch.setattr(v176.importlib, "import_module", fake_import)
+    assert v176._install_v183_kraken_capital_balance_liveness() is True

--- a/tests/test_runtime_kraken_capital_balance_liveness_v183.py
+++ b/tests/test_runtime_kraken_capital_balance_liveness_v183.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import bot.runtime_kraken_capital_balance_liveness_v183_patch as v183
+
+
+def _fake_broker_module(events):
+    module = ModuleType("bot.broker_manager")
+
+    class KrakenBroker:
+        def __init__(self):
+            self.account_identifier = "PLATFORM"
+
+        def _get_asset_usd_price(self, symbol):
+            events.append(("network_price", symbol))
+            return 123.0
+
+        def get_account_balance(self, verbose=True):
+            events.append(("balance_enter", v183._in_capital_balance_context(self)))
+            price = self._get_asset_usd_price("BTC")
+            events.append(("balance_price", price))
+            return 250.0
+
+    module.KrakenBroker = KrakenBroker
+    return module, KrakenBroker
+
+
+def test_normal_price_lookup_unchanged_outside_capital_balance_context(monkeypatch):
+    events = []
+    module, broker_cls = _fake_broker_module(events)
+    real_import = v183.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(v183.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v183, "_cached_asset_price", lambda broker, symbol: None)
+
+    assert v183._patch_kraken_balance_context() is True
+    broker = broker_cls()
+
+    assert broker._get_asset_usd_price("ETH") == 123.0
+    assert events == [("network_price", "ETH")]
+
+
+def test_capital_balance_cache_hit_avoids_network_lookup(monkeypatch):
+    events = []
+    module, broker_cls = _fake_broker_module(events)
+    real_import = v183.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(v183.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v183, "_cached_asset_price", lambda broker, symbol: 77.0)
+
+    assert v183._patch_kraken_balance_context() is True
+    broker = broker_cls()
+
+    assert broker.get_account_balance(verbose=False) == 250.0
+    assert events == [
+        ("balance_enter", True),
+        ("balance_price", 77.0),
+    ]
+    assert v183._in_capital_balance_context(broker) is False
+
+
+def test_capital_balance_cache_miss_fails_closed_without_network_lookup(monkeypatch):
+    events = []
+    module, broker_cls = _fake_broker_module(events)
+    real_import = v183.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(v183.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v183, "_cached_asset_price", lambda broker, symbol: None)
+
+    assert v183._patch_kraken_balance_context() is True
+    broker = broker_cls()
+
+    assert broker.get_account_balance() == 250.0
+    assert events == [
+        ("balance_enter", True),
+        ("balance_price", 0.0),
+    ]
+    assert v183._in_capital_balance_context(broker) is False
+
+
+def test_balance_context_restores_nested_thread_local_state(monkeypatch):
+    events = []
+    module, broker_cls = _fake_broker_module(events)
+    real_import = v183.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(v183.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v183, "_cached_asset_price", lambda broker, symbol: 11.0)
+
+    outer = object()
+    v183._LOCAL.active = True
+    v183._LOCAL.broker = outer
+    try:
+        assert v183._patch_kraken_balance_context() is True
+        broker = broker_cls()
+        broker.get_account_balance()
+        assert v183._LOCAL.active is True
+        assert v183._LOCAL.broker is outer
+    finally:
+        v183._LOCAL.active = False
+        v183._LOCAL.broker = None
+
+
+def test_release_manifest_attests_v183(monkeypatch):
+    required = {}
+    fake_manifest = SimpleNamespace(_REQUIRED_FLAGS=required)
+    real_import = v183.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.runtime_release_manifest_patch":
+            return fake_manifest
+        return real_import(name)
+
+    monkeypatch.setattr(v183.importlib, "import_module", fake_import)
+
+    assert v183._patch_release_manifest() is True
+    assert required["runtime_kraken_capital_balance_liveness_v183"] == (
+        "NIJA_RUNTIME_KRAKEN_CAPITAL_BALANCE_LIVENESS_V183_READY"
+    )
+
+
+def test_safety_environment_not_modified(monkeypatch):
+    monkeypatch.setenv("NIJA_EMERGENCY_STOP", "1")
+    monkeypatch.setenv("NIJA_NONCE_READY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+
+    assert __import__("os").environ["NIJA_EMERGENCY_STOP"] == "1"
+    assert __import__("os").environ["NIJA_NONCE_READY"] == "0"
+    assert __import__("os").environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"


### PR DESCRIPTION
Production evidence on `cc579542218dfacce64738ba1ca78e134f7f6da5` shows release readiness, writer/core health, and 3/3 position reconciliation are healthy, while CapitalAuthority remains at 2/3 because Kraken's capital worker exceeds the bounded proactive refresh window. The canonical Kraken balance path performs Balance -> serial non-fiat public price lookups/emergency resolution -> TradeBalance. Cold pricing can consume the entire batch budget before Kraken returns.

This PR adds v183 to make non-fiat asset valuation cache-only only while `KrakenBroker.get_account_balance()` is executing. Normal market pricing is unchanged. Kraken's authenticated bounded Balance and TradeBalance remain authoritative, and existing `total_funds=max(local valuation, TradeBalance eb)` logic is unchanged. If those authenticated reads cannot provide usable capital, Kraken remains excluded and the complete-broker publication gate continues to fail closed.

It also integrates v183 into the existing v176 release chain and adds focused regression coverage for cache hit/miss behavior, context restoration, normal pricing preservation, manifest attestation, and v176 installation.

No freshness TTL, publication expiry, broker count, capital value fabrication, global epoch bypass, writer/nonce/risk state, kill switch, activation state, execution permission, signal threshold, or trade routing is changed.