### PR TITLE
Reassert kill-switch provenance after installer replay v185

### DIFF
--- a/bot/kill_switch_persistence_provenance_v143_patch.py
+++ b/bot/kill_switch_persistence_provenance_v143_patch.py
@@ -19,6 +19,12 @@ v143 repairs provenance only; it does not clear a kill switch itself:
 * preserve manual/UI/CLI, unrelated automatic risk, unknown-source, direct new
   heartbeat, and post-deactivation file stops fail-closed.
 
+v185 hardens v143's idempotence after production installer replay. A replay can
+replace ``KillSwitch.get_status`` or one of the causal-reader function objects
+without clearing v143's process-local installed flag. v143 now reasserts its
+status wrapper, causal-reader anchors, and release-manifest contract on every
+installer invocation instead of returning early solely because the flag is set.
+
 No live state, execution authority, risk gate, nonce, writer lease, SEAK state,
 capital freshness, or publication expiry is changed by this patch.
 """
@@ -33,8 +39,10 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.kill_switch_persistence_provenance_v143")
 MARKER = "20260818-kill-switch-persistence-provenance-v143"
+REASSERT_MARKER = "20260822-kill-switch-provenance-reassert-v185"
 RELEASE_ID = "20260818-runtime-convergence-v143"
 _FLAG = "NIJA_KILL_SWITCH_PERSISTENCE_PROVENANCE_V143_READY"
+_REASSERT_FLAG = "NIJA_KILL_SWITCH_PROVENANCE_REASSERT_V185_READY"
 _PATCH_ATTR = "_nija_kill_switch_persistence_provenance_v143"
 _META_KEY = "_nija_persisted_cause_v143"
 _DEPTH_KEY = "_nija_persistence_history_depth_v143"
@@ -208,6 +216,19 @@ def _causal_activation_from_status(
     return str(latest.get("reason") or ""), str(latest.get("source") or "")
 
 
+def _wrap_causal_reader(current: Any, fallback_attr: str) -> Any:
+    if getattr(current, _PATCH_ATTR, False):
+        return current
+
+    @wraps(current)
+    def causal_activation_v143(status: dict[str, Any]) -> tuple[str, str]:
+        return _causal_activation_from_status(status, current)
+
+    setattr(causal_activation_v143, _PATCH_ATTR, True)
+    setattr(causal_activation_v143, fallback_attr, current)
+    return causal_activation_v143
+
+
 def _patch_causal_readers() -> bool:
     v140 = importlib.import_module("bot.runtime_killswitch_authority_liveness_patch")
     v131 = importlib.import_module("bot.readiness_killswitch_causality_v131_patch")
@@ -218,30 +239,15 @@ def _patch_causal_readers() -> bool:
     if not callable(current_v140) or not callable(current_v131):
         return False
 
-    if getattr(current_v140, _PATCH_ATTR, False) and getattr(current_v131, _PATCH_ATTR, False):
-        v130._latest_activation = current_v140
-        return True
+    anchored_v140 = _wrap_causal_reader(current_v140, "_nija_v143_v140_fallback")
+    anchored_v131 = _wrap_causal_reader(current_v131, "_nija_v143_v131_fallback")
+    v140._causal_activation = anchored_v140
+    v131._causal_activation = anchored_v131
 
-    @wraps(current_v140)
-    def causal_activation_v143(status: dict[str, Any]) -> tuple[str, str]:
-        return _causal_activation_from_status(status, current_v140)
-
-    setattr(causal_activation_v143, _PATCH_ATTR, True)
-    setattr(causal_activation_v143, "_nija_v143_v140_fallback", current_v140)
-    v140._causal_activation = causal_activation_v143
-
-    @wraps(current_v131)
-    def causal_activation_v143_v131(status: dict[str, Any]) -> tuple[str, str]:
-        return _causal_activation_from_status(status, current_v131)
-
-    setattr(causal_activation_v143_v131, _PATCH_ATTR, True)
-    setattr(causal_activation_v143_v131, "_nija_v143_v131_fallback", current_v131)
-    v131._causal_activation = causal_activation_v143_v131
-
-    # v130 captured v131's old function object during its installer. Re-anchor
-    # that compatibility pointer so direct v130 recovery sees the same bounded
-    # provenance record as v132/v140.
-    v130._latest_activation = causal_activation_v143_v131
+    # v130 captured v131's old function object during its installer. Always
+    # re-anchor that compatibility pointer so installer replay cannot leave it
+    # reading a stale bounded-history implementation while v143 reports ready.
+    v130._latest_activation = anchored_v131
     return True
 
 
@@ -253,6 +259,7 @@ def _patch_release_manifest() -> bool:
         return False
 
     required["kill_switch_persistence_provenance_v143"] = _FLAG
+    required["kill_switch_provenance_reassert_v185"] = _REASSERT_FLAG
     own = ("bot.kill_switch_persistence_provenance_v143_patch", "install_import_hook")
     if own not in installers:
         manifest._INSTALLERS = tuple(installers) + (own,)
@@ -266,19 +273,23 @@ def _patch_release_manifest() -> bool:
 def install_import_hook() -> bool:
     global _INSTALLED
     with _LOCK:
-        if _INSTALLED and os.environ.get(_FLAG) == "1":
-            return True
-
         # v143 is a follow-on to the existing narrow v140 recovery and the v142
         # runtime release. Refuse partial installation rather than widening any
         # recovery path in an unknown runtime composition.
         if os.environ.get("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY") != "1":
             os.environ.pop(_FLAG, None)
+            os.environ.pop(_REASSERT_FLAG, None)
             return False
         if os.environ.get("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY") != "1":
             os.environ.pop(_FLAG, None)
+            os.environ.pop(_REASSERT_FLAG, None)
             return False
 
+        # Do not return early merely because process-local installation state is
+        # already true. Release verification can replay installers after imports
+        # or compatibility layers replace function/class objects. Reassert each
+        # non-authoritative wrapper every time so "ready" means currently owned.
+        was_installed = bool(_INSTALLED and os.environ.get(_FLAG) == "1")
         try:
             ok = bool(
                 _patch_kill_switch_status()
@@ -298,10 +309,12 @@ def install_import_hook() -> bool:
 
         if not ok:
             os.environ.pop(_FLAG, None)
+            os.environ.pop(_REASSERT_FLAG, None)
             os.environ["NIJA_RUNTIME_RELEASE_READY"] = "0"
             return False
 
         os.environ[_FLAG] = "1"
+        os.environ[_REASSERT_FLAG] = "1"
         first = not _INSTALLED
         _INSTALLED = True
 
@@ -315,6 +328,15 @@ def install_import_hook() -> bool:
             MARKER,
             RELEASE_ID,
         )
+    elif was_installed:
+        LOGGER.critical(
+            "KILL_SWITCH_PROVENANCE_V185_REASSERTED marker=%s "
+            "kill_switch_status_owner=true causal_readers_reanchored=true "
+            "v130_pointer_reanchored=true generic_auto_clear=false "
+            "manual_ui_cli_stops_preserved=true risk_stops_preserved=true "
+            "execution_authority_unchanged=true force_live=false",
+            REASSERT_MARKER,
+        )
     return True
 
 
@@ -324,6 +346,7 @@ def install() -> bool:
 
 __all__ = [
     "MARKER",
+    "REASSERT_MARKER",
     "RELEASE_ID",
     "install",
     "install_import_hook",

--- a/tests/test_kill_switch_persistence_provenance_v143_unittest.py
+++ b/tests/test_kill_switch_persistence_provenance_v143_unittest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import threading
+import types
 import unittest
 from pathlib import Path
 
@@ -29,7 +31,6 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
         self.assertEqual(meta.get("reason"), HEARTBEAT)
         self.assertEqual(meta.get("persistence_records_skipped"), 6)
 
-        # Canonical public status would expose only five FILE_SYSTEM records.
         status = {
             "is_active": True,
             "recent_history": history[-5:],
@@ -106,6 +107,100 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
         self.assertEqual(status[mod._DEPTH_KEY], 9)
         self.assertEqual(status[mod._META_KEY].get("source"), "MANUAL")
         self.assertNotIn("full_history", status)
+
+    def test_installer_reasserts_wrappers_after_replay_drift(self) -> None:
+        class FakeKillSwitch:
+            def __init__(self) -> None:
+                self._lock = threading.Lock()
+                self._activation_history = [
+                    {"source": "AUTOMATIC", "reason": HEARTBEAT},
+                    dict(FILE),
+                    dict(FILE),
+                ]
+
+            def get_status(self):
+                with self._lock:
+                    return {"is_active": True, "recent_history": self._activation_history[-5:]}
+
+        def base_causal(status):
+            history = list(status.get("recent_history") or [])
+            latest = history[-1] if history else {}
+            return str(latest.get("reason") or ""), str(latest.get("source") or "")
+
+        v140 = types.SimpleNamespace(_causal_activation=base_causal)
+        v131 = types.SimpleNamespace(_causal_activation=base_causal)
+        v130 = types.SimpleNamespace(_latest_activation=base_causal)
+        manifest = types.SimpleNamespace(_REQUIRED_FLAGS={}, _INSTALLERS=tuple(), DECLARED_RELEASE_ID="old", RELEASE_ID="old")
+        kill_module = types.SimpleNamespace(KillSwitch=FakeKillSwitch)
+        modules = {
+            "bot.kill_switch": kill_module,
+            "bot.runtime_killswitch_authority_liveness_patch": v140,
+            "bot.readiness_killswitch_causality_v131_patch": v131,
+            "bot.kill_switch_stale_heartbeat_recovery_v130_patch": v130,
+            "bot.runtime_release_manifest_patch": manifest,
+        }
+
+        original_import = mod.importlib.import_module
+        original_installed = mod._INSTALLED
+        original_flag = os.environ.get(mod._FLAG)
+        original_reassert = os.environ.get(mod._REASSERT_FLAG)
+        original_v140_ready = os.environ.get("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY")
+        original_v142_ready = os.environ.get("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY")
+        mod.importlib.import_module = lambda name: modules[name] if name in modules else original_import(name)
+        os.environ["NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"] = "1"
+        os.environ["NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"] = "1"
+        mod._INSTALLED = False
+        try:
+            self.assertTrue(mod.install_import_hook())
+            first_status_owner = FakeKillSwitch.get_status
+            self.assertTrue(getattr(first_status_owner, mod._PATCH_ATTR, False))
+            first_v140 = v140._causal_activation
+            first_v131 = v131._causal_activation
+            self.assertTrue(getattr(first_v140, mod._PATCH_ATTR, False))
+            self.assertTrue(getattr(first_v131, mod._PATCH_ATTR, False))
+
+            # Simulate compatibility/import replay replacing all three anchors
+            # while the process-local installed flag remains set.
+            def drifted_status(self):
+                with self._lock:
+                    return {"is_active": True, "recent_history": self._activation_history[-5:]}
+
+            FakeKillSwitch.get_status = drifted_status
+            v140._causal_activation = base_causal
+            v131._causal_activation = base_causal
+            v130._latest_activation = base_causal
+
+            self.assertTrue(mod.install_import_hook())
+            self.assertTrue(getattr(FakeKillSwitch.get_status, mod._PATCH_ATTR, False))
+            self.assertTrue(getattr(v140._causal_activation, mod._PATCH_ATTR, False))
+            self.assertTrue(getattr(v131._causal_activation, mod._PATCH_ATTR, False))
+            self.assertIs(v130._latest_activation, v131._causal_activation)
+            self.assertEqual(os.environ.get(mod._REASSERT_FLAG), "1")
+
+            status = FakeKillSwitch().get_status()
+            self.assertEqual(status[mod._META_KEY].get("reason"), HEARTBEAT)
+            reason, source = v140._causal_activation(status)
+            self.assertEqual(reason, HEARTBEAT)
+            self.assertEqual(source, "AUTOMATIC")
+        finally:
+            mod.importlib.import_module = original_import
+            mod._INSTALLED = original_installed
+            if original_flag is None:
+                os.environ.pop(mod._FLAG, None)
+            else:
+                os.environ[mod._FLAG] = original_flag
+            if original_reassert is None:
+                os.environ.pop(mod._REASSERT_FLAG, None)
+            else:
+                os.environ[mod._REASSERT_FLAG] = original_reassert
+            if original_v140_ready is None:
+                os.environ.pop("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY", None)
+            else:
+                os.environ["NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"] = original_v140_ready
+            if original_v142_ready is None:
+                os.environ.pop("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY", None)
+            else:
+                os.environ["NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"] = original_v142_ready
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Production logs on 2026-08-22 show the runtime fully recovered on writer/core, 3/3 position sync, and accepted fresh 3-broker capital, while the kill switch remains latched with `KILL_SWITCH_V132_PRESERVED detail=causal_reason_not_retired_heartbeat` during repeated release-installer replay.

Root cause: `kill_switch_persistence_provenance_v143_patch.install_import_hook()` returned early when its process-local installed flag was already set. If compatibility/release replay later replaced `KillSwitch.get_status` or the v140/v131/v130 causal-reader function objects, v143 could remain reported ready without re-anchoring the provenance wrappers.

Fix:
- reassert the v143 status wrapper and causal-reader anchors on every installer invocation;
- always re-anchor v130's compatibility pointer to the current v131 provenance reader;
- add v185 readiness flag/marker for this reassertion contract;
- preserve all existing fail-closed rules: no generic kill-switch clearing, no operator/UI/CLI/risk/drawdown stop bypass, no forced activation, no freshness extension, no synthetic capital, no execution-authority grant;
- add a regression test simulating wrapper drift after installation and proving a second installer call restores all anchors while preserving bounded provenance semantics.

This patch does not clear any kill switch by itself. Existing v140/v132 logic may recover only the already-supported retired authority-heartbeat/core-death persisted stop after current writer/core/readiness/position/bootstrap proofs are genuinely healthy.