### PR TITLE
Wake heartbeat immediately after verified kill-switch clear v225

### DIFF
--- a/bot/runtime_heartbeat_killswitch_clear_wakeup_v225_patch.py
+++ b/bot/runtime_heartbeat_killswitch_clear_wakeup_v225_patch.py
@@ -1,0 +1,231 @@
+"""Wake a sleeping heartbeat verifier when the canonical kill switch clears (v225).
+
+Production on 2026-08-24 showed the canonical exchange stop clearing after
+platform position sync had already become ready. v202 only shortens the normal
+heartbeat retry sleep for a position_sync_ready false->true transition, so a
+heartbeat that failed while the stop was active can otherwise remain asleep
+until its normal retry interval even though the blocker has disappeared.
+
+v225 makes one liveness-only change: while a heartbeat retry is already sleeping
+and the canonical kill switch was active at the start of that sleep, wake the
+sleep as soon as the same canonical switch is observed inactive. The next loop
+iteration executes the unchanged heartbeat verification path and must still pass
+writer, nonce, reconciliation, capital, risk, broker-health, ECEL, min-notional,
+exchange acknowledgement, and fill-verification gates.
+
+This patch never deactivates the kill switch, never marks readiness, never grants
+execution authority, never fabricates heartbeat/order/fill proof, and never
+forces LIVE_ACTIVE. v202's existing position-sync wakeup behavior is preserved.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_heartbeat_killswitch_clear_wakeup_v225")
+MARKER = "20260824-heartbeat-killswitch-clear-wakeup-v225"
+_READY_FLAG = "NIJA_HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_READY"
+_PATCH_ATTR = "_nija_heartbeat_killswitch_clear_wakeup_v225"
+_IMPORT_HOOK_ATTR = "_NIJA_HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_IMPORT_HOOK"
+_TARGET_SUFFIX = "runtime_heartbeat_position_sync_wakeup_v202_patch"
+_POLL_S = 0.25
+
+
+def _canonical_kill_switch_active() -> tuple[bool, bool]:
+    """Return (known, active) from the canonical KillSwitch singleton."""
+    try:
+        module = sys.modules.get("bot.kill_switch") or sys.modules.get("kill_switch")
+        if not isinstance(module, ModuleType):
+            module = importlib.import_module("bot.kill_switch")
+        getter = getattr(module, "get_kill_switch", None)
+        if not callable(getter):
+            return False, False
+        kill_switch = getter()
+        probe = getattr(kill_switch, "is_active", None)
+        if not callable(probe):
+            return False, False
+        return True, bool(probe())
+    except Exception:
+        return False, False
+
+
+def _patch_v202(module: ModuleType) -> bool:
+    """Extend v202's sleep helper without changing its runner or probe logic."""
+    current = getattr(module, "_wait_for_retry_or_position_sync", None)
+    position_reader = getattr(module, "_position_sync_ready", None)
+    if not callable(current) or not callable(position_reader):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def wait_v225(sleep_s: float) -> bool:
+        duration = max(0.0, float(sleep_s or 0.0))
+        if duration <= 0.0:
+            return False
+
+        # If the kill switch is not known-active at the start of the retry sleep,
+        # preserve v202 exactly. This prevents rapid retries for unrelated errors.
+        kill_known, kill_active = _canonical_kill_switch_active()
+        if not kill_known or not kill_active:
+            return bool(current(duration))
+
+        try:
+            pos_known, pos_ready = position_reader()
+        except Exception:
+            pos_known, pos_ready = False, False
+
+        deadline = time.monotonic() + duration
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                return False
+            time.sleep(min(_POLL_S, remaining))
+
+            # Preserve v202's existing false->true position-sync transition.
+            if pos_known and not pos_ready:
+                try:
+                    current_pos_known, current_pos_ready = position_reader()
+                except Exception:
+                    current_pos_known, current_pos_ready = False, False
+                if current_pos_known and current_pos_ready:
+                    return True
+
+            current_kill_known, current_kill_active = _canonical_kill_switch_active()
+            if current_kill_known and not current_kill_active:
+                LOGGER.critical(
+                    "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_TRIGGERED marker=%s "
+                    "kill_switch_transition=true_to_false retry_sleep_shortened=true "
+                    "next_probe_unchanged=true readiness_fabricated=false "
+                    "execution_authority_granted=false proof_fabricated=false "
+                    "writer_nonce_risk_reconciliation_capital_broker_health_ecel_min_notional_order_fill_gates_unchanged=true "
+                    "forced_activation=false safety_gates_bypassed=false",
+                    MARKER,
+                )
+                # Return False intentionally: the v202 runner will continue to
+                # its next attempt immediately, but will not mislabel this wake as
+                # a position-sync transition in its own diagnostic.
+                return False
+
+    setattr(wait_v225, _PATCH_ATTR, True)
+    setattr(wait_v225, "__wrapped__", current)
+    setattr(module, "_wait_for_retry_or_position_sync", wait_v225)
+    installed = getattr(module, "_wait_for_retry_or_position_sync", None)
+    return bool(callable(installed) and getattr(installed, _PATCH_ATTR, False))
+
+
+def _patch_loaded_v202() -> bool:
+    patched = False
+    for name in (
+        "bot.runtime_heartbeat_position_sync_wakeup_v202_patch",
+        "runtime_heartbeat_position_sync_wakeup_v202_patch",
+    ):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_v202(module) or patched
+    return patched
+
+
+def _register_manifest_if_loaded() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch")
+    if not isinstance(manifest, ModuleType):
+        return True
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict):
+        return False
+    required["heartbeat_killswitch_clear_wakeup_v225"] = _READY_FLAG
+    own = ("bot.runtime_heartbeat_killswitch_clear_wakeup_v225_patch", "install_import_hook")
+    if isinstance(installers, tuple) and own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+    return True
+
+
+def _install_import_hook() -> bool:
+    if bool(getattr(builtins, _IMPORT_HOOK_ATTR, False)):
+        return True
+    original_import: Callable[..., Any] = builtins.__import__
+
+    def importing(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+        result = original_import(name, globals, locals, fromlist, level)
+        imported_name = str(name or "")
+        if imported_name.endswith(_TARGET_SUFFIX):
+            try:
+                _patch_loaded_v202()
+            except Exception as exc:
+                LOGGER.warning(
+                    "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_REASSERT_ERROR marker=%s "
+                    "imported=%s err=%s:%s trading_fail_closed=true",
+                    MARKER,
+                    imported_name,
+                    type(exc).__name__,
+                    exc,
+                )
+        if imported_name.endswith("runtime_release_manifest_patch"):
+            try:
+                _register_manifest_if_loaded()
+            except Exception:
+                pass
+        return result
+
+    builtins.__import__ = importing
+    setattr(builtins, _IMPORT_HOOK_ATTR, True)
+    return True
+
+
+def install() -> bool:
+    hook_ok = _install_import_hook()
+    patch_ok = _patch_loaded_v202()
+    manifest_ok = _register_manifest_if_loaded()
+    # v202 may legitimately not be imported yet. In that case the import hook is
+    # the installation and will patch v202 immediately after its later import.
+    v202_loaded = any(
+        isinstance(sys.modules.get(name), ModuleType)
+        for name in (
+            "bot.runtime_heartbeat_position_sync_wakeup_v202_patch",
+            "runtime_heartbeat_position_sync_wakeup_v202_patch",
+        )
+    )
+    ready = bool(hook_ok and manifest_ok and (patch_ok or not v202_loaded))
+    os.environ[_READY_FLAG] = "1" if ready else "0"
+    if not ready:
+        LOGGER.critical(
+            "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_FAILED marker=%s hook=%s patch=%s manifest=%s "
+            "v202_loaded=%s trading_fail_closed=true",
+            MARKER,
+            str(hook_ok).lower(),
+            str(patch_ok).lower(),
+            str(manifest_ok).lower(),
+            str(v202_loaded).lower(),
+        )
+        return False
+
+    LOGGER.critical(
+        "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225_READY marker=%s ready=true "
+        "kill_switch_clear_wakeup=true position_sync_v202_preserved=true "
+        "retry_only=true kill_switch_mutated=false readiness_fabricated=false "
+        "execution_authority_granted=false proof_fabricated=false forced_activation=false "
+        "safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_kill_switch_active",
+    "_patch_v202",
+]

--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -6,10 +6,10 @@ flag may remain truthy. Redis being absent is a blocker, never permission to
 replace distributed ownership with a process-local assertion.
 
 The earliest startup path also installs the kill-switch provenance, failure
-classification, durable guarded-replay, exchange rejection sample, and
-exchange-rejection provenance repairs before normal runtime modules can
-instantiate or use the hard-stop singleton. These repairs never clear an
-unproven stop or grant trading authority.
+classification, durable guarded-replay, exchange rejection sample,
+exchange-rejection provenance, and heartbeat recovery-liveness repairs before
+normal runtime modules can instantiate or use the hard-stop singleton. These
+repairs never clear an unproven stop or grant trading authority.
 """
 
 from __future__ import annotations
@@ -105,6 +105,10 @@ def _install_early_safety_repairs() -> None:
             "exchange_reject_provenance_v224_patch",
             "EXCHANGE_REJECT_PROVENANCE_V224",
         ),
+        (
+            "runtime_heartbeat_killswitch_clear_wakeup_v225_patch",
+            "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225",
+        ),
     )
     for module_name, label in repairs:
         try:
@@ -189,7 +193,7 @@ def install_import_hook() -> None:
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. Importing bot.kill_switch defines the class but
 # does not instantiate the singleton, so v217 can safely patch constructor-time
-# file handling before the first get_kill_switch() call. v221/v222/v224 do not
-# force release-manifest imports here; they wait for canonical runtime loading.
+# file handling before the first get_kill_switch() call. v221/v222/v224/v225 do
+# not force release-manifest imports here; they wait for canonical runtime loading.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/bot/tests/test_heartbeat_killswitch_clear_wakeup_v225.py
+++ b/bot/tests/test_heartbeat_killswitch_clear_wakeup_v225.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import types
+
+from bot import runtime_heartbeat_killswitch_clear_wakeup_v225_patch as v225
+
+
+def _fake_v202(wait_result=False):
+    module = types.ModuleType("bot.runtime_heartbeat_position_sync_wakeup_v202_patch")
+    module.position_state = (True, True)
+    module.wait_calls = []
+
+    def _position_sync_ready():
+        return module.position_state
+
+    def _wait_for_retry_or_position_sync(sleep_s):
+        module.wait_calls.append(sleep_s)
+        return wait_result
+
+    module._position_sync_ready = _position_sync_ready
+    module._wait_for_retry_or_position_sync = _wait_for_retry_or_position_sync
+    return module
+
+
+def test_preserves_v202_when_kill_switch_not_active(monkeypatch):
+    module = _fake_v202(wait_result=True)
+    monkeypatch.setattr(v225, "_canonical_kill_switch_active", lambda: (True, False))
+    assert v225._patch_v202(module)
+
+    assert module._wait_for_retry_or_position_sync(0.01) is True
+    assert module.wait_calls == [0.01]
+
+
+def test_wakes_immediately_after_true_to_false_kill_switch_transition(monkeypatch):
+    module = _fake_v202(wait_result=False)
+    states = iter([(True, True), (True, False)])
+    monkeypatch.setattr(v225, "_canonical_kill_switch_active", lambda: next(states))
+    monkeypatch.setattr(v225.time, "sleep", lambda _seconds: None)
+    ticks = iter([0.0, 0.0])
+    monkeypatch.setattr(v225.time, "monotonic", lambda: next(ticks))
+    assert v225._patch_v202(module)
+
+    # False is intentional: v202 must not mislabel the wake as position-sync.
+    assert module._wait_for_retry_or_position_sync(15.0) is False
+    assert module.wait_calls == []
+
+
+def test_position_sync_wakeup_is_preserved_while_kill_switch_active(monkeypatch):
+    module = _fake_v202(wait_result=False)
+    position_states = iter([(True, False), (True, True)])
+    module._position_sync_ready = lambda: next(position_states)
+    monkeypatch.setattr(v225, "_canonical_kill_switch_active", lambda: (True, True))
+    monkeypatch.setattr(v225.time, "sleep", lambda _seconds: None)
+    ticks = iter([0.0, 0.0])
+    monkeypatch.setattr(v225.time, "monotonic", lambda: next(ticks))
+    assert v225._patch_v202(module)
+
+    assert module._wait_for_retry_or_position_sync(15.0) is True
+
+
+def test_unknown_kill_switch_state_preserves_original_wait(monkeypatch):
+    module = _fake_v202(wait_result=False)
+    monkeypatch.setattr(v225, "_canonical_kill_switch_active", lambda: (False, False))
+    assert v225._patch_v202(module)
+
+    assert module._wait_for_retry_or_position_sync(0.01) is False
+    assert module.wait_calls == [0.01]


### PR DESCRIPTION
## Production evidence
The 2026-08-24 runtime reaches authoritative platform position sync for Kraken/Coinbase/OKX, then later shows the canonical kill switch clear. The preceding activation defer still reflects authority/execution/nonce proofs withheld while the stop was active. The existing v202 heartbeat retry wakeup only reacts to `position_sync_ready` false→true, so when position sync is already ready before the stop clears, the real heartbeat verifier can remain asleep for its normal retry interval.

## V225 fix
- Watch only an already-active canonical kill switch during an existing heartbeat retry sleep.
- Wake that sleep immediately on a real canonical `true -> false` kill-switch transition.
- Preserve v202 position-sync wakeup behavior.
- If the kill-switch state is unknown or was not active when the sleep began, preserve the original v202 wait unchanged.
- Install the repair from the early live startup safety chain without importing/constructing a strategy.
- Add focused regression coverage.

## Safety
V225 never deactivates a kill switch, never marks readiness, never grants execution authority, never bypasses Redis writer/nonce stability, risk, reconciliation, capital, broker health, ECEL, min-notional, order acknowledgement, or fill verification, and never forces `LIVE_ACTIVE`. It only lets the unchanged real heartbeat verification path retry sooner after the actual blocker is already gone.