### PR TITLE
V229: converge same-cycle capital provenance across aliases

### DIFF
--- a/bot/runtime_capital_provenance_alias_convergence_v229_patch.py
+++ b/bot/runtime_capital_provenance_alias_convergence_v229_patch.py
@@ -1,0 +1,293 @@
+"""Converge same-cycle capital refresh provenance across import aliases (v229).
+
+Production evidence on 2026-08-25 showed a canonical capital publication rejected
+as ``incomplete_broker_aggregation:2/3`` while the stalled-writer diagnostic
+reported ``valid_brokers=3`` and position sync remained 3/3.  The v209 zero
+balance completeness repair is intentionally fail closed, but its provenance
+reader returned the first loaded stall-guard alias even when that alias did not
+own the current thread's active refresh context.  A second alias could therefore
+hold the real same-cycle ``live_brokers`` evidence while v209 saw an empty/default
+status and declined the legitimate zero-balance entry.
+
+v229 changes only provenance selection.  It inspects every known stall-guard
+alias, considers only aliases whose thread-local refresh context is actively in
+flight on the publishing thread, deduplicates identical module objects, and
+merges evidence conservatively.  Exclusion or disagreement always wins over a
+live observation.  The existing v209 rules remain authoritative: only an exact
+same-cycle live zero may restore a missing broker key; positive balances are
+never synthesized; timeout/error/stale/unknown brokers remain excluded; capital
+amounts, freshness, completeness thresholds, writer/nonce/risk/kill-switch,
+order/fill and activation gates are unchanged.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import math
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_provenance_alias_convergence_v229")
+MARKER = "20260825-runtime-capital-provenance-alias-convergence-v229"
+RELEASE_ID = "20260825-runtime-convergence-v229"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_PROVENANCE_ALIAS_V229_READY"
+_PATCH_ATTR = "_nija_runtime_capital_provenance_alias_v229"
+_LOCK = threading.RLock()
+_GUARD_NAMES = (
+    "nija_capital_refresh_stall_guard_v35_prebot",
+    "bot.capital_refresh_stall_guard_v35",
+    "capital_refresh_stall_guard_v35",
+)
+
+
+def _key(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").strip().lower()
+
+
+def _row_scalar(row: Any) -> float | None:
+    try:
+        if isinstance(row, dict):
+            value = float(row.get("value", 0.0))
+        else:
+            value = float(row)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(value) or value < 0.0:
+        return None
+    return value
+
+
+def _active_guard_statuses() -> list[tuple[str, ModuleType, dict[str, Any]]]:
+    """Return only same-thread guard aliases with an active refresh context."""
+    rows: list[tuple[str, ModuleType, dict[str, Any]]] = []
+    seen: set[int] = set()
+    for name in _GUARD_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType) or id(module) in seen:
+            continue
+        seen.add(id(module))
+        context = getattr(module, "_REFRESH_CONTEXT", None)
+        if context is None or not bool(getattr(context, "in_refresh", False)):
+            continue
+        getter = getattr(module, "current_refresh_fallback_status", None)
+        if not callable(getter):
+            continue
+        try:
+            status = dict(getter())
+        except Exception as exc:
+            LOGGER.warning(
+                "CAPITAL_PROVENANCE_ALIAS_V229_READ_FAILED marker=%s alias=%s error=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                name,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+        rows.append((name, module, status))
+    return rows
+
+
+def _merged_active_guard_status() -> dict[str, Any]:
+    """Merge active alias evidence with exclusion/conflict taking precedence."""
+    rows = _active_guard_statuses()
+    if not rows:
+        return {}
+
+    live: dict[str, dict[str, Any]] = {}
+    excluded: dict[str, dict[str, Any]] = {}
+    fallbacks: dict[str, dict[str, Any]] = {}
+    live_values: dict[str, float] = {}
+    conflicts: set[str] = set()
+    used_fallback = False
+
+    for alias, _module, status in rows:
+        used_fallback = used_fallback or bool(status.get("used_fallback", False))
+
+        for raw_key, raw_row in dict(status.get("brokers", {}) or {}).items():
+            broker = _key(raw_key)
+            if broker and broker not in fallbacks:
+                fallbacks[broker] = dict(raw_row or {}) if isinstance(raw_row, dict) else {"value": raw_row}
+
+        for raw_key, raw_row in dict(status.get("excluded_brokers", {}) or {}).items():
+            broker = _key(raw_key)
+            if not broker:
+                continue
+            row = dict(raw_row or {}) if isinstance(raw_row, dict) else {"reason": str(raw_row)}
+            row.setdefault("reason", "excluded_by_active_alias")
+            row["alias"] = alias
+            excluded[broker] = row
+
+        for raw_key, raw_row in dict(status.get("live_brokers", {}) or {}).items():
+            broker = _key(raw_key)
+            scalar = _row_scalar(raw_row)
+            if not broker or scalar is None:
+                continue
+            previous = live_values.get(broker)
+            if previous is not None and not math.isclose(previous, scalar, rel_tol=0.0, abs_tol=1e-12):
+                conflicts.add(broker)
+                excluded[broker] = {
+                    "reason": "active_alias_value_conflict",
+                    "first_value": previous,
+                    "second_value": scalar,
+                    "alias": alias,
+                    "cached_valid": False,
+                }
+                continue
+            live_values[broker] = scalar
+            row = dict(raw_row or {}) if isinstance(raw_row, dict) else {"value": scalar}
+            row["value"] = scalar
+            row["alias"] = alias
+            live[broker] = row
+
+    # Safety rule: any active exclusion or cross-alias disagreement wins.
+    for broker in set(excluded) | conflicts:
+        live.pop(broker, None)
+
+    all_recent = bool(
+        used_fallback
+        and fallbacks
+        and not excluded
+        and all(bool(row.get("cached_valid", row.get("observed", False))) for row in fallbacks.values())
+    )
+    result = {
+        "used_fallback": used_fallback,
+        "all_recent": all_recent,
+        "brokers": fallbacks,
+        "excluded_brokers": excluded,
+        "live_brokers": live,
+        "source": "v229_active_alias_merge",
+        "active_aliases": tuple(alias for alias, _module, _status in rows),
+    }
+    if len(rows) > 1 or conflicts:
+        LOGGER.warning(
+            "CAPITAL_PROVENANCE_ALIAS_V229_MERGED marker=%s aliases=%s live=%s excluded=%s conflicts=%s "
+            "exclusion_wins=true stale_aliases_ignored=true capital_mutated=false trading_fail_closed=true",
+            MARKER,
+            list(result["active_aliases"]),
+            sorted(live),
+            sorted(excluded),
+            sorted(conflicts),
+        )
+    return result
+
+
+def _patch_v209() -> bool:
+    try:
+        v209 = importlib.import_module("bot.runtime_zero_balance_completeness_v209_patch")
+    except Exception:
+        return False
+
+    installer = getattr(v209, "install", None)
+    if callable(installer) and installer() is False:
+        return False
+
+    current_guard = getattr(v209, "_guard_status", None)
+    if not callable(current_guard):
+        return False
+    if not bool(getattr(current_guard, _PATCH_ATTR, False)):
+        @wraps(current_guard)
+        def guard_v229() -> dict[str, Any]:
+            active = _merged_active_guard_status()
+            if active:
+                return active
+            # No same-thread active refresh provenance means v209 must not use a
+            # stale/default alias as evidence for a new zero-balance entry.
+            return {}
+
+        setattr(guard_v229, _PATCH_ATTR, True)
+        setattr(guard_v229, "__wrapped__", current_guard)
+        v209._guard_status = guard_v229
+
+    current_augment = getattr(v209, "_augment_snapshot", None)
+    if not callable(current_augment):
+        return False
+    if not bool(getattr(current_augment, _PATCH_ATTR, False)):
+        @wraps(current_augment)
+        def augment_v229(snapshot: Any):
+            balances = dict(getattr(snapshot, "broker_balances", {}) or {})
+            before_keys = sorted({_key(key) for key in balances if _key(key)})
+            try:
+                expected = max(0, int(getattr(snapshot, "expected_brokers", 0) or 0))
+            except (TypeError, ValueError):
+                expected = 0
+            augmented, additions = current_augment(snapshot)
+            if expected > len(before_keys):
+                status = _merged_active_guard_status()
+                live_keys = sorted({_key(key) for key in dict(status.get("live_brokers", {}) or {}) if _key(key)})
+                excluded_keys = sorted({_key(key) for key in dict(status.get("excluded_brokers", {}) or {}) if _key(key)})
+                candidate_missing = sorted((set(live_keys) | set(excluded_keys)) - set(before_keys))
+                LOGGER.warning(
+                    "CAPITAL_COMPLETENESS_V229_DIAGNOSTIC marker=%s expected=%d entries_before=%d "
+                    "snapshot_keys=%s live_keys=%s excluded_keys=%s candidate_missing=%s additions=%s "
+                    "positive_balance_fabricated=false timeout_exclusions_preserved=true "
+                    "freshness_extended=false completeness_threshold_unchanged=true trading_fail_closed=true",
+                    MARKER,
+                    expected,
+                    len(before_keys),
+                    before_keys,
+                    live_keys,
+                    excluded_keys,
+                    candidate_missing,
+                    list(additions),
+                )
+            return augmented, additions
+
+        setattr(augment_v229, _PATCH_ATTR, True)
+        setattr(augment_v229, "__wrapped__", current_augment)
+        v209._augment_snapshot = augment_v229
+
+    return bool(
+        getattr(getattr(v209, "_guard_status", None), _PATCH_ATTR, False)
+        and getattr(getattr(v209, "_augment_snapshot", None), _PATCH_ATTR, False)
+    )
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_provenance_alias_v229"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        v209_ok = _patch_v209()
+        manifest_ok = _patch_release_manifest()
+        ready = bool(v209_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_PROVENANCE_ALIAS_V229 marker=%s ready=%s "
+            "active_refresh_alias_only=true duplicate_module_dedup=true exclusion_wins=true "
+            "alias_conflict_fail_closed=true same_cycle_live_zero_rule_preserved=true "
+            "positive_balance_fabricated=false stale_balance_reused=false freshness_extended=false "
+            "completeness_threshold_unchanged=true writer_nonce_risk_killswitch_order_fill_gates_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+            str(ready).lower(),
+        )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_active_guard_statuses",
+    "_merged_active_guard_status",
+    "_patch_v209",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -11,8 +11,9 @@ the v158 bounded capital-pipeline publication-margin repair, the v161
 capital/position liveness convergence repair, the v162 retired-observation
 fence, the v163 activation proof convergence repair, the v164 canonical
 capital publication/worker-liveness repair, the v165 proactive publication
-scheduler convergence repair, the v167 runtime refresh-demand attestation, and
-the v209 confirmed-zero-balance completeness repair.
+scheduler convergence repair, the v167 runtime refresh-demand attestation, the
+v209 confirmed-zero-balance completeness repair, and the v229 same-cycle capital
+provenance alias convergence repair.
 """
 from __future__ import annotations
 
