### PR TITLE
Recheck kill-switch after provenance reassert v186

### DIFF
--- a/bot/kill_switch_persistence_provenance_v143_patch.py
+++ b/bot/kill_switch_persistence_provenance_v143_patch.py
@@ -25,6 +25,14 @@ without clearing v143's process-local installed flag. v143 now reasserts its
 status wrapper, causal-reader anchors, and release-manifest contract on every
 installer invocation instead of returning early solely because the flag is set.
 
+v186 closes the ordering gap observed in production: the v132 durability worker
+can evaluate a persisted stop immediately before v185 repairs the causal-reader
+anchors. After a successful reassertion, v186 performs one immediate call to the
+existing guarded v132 recovery entry point and emits a bounded causal class. It
+does not widen eligibility, call ``KillSwitch.deactivate`` directly, grant
+execution authority, or force LIVE_ACTIVE. Manual/UI/CLI, risk, drawdown,
+liquidation, panic, unknown-source, and provenance-boundary stops remain closed.
+
 No live state, execution authority, risk gate, nonce, writer lease, SEAK state,
 capital freshness, or publication expiry is changed by this patch.
 """
@@ -40,9 +48,11 @@ from typing import Any
 LOGGER = logging.getLogger("nija.kill_switch_persistence_provenance_v143")
 MARKER = "20260818-kill-switch-persistence-provenance-v143"
 REASSERT_MARKER = "20260822-kill-switch-provenance-reassert-v185"
+POST_REASSERT_MARKER = "20260822-kill-switch-post-reassert-recheck-v186"
 RELEASE_ID = "20260818-runtime-convergence-v143"
 _FLAG = "NIJA_KILL_SWITCH_PERSISTENCE_PROVENANCE_V143_READY"
 _REASSERT_FLAG = "NIJA_KILL_SWITCH_PROVENANCE_REASSERT_V185_READY"
+_POST_REASSERT_FLAG = "NIJA_KILL_SWITCH_POST_REASSERT_RECHECK_V186_READY"
 _PATCH_ATTR = "_nija_kill_switch_persistence_provenance_v143"
 _META_KEY = "_nija_persisted_cause_v143"
 _DEPTH_KEY = "_nija_persistence_history_depth_v143"
@@ -60,13 +70,7 @@ def _restart_persistence_record(item: object) -> bool:
 
 
 def _derive_persisted_cause(history: object) -> dict[str, Any] | None:
-    """Return one bounded causal record for the current restart-persisted stop.
-
-    A source-less record is written by ``KillSwitch.deactivate`` and therefore
-    terminates provenance. Crossing that boundary could misattribute a later
-    manually-created ``EMERGENCY_STOP`` file to an older automatic heartbeat
-    activation, so v143 deliberately refuses to scan past it.
-    """
+    """Return one bounded causal record for the current restart-persisted stop."""
     if not isinstance(history, list) or not history:
         return None
     latest = history[-1]
@@ -243,12 +247,98 @@ def _patch_causal_readers() -> bool:
     anchored_v131 = _wrap_causal_reader(current_v131, "_nija_v143_v131_fallback")
     v140._causal_activation = anchored_v140
     v131._causal_activation = anchored_v131
-
-    # v130 captured v131's old function object during its installer. Always
-    # re-anchor that compatibility pointer so installer replay cannot leave it
-    # reading a stale bounded-history implementation while v143 reports ready.
     v130._latest_activation = anchored_v131
     return True
+
+
+def _causal_class(reason: object, source: object) -> str:
+    """Return a bounded diagnostic class without widening recovery eligibility."""
+    reason_l = str(reason or "").strip().lower()
+    source_u = str(source or "").strip().upper()
+    if source_u == "PROVENANCE_BOUNDARY" or reason_l.startswith("v143_provenance_blocked:"):
+        return "provenance_boundary"
+    if source_u in {"MANUAL", "UI", "CLI"} or any(
+        token in reason_l for token in ("operator", "manual", "ui stop", "cli stop")
+    ):
+        return "manual_or_operator"
+    if any(
+        token in reason_l
+        for token in (
+            "drawdown", "daily loss", "weekly loss", "loss limit", "consecutive losses",
+            "liquidation", "panic", "api instability", "unexpected balance", "balance delta",
+        )
+    ):
+        return "risk_or_drawdown"
+    heartbeat = "authority_heartbeat_expired" in reason_l or "authority heartbeat expired" in reason_l
+    dead_core = "core_thread_dead" in reason_l or "nija_core_thread_alive" in reason_l
+    if heartbeat and dead_core:
+        return "retired_heartbeat_core_signature"
+    if heartbeat:
+        return "heartbeat_other_signature"
+    if source_u == "FILE_SYSTEM" or "kill switch file detected" in reason_l:
+        return "filesystem_persistence"
+    if not reason_l and not source_u:
+        return "unknown"
+    return "other_preserved"
+
+
+def _post_reassert_recheck() -> bool:
+    """Immediately re-run the existing guarded recovery after causal re-anchoring.
+
+    This function deliberately delegates the decision to v132/v140. It never
+    calls KillSwitch.deactivate itself and never modifies readiness or authority.
+    """
+    recovered = False
+    active_before: object = "unknown"
+    active_after: object = "unknown"
+    causal_source = ""
+    causal_reason = ""
+    diagnostic = "unknown"
+    try:
+        kill_module = importlib.import_module("bot.kill_switch")
+        getter = getattr(kill_module, "get_kill_switch", None)
+        kill_switch = getter() if callable(getter) else None
+        status = kill_switch.get_status() if kill_switch is not None else {}
+        active_before = bool(status.get("is_active")) if isinstance(status, dict) else "unknown"
+
+        v140 = importlib.import_module("bot.runtime_killswitch_authority_liveness_patch")
+        reader = getattr(v140, "_causal_activation", None)
+        if callable(reader) and isinstance(status, dict):
+            causal_reason, causal_source = reader(status)
+        diagnostic = _causal_class(causal_reason, causal_source)
+
+        v132 = importlib.import_module("bot.readiness_killswitch_durability_v132_patch")
+        attempt = getattr(v132, "_attempt_persisted_stop_recovery", None)
+        if callable(attempt) and active_before is True:
+            recovered = bool(attempt())
+
+        if kill_switch is not None:
+            status_after = kill_switch.get_status()
+            if isinstance(status_after, dict):
+                active_after = bool(status_after.get("is_active"))
+    except Exception as exc:
+        LOGGER.warning(
+            "KILL_SWITCH_PROVENANCE_V186_RECHECK_ERROR marker=%s err=%s:%s "
+            "trading_fail_closed=true eligibility_unchanged=true",
+            POST_REASSERT_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    LOGGER.critical(
+        "KILL_SWITCH_PROVENANCE_V186_POST_REASSERT_RECHECK marker=%s "
+        "attempted=%s recovered=%s active_before=%s active_after=%s causal_class=%s "
+        "eligibility_unchanged=true direct_deactivate=false generic_auto_clear=false "
+        "manual_ui_cli_stops_preserved=true risk_stops_preserved=true force_live=false",
+        POST_REASSERT_MARKER,
+        str(active_before is True).lower(),
+        str(recovered).lower(),
+        active_before,
+        active_after,
+        diagnostic,
+    )
+    return recovered
 
 
 def _patch_release_manifest() -> bool:
@@ -260,6 +350,7 @@ def _patch_release_manifest() -> bool:
 
     required["kill_switch_persistence_provenance_v143"] = _FLAG
     required["kill_switch_provenance_reassert_v185"] = _REASSERT_FLAG
+    required["kill_switch_post_reassert_recheck_v186"] = _POST_REASSERT_FLAG
     own = ("bot.kill_switch_persistence_provenance_v143_patch", "install_import_hook")
     if own not in installers:
         manifest._INSTALLERS = tuple(installers) + (own,)
@@ -273,22 +364,17 @@ def _patch_release_manifest() -> bool:
 def install_import_hook() -> bool:
     global _INSTALLED
     with _LOCK:
-        # v143 is a follow-on to the existing narrow v140 recovery and the v142
-        # runtime release. Refuse partial installation rather than widening any
-        # recovery path in an unknown runtime composition.
         if os.environ.get("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY") != "1":
             os.environ.pop(_FLAG, None)
             os.environ.pop(_REASSERT_FLAG, None)
+            os.environ.pop(_POST_REASSERT_FLAG, None)
             return False
         if os.environ.get("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY") != "1":
             os.environ.pop(_FLAG, None)
             os.environ.pop(_REASSERT_FLAG, None)
+            os.environ.pop(_POST_REASSERT_FLAG, None)
             return False
 
-        # Do not return early merely because process-local installation state is
-        # already true. Release verification can replay installers after imports
-        # or compatibility layers replace function/class objects. Reassert each
-        # non-authoritative wrapper every time so "ready" means currently owned.
         was_installed = bool(_INSTALLED and os.environ.get(_FLAG) == "1")
         try:
             ok = bool(
@@ -310,11 +396,13 @@ def install_import_hook() -> bool:
         if not ok:
             os.environ.pop(_FLAG, None)
             os.environ.pop(_REASSERT_FLAG, None)
+            os.environ.pop(_POST_REASSERT_FLAG, None)
             os.environ["NIJA_RUNTIME_RELEASE_READY"] = "0"
             return False
 
         os.environ[_FLAG] = "1"
         os.environ[_REASSERT_FLAG] = "1"
+        os.environ[_POST_REASSERT_FLAG] = "1"
         first = not _INSTALLED
         _INSTALLED = True
 
@@ -337,6 +425,11 @@ def install_import_hook() -> bool:
             "execution_authority_unchanged=true force_live=false",
             REASSERT_MARKER,
         )
+
+    # Perform the recheck only after the installer lock is released. The existing
+    # v132/v140 recovery path remains the sole authority to deactivate an
+    # eligible retired heartbeat stop.
+    _post_reassert_recheck()
     return True
 
 
@@ -347,11 +440,14 @@ def install() -> bool:
 __all__ = [
     "MARKER",
     "REASSERT_MARKER",
+    "POST_REASSERT_MARKER",
     "RELEASE_ID",
     "install",
     "install_import_hook",
     "_derive_persisted_cause",
     "_causal_activation_from_status",
+    "_causal_class",
+    "_post_reassert_recheck",
     "_patch_kill_switch_status",
     "_patch_causal_readers",
     "_patch_release_manifest",

--- a/tests/test_kill_switch_persistence_provenance_v143_unittest.py
+++ b/tests/test_kill_switch_persistence_provenance_v143_unittest.py
@@ -108,6 +108,91 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
         self.assertEqual(status[mod._META_KEY].get("source"), "MANUAL")
         self.assertNotIn("full_history", status)
 
+    def test_causal_class_preserves_safety_categories(self) -> None:
+        self.assertEqual(mod._causal_class(HEARTBEAT, "AUTOMATIC"), "retired_heartbeat_core_signature")
+        self.assertEqual(mod._causal_class("operator manual stop", "MANUAL"), "manual_or_operator")
+        self.assertEqual(mod._causal_class("drawdown loss limit reached", "AUTO"), "risk_or_drawdown")
+        self.assertEqual(
+            mod._causal_class("v143_provenance_blocked:origin_unavailable", "PROVENANCE_BOUNDARY"),
+            "provenance_boundary",
+        )
+
+    def test_post_reassert_recheck_delegates_without_direct_clear(self) -> None:
+        class FakeKillSwitch:
+            def __init__(self) -> None:
+                self.active = True
+                self.deactivate_calls = 0
+
+            def get_status(self):
+                return {
+                    "is_active": self.active,
+                    "recent_history": [dict(FILE)],
+                    mod._META_KEY: {"source": "AUTOMATIC", "reason": HEARTBEAT},
+                }
+
+            def deactivate(self, *args, **kwargs):
+                self.deactivate_calls += 1
+                raise AssertionError("v186 must never call deactivate directly")
+
+        kill_switch = FakeKillSwitch()
+        attempts = []
+
+        def attempt():
+            attempts.append(True)
+            return False
+
+        v140 = types.SimpleNamespace(
+            _causal_activation=lambda status: mod._causal_activation_from_status(status)
+        )
+        v132 = types.SimpleNamespace(_attempt_persisted_stop_recovery=attempt)
+        modules = {
+            "bot.kill_switch": types.SimpleNamespace(get_kill_switch=lambda: kill_switch),
+            "bot.runtime_killswitch_authority_liveness_patch": v140,
+            "bot.readiness_killswitch_durability_v132_patch": v132,
+        }
+        original_import = mod.importlib.import_module
+        mod.importlib.import_module = lambda name: modules[name] if name in modules else original_import(name)
+        try:
+            self.assertFalse(mod._post_reassert_recheck())
+        finally:
+            mod.importlib.import_module = original_import
+
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(kill_switch.deactivate_calls, 0)
+        self.assertTrue(kill_switch.active)
+
+    def test_post_reassert_recheck_manual_stop_remains_delegated_and_active(self) -> None:
+        class FakeKillSwitch:
+            def get_status(self):
+                return {
+                    "is_active": True,
+                    "recent_history": [dict(FILE)],
+                    mod._META_KEY: {
+                        "source": "MANUAL",
+                        "reason": "operator manual stop for maintenance",
+                    },
+                }
+
+        calls = []
+        v140 = types.SimpleNamespace(
+            _causal_activation=lambda status: mod._causal_activation_from_status(status)
+        )
+        v132 = types.SimpleNamespace(
+            _attempt_persisted_stop_recovery=lambda: calls.append("attempt") or False
+        )
+        modules = {
+            "bot.kill_switch": types.SimpleNamespace(get_kill_switch=lambda: FakeKillSwitch()),
+            "bot.runtime_killswitch_authority_liveness_patch": v140,
+            "bot.readiness_killswitch_durability_v132_patch": v132,
+        }
+        original_import = mod.importlib.import_module
+        mod.importlib.import_module = lambda name: modules[name] if name in modules else original_import(name)
+        try:
+            self.assertFalse(mod._post_reassert_recheck())
+        finally:
+            mod.importlib.import_module = original_import
+        self.assertEqual(calls, ["attempt"])
+
     def test_installer_reasserts_wrappers_after_replay_drift(self) -> None:
         class FakeKillSwitch:
             def __init__(self) -> None:
@@ -122,6 +207,8 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
                 with self._lock:
                     return {"is_active": True, "recent_history": self._activation_history[-5:]}
 
+        singleton = FakeKillSwitch()
+
         def base_causal(status):
             history = list(status.get("recent_history") or [])
             latest = history[-1] if history else {}
@@ -130,22 +217,30 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
         v140 = types.SimpleNamespace(_causal_activation=base_causal)
         v131 = types.SimpleNamespace(_causal_activation=base_causal)
         v130 = types.SimpleNamespace(_latest_activation=base_causal)
+        v132 = types.SimpleNamespace(_attempt_persisted_stop_recovery=lambda: False)
         manifest = types.SimpleNamespace(_REQUIRED_FLAGS={}, _INSTALLERS=tuple(), DECLARED_RELEASE_ID="old", RELEASE_ID="old")
-        kill_module = types.SimpleNamespace(KillSwitch=FakeKillSwitch)
+        kill_module = types.SimpleNamespace(KillSwitch=FakeKillSwitch, get_kill_switch=lambda: singleton)
         modules = {
             "bot.kill_switch": kill_module,
             "bot.runtime_killswitch_authority_liveness_patch": v140,
             "bot.readiness_killswitch_causality_v131_patch": v131,
             "bot.kill_switch_stale_heartbeat_recovery_v130_patch": v130,
+            "bot.readiness_killswitch_durability_v132_patch": v132,
             "bot.runtime_release_manifest_patch": manifest,
         }
 
         original_import = mod.importlib.import_module
         original_installed = mod._INSTALLED
-        original_flag = os.environ.get(mod._FLAG)
-        original_reassert = os.environ.get(mod._REASSERT_FLAG)
-        original_v140_ready = os.environ.get("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY")
-        original_v142_ready = os.environ.get("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY")
+        tracked_envs = {
+            name: os.environ.get(name)
+            for name in (
+                mod._FLAG,
+                mod._REASSERT_FLAG,
+                mod._POST_REASSERT_FLAG,
+                "NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY",
+                "NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY",
+            )
+        }
         mod.importlib.import_module = lambda name: modules[name] if name in modules else original_import(name)
         os.environ["NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"] = "1"
         os.environ["NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"] = "1"
@@ -154,13 +249,9 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
             self.assertTrue(mod.install_import_hook())
             first_status_owner = FakeKillSwitch.get_status
             self.assertTrue(getattr(first_status_owner, mod._PATCH_ATTR, False))
-            first_v140 = v140._causal_activation
-            first_v131 = v131._causal_activation
-            self.assertTrue(getattr(first_v140, mod._PATCH_ATTR, False))
-            self.assertTrue(getattr(first_v131, mod._PATCH_ATTR, False))
+            self.assertTrue(getattr(v140._causal_activation, mod._PATCH_ATTR, False))
+            self.assertTrue(getattr(v131._causal_activation, mod._PATCH_ATTR, False))
 
-            # Simulate compatibility/import replay replacing all three anchors
-            # while the process-local installed flag remains set.
             def drifted_status(self):
                 with self._lock:
                     return {"is_active": True, "recent_history": self._activation_history[-5:]}
@@ -176,6 +267,11 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
             self.assertTrue(getattr(v131._causal_activation, mod._PATCH_ATTR, False))
             self.assertIs(v130._latest_activation, v131._causal_activation)
             self.assertEqual(os.environ.get(mod._REASSERT_FLAG), "1")
+            self.assertEqual(os.environ.get(mod._POST_REASSERT_FLAG), "1")
+            self.assertEqual(
+                manifest._REQUIRED_FLAGS.get("kill_switch_post_reassert_recheck_v186"),
+                mod._POST_REASSERT_FLAG,
+            )
 
             status = FakeKillSwitch().get_status()
             self.assertEqual(status[mod._META_KEY].get("reason"), HEARTBEAT)
@@ -185,22 +281,11 @@ class KillSwitchPersistenceProvenanceV143Tests(unittest.TestCase):
         finally:
             mod.importlib.import_module = original_import
             mod._INSTALLED = original_installed
-            if original_flag is None:
-                os.environ.pop(mod._FLAG, None)
-            else:
-                os.environ[mod._FLAG] = original_flag
-            if original_reassert is None:
-                os.environ.pop(mod._REASSERT_FLAG, None)
-            else:
-                os.environ[mod._REASSERT_FLAG] = original_reassert
-            if original_v140_ready is None:
-                os.environ.pop("NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY", None)
-            else:
-                os.environ["NIJA_RUNTIME_KILLSWITCH_AUTHORITY_LIVENESS_V140_READY"] = original_v140_ready
-            if original_v142_ready is None:
-                os.environ.pop("NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY", None)
-            else:
-                os.environ["NIJA_CAPITAL_PUBLICATION_LIVENESS_V142_READY"] = original_v142_ready
+            for name, value in tracked_envs.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Production at deployment 002b8d946ea2b469f3a67cc341dbcebeac955a29 proved writer generation 4631, authority_ready, position_sync_ready, and all three platform brokers active. It also showed `KILL_SWITCH_V132_PRESERVED detail=causal_reason_not_retired_heartbeat` at 18:31:00.233, immediately followed by `KILL_SWITCH_PROVENANCE_V185_REASSERTED` at 18:31:00.247. That ordering leaves the repaired causal readers installed only after the guarded recovery decision that just ran; recovery then depends on the background five-second retry.

v186 closes only that ordering/diagnostic gap:
- after v185/v143 successfully reanchors the provenance readers, invoke the existing v132 `_attempt_persisted_stop_recovery()` once immediately;
- do not change v132/v140 eligibility or call `KillSwitch.deactivate` directly;
- emit a bounded causal class (`retired_heartbeat_core_signature`, `manual_or_operator`, `risk_or_drawdown`, `provenance_boundary`, `filesystem_persistence`, `heartbeat_other_signature`, `other_preserved`, `unknown`) instead of widening auto-clear behavior;
- add `NIJA_KILL_SWITCH_POST_REASSERT_RECHECK_V186_READY` to the release contract;
- add regression tests proving delegation only and that manual/risk stops remain active.

Safety remains fail closed: no generic kill-switch clear, no manual/UI/CLI/risk/drawdown/liquidation/panic bypass, no forced activation, no execution-authority grant, no synthetic readiness/capital, and no freshness extension.