### PR TITLE
V228: require exchange provenance for rejection telemetry

### DIFF
--- a/bot/exchange_reject_dispatch_provenance_v228_patch.py
+++ b/bot/exchange_reject_dispatch_provenance_v228_patch.py
@@ -1,0 +1,201 @@
+"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228).
+
+Production on 2026-08-25 showed the canonical EXCHANGE_MONITOR stop holding a
+5/5 rejection window while the runtime was otherwise converged.  The execution
+pipeline can return failures before a broker order is sent (for example
+``dispatch_disabled: dispatch.enabled=false``) and later route those failures
+through ``_on_order_rejected``.  The pipeline's synthetic telemetry order ID
+alone does not prove that an exchange saw or rejected an order.
+
+v228 patches only the telemetry emission boundary.  Known local, authority,
+state-machine, liquidity, routing, risk, ECEL, disconnected-adapter and other
+pre-dispatch failures are logged as non-exchange outcomes and are not appended
+to ExchangeKillSwitchProtector's order-rejection window.  Errors that are not
+classified as local continue through the existing path unchanged, so genuine
+broker/exchange rejection telemetry, thresholds and fail-closed behavior remain
+intact.
+
+This patch never clears a kill switch, resets a rejection window, marks
+readiness, grants execution authority, fabricates broker ACK/fill proof, changes
+minimum notional/risk rules, or forces LIVE_ACTIVE.  A persisted historical
+rejection stop must still satisfy v226's independent recovery proof after a
+process restart.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.exchange_reject_dispatch_provenance_v228")
+MARKER = "20260825-exchange-reject-dispatch-provenance-v228"
+_FLAG = "NIJA_EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY"
+_PATCH_ATTR = "_nija_exchange_reject_dispatch_provenance_v228"
+_LOCK = threading.RLock()
+_THREAD: threading.Thread | None = None
+
+# These are outcomes that can be produced without a broker order ever reaching
+# an exchange.  They must never contribute to the exchange rejection-rate gate.
+_NON_EXCHANGE_MARKERS = (
+    "dispatch_disabled",
+    "executionauthority reject",
+    "execution_authority_blocked",
+    "execution_authority_runtime",
+    "execution_authority_halt",
+    "execution gate pending",
+    "blocked by state_machine",
+    "state_machine=emergency_stop",
+    "state_machine=live_pending_confirmation",
+    "state_machine=off",
+    "runtime authority convergence lost",
+    "seak halted",
+    "trading blocked",
+    "exchangekillswitch: exchange health red",
+    "exchange health red — trade blocked",
+    "liquidityintelligenceengine",
+    "liquidity grade below",
+    "no available venue found",
+    "no execution router available",
+    "broker_adapter_not_connected",
+    "execution blocked:",
+    "no_execution_venue_available",
+    "broker_not_registered",
+    "replacement_unavailable",
+    "direct_broker_metadata_mismatch",
+    "direct_broker_metadata_cleared",
+    "routing candidate",
+    "internal route",
+    "venue registry",
+    "pretraderiskengine reject",
+    "riskgovernor blocked",
+    "slippageguard blocked",
+    "capitalauthorization deny",
+    "marginhealthgate reject",
+    "ecel unavailable",
+    "ecel reject:",
+    "orderfeasibility deny",
+    "postguard deny",
+)
+
+
+def _is_non_exchange_rejection(reason: Any) -> bool:
+    text = str(reason or "").strip().lower()
+    return bool(text) and any(marker in text for marker in _NON_EXCHANGE_MARKERS)
+
+
+def _patch_execution_pipeline() -> bool:
+    module = importlib.import_module("bot.execution_pipeline")
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "_emit_execution_rejection_telemetry", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def _emit_execution_rejection_telemetry_v228(
+        self: Any,
+        *,
+        symbol: str,
+        side: str,
+        reason: str,
+    ) -> Any:
+        if _is_non_exchange_rejection(reason):
+            LOGGER.critical(
+                "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s "
+                "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
+                "exchange_order_provenance=false kill_switch_unchanged=true "
+                "execution_authority_unchanged=true safety_gates_bypassed=false",
+                MARKER,
+                str(symbol)[:64],
+                str(side)[:32],
+                str(reason)[:512],
+            )
+            return None
+        return current(self, symbol=symbol, side=side, reason=reason)
+
+    setattr(_emit_execution_rejection_telemetry_v228, _PATCH_ATTR, True)
+    setattr(_emit_execution_rejection_telemetry_v228, "__wrapped__", current)
+    setattr(cls, "_emit_execution_rejection_telemetry", _emit_execution_rejection_telemetry_v228)
+    return True
+
+
+def _register_manifest_if_loaded() -> bool:
+    manifest = sys.modules.get("bot.runtime_release_manifest_patch")
+    if not isinstance(manifest, ModuleType):
+        return True
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict):
+        return False
+    required["exchange_reject_dispatch_provenance_v228"] = _FLAG
+    own = ("bot.exchange_reject_dispatch_provenance_v228_patch", "install_import_hook")
+    if isinstance(installers, tuple) and own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+    return True
+
+
+def _worker() -> None:
+    while True:
+        try:
+            _patch_execution_pipeline()
+            _register_manifest_if_loaded()
+        except Exception as exc:
+            LOGGER.warning(
+                "EXCHANGE_REJECT_V228_REASSERT_ERROR marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(5.0)
+
+
+def install() -> bool:
+    global _THREAD
+    if not _patch_execution_pipeline():
+        os.environ[_FLAG] = "0"
+        return False
+    if not _register_manifest_if_loaded():
+        os.environ[_FLAG] = "0"
+        return False
+    os.environ[_FLAG] = "1"
+    with _LOCK:
+        if _THREAD is None or not _THREAD.is_alive():
+            _THREAD = threading.Thread(
+                target=_worker,
+                name="ExchangeRejectDispatchProvenanceV228",
+                daemon=True,
+            )
+            _THREAD.start()
+    LOGGER.critical(
+        "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s ready=true "
+        "local_predispatch_rejects_excluded=true real_exchange_path_unchanged=true "
+        "rejection_thresholds_unchanged=true rejection_window_not_cleared=true "
+        "kill_switch_unchanged=true execution_authority_unchanged=true "
+        "forced_activation=false safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_is_non_exchange_rejection",
+    "_patch_execution_pipeline",
+]

--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -7,10 +7,10 @@ replace distributed ownership with a process-local assertion.
 
 The earliest startup path also installs the kill-switch provenance, failure
 classification, durable guarded-replay, exchange rejection sample,
-exchange-rejection provenance, Kraken capital admission, stale rejection recovery,
-and heartbeat recovery-liveness repairs before normal runtime modules can
-instantiate or use the hard-stop singleton. These repairs never clear an
-unproven stop or grant trading authority.
+exchange-rejection provenance, dispatch provenance, Kraken capital admission,
+stale rejection recovery, and heartbeat recovery-liveness repairs before normal
+runtime modules can instantiate or use the hard-stop singleton. These repairs
+never clear an unproven stop or grant trading authority.
 """
 
 from __future__ import annotations
@@ -105,6 +105,10 @@ def _install_early_safety_repairs() -> None:
         (
             "exchange_reject_provenance_v224_patch",
             "EXCHANGE_REJECT_PROVENANCE_V224",
+        ),
+        (
+            "exchange_reject_dispatch_provenance_v228_patch",
+            "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228",
         ),
         (
             "runtime_kraken_capital_admission_v227_patch",
@@ -202,7 +206,7 @@ def install_import_hook() -> None:
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. Importing bot.kill_switch defines the class but
 # does not instantiate the singleton, so v217 can safely patch constructor-time
-# file handling before the first get_kill_switch() call. v221/v222/v224/v225/v226/v227
+# file handling before the first get_kill_switch() call. v221/v222/v224/v225/v226/v227/v228
 # do not force release-manifest imports here; they wait for canonical runtime loading.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
+++ b/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from bot.exchange_kill_switch import ExchangeKillSwitchConfig, ExchangeKillSwitchProtector
+from bot import exchange_reject_dispatch_provenance_v228_patch as v228
+import bot.execution_pipeline as execution_pipeline
+
+
+def _protector(tmp_path):
+    cfg = ExchangeKillSwitchConfig(auto_trigger_enabled=False)
+    protector = ExchangeKillSwitchProtector(cfg)
+    protector.STATE_FILE = tmp_path / "exchange_kill_switch_state.json"
+    protector.reset("v228 test isolation")
+    return protector
+
+
+def _pipeline_stub():
+    return execution_pipeline.ExecutionPipeline.__new__(execution_pipeline.ExecutionPipeline)
+
+
+def test_non_exchange_classifier_covers_predispatch_failures():
+    reasons = (
+        "dispatch_disabled: dispatch.enabled=false",
+        "ExecutionAuthority reject: SEAK halted (emergency stop)",
+        "Execution gate pending (state_machine=EMERGENCY_STOP)",
+        "Runtime authority convergence lost",
+        "ExchangeKillSwitch: exchange health RED — trade blocked",
+        "LiquidityIntelligenceEngine: liquidity grade below FAIR",
+        "No available venue found for order routing",
+        "BROKER_ADAPTER_NOT_CONNECTED",
+        "RiskGovernor blocked: risk budget exhausted",
+        "ECEL reject: local contract unavailable",
+    )
+    for reason in reasons:
+        assert v228._is_non_exchange_rejection(reason) is True
+
+
+def test_classifier_does_not_swallow_unclassified_exchange_rejects():
+    assert v228._is_non_exchange_rejection("Kraken AddOrder rejected: EOrder:Insufficient margin") is False
+    assert v228._is_non_exchange_rejection("Coinbase order rejected: UNKNOWN_EXCHANGE_FAILURE") is False
+
+
+def test_dispatch_disabled_does_not_mutate_exchange_rejection_window(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(execution_pipeline, "get_exchange_kill_switch_protector", lambda: protector)
+    assert v228._patch_execution_pipeline()
+
+    execution_pipeline.ExecutionPipeline._emit_execution_rejection_telemetry(
+        _pipeline_stub(),
+        symbol="BTC-USD",
+        side="buy",
+        reason="dispatch_disabled: dispatch.enabled=false",
+    )
+
+    assert list(protector._order_results) == []
+
+
+def test_unknown_exchange_reject_still_reaches_exchange_monitor(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(execution_pipeline, "get_exchange_kill_switch_protector", lambda: protector)
+    assert v228._patch_execution_pipeline()
+
+    execution_pipeline.ExecutionPipeline._emit_execution_rejection_telemetry(
+        _pipeline_stub(),
+        symbol="BTC-USD",
+        side="buy",
+        reason="Kraken AddOrder rejected: EOrder:Insufficient margin",
+    )
+
+    assert list(protector._order_results) == [False]


### PR DESCRIPTION
## Problem
Production runtime is holding an EXCHANGE_MONITOR kill switch at 5/5 rejected orders even after capital publication and 3/3 position sync recover. Inspection found that `ExecutionPipeline._dispatch()` can return local/pre-dispatch failures such as `dispatch_disabled: dispatch.enabled=false`; the caller subsequently routes non-throttled failures through `_on_order_rejected()`, whose telemetry helper can append a synthetic `exec-reject:pipeline:*` rejection to the exchange monitor. V224 only suppresses synthetic pipeline failures after the global stop is already active, so pre-stop local failures can still contribute to the initial rejection-rate stop.

## Fix
- Add `exchange_reject_dispatch_provenance_v228_patch.py`.
- Exclude known local/pre-dispatch authority, state-machine, liquidity, routing, risk, ECEL, disconnected-adapter, and dispatch-disabled outcomes from ExchangeKillSwitchProtector's order-rejection window.
- Preserve unclassified/genuine broker-exchange rejection telemetry unchanged.
- Install v228 in the earliest strict-live startup safety repair chain.
- Add regression coverage for `dispatch_disabled` and other local failures, plus proof that an unclassified Kraken rejection still reaches the exchange monitor.

## Safety invariants
- Does not clear/reset the kill switch or rejection window.
- Does not change the 5-sample/rejection thresholds.
- Does not grant authority/nonce/execution readiness.
- Does not alter capital, position-sync, ECEL, min-notional, or risk gates.
- Does not fabricate broker ACK/fill proof or force LIVE_ACTIVE.
- Existing persisted 5/5 stop must still pass v226's independent restart/health proof before recovery.

## Expected production recovery
After deployment/restart, v228 prevents new local pre-dispatch outcomes from contaminating the current process rejection window. If the existing persisted 5/5 stop satisfies v226 and the new process has an empty current rejection window plus healthy structural/non-order gates, v226 may clear that historical latch. NIJA must then re-earn authority, nonce, heartbeat broker ACK/order verification, fill proof, execution_ready, and LIVE_ACTIVE normally.