### PR TITLE
Fix exchange rejection sample kill-switch latch

### DIFF
--- a/bot/exchange_rejection_sample_guard_v222_patch.py
+++ b/bot/exchange_rejection_sample_guard_v222_patch.py
@@ -1,0 +1,341 @@
+"""Guard exchange rejection-rate kill switching against tiny samples (v222).
+
+Production on 2026-08-24 proved the exchange rejection-rate gate could trip the
+canonical global kill switch on the first rejected order: 1/1 = 100% >= 50%.
+That is mathematically true but statistically insufficient to establish an
+exchange rejection storm. The resulting EXCHANGE_MONITOR stop then persisted
+across healthy runtime recovery and blocked the verification heartbeat itself.
+
+v222 makes two narrow changes without bypassing safety controls:
+
+1. The order-rejection RED gate requires a minimum sample count (default 5,
+   bounded to [2, order_window_size]). Before that count, rejected samples are
+   YELLOW/insufficient-sample diagnostics, never RED.
+2. A lifetime recovery worker may clear only the exact historical
+   EXCHANGE_MONITOR single-sample signature ``(1/1 orders rejected)`` and only
+   after the exact writer/core is healthy and all non-stop structural readiness
+   proofs are current. Manual/UI/CLI, drawdown, risk, authentication, balance,
+   API-instability, unknown, and multi-sample exchange stops remain preserved.
+
+After deactivation, authority/nonce/execution readiness must be re-earned by the
+normal canonical runtime. This patch never marks those proofs, never forces
+LIVE_ACTIVE, and never fabricates execution/order/fill evidence.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+import time
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.exchange_rejection_sample_guard_v222")
+MARKER = "20260824-exchange-rejection-sample-guard-v222"
+_FLAG = "NIJA_EXCHANGE_REJECTION_SAMPLE_GUARD_V222_READY"
+_PATCH_ATTR = "_nija_exchange_rejection_sample_guard_v222"
+_LOCK = threading.RLock()
+_THREAD: threading.Thread | None = None
+_RECOVERED = False
+
+
+def _minimum_samples(cfg: Any) -> int:
+    try:
+        window = max(2, int(getattr(cfg, "order_window_size", 20) or 20))
+    except Exception:
+        window = 20
+    try:
+        requested = int(float(os.environ.get("NIJA_ORDER_REJECT_MIN_SAMPLES", "5") or "5"))
+    except Exception:
+        requested = 5
+    return max(2, min(requested, window))
+
+
+def _patch_rejection_gate() -> bool:
+    module = importlib.import_module("bot.exchange_kill_switch")
+    cls = getattr(module, "ExchangeKillSwitchProtector", None)
+    gate_result = getattr(module, "GateResult", None)
+    gate_status = getattr(module, "GateStatus", None)
+    if not isinstance(cls, type) or gate_result is None or gate_status is None:
+        return False
+
+    current = getattr(cls, "_gate_order_rejection", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def guarded(self: Any):
+        cfg = getattr(self, "_cfg", None)
+        lock = getattr(self, "_lock", None)
+        if cfg is None or lock is None:
+            return current(self)
+        try:
+            with lock:
+                results = list(getattr(self, "_order_results", ()))
+        except Exception:
+            return current(self)
+
+        if not results:
+            return current(self)
+
+        total = len(results)
+        rejected = sum(1 for item in results if not item)
+        min_samples = _minimum_samples(cfg)
+        if total < min_samples:
+            rate = rejected / total
+            detail = {
+                "window_orders": total,
+                "rejected": rejected,
+                "rejection_rate_pct": round(rate * 100, 1),
+                "minimum_samples_for_red": min_samples,
+                "sample_sufficient": False,
+            }
+            if rejected:
+                return gate_result(
+                    "order_rejection",
+                    gate_status.YELLOW,
+                    f"Order rejection sample insufficient for RED: {rejected}/{total} rejected; "
+                    f"need {min_samples} samples",
+                    detail,
+                )
+            return gate_result(
+                "order_rejection",
+                gate_status.GREEN,
+                f"Order rejection sample warming: 0/{total} rejected; need {min_samples} samples",
+                detail,
+            )
+
+        result = current(self)
+        try:
+            if isinstance(getattr(result, "detail", None), dict):
+                result.detail.setdefault("minimum_samples_for_red", min_samples)
+                result.detail.setdefault("sample_sufficient", True)
+        except Exception:
+            pass
+        return result
+
+    setattr(guarded, _PATCH_ATTR, True)
+    setattr(guarded, "__wrapped__", current)
+    cls._gate_order_rejection = guarded
+    return True
+
+
+def _causal_record(status: dict[str, Any]) -> dict[str, Any]:
+    try:
+        v219 = importlib.import_module("bot.kill_switch_false_auth_recovery_v219_patch")
+        helper = getattr(v219, "_causal_record", None)
+        if callable(helper):
+            record = helper(status)
+            if isinstance(record, dict):
+                return record
+    except Exception:
+        pass
+    history = list(status.get("recent_history") or [])
+    for item in reversed(history):
+        if not isinstance(item, dict):
+            return {}
+        source = str(item.get("source") or "").strip()
+        reason = str(item.get("reason") or "").strip()
+        if source.upper() == "FILE_SYSTEM" and "kill switch file detected" in reason.lower():
+            continue
+        if source:
+            return {"source": source, "reason": reason}
+        return {}
+    return {}
+
+
+def _exact_single_sample_stop(record: dict[str, Any]) -> tuple[bool, str]:
+    source = str(record.get("source") or "").strip().upper()
+    reason = str(record.get("reason") or "").strip()
+    lowered = reason.lower()
+    if source != "EXCHANGE_MONITOR":
+        return False, f"source_not_exchange_monitor:{source or 'missing'}"
+    required = (
+        "exchange kill-switch: order rejection rate 100.0%",
+        "(1/1 orders rejected)",
+    )
+    if not all(token in lowered for token in required):
+        return False, "reason_not_exact_single_sample_rejection"
+    forbidden = (
+        "manual", "drawdown", "daily loss", "weekly loss", "invalid_credentials",
+        "unauthorized", "invalid key", "signature", "balance delta", "api instability",
+    )
+    if any(token in lowered for token in forbidden):
+        return False, "unsafe_reason_overlap"
+    return True, reason[:512]
+
+
+def _writer_and_structural_ready() -> tuple[bool, str]:
+    try:
+        v219 = importlib.import_module("bot.kill_switch_false_auth_recovery_v219_patch")
+        writer = getattr(v219, "_writer_healthy", None)
+        structural = getattr(v219, "_structural_readiness", None)
+        if not callable(writer) or not callable(structural):
+            return False, "v219_readiness_helpers_missing"
+        writer_ok, writer_detail = writer()
+        if not writer_ok:
+            return False, f"writer:{writer_detail}"
+        structural_ok, structural_detail = structural()
+        if not structural_ok:
+            return False, f"structural:{structural_detail}"
+        return True, "writer_and_structural_current"
+    except Exception as exc:
+        return False, f"readiness_probe_error:{type(exc).__name__}:{exc}"
+
+
+def attempt_recovery_once() -> bool:
+    global _RECOVERED
+    if _RECOVERED:
+        return False
+    try:
+        kill_module = importlib.import_module("bot.kill_switch")
+        getter = getattr(kill_module, "get_kill_switch", None)
+        ks = getter() if callable(getter) else None
+        if ks is None or not callable(getattr(ks, "get_status", None)):
+            return False
+        status = dict(ks.get_status() or {})
+        if not bool(status.get("is_active")):
+            return False
+
+        record = _causal_record(status)
+        signature_ok, signature_detail = _exact_single_sample_stop(record)
+        if not signature_ok:
+            LOGGER.info(
+                "EXCHANGE_REJECTION_V222_RECOVERY_INELIGIBLE marker=%s detail=%s active_preserved=true",
+                MARKER,
+                signature_detail,
+            )
+            return False
+
+        ready, ready_detail = _writer_and_structural_ready()
+        if not ready:
+            LOGGER.warning(
+                "EXCHANGE_REJECTION_V222_RECOVERY_WAIT marker=%s blocker=%s active_preserved=true",
+                MARKER,
+                ready_detail,
+            )
+            return False
+
+        deactivate = getattr(ks, "deactivate", None)
+        if not callable(deactivate):
+            return False
+        result = deactivate("v222 verified recovery from legacy 1/1 exchange rejection sample latch")
+        if result is False:
+            LOGGER.critical(
+                "EXCHANGE_REJECTION_V222_DEACTIVATE_REFUSED marker=%s trading_fail_closed=true",
+                MARKER,
+            )
+            return False
+
+        after = dict(ks.get_status() or {})
+        if bool(after.get("is_active")) or bool(after.get("kill_file_exists")):
+            LOGGER.critical(
+                "EXCHANGE_REJECTION_V222_VERIFY_FAILED marker=%s active=%s marker_exists=%s trading_fail_closed=true",
+                MARKER,
+                str(bool(after.get("is_active"))).lower(),
+                str(bool(after.get("kill_file_exists"))).lower(),
+            )
+            return False
+
+        try:
+            exchange_module = importlib.import_module("bot.exchange_kill_switch")
+            protector_getter = getattr(exchange_module, "get_exchange_kill_switch_protector", None)
+            protector = protector_getter() if callable(protector_getter) else None
+            reset = getattr(protector, "reset", None)
+            if callable(reset):
+                reset("v222 cleared legacy single-sample rejection latch after verified recovery")
+        except Exception as exc:
+            LOGGER.warning(
+                "EXCHANGE_REJECTION_V222_PROTECTOR_RESET_WARN marker=%s err=%s:%s",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+
+        _RECOVERED = True
+        LOGGER.critical(
+            "EXCHANGE_REJECTION_V222_RECOVERED marker=%s causal_source=EXCHANGE_MONITOR "
+            "legacy_single_sample=true causal_reason=%s writer_proof=exact structural_proofs=current "
+            "authority_nonce_execution_not_fabricated=true activation_must_reprove=true "
+            "forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+            signature_detail,
+        )
+        return True
+    except Exception as exc:
+        LOGGER.warning(
+            "EXCHANGE_REJECTION_V222_RECOVERY_ERROR marker=%s err=%s:%s active_preserved=true trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        installers = getattr(manifest, "_INSTALLERS", None)
+        if not isinstance(required, dict) or not isinstance(installers, tuple):
+            return False
+        required["exchange_rejection_sample_guard_v222"] = _FLAG
+        own = ("bot.exchange_rejection_sample_guard_v222_patch", "install_import_hook")
+        if own not in installers:
+            manifest._INSTALLERS = tuple(installers) + (own,)
+        return True
+    except Exception:
+        return False
+
+
+def _worker() -> None:
+    while True:
+        try:
+            _patch_rejection_gate()
+            _register_manifest()
+            attempt_recovery_once()
+        except Exception as exc:
+            LOGGER.warning(
+                "EXCHANGE_REJECTION_V222_WORKER_ERROR marker=%s err=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(5.0)
+
+
+def install() -> bool:
+    global _THREAD
+    if not _patch_rejection_gate():
+        return False
+    os.environ[_FLAG] = "1"
+    _register_manifest()
+    with _LOCK:
+        if _THREAD is None or not _THREAD.is_alive():
+            _THREAD = threading.Thread(
+                target=_worker,
+                name="ExchangeRejectionSampleGuardV222",
+                daemon=True,
+            )
+            _THREAD.start()
+    LOGGER.critical(
+        "EXCHANGE_REJECTION_SAMPLE_GUARD_V222_READY marker=%s ready=true min_samples=%d "
+        "single_sample_red_blocked=true exact_legacy_recovery_only=true manual_ui_cli_risk_auth_unknown_preserved=true "
+        "execution_authority_unchanged=true forced_activation=false safety_gates_bypassed=false",
+        MARKER,
+        _minimum_samples(getattr(importlib.import_module("bot.exchange_kill_switch").ExchangeKillSwitchProtector(), "_cfg", None)),
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER", "install", "install_import_hook", "attempt_recovery_once",
+    "_minimum_samples", "_exact_single_sample_stop", "_writer_and_structural_ready",
+]

--- a/bot/exchange_rejection_sample_guard_v222_patch.py
+++ b/bot/exchange_rejection_sample_guard_v222_patch.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 import importlib
 import logging
 import os
+import sys
 import threading
 import time
 from functools import wraps
+from types import ModuleType
 from typing import Any
 
 LOGGER = logging.getLogger("nija.exchange_rejection_sample_guard_v222")
@@ -276,19 +278,28 @@ def attempt_recovery_once() -> bool:
 
 
 def _register_manifest() -> bool:
-    try:
-        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
-        required = getattr(manifest, "_REQUIRED_FLAGS", None)
-        installers = getattr(manifest, "_INSTALLERS", None)
-        if not isinstance(required, dict) or not isinstance(installers, tuple):
-            return False
-        required["exchange_rejection_sample_guard_v222"] = _FLAG
-        own = ("bot.exchange_rejection_sample_guard_v222_patch", "install_import_hook")
-        if own not in installers:
-            manifest._INSTALLERS = tuple(installers) + (own,)
-        return True
-    except Exception:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch")
+    if not isinstance(manifest, ModuleType):
         return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict) or not isinstance(installers, tuple):
+        return False
+    required["exchange_rejection_sample_guard_v222"] = _FLAG
+    own = ("bot.exchange_rejection_sample_guard_v222_patch", "install_import_hook")
+    if own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+    return True
+
+
+def _configured_minimum_samples() -> int:
+    try:
+        module = importlib.import_module("bot.exchange_kill_switch")
+        cfg_cls = getattr(module, "ExchangeKillSwitchConfig", None)
+        cfg = cfg_cls() if callable(cfg_cls) else None
+        return _minimum_samples(cfg)
+    except Exception:
+        return 5
 
 
 def _worker() -> None:
@@ -326,7 +337,7 @@ def install() -> bool:
         "single_sample_red_blocked=true exact_legacy_recovery_only=true manual_ui_cli_risk_auth_unknown_preserved=true "
         "execution_authority_unchanged=true forced_activation=false safety_gates_bypassed=false",
         MARKER,
-        _minimum_samples(getattr(importlib.import_module("bot.exchange_kill_switch").ExchangeKillSwitchProtector(), "_cfg", None)),
+        _configured_minimum_samples(),
     )
     return True
 

--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -6,9 +6,9 @@ flag may remain truthy. Redis being absent is a blocker, never permission to
 replace distributed ownership with a process-local assertion.
 
 The earliest startup path also installs the kill-switch provenance, failure
-classification, and durable guarded-replay repairs before normal runtime modules
-can instantiate or use the hard-stop singleton. These repairs never clear an
-unproven stop or grant trading authority.
+classification, durable guarded-replay, and exchange rejection sample repairs
+before normal runtime modules can instantiate or use the hard-stop singleton.
+These repairs never clear an unproven stop or grant trading authority.
 """
 
 from __future__ import annotations
