### PR TITLE
Fix exchange rejection provenance under hard stop

### DIFF
--- a/bot/exchange_reject_provenance_v224_patch.py
+++ b/bot/exchange_reject_provenance_v224_patch.py
@@ -1,0 +1,169 @@
+"""Prevent local hard-stop blocks from poisoning exchange rejection telemetry (v224).
+
+A production run on 2026-08-24 showed that ExecutionPipeline reports synthetic
+pipeline failures to ExchangeKillSwitchProtector with order IDs prefixed by
+``exec-reject:pipeline:``. When the canonical global kill switch is already
+active, those failures are local fail-closed blocks: no exchange order is sent.
+Counting them as exchange rejections creates a self-amplifying feedback loop
+where the stop itself increases the rejection-rate sample.
+
+v224 makes one narrow behavioral change: while the canonical global kill switch
+is already active, synthetic pipeline rejection IDs are excluded from the
+exchange-rejection rolling window. Real broker/exchange order results, synthetic
+pipeline failures observed before a global hard stop, accepted orders, rejection
+thresholds, minimum sample size, and all kill-switch activation/deactivation
+semantics remain unchanged.
+
+This patch never deactivates a kill switch, clears EMERGENCY_STOP, modifies
+readiness, grants execution authority, fabricates order/fill proof, or forces
+LIVE_ACTIVE.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.exchange_reject_provenance_v224")
+MARKER = "20260824-exchange-reject-provenance-v224"
+_FLAG = "NIJA_EXCHANGE_REJECT_PROVENANCE_V224_READY"
+_PATCH_ATTR = "_nija_exchange_reject_provenance_v224"
+_SYNTHETIC_PREFIX = "exec-reject:pipeline:"
+_LOCK = threading.RLock()
+_THREAD: threading.Thread | None = None
+
+
+def _is_synthetic_pipeline_reject(order_id: Any) -> bool:
+    return str(order_id or "").strip().lower().startswith(_SYNTHETIC_PREFIX)
+
+
+def _global_stop_active(protector: Any) -> bool:
+    probe = getattr(protector, "_global_kill_switch_active", None)
+    if not callable(probe):
+        return False
+    try:
+        return probe() is True
+    except Exception:
+        return False
+
+
+def _patch_record_order_result() -> bool:
+    module = importlib.import_module("bot.exchange_kill_switch")
+    cls = getattr(module, "ExchangeKillSwitchProtector", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "record_order_result", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def record_order_result_v224(
+        self: Any,
+        order_id: str,
+        accepted: bool,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        # A synthetic pipeline failure while the canonical global stop is
+        # already active is a local fail-closed outcome, not an exchange order
+        # rejection. No broker request was permitted to leave the pipeline.
+        if (
+            accepted is False
+            and _is_synthetic_pipeline_reject(order_id)
+            and _global_stop_active(self)
+        ):
+            LOGGER.critical(
+                "EXCHANGE_REJECT_V224_LOCAL_STOP_IGNORED marker=%s order_id=%s "
+                "global_kill_switch_active=true synthetic_pipeline_reject=true "
+                "exchange_sample_mutated=false real_exchange_results_unchanged=true "
+                "kill_switch_unchanged=true execution_authority_unchanged=true",
+                MARKER,
+                str(order_id)[:256],
+            )
+            return None
+        return current(self, order_id, accepted, *args, **kwargs)
+
+    setattr(record_order_result_v224, _PATCH_ATTR, True)
+    setattr(record_order_result_v224, "__wrapped__", current)
+    setattr(cls, "record_order_result", record_order_result_v224)
+    return True
+
+
+def _register_manifest() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch")
+    if not isinstance(manifest, ModuleType):
+        return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict) or not isinstance(installers, tuple):
+        return False
+    required["exchange_reject_provenance_v224"] = _FLAG
+    own = ("bot.exchange_reject_provenance_v224_patch", "install_import_hook")
+    if own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+    return True
+
+
+def _worker() -> None:
+    while True:
+        try:
+            _patch_record_order_result()
+            _register_manifest()
+        except Exception as exc:
+            LOGGER.warning(
+                "EXCHANGE_REJECT_PROVENANCE_V224_REASSERT_ERROR marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(5.0)
+
+
+def install() -> bool:
+    global _THREAD
+    if not _patch_record_order_result():
+        return False
+    os.environ[_FLAG] = "1"
+    _register_manifest()
+    with _LOCK:
+        if _THREAD is None or not _THREAD.is_alive():
+            _THREAD = threading.Thread(
+                target=_worker,
+                name="ExchangeRejectProvenanceV224",
+                daemon=True,
+            )
+            _THREAD.start()
+    LOGGER.critical(
+        "EXCHANGE_REJECT_PROVENANCE_V224_READY marker=%s ready=true "
+        "synthetic_pipeline_blocks_while_global_stop_ignored=true "
+        "real_exchange_results_unchanged=true pre_stop_synthetic_results_unchanged=true "
+        "thresholds_unchanged=true minimum_sample_unchanged=true auto_recovery=false "
+        "kill_switch_unchanged=true execution_authority_unchanged=true "
+        "forced_activation=false safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_is_synthetic_pipeline_reject",
+    "_global_stop_active",
+    "_patch_record_order_result",
+]

--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -6,9 +6,10 @@ flag may remain truthy. Redis being absent is a blocker, never permission to
 replace distributed ownership with a process-local assertion.
 
 The earliest startup path also installs the kill-switch provenance, failure
-classification, durable guarded-replay, and exchange rejection sample repairs
-before normal runtime modules can instantiate or use the hard-stop singleton.
-These repairs never clear an unproven stop or grant trading authority.
+classification, durable guarded-replay, exchange rejection sample, and
+exchange-rejection provenance repairs before normal runtime modules can
+instantiate or use the hard-stop singleton. These repairs never clear an
+unproven stop or grant trading authority.
 """
 
 from __future__ import annotations
