### PR TITLE
Recognize authenticated Kraken aggregate valuation v184

### DIFF
--- a/bot/runtime_capital_reactivation_v176_patch.py
+++ b/bot/runtime_capital_reactivation_v176_patch.py
@@ -14,9 +14,9 @@ false proof is still revoked and LIVE state still fails closed. No freshness
 TTL, capital value, safety gate, signal threshold, nonce rule, kill switch, or
 execution permission is altered.
 
-The 2026-08-21/22 follow-ups install v179, v178, v180, v181, v182, and v183 before
-the coordinator wrapper. v179 converges bootstrap-seed generation identity plus
-the canonical hydration event invariant; v178 repairs only the exact
+The 2026-08-21/22 follow-ups install v179, v178, v180, v181, v182, v183, and v184
+before the coordinator wrapper. v179 converges bootstrap-seed generation identity
+plus the canonical hydration event invariant; v178 repairs only the exact
 same-canonical-publication status-poisoning case for ``snapshot_not_newer``;
 v180 prevents a private direct refresh fallback from replacing a previously
 complete canonical broker set after bootstrap; v181 restores v142 generation
@@ -24,8 +24,11 @@ context only for the exact current canonical coordinator worker after rollover;
 v182 reasserts the exact v98 authoritative position-fetch proof wrapper and
 requires both adoption and fetch proof for platform position convergence; v183
 keeps Kraken capital-refresh asset valuation cache-only so the existing bounded