@@ -204,6 +205,14 @@ def _install_v209_zero_balance_completeness() -> bool:
     )
 
 
+def _install_v229_capital_provenance_alias() -> bool:
+    return _install_named(
+        "bot.runtime_capital_provenance_alias_convergence_v229_patch",
+        "v229_install_missing",
+        "RUNTIME_CAPITAL_PROVENANCE_ALIAS_V229_INSTALL_ERROR",
+    )
+
+
 def _iteration() -> bool:
     changed = _canonicalize_alias()
     required = _apply_broker_threshold()
@@ -219,6 +228,9 @@ def _iteration() -> bool:
     v165_installed = _install_v165_capital_publication_scheduling()
     v167_installed = _install_v167_refresh_demand()
     v209_installed = _install_v209_zero_balance_completeness()
+    # v229 must attach after v209 so it can harden v209's provenance reader
+    # without replacing the existing exact-live-zero admission rule.
+    v229_installed = _install_v229_capital_provenance_alias()
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning(
@@ -231,7 +243,7 @@ def _iteration() -> bool:
         "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s "
         "v154_installed=%s v155_installed=%s v157_installed=%s v158_installed=%s "
         "v161_installed=%s v162_installed=%s v163_installed=%s v164_installed=%s "
-        "v165_installed=%s v167_installed=%s v209_installed=%s",
+        "v165_installed=%s v167_installed=%s v209_installed=%s v229_installed=%s",
         _MARKER,
         _policy(),
         required,
@@ -247,6 +259,7 @@ def _iteration() -> bool:
         str(v165_installed).lower(),
         str(v167_installed).lower(),
         str(v209_installed).lower(),
+        str(v229_installed).lower(),
     )
     return bool(
         v154_installed
@@ -260,6 +273,7 @@ def _iteration() -> bool:
         and v165_installed
         and v167_installed
         and v209_installed
+        and v229_installed
     )
 
 
