### PR TITLE
Fix position-sync readiness installer replay regression v188

### DIFF
--- a/bot/position_sync_dispatch_authority_v96_patch.py
+++ b/bot/position_sync_dispatch_authority_v96_patch.py
@@ -11,6 +11,14 @@ false value immediately makes execution non-permitted; a true-to-false
 regression also advances the global epoch and revokes an existing activation
 commit through the canonical coordinator path.
 
+v188 makes installer replay idempotent. The first install remains fail-closed,
+but a later installer replay must not erase a proven live position-sync state by
+publishing an empty ``manager=None`` snapshot. Replays re-evaluate the canonical
+manager when available; if the canonical manager is temporarily unavailable,
+the existing readiness value is preserved rather than synthetically regressed.
+Real position-sync regressions still publish ``False`` through the normal live
+manager/startup hooks.
+
 No writer, nonce, capital, risk, strategy, kill-switch, or execution authority is
 synthesized here. Readiness becomes true only when at least one broker is
 connected and every currently connected platform/user broker has completed an
@@ -29,6 +37,7 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.position_sync_dispatch_authority_v96")
 MARKER = "20260814-position-sync-dispatch-authority-v96"
+REPLAY_MARKER = "20260822-position-sync-install-replay-v188"
 READINESS_KEY = "position_sync_ready"
 _LOCK = threading.RLock()
 _HOOK_FLAG = "_NIJA_POSITION_SYNC_DISPATCH_AUTHORITY_V96_IMPORT_HOOK"
@@ -97,6 +106,75 @@ def publish_position_sync_readiness(manager: Any, *, source: str) -> tuple[bool,
         status,
     )
     return bool(ready), pending, status
+
+
+def _current_readiness_value() -> bool:
+    """Read canonical readiness truth without mutating it."""
+    try:
+        readiness = _readiness_module()
+        snapshot = getattr(readiness, "snapshot", None)
+        table = dict(snapshot()) if callable(snapshot) else {}
+        return bool(table.get(READINESS_KEY, False))
+    except Exception:
+        return False
+
+
+def _replay_safe_install_seed() -> None:
+    """Seed fail-closed exactly once; replay from live truth thereafter.
+
+    The builtins hook flag is process-wide and survives module import aliases and
+    installer replay. On first install there is no trusted position snapshot yet,
+    so publish ``False`` exactly as v96 historically did. On subsequent replays,
+    prefer a fresh canonical-manager evaluation. If that manager cannot be
+    resolved transiently, leave the existing canonical readiness bit untouched.
+    """
+    first_install = not bool(getattr(builtins, _HOOK_FLAG, False))
+    if first_install:
+        publish_position_sync_readiness(None, source="install_fail_closed")
+        LOGGER.critical(
+            "POSITION_SYNC_V188_INSTALL_SEED marker=%s mode=first_install ready=false "
+            "fail_closed=true existing_proof_overwritten=false",
+            REPLAY_MARKER,
+        )
+        return
+
+    manager = None
+    try:
+        manager = _v95_module()._canonical_manager()
+    except Exception as exc:
+        LOGGER.warning(
+            "POSITION_SYNC_V188_REPLAY_MANAGER_UNAVAILABLE marker=%s error=%s:%s "
+            "existing_readiness_preserved=true synthetic_regression=false",
+            REPLAY_MARKER,
+            type(exc).__name__,
+            exc,
+        )
+
+    if manager is not None:
+        ready, pending, status = publish_position_sync_readiness(
+            manager,
+            source="install_replay_canonical_manager",
+        )
+        LOGGER.critical(
+            "POSITION_SYNC_V188_INSTALL_REPLAY marker=%s manager_resolved=true ready=%s "
+            "pending=%s status=%s canonical_recheck=true synthetic_regression=false",
+            REPLAY_MARKER,
+            str(bool(ready)).lower(),
+            pending,
+            status,
+        )
+        return
+
+    existing = _current_readiness_value()
+    os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "1" if existing else "0"
+    os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "1" if existing else "0"
+    LOGGER.critical(
+        "POSITION_SYNC_V188_INSTALL_REPLAY marker=%s manager_resolved=false "
+        "existing_ready=%s existing_readiness_preserved=true synthetic_regression=false "
+        "fail_closed_if_unproven=true",
+        REPLAY_MARKER,
+        str(bool(existing)).lower(),
+    )
 
 
 def _patch_mabm(module: ModuleType) -> bool:
@@ -169,9 +247,7 @@ def _patch_loaded() -> bool:
 
 def install_import_hook() -> bool:
     with _LOCK:
-        # Establish the fail-closed key before activation can consume an old
-        # coordinator commit. An absent/empty broker set is intentionally false.
-        publish_position_sync_readiness(None, source="install_fail_closed")
+        _replay_safe_install_seed()
         _patch_loaded()
         if not getattr(builtins, _HOOK_FLAG, False):
             original_import = builtins.__import__