@@ -96,6 +96,10 @@ def _install_early_safety_repairs() -> None:
             "kill_switch_durable_replay_v221_patch",
             "KILL_SWITCH_DURABLE_REPLAY_V221",
         ),
+        (
+            "exchange_rejection_sample_guard_v222_patch",
+            "EXCHANGE_REJECTION_SAMPLE_GUARD_V222",
+        ),
     )
     for module_name, label in repairs:
         try:
@@ -180,7 +184,7 @@ def install_import_hook() -> None:
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. Importing bot.kill_switch defines the class but
 # does not instantiate the singleton, so v217 can safely patch constructor-time
-# file handling before the first get_kill_switch() call. v221 itself does not
-# import the release manifest here; it waits for the canonical runtime to load it.
+# file handling before the first get_kill_switch() call. v221/v222 do not force
+# release-manifest imports here; they wait for canonical runtime loading.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/bot/tests/test_exchange_rejection_sample_guard_v222.py
+++ b/bot/tests/test_exchange_rejection_sample_guard_v222.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bot.exchange_kill_switch import ExchangeKillSwitchConfig, ExchangeKillSwitchProtector, GateStatus
+from bot import exchange_rejection_sample_guard_v222_patch as v222
+
+
+@pytest.fixture(autouse=True)
+def _min_samples(monkeypatch):
+    monkeypatch.setenv("NIJA_ORDER_REJECT_MIN_SAMPLES", "5")
+    assert v222._patch_rejection_gate()
+
+
+def _protector(tmp_path):
+    cfg = ExchangeKillSwitchConfig(
+        order_window_size=20,
+        order_reject_rate_threshold=0.5,
+        order_reject_rate_caution=0.25,
+        auto_trigger_enabled=False,
+    )
+    protector = ExchangeKillSwitchProtector(cfg)
+    protector.STATE_FILE = tmp_path / "exchange_kill_switch_state.json"
+    protector.reset("v222 test isolation")
+    return protector
+
+
+def test_single_rejection_is_insufficient_for_red(tmp_path):
+    protector = _protector(tmp_path)
+    protector.record_order_result("first-rejection", accepted=False)
+
+    gate = protector._gate_order_rejection()
+
+    assert gate.status == GateStatus.YELLOW
+    assert gate.detail["window_orders"] == 1
+    assert gate.detail["rejected"] == 1
+    assert gate.detail["sample_sufficient"] is False
+    assert gate.detail["minimum_samples_for_red"] == 5
+
+
+def test_high_rate_below_minimum_sample_stays_yellow(tmp_path):
+    protector = _protector(tmp_path)
+    protector.record_order_result("bad-1", accepted=False)
+    protector.record_order_result("bad-2", accepted=False)
+    protector.record_order_result("ok-1", accepted=True)
+    protector.record_order_result("ok-2", accepted=True)
+
+    gate = protector._gate_order_rejection()
+
+    assert gate.status == GateStatus.YELLOW
+    assert gate.detail["rejection_rate_pct"] == 50.0
+    assert gate.detail["sample_sufficient"] is False
+
+
+def test_red_gate_still_works_once_minimum_sample_is_met(tmp_path):
+    protector = _protector(tmp_path)
+    for order_id in ("bad-1", "bad-2", "bad-3"):
+        protector.record_order_result(order_id, accepted=False)
+    for order_id in ("ok-1", "ok-2"):
+        protector.record_order_result(order_id, accepted=True)
+
+    gate = protector._gate_order_rejection()
+
+    assert gate.status == GateStatus.RED
+    assert gate.detail["window_orders"] == 5
+    assert gate.detail["rejected"] == 3
+    assert gate.detail["sample_sufficient"] is True
+
+
+def test_exact_legacy_single_sample_exchange_stop_is_eligible():
+    ok, detail = v222._exact_single_sample_stop(
+        {
+            "source": "EXCHANGE_MONITOR",
+            "reason": "Exchange kill-switch: Order rejection rate 100.0% >= 50% (1/1 orders rejected)",
+        }
+    )
+
+    assert ok is True
+    assert "1/1 orders rejected" in detail
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    [
+        ("UI", "Exchange kill-switch: Order rejection rate 100.0% >= 50% (1/1 orders rejected)"),
+        ("FAILURE_MODE_MANAGER", "Exchange kill-switch: Order rejection rate 100.0% >= 50% (1/1 orders rejected)"),
+        ("EXCHANGE_MONITOR", "Exchange kill-switch: Order rejection rate 100.0% >= 50% (2/2 orders rejected)"),
+        ("EXCHANGE_MONITOR", "Exchange kill-switch: Order rejection rate 50.0% >= 50% (5/10 orders rejected)"),
+        ("EXCHANGE_MONITOR", "Exchange kill-switch: Order rejection rate 100.0% >= 50% (1/1 orders rejected) manual"),
+    ],
+)
+def test_recovery_signature_rejects_non_exact_or_unsafe_stops(source, reason):
+    ok, _ = v222._exact_single_sample_stop({"source": source, "reason": reason})
+    assert ok is False
+
+
+def test_minimum_samples_is_bounded(monkeypatch):
+    cfg = ExchangeKillSwitchConfig(order_window_size=4)
+
+    monkeypatch.setenv("NIJA_ORDER_REJECT_MIN_SAMPLES", "1")
+    assert v222._minimum_samples(cfg) == 2
+
+    monkeypatch.setenv("NIJA_ORDER_REJECT_MIN_SAMPLES", "99")
+    assert v222._minimum_samples(cfg) == 4


### PR DESCRIPTION
Repairs the production failure where the exchange rejection-rate gate can trip the global kill switch on the first rejected order (1/1 = 100%).

Changes:
- add v222 rejection-sample guard with a minimum sample count before RED
- preserve RED behavior once the sample is sufficient (default minimum 5)
- add narrowly verified recovery for the exact historical EXCHANGE_MONITOR `(1/1 orders rejected)` latch only after exact writer/core health and structural readiness are current
- preserve manual/UI/CLI, drawdown, risk, credential/auth, balance, API-instability, unknown, and multi-sample stops
- install v222 from the early live-startup safety path
- add focused regression tests

Safety invariants:
- no authority/nonce/execution proof fabrication
- no forced LIVE_ACTIVE
- no risk/min-notional/ECEL bypass
- no generic kill-switch auto-clear
- activation must re-prove normally after the exact legacy latch is cleared