@@ -100,6 +101,10 @@ def _install_early_safety_repairs() -> None:
             "exchange_rejection_sample_guard_v222_patch",
             "EXCHANGE_REJECTION_SAMPLE_GUARD_V222",
         ),
+        (
+            "exchange_reject_provenance_v224_patch",
+            "EXCHANGE_REJECT_PROVENANCE_V224",
+        ),
     )
     for module_name, label in repairs:
         try:
@@ -184,7 +189,7 @@ def install_import_hook() -> None:
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. Importing bot.kill_switch defines the class but
 # does not instantiate the singleton, so v217 can safely patch constructor-time
-# file handling before the first get_kill_switch() call. v221/v222 do not force
-# release-manifest imports here; they wait for canonical runtime loading.
+# file handling before the first get_kill_switch() call. v221/v222/v224 do not
+# force release-manifest imports here; they wait for canonical runtime loading.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/bot/tests/test_exchange_reject_provenance_v224.py
+++ b/bot/tests/test_exchange_reject_provenance_v224.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from bot.exchange_kill_switch import ExchangeKillSwitchConfig, ExchangeKillSwitchProtector
+from bot import exchange_reject_provenance_v224_patch as v224
+
+
+def _protector(tmp_path):
+    cfg = ExchangeKillSwitchConfig(auto_trigger_enabled=False)
+    protector = ExchangeKillSwitchProtector(cfg)
+    protector.STATE_FILE = tmp_path / "exchange_kill_switch_state.json"
+    protector.reset("v224 test isolation")
+    assert v224._patch_record_order_result()
+    return protector
+
+
+def test_synthetic_pipeline_reject_is_ignored_while_global_stop_active(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(protector, "_global_kill_switch_active", lambda: True)
+
+    protector.record_order_result(
+        "exec-reject:pipeline:BTC-USD:buy:123",
+        accepted=False,
+    )
+
+    assert list(protector._order_results) == []
+
+
+def test_synthetic_pipeline_reject_still_counts_before_global_stop(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(protector, "_global_kill_switch_active", lambda: False)
+
+    protector.record_order_result(
+        "exec-reject:pipeline:BTC-USD:buy:124",
+        accepted=False,
+    )
+
+    assert list(protector._order_results) == [False]
+
+
+def test_real_exchange_reject_still_counts_while_global_stop_active(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(protector, "_global_kill_switch_active", lambda: True)
+
+    protector.record_order_result("kraken-order-123", accepted=False)
+
+    assert list(protector._order_results) == [False]
+
+
+def test_accepted_real_order_still_counts(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(protector, "_global_kill_switch_active", lambda: True)
+
+    protector.record_order_result("coinbase-order-456", accepted=True)
+
+    assert list(protector._order_results) == [True]
+
+
+def test_synthetic_classifier_is_narrow():
+    assert v224._is_synthetic_pipeline_reject("exec-reject:pipeline:ETH-USD:buy:1") is True
+    assert v224._is_synthetic_pipeline_reject("kraken-exec-reject:pipeline:1") is False
+    assert v224._is_synthetic_pipeline_reject("exec-reject:router:ETH-USD") is False


### PR DESCRIPTION
## Production evidence
The deployed V223 runtime (`0cb25862231fd58e8cf6f703852bfca511aa6fdb`) is currently blocked by an active `EMERGENCY_STOP`. The heartbeat fails locally at ExecutionGate with `Emergency stop is active`, but `ExecutionPipeline._on_order_rejected()` reports the synthetic `exec-reject:pipeline:*` failure to `ExchangeKillSwitchProtector` as an exchange rejection. This allows the existing hard stop to inflate the exchange rejection sample while no broker order is sent.

## V224 fix
- Ignore only synthetic `exec-reject:pipeline:*` rejected results when the canonical global kill switch is already active.
- Preserve real broker/exchange accepted and rejected order telemetry unchanged.
- Preserve synthetic pipeline rejection accounting before a global stop is active.
- Install the guard in the earliest live startup safety repair path.
- Dynamically register V224 with the runtime release manifest.
- Add focused regression tests for the exact provenance boundary.

## Safety
This change does **not** deactivate the current kill switch or remove `EMERGENCY_STOP`. It does not alter rejection thresholds/minimum samples, writer authority, nonce, capital, risk, ECEL, broker health, order/fill proof, or activation state. The existing 5/5 stop remains preserved because current stored state cannot prove that all five samples were synthetic local blocks.