-Balance + TradeBalance path can finish inside the proactive pipeline budget.
-None of these patches broadens freshness or activation policy.
+Balance + TradeBalance path can finish inside the proactive pipeline budget;
+v184 lets Stage-4 valuation confidence recognize only fresh authenticated
+TradeBalance equivalent-equity proof from the same balance epoch while preserving
+the raw per-asset pricing metric. None of these patches broadens freshness or
+activation policy.
 """
 from __future__ import annotations
 
@@ -184,6 +187,13 @@ def _install_v183_kraken_capital_balance_liveness() -> bool:
     )
 
 
+def _install_v184_kraken_aggregate_valuation_confidence() -> bool:
+    return _install_named(
+        "bot.runtime_kraken_aggregate_valuation_confidence_v184_patch",
+        "RUNTIME_KRAKEN_AGGREGATE_VALUATION_CONFIDENCE_V184",
+    )
+
+
 def _patch_coordinator() -> bool:
     try:
         module = importlib.import_module("bot.capital_flow_state_machine")
@@ -232,6 +242,7 @@ def install() -> bool:
         v181_ok = _install_v181_generation_context()
         v182_ok = _install_v182_position_fetch_proof()
         v183_ok = _install_v183_kraken_capital_balance_liveness()
+        v184_ok = _install_v184_kraken_aggregate_valuation_confidence()
         coordinator_ok = _patch_coordinator()
         manifest_ok = _patch_release_manifest()
         ready = bool(
@@ -241,6 +252,7 @@ def install() -> bool:
             and v181_ok
             and v182_ok
             and v183_ok
+            and v184_ok
             and coordinator_ok
             and manifest_ok
         )
@@ -248,8 +260,8 @@ def install() -> bool:
         if not ready:
             LOGGER.critical(
                 "RUNTIME_CAPITAL_REACTIVATION_V176_FAILED marker=%s v179_ok=%s v178_ok=%s "
-                "v180_ok=%s v181_ok=%s v182_ok=%s v183_ok=%s coordinator_ok=%s manifest_ok=%s "
-                "trading_fail_closed=true",
+                "v180_ok=%s v181_ok=%s v182_ok=%s v183_ok=%s v184_ok=%s "
+                "coordinator_ok=%s manifest_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(v179_ok).lower(),
                 str(v178_ok).lower(),
@@ -257,6 +269,7 @@ def install() -> bool:
                 str(v181_ok).lower(),
                 str(v182_ok).lower(),
                 str(v183_ok).lower(),
+                str(v184_ok).lower(),
                 str(coordinator_ok).lower(),
                 str(manifest_ok).lower(),
             )
@@ -266,6 +279,7 @@ def install() -> bool:
             "v179_bootstrap_capital_publication=true v178_publication_identity=true "
             "v180_direct_refresh_downgrade=true v181_generation_context=true "
             "v182_position_fetch_proof=true v183_kraken_capital_balance_liveness=true "
+            "v184_kraken_aggregate_valuation_confidence=true "
             "post_publication_proof_recheck=true canonical_commit_only=true "
             "v133_fail_closed_preserved=true freshness_ttl_unchanged=true "
             "forced_activation=false safety_gates_bypassed=false",
@@ -291,5 +305,6 @@ __all__ = [
     "_install_v181_generation_context",
     "_install_v182_position_fetch_proof",
     "_install_v183_kraken_capital_balance_liveness",
+    "_install_v184_kraken_aggregate_valuation_confidence",
     "_patch_coordinator",
 ]

--- a/bot/runtime_kraken_aggregate_valuation_confidence_v184_patch.py
+++ b/bot/runtime_kraken_aggregate_valuation_confidence_v184_patch.py
@@ -1,0 +1,290 @@
+"""Use authenticated Kraken aggregate-equity proof for capital confidence.
+
+Production on 2026-08-22 showed the v183 capital-liveness repair working:
+CapitalAuthority publishes a fresh accepted 3/3 platform snapshot, Kraken
+TradeBalance returns a positive authenticated equivalent balance (``eb``), and
+position/writer/runtime readiness are healthy.  The capital runtime nevertheless
+remains RUN_DEGRADED because Stage 4's legacy pricing-coverage input stays 0.0:
+v183 intentionally avoids cold per-asset public ticker calls during the bounded
+capital refresh.
+
+v184 preserves the raw per-asset pricing metric and adds a narrowly-scoped
+aggregate valuation proof.  A successful authenticated read-only ``TradeBalance``
+response records its positive ``eb`` and timestamp on the exact Kraken broker
+instance.  ``get_last_pricing_coverage`` is then allowed to return effective
+valuation coverage=1.0 only when all of the following are true:
+
+* the most recent TradeBalance response was successful and ``eb`` is positive;
+* its proof timestamp is still inside the canonical capital freshness TTL;
+* the broker's last successful balance timestamp is also inside that TTL;
+* the TradeBalance and balance observations belong to the same fetch epoch
+  (bounded timestamp skew);
+* Kraken reports zero consecutive balance errors and is not unavailable/error.
+
+The historical ``_last_pricing_coverage_pct`` field is NOT modified, so raw
+per-asset pricing diagnostics remain truthful.  This patch only supplies the
+Stage-4 legacy coverage accessor with the stronger authenticated aggregate-equity
+valuation authority that already determines ``total_funds`` in broker_manager.
+
+No balance/capital value is synthesized.  No freshness TTL, publication expiry,
+broker completeness, writer/nonce/risk state, kill switch, activation state,
+execution permission, signal threshold, market-quality gate, or trade routing is
+changed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("nija.runtime_kraken_aggregate_valuation_confidence_v184")
+MARKER = "20260822-runtime-kraken-aggregate-valuation-confidence-v184"
+RELEASE_ID = "20260822-runtime-convergence-v184"
+_READY_FLAG = "NIJA_RUNTIME_KRAKEN_AGGREGATE_VALUATION_CONFIDENCE_V184_READY"
+_PRIVATE_ATTR = "_nija_runtime_kraken_aggregate_valuation_confidence_v184_private"
+_COVERAGE_ATTR = "_nija_runtime_kraken_aggregate_valuation_confidence_v184_coverage"
+_PROOF_EQUITY_ATTR = "_nija_v184_tradebalance_equity_usd"
+_PROOF_TS_ATTR = "_nija_v184_tradebalance_equity_ts"
+_LOCK = threading.RLock()
+
+
+def _positive_float(value: Any) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed > 0.0 else None
+
+
+def _canonical_freshness_ttl_s() -> float:
+    """Read, never extend, the canonical capital freshness TTL."""
+    try:
+        module = importlib.import_module("bot.capital_flow_state_machine")
+        ttl = float(getattr(module, "FRESHNESS_TTL_S", 90.0) or 90.0)
+    except Exception:
+        ttl = 90.0
+    return max(1.0, min(90.0, ttl))
+
+
+def _clear_aggregate_proof(instance: Any) -> None:
+    setattr(instance, _PROOF_EQUITY_ATTR, 0.0)
+    setattr(instance, _PROOF_TS_ATTR, 0.0)
+
+
+def _record_tradebalance_result(instance: Any, result: Any) -> None:
+    """Record only successful authenticated TradeBalance equivalent equity."""
+    if not isinstance(result, dict) or result.get("error"):
+        _clear_aggregate_proof(instance)
+        return
+    payload = result.get("result")
+    if not isinstance(payload, dict):
+        _clear_aggregate_proof(instance)
+        return
+    equity = _positive_float(payload.get("eb"))
+    if equity is None:
+        _clear_aggregate_proof(instance)
+        return
+    setattr(instance, _PROOF_EQUITY_ATTR, equity)
+    setattr(instance, _PROOF_TS_ATTR, time.time())
+
+
+def _aggregate_proof_status(instance: Any, *, now: Optional[float] = None) -> tuple[bool, str, float, float]:
+    """Return whether aggregate-equity proof is current and same-epoch."""
+    current = time.time() if now is None else float(now)
+    equity = _positive_float(getattr(instance, _PROOF_EQUITY_ATTR, 0.0)) or 0.0
+    try:
+        proof_ts = float(getattr(instance, _PROOF_TS_ATTR, 0.0) or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        proof_ts = 0.0
+    if equity <= 0.0 or proof_ts <= 0.0:
+        return False, "aggregate_proof_missing", equity, float("inf")
+
+    ttl = _canonical_freshness_ttl_s()
+    proof_age = max(0.0, current - proof_ts)
+    if proof_age > ttl:
+        return False, "aggregate_proof_stale", equity, proof_age
+
+    balance_ts = None
+    getter = getattr(instance, "get_balance_fetch_timestamp", None)
+    if callable(getter):
+        try:
+            value = getter()
+            if value is not None:
+                balance_ts = float(value)
+        except Exception:
+            balance_ts = None
+    if balance_ts is None or balance_ts <= 0.0:
+        return False, "balance_timestamp_missing", equity, proof_age
+
+    balance_age = max(0.0, current - balance_ts)
+    if balance_age > ttl:
+        return False, "balance_observation_stale", equity, proof_age
+
+    # get_account_balance sets _balance_last_updated immediately after the
+    # authenticated TradeBalance call.  Allow a small scheduling/logging gap,
+    # but never join unrelated observations from different refresh epochs.
+    if abs(balance_ts - proof_ts) > 5.0:
+        return False, "aggregate_balance_epoch_mismatch", equity, proof_age
+
+    errors_getter = getattr(instance, "get_error_count", None)
+    if callable(errors_getter):
+        try:
+            if int(errors_getter()) != 0:
+                return False, "kraken_balance_errors_present", equity, proof_age
+        except Exception:
+            return False, "kraken_error_state_unknown", equity, proof_age
+
+    available_getter = getattr(instance, "is_available", None)
+    if callable(available_getter):
+        try:
+            if not bool(available_getter()):
+                return False, "kraken_unavailable", equity, proof_age
+        except Exception:
+            return False, "kraken_availability_unknown", equity, proof_age
+
+    if str(getattr(instance, "kraken_health", "OK") or "OK").upper() == "ERROR":
+        return False, "kraken_health_error", equity, proof_age
+
+    return True, "authenticated_tradebalance_equity", equity, proof_age
+
+
+def _chain_has_exact_wrapper(head: Any, marker_attr: str) -> bool:
+    seen: set[int] = set()
+    current = head
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        owner = getattr(current, "__globals__", {})
+        if bool(getattr(current, marker_attr, False)) and owner.get("MARKER") == MARKER:
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
+def _patch_kraken_provenance() -> bool:
+    module = importlib.import_module("bot.broker_manager")
+    broker_cls = getattr(module, "KrakenBroker", None)
+    if not isinstance(broker_cls, type):
+        return False
+
+    current_private = getattr(broker_cls, "_kraken_private_call", None)
+    current_coverage = getattr(broker_cls, "get_last_pricing_coverage", None)
+    if not callable(current_private) or not callable(current_coverage):
+        return False
+
+    if not _chain_has_exact_wrapper(current_private, _PRIVATE_ATTR):
+        original_private = current_private
+
+        @wraps(original_private)
+        def kraken_private_call_v184(self: Any, method: str, *args: Any, **kwargs: Any):
+            is_tradebalance = str(method or "") == "TradeBalance"
+            try:
+                result = original_private(self, method, *args, **kwargs)
+            except Exception:
+                if is_tradebalance:
+                    _clear_aggregate_proof(self)
+                raise
+            if is_tradebalance:
+                _record_tradebalance_result(self, result)
+            return result
+
+        kraken_private_call_v184.__name__ = "kraken_private_call_v184"
+        setattr(kraken_private_call_v184, _PRIVATE_ATTR, True)
+        setattr(kraken_private_call_v184, "__wrapped__", original_private)
+        broker_cls._kraken_private_call = kraken_private_call_v184
+
+    if not _chain_has_exact_wrapper(current_coverage, _COVERAGE_ATTR):
+        original_coverage = current_coverage
+
+        @wraps(original_coverage)
+        def pricing_coverage_v184(self: Any) -> float:
+            try:
+                raw_coverage = max(0.0, min(1.0, float(original_coverage(self))))
+            except Exception:
+                raw_coverage = 0.0
+            valid, reason, equity, proof_age = _aggregate_proof_status(self)
+            if not valid:
+                return raw_coverage
+            effective = max(raw_coverage, 1.0)
+            LOGGER.info(
+                "KRAKEN_CAPITAL_V184_AGGREGATE_VALUATION_PROOF marker=%s account=%s "
+                "eb=%.8f proof_age_s=%.3f raw_asset_pricing_coverage=%.3f "
+                "effective_valuation_coverage=%.3f reason=%s "
+                "asset_prices_fabricated=false freshness_extended=false",
+                MARKER,
+                getattr(self, "account_identifier", "unknown"),
+                equity,
+                proof_age,
+                raw_coverage,
+                effective,
+                reason,
+            )
+            return effective
+
+        pricing_coverage_v184.__name__ = "pricing_coverage_v184"
+        setattr(pricing_coverage_v184, _COVERAGE_ATTR, True)
+        setattr(pricing_coverage_v184, "__wrapped__", original_coverage)
+        broker_cls.get_last_pricing_coverage = pricing_coverage_v184
+
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_kraken_aggregate_valuation_confidence_v184"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        provenance_ok = _patch_kraken_provenance()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(provenance_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_KRAKEN_AGGREGATE_VALUATION_CONFIDENCE_V184_FAILED marker=%s "
+                "provenance_ok=%s manifest_ok=%s trading_fail_closed=true",
+                MARKER,
+                str(provenance_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_KRAKEN_AGGREGATE_VALUATION_CONFIDENCE_V184 marker=%s ready=true "
+            "authenticated_tradebalance_equity_required=true same_balance_epoch_required=true "
+            "raw_asset_pricing_metric_preserved=true effective_valuation_coverage=true "
+            "freshness_ttl_unchanged=true publication_expiry_extended=false "
+            "capital_mutated=false asset_prices_fabricated=false forced_activation=false "
+            "signal_thresholds_unchanged=true safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_aggregate_proof_status",
+    "_clear_aggregate_proof",
+    "_record_tradebalance_result",
+    "_patch_kraken_provenance",
+    "_patch_release_manifest",
+]

--- a/tests/test_runtime_convergence_v176_v177.py
+++ b/tests/test_runtime_convergence_v176_v177.py
@@ -77,3 +77,16 @@ def test_v176_installs_v183_kraken_capital_balance_liveness(monkeypatch):
 
     monkeypatch.setattr(v176.importlib, "import_module", fake_import)
     assert v176._install_v183_kraken_capital_balance_liveness() is True
+
+
+def test_v176_installs_v184_kraken_aggregate_valuation_confidence(monkeypatch):
+    fake_v184 = types.SimpleNamespace(install=lambda: True)
+    original_import = v176.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.runtime_kraken_aggregate_valuation_confidence_v184_patch":
+            return fake_v184
+        return original_import(name)
+
+    monkeypatch.setattr(v176.importlib, "import_module", fake_import)
+    assert v176._install_v184_kraken_aggregate_valuation_confidence() is True

--- a/tests/test_runtime_kraken_aggregate_valuation_confidence_v184.py
+++ b/tests/test_runtime_kraken_aggregate_valuation_confidence_v184.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import time
+from types import ModuleType, SimpleNamespace
+
+import bot.runtime_kraken_aggregate_valuation_confidence_v184_patch as v184
+
+
+class FakeKraken:
+    def __init__(self):
+        self._balance_last_updated = time.time()
+        self._balance_fetch_errors = 0
+        self._is_available = True
+        self.kraken_health = "OK"
+        self.account_identifier = "PLATFORM"
+        self._last_pricing_coverage_pct = 0.0
+
+    def get_balance_fetch_timestamp(self):
+        return self._balance_last_updated
+
+    def get_error_count(self):
+        return self._balance_fetch_errors
+
+    def is_available(self):
+        return self._is_available
+
+    def get_last_pricing_coverage(self):
+        return self._last_pricing_coverage_pct
+
+    def _kraken_private_call(self, method, *args, **kwargs):
+        if method == "TradeBalance":
+            return {"error": [], "result": {"eb": "250.3578", "tb": "249.3992"}}
+        return {"error": [], "result": {}}
+
+
+def _fake_broker_module():
+    module = ModuleType("bot.broker_manager")
+    module.KrakenBroker = FakeKraken
+    return module
+
+
+def test_successful_authenticated_tradebalance_promotes_effective_valuation_coverage(monkeypatch):
+    module = _fake_broker_module()
+    real_import = v184.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        if name == "bot.capital_flow_state_machine":
+            return SimpleNamespace(FRESHNESS_TTL_S=90.0)
+        return real_import(name)
+
+    monkeypatch.setattr(v184.importlib, "import_module", fake_import)
+    assert v184._patch_kraken_provenance() is True
+
+    broker = module.KrakenBroker()
+    result = broker._kraken_private_call("TradeBalance", {"asset": "ZUSD"})
+    broker._balance_last_updated = time.time()
+
+    assert result["result"]["eb"] == "250.3578"
+    assert broker.get_last_pricing_coverage() == 1.0
+    assert broker._last_pricing_coverage_pct == 0.0
+
+
+def test_failed_tradebalance_clears_proof(monkeypatch):
+    broker = FakeKraken()
+    v184._record_tradebalance_result(broker, {"error": [], "result": {"eb": "250.0"}})
+    assert getattr(broker, v184._PROOF_EQUITY_ATTR) == 250.0
+
+    v184._record_tradebalance_result(broker, {"error": ["EAPI:Invalid key"], "result": {}})
+    assert getattr(broker, v184._PROOF_EQUITY_ATTR) == 0.0
+    assert getattr(broker, v184._PROOF_TS_ATTR) == 0.0
+
+
+def test_stale_aggregate_proof_does_not_promote(monkeypatch):
+    broker = FakeKraken()
+    now = time.time()
+    setattr(broker, v184._PROOF_EQUITY_ATTR, 250.0)
+    setattr(broker, v184._PROOF_TS_ATTR, now - 91.0)
+    broker._balance_last_updated = now
+    monkeypatch.setattr(v184, "_canonical_freshness_ttl_s", lambda: 90.0)
+
+    valid, reason, _, _ = v184._aggregate_proof_status(broker, now=now)
+    assert valid is False
+    assert reason == "aggregate_proof_stale"
+
+
+def test_mismatched_balance_epoch_does_not_promote(monkeypatch):
+    broker = FakeKraken()
+    now = time.time()
+    setattr(broker, v184._PROOF_EQUITY_ATTR, 250.0)
+    setattr(broker, v184._PROOF_TS_ATTR, now)
+    broker._balance_last_updated = now - 10.0
+    monkeypatch.setattr(v184, "_canonical_freshness_ttl_s", lambda: 90.0)
+
+    valid, reason, _, _ = v184._aggregate_proof_status(broker, now=now)
+    assert valid is False
+    assert reason == "aggregate_balance_epoch_mismatch"
+
+
+def test_balance_error_state_does_not_promote(monkeypatch):
+    broker = FakeKraken()
+    now = time.time()
+    setattr(broker, v184._PROOF_EQUITY_ATTR, 250.0)
+    setattr(broker, v184._PROOF_TS_ATTR, now)
+    broker._balance_last_updated = now
+    broker._balance_fetch_errors = 1
+    monkeypatch.setattr(v184, "_canonical_freshness_ttl_s", lambda: 90.0)
+
+    valid, reason, _, _ = v184._aggregate_proof_status(broker, now=now)
+    assert valid is False
+    assert reason == "kraken_balance_errors_present"
+
+
+def test_non_tradebalance_private_calls_do_not_create_proof(monkeypatch):
+    module = _fake_broker_module()
+    real_import = v184.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.broker_manager":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(v184.importlib, "import_module", fake_import)
+    assert v184._patch_kraken_provenance() is True
+
+    broker = module.KrakenBroker()
+    broker._kraken_private_call("Balance")
+    assert getattr(broker, v184._PROOF_EQUITY_ATTR, 0.0) == 0.0
+
+
+def test_release_manifest_attests_v184(monkeypatch):
+    required = {}
+    fake_manifest = SimpleNamespace(_REQUIRED_FLAGS=required)
+    real_import = v184.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.runtime_release_manifest_patch":
+            return fake_manifest
+        return real_import(name)
+
+    monkeypatch.setattr(v184.importlib, "import_module", fake_import)
+    assert v184._patch_release_manifest() is True
+    assert required["runtime_kraken_aggregate_valuation_confidence_v184"] == (
+        "NIJA_RUNTIME_KRAKEN_AGGREGATE_VALUATION_CONFIDENCE_V184_READY"
+    )
+
+
+def test_safety_environment_is_not_modified(monkeypatch):
+    monkeypatch.setenv("NIJA_EMERGENCY_STOP", "1")
+    monkeypatch.setenv("NIJA_NONCE_READY", "0")
+    monkeypatch.setenv("NIJA_RUNTIME_EXECUTION_AUTHORITY", "0")
+
+    assert __import__("os").environ["NIJA_EMERGENCY_STOP"] == "1"
+    assert __import__("os").environ["NIJA_NONCE_READY"] == "0"
+    assert __import__("os").environ["NIJA_RUNTIME_EXECUTION_AUTHORITY"] == "0"


### PR DESCRIPTION
Production on `3c6f6fd84f5b6054dc80a30f0b3246c5a253d7c2` shows fresh accepted 3/3 capital, clean position reconciliation, healthy writer/core, and v183 working, but Stage 4 stays LOW because `get_last_pricing_coverage()` remains 0.0 when v183 intentionally skips cold per-asset public pricing. Kraken's authenticated read-only `TradeBalance` already returns positive equivalent equity (`eb`) and is the existing authoritative fallback used to compute `total_funds`.

This PR adds v184 to record only successful authenticated TradeBalance equivalent-equity proof and let the Stage-4 legacy coverage accessor treat that as full aggregate valuation coverage only when the proof is fresh, the balance observation is fresh, both belong to the same fetch epoch, Kraken has zero balance errors, and the broker is available/healthy. Raw `_last_pricing_coverage_pct` remains unchanged, so per-asset pricing diagnostics stay truthful.

The patch does not synthesize capital or asset prices and does not change the 90-second freshness TTL, publication expiry, 3/3 broker completeness, writer/nonce/risk/kill-switch state, activation rules, execution permission, market quality gates, signal thresholds, or trade routing. Stale/mismatched/errored proof fails closed to the raw coverage value.