@@ -188,9 +264,10 @@ def install_import_hook() -> bool:
             setattr(builtins, _HOOK_FLAG, True)
 
         os.environ["NIJA_POSITION_SYNC_DISPATCH_AUTHORITY_V96_INSTALLED"] = "1"
+        os.environ["NIJA_POSITION_SYNC_INSTALL_REPLAY_V188_READY"] = "1"
         LOGGER.critical(
             "POSITION_SYNC_DISPATCH_AUTHORITY_V96_INSTALLED marker=%s readiness_key=%s "
-            "fail_closed=true stale_commit_revocation=true safety_gates_unchanged=true",
+            "fail_closed=true replay_safe_v188=true stale_commit_revocation=true safety_gates_unchanged=true",
             MARKER,
             READINESS_KEY,
         )
@@ -203,10 +280,13 @@ def install() -> bool:
 
 __all__ = [
     "MARKER",
+    "REPLAY_MARKER",
     "READINESS_KEY",
     "install",
     "install_import_hook",
     "publish_position_sync_readiness",
+    "_current_readiness_value",
+    "_replay_safe_install_seed",
     "_patch_mabm",
     "_patch_startup_sync",
 ]

--- a/bot/tests/test_position_sync_dispatch_authority_v96.py
+++ b/bot/tests/test_position_sync_dispatch_authority_v96.py
@@ -12,6 +12,7 @@ class PositionSyncDispatchAuthorityV96Tests(unittest.TestCase):
     def tearDown(self) -> None:
         os.environ.pop("NIJA_POSITION_SYNC_ACTIVATION_READY", None)
         os.environ.pop("NIJA_POSITION_SYNC_DISPATCH_READY", None)
+        os.environ.pop("NIJA_POSITION_SYNC_INSTALL_REPLAY_V188_READY", None)
 
     def test_publish_is_fail_closed_without_connected_brokers(self) -> None:
         calls = []
@@ -66,6 +67,39 @@ class PositionSyncDispatchAuthorityV96Tests(unittest.TestCase):
             ],
         )
         self.assertEqual(os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"], "0")
+
+    def test_first_install_seed_remains_fail_closed(self) -> None:
+        with mock.patch.object(v96.builtins, v96._HOOK_FLAG, False, create=True), mock.patch.object(
+            v96, "publish_position_sync_readiness"
+        ) as publish:
+            v96._replay_safe_install_seed()
+        publish.assert_called_once_with(None, source="install_fail_closed")
+
+    def test_replay_rechecks_canonical_manager_and_preserves_real_regression(self) -> None:
+        manager = object()
+        v95 = types.SimpleNamespace(_canonical_manager=lambda: manager)
+        with mock.patch.object(v96.builtins, v96._HOOK_FLAG, True, create=True), mock.patch.object(
+            v96, "_v95_module", return_value=v95
+        ), mock.patch.object(
+            v96,
+            "publish_position_sync_readiness",
+            return_value=(False, ["platform:kraken"], {"platform:kraken": False}),
+        ) as publish:
+            v96._replay_safe_install_seed()
+        publish.assert_called_once_with(manager, source="install_replay_canonical_manager")
+
+    def test_replay_without_manager_preserves_existing_true_proof(self) -> None:
+        readiness = types.SimpleNamespace(snapshot=lambda: {v96.READINESS_KEY: True})
+        v95 = types.SimpleNamespace(_canonical_manager=lambda: None)
+        with mock.patch.object(v96.builtins, v96._HOOK_FLAG, True, create=True), mock.patch.object(
+            v96, "_readiness_module", return_value=readiness
+        ), mock.patch.object(v96, "_v95_module", return_value=v95), mock.patch.object(
+            v96, "publish_position_sync_readiness"
+        ) as publish:
+            v96._replay_safe_install_seed()
+        publish.assert_not_called()
+        self.assertEqual(os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"], "1")
+        self.assertEqual(os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"], "1")
 
     def test_startup_sync_wrapper_publishes_after_reconciliation(self) -> None:
         manager = object()


### PR DESCRIPTION
Production on deployment 3a696a89 showed all Kraken/Coinbase/OKX position-sync proofs become ready, then a later runtime installer replay called v96's unconditional `publish_position_sync_readiness(None, source="install_fail_closed")`, synthetically regressing canonical `position_sync_ready` and causing v154 to block activation.

v188 keeps first installation fail-closed, but makes later installer replays idempotent: re-evaluate the canonical manager when available; if temporarily unavailable, preserve existing canonical readiness instead of publishing an empty false snapshot. Real live position-sync regressions still flow through the existing MABM/startup hooks with `allow_regression=True`.

Adds focused tests for first-install fail-closed behavior, canonical replay recheck/regression, and preservation of an existing true proof when the manager is temporarily unavailable. No broker, capital, risk, kill-switch, writer, nonce, activation, or execution gate is bypassed.