@@ -289,7 +303,8 @@ def install() -> bool:
             "v158_capital_margin=true v161_capital_position_convergence=true "
             "v162_late_observation_fence=true v163_activation_convergence=true "
             "v164_capital_publication_liveness=true v165_capital_publication_scheduling=true "
-            "v167_refresh_demand=true v209_zero_balance_completeness=true",
+            "v167_refresh_demand=true v209_zero_balance_completeness=true "
+            "v229_capital_provenance_alias=true",
             _MARKER,
             _policy(),
             _required_broker_count(),
@@ -315,5 +330,6 @@ __all__ = [
     "_install_v165_capital_publication_scheduling",
     "_install_v167_refresh_demand",
     "_install_v209_zero_balance_completeness",
+    "_install_v229_capital_provenance_alias",
     "_iteration",
 ]

--- a/bot/tests/test_runtime_capital_provenance_alias_convergence_v229.py
+++ b/bot/tests/test_runtime_capital_provenance_alias_convergence_v229.py
@@ -1,0 +1,193 @@
+"""Regression tests for capital refresh provenance alias convergence v229."""
+from __future__ import annotations
+
+import sys
+import unittest
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import bot.runtime_capital_provenance_alias_convergence_v229_patch as v229
+import bot.runtime_zero_balance_completeness_v209_patch as v209
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    real_capital: float
+    broker_balances: dict[str, float]
+    broker_count: int
+    expected_brokers: int = 3
+
+
+def _guard(name: str, *, active: bool, live: dict | None = None, excluded: dict | None = None) -> ModuleType:
+    module = ModuleType(name)
+    module._REFRESH_CONTEXT = SimpleNamespace(in_refresh=active)
+
+    def current_refresh_fallback_status():
+        return {
+            "live_brokers": dict(live or {}),
+            "excluded_brokers": dict(excluded or {}),
+            "brokers": {},
+            "used_fallback": False,
+            "all_recent": False,
+            "source": "live_exchange",
+        }
+
+    module.current_refresh_fallback_status = current_refresh_fallback_status
+    return module
+
+
+class CapitalProvenanceAliasV229Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.snapshot = _Snapshot(
+            real_capital=345.68,
+            broker_balances={"kraken": 250.0, "coinbase": 95.68},
+            broker_count=2,
+        )
+
+    def test_inactive_first_alias_does_not_hide_active_live_zero(self) -> None:
+        inactive = _guard("nija_capital_refresh_stall_guard_v35_prebot", active=False)
+        active = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 0.0}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": inactive,
+                "bot.capital_refresh_stall_guard_v35": active,
+                "capital_refresh_stall_guard_v35": active,
+            },
+            clear=False,
+        ):
+            with patch.object(v209, "_guard_status", v229._merged_active_guard_status):
+                augmented, additions = v209._augment_snapshot(self.snapshot)
+
+        self.assertEqual(additions, ("okx",))
+        self.assertEqual(augmented.broker_count, 3)
+        self.assertEqual(augmented.broker_balances["okx"], 0.0)
+        self.assertEqual(augmented.real_capital, self.snapshot.real_capital)
+
+    def test_duplicate_alias_object_is_deduplicated(self) -> None:
+        active = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 0.0}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": active,
+                "bot.capital_refresh_stall_guard_v35": active,
+                "capital_refresh_stall_guard_v35": active,
+            },
+            clear=False,
+        ):
+            rows = v229._active_guard_statuses()
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], "nija_capital_refresh_stall_guard_v35_prebot")
+
+    def test_active_exclusion_wins_over_live_zero(self) -> None:
+        live = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 0.0}},
+        )
+        excluded = _guard(
+            "capital_refresh_stall_guard_v35",
+            active=True,
+            excluded={"okx": {"reason": "timeout", "cached_valid": False}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": _guard("prebot", active=False),
+                "bot.capital_refresh_stall_guard_v35": live,
+                "capital_refresh_stall_guard_v35": excluded,
+            },
+            clear=False,
+        ):
+            status = v229._merged_active_guard_status()
+            with patch.object(v209, "_guard_status", v229._merged_active_guard_status):
+                augmented, additions = v209._augment_snapshot(self.snapshot)
+
+        self.assertNotIn("okx", status["live_brokers"])
+        self.assertIn("okx", status["excluded_brokers"])
+        self.assertIs(augmented, self.snapshot)
+        self.assertEqual(additions, ())
+
+    def test_conflicting_active_values_fail_closed(self) -> None:
+        zero = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 0.0}},
+        )
+        positive = _guard(
+            "capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 1.25}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": _guard("prebot", active=False),
+                "bot.capital_refresh_stall_guard_v35": zero,
+                "capital_refresh_stall_guard_v35": positive,
+            },
+            clear=False,
+        ):
+            status = v229._merged_active_guard_status()
+            with patch.object(v209, "_guard_status", v229._merged_active_guard_status):
+                augmented, additions = v209._augment_snapshot(self.snapshot)
+
+        self.assertNotIn("okx", status["live_brokers"])
+        self.assertEqual(status["excluded_brokers"]["okx"]["reason"], "active_alias_value_conflict")
+        self.assertIs(augmented, self.snapshot)
+        self.assertEqual(additions, ())
+
+    def test_all_aliases_inactive_returns_no_provenance(self) -> None:
+        inactive = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=False,
+            live={"okx": {"value": 0.0}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": inactive,
+                "bot.capital_refresh_stall_guard_v35": inactive,
+                "capital_refresh_stall_guard_v35": inactive,
+            },
+            clear=False,
+        ):
+            status = v229._merged_active_guard_status()
+
+        self.assertEqual(status, {})
+
+    def test_positive_missing_balance_is_never_synthesized(self) -> None:
+        active = _guard(
+            "bot.capital_refresh_stall_guard_v35",
+            active=True,
+            live={"okx": {"value": 1.25}},
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "nija_capital_refresh_stall_guard_v35_prebot": _guard("prebot", active=False),
+                "bot.capital_refresh_stall_guard_v35": active,
+                "capital_refresh_stall_guard_v35": active,
+            },
+            clear=False,
+        ):
+            with patch.object(v209, "_guard_status", v229._merged_active_guard_status):
+                augmented, additions = v209._augment_snapshot(self.snapshot)
+
+        self.assertIs(augmented, self.snapshot)
+        self.assertEqual(additions, ())
+        self.assertNotIn("okx", augmented.broker_balances)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Production evidence
The deployed v228 runtime is healthy for kill-switch recovery and position sync, but canonical capital publication regressed to `incomplete_broker_aggregation:2/3` while the runtime simultaneously reports `valid_brokers=3` and positive hydrated capital.

## Root cause addressed
v209 correctly restores only a confirmed same-cycle live zero-balance broker. Its provenance reader, however, returns the first loaded capital-refresh stall-guard alias. If that alias is not the module object owning the current thread-local refresh context, v209 can see empty/default provenance while another loaded alias contains the real same-cycle `live_brokers` evidence.

## V229
- inspects all known stall-guard aliases
- uses only aliases with an active refresh context on the publishing thread
- deduplicates aliases that point to the same module object
- merges evidence conservatively
- exclusion or conflicting observations always win fail-closed
- preserves v209's exact-live-zero-only admission rule
- never synthesizes positive balances
- never revives timeout/error/stale brokers
- keeps 3/3 completeness, freshness, writer, nonce, risk, kill-switch, ECEL, order/fill and activation gates unchanged
- adds an exact diagnostic for snapshot/live/excluded/missing broker keys

Regression tests cover inactive-first-alias drift, duplicate alias identity, timeout exclusion precedence, conflicting values, inactive provenance, and positive-balance non-fabrication.