### PR TITLE
V230: converge CapitalAuthority publisher aliases

### DIFF
--- a/bot/runtime_capital_authority_alias_v230_patch.py
+++ b/bot/runtime_capital_authority_alias_v230_patch.py
@@ -1,0 +1,183 @@
+"""Patch every loaded CapitalAuthority publisher alias with V209/V229 completeness logic.
+
+Production on 2026-08-25 showed V229 ready while canonical publication still
+failed closed as incomplete_broker_aggregation:2/3 and heartbeat execution was
+blocked by capital_snapshot_stale.  V209 patches bot.capital_authority only; a
+separately loaded capital_authority module can therefore publish without V209's
+same-cycle exact-zero augmentation.
+
+V230 patches publish_snapshot on every loaded CapitalAuthority class reachable
+through bot.capital_authority and capital_authority.  Duplicate module/class
+identities are deduplicated.  The wrapper delegates augmentation to V209, whose
+provenance reader is hardened by V229.  Therefore only a same-cycle live exact
+zero can restore a missing broker entry; positive, stale, timeout, error,
+excluded or conflicting observations remain fail closed.
+
+V230 never fabricates positive capital, changes capital totals, freshness TTL,
+completeness thresholds, writer/nonce/risk/kill-switch state, execution proof,
+order/fill proof, or activation state.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_capital_authority_alias_v230")
+MARKER = "20260825-runtime-capital-authority-alias-v230"
+RELEASE_ID = "20260825-runtime-convergence-v230"
+_READY_FLAG = "NIJA_RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230_READY"
+_PATCH_ATTR = "_nija_runtime_capital_authority_alias_v230"
+_LOCK = threading.RLock()
+_THREAD: threading.Thread | None = None
+_AUTHORITY_NAMES = ("bot.capital_authority", "capital_authority")
+
+
+def _loaded_authority_classes() -> list[tuple[str, type]]:
+    """Return distinct loaded CapitalAuthority classes across canonical aliases."""
+    rows: list[tuple[str, type]] = []
+    seen: set[int] = set()
+    for name in _AUTHORITY_NAMES:
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        cls = getattr(module, "CapitalAuthority", None)
+        if not isinstance(cls, type) or id(cls) in seen:
+            continue
+        seen.add(id(cls))
+        rows.append((name, cls))
+    return rows
+
+
+def _patch_class(alias: str, cls: type) -> bool:
+    current = getattr(cls, "publish_snapshot", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def publish_v230(self: Any, snapshot: Any, writer_id: str) -> bool:
+        try:
+            v209 = importlib.import_module("bot.runtime_zero_balance_completeness_v209_patch")
+            augment = getattr(v209, "_augment_snapshot", None)
+            if not callable(augment):
+                raise RuntimeError("v209_augment_missing")
+            augmented, additions = augment(snapshot)
+        except Exception as exc:
+            LOGGER.error(
+                "CAPITAL_AUTHORITY_ALIAS_V230_AUGMENT_FAILED marker=%s alias=%s error=%s:%s "
+                "snapshot_unchanged=true trading_fail_closed=true",
+                MARKER, alias, type(exc).__name__, exc,
+            )
+            augmented, additions = snapshot, ()
+
+        if additions:
+            LOGGER.critical(
+                "CAPITAL_AUTHORITY_ALIAS_V230_RESTORED marker=%s alias=%s brokers=%s "
+                "exact_same_cycle_zero_only=true positive_balance_fabricated=false "
+                "capital_total_unchanged=true freshness_extended=false "
+                "completeness_threshold_unchanged=true execution_authority_granted=false "
+                "forced_trade=false safety_gates_bypassed=false",
+                MARKER, alias, list(additions),
+            )
+        return bool(current(self, augmented, writer_id))
+
+    setattr(publish_v230, _PATCH_ATTR, True)
+    setattr(publish_v230, "__wrapped__", current)
+    cls.publish_snapshot = publish_v230
+    return True
+
+
+def _patch_loaded_aliases() -> tuple[int, int]:
+    """Patch every distinct currently loaded publisher class."""
+    rows = _loaded_authority_classes()
+    patched = 0
+    for alias, cls in rows:
+        if _patch_class(alias, cls):
+            patched += 1
+    return patched, len(rows)
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_capital_authority_alias_v230"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def _worker() -> None:
+    while True:
+        try:
+            _patch_loaded_aliases()
+            _register_manifest()
+        except Exception as exc:
+            LOGGER.warning(
+                "CAPITAL_AUTHORITY_ALIAS_V230_REASSERT_ERROR marker=%s error=%s:%s "
+                "trading_fail_closed=true",
+                MARKER, type(exc).__name__, exc,
+            )
+        time.sleep(max(1.0, float(os.environ.get("NIJA_CAPITAL_AUTHORITY_ALIAS_V230_INTERVAL_S", "5") or 5)))
+
+
+def install() -> bool:
+    global _THREAD
+    with _LOCK:
+        # Ensure V209 then V229 are attached before this publisher wrapper.
+        v209 = importlib.import_module("bot.runtime_zero_balance_completeness_v209_patch")
+        v229 = importlib.import_module("bot.runtime_capital_provenance_alias_convergence_v229_patch")
+        if getattr(v209, "install", lambda: False)() is False:
+            os.environ[_READY_FLAG] = "0"
+            return False
+        if getattr(v229, "install", lambda: False)() is False:
+            os.environ[_READY_FLAG] = "0"
+            return False
+
+        # Import canonical authority so at least one real publisher must exist.
+        importlib.import_module("bot.capital_authority")
+        patched, loaded = _patch_loaded_aliases()
+        manifest_ok = _register_manifest()
+        ready = bool(loaded >= 1 and patched == loaded and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if ready and (_THREAD is None or not _THREAD.is_alive()):
+            _THREAD = threading.Thread(
+                target=_worker,
+                name="RuntimeCapitalAuthorityAliasV230",
+                daemon=True,
+            )
+            _THREAD.start()
+        LOGGER.critical(
+            "RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230 marker=%s ready=%s loaded_alias_classes=%d "
+            "patched_alias_classes=%d duplicate_identity_dedup=true v209_v229_required=true "
+            "exact_same_cycle_zero_only=true positive_balance_fabricated=false stale_balance_reused=false "
+            "freshness_extended=false completeness_threshold_unchanged=true "
+            "writer_nonce_risk_killswitch_order_fill_gates_unchanged=true forced_activation=false "
+            "safety_gates_bypassed=false",
+            MARKER, str(ready).lower(), loaded, patched,
+        )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_loaded_authority_classes",
+    "_patch_loaded_aliases",
+]

--- a/bot/runtime_capital_authority_alias_v230_patch.py
+++ b/bot/runtime_capital_authority_alias_v230_patch.py
@@ -2,16 +2,16 @@
 
 Production on 2026-08-25 showed V229 ready while canonical publication still
 failed closed as incomplete_broker_aggregation:2/3 and heartbeat execution was
-blocked by capital_snapshot_stale.  V209 patches bot.capital_authority only; a
+blocked by capital_snapshot_stale. V209 patches bot.capital_authority only; a
 separately loaded capital_authority module can therefore publish without V209's
 same-cycle exact-zero augmentation.
 
 V230 patches publish_snapshot on every loaded CapitalAuthority class reachable
-through bot.capital_authority and capital_authority.  Duplicate module/class
-identities are deduplicated.  The wrapper delegates augmentation to V209, whose
-provenance reader is hardened by V229.  Therefore only a same-cycle live exact
-zero can restore a missing broker entry; positive, stale, timeout, error,
-excluded or conflicting observations remain fail closed.
+through bot.capital_authority and capital_authority. Duplicate module/class
+identities are deduplicated. The wrapper delegates augmentation to V209, whose
+provenance reader is hardened by V229 before V230 is installed from V229. Thus
+only a same-cycle live exact zero can restore a missing broker entry; positive,
+stale, timeout, error, excluded or conflicting observations remain fail closed.
 
 V230 never fabricates positive capital, changes capital totals, freshness TTL,
 completeness thresholds, writer/nonce/risk/kill-switch state, execution proof,
@@ -96,7 +96,6 @@ def _patch_class(alias: str, cls: type) -> bool:
 
 
 def _patch_loaded_aliases() -> tuple[int, int]:
-    """Patch every distinct currently loaded publisher class."""
     rows = _loaded_authority_classes()
     patched = 0
     for alias, cls in rows:
@@ -134,17 +133,12 @@ def _worker() -> None:
 def install() -> bool:
     global _THREAD
     with _LOCK:
-        # Ensure V209 then V229 are attached before this publisher wrapper.
+        # V229 invokes V230 only after V209 and V229 provenance hooks are ready.
         v209 = importlib.import_module("bot.runtime_zero_balance_completeness_v209_patch")
-        v229 = importlib.import_module("bot.runtime_capital_provenance_alias_convergence_v229_patch")
         if getattr(v209, "install", lambda: False)() is False:
             os.environ[_READY_FLAG] = "0"
             return False
-        if getattr(v229, "install", lambda: False)() is False:
-            os.environ[_READY_FLAG] = "0"
-            return False
 
-        # Import canonical authority so at least one real publisher must exist.
         importlib.import_module("bot.capital_authority")
         patched, loaded = _patch_loaded_aliases()
         manifest_ok = _register_manifest()

--- a/bot/runtime_capital_provenance_alias_convergence_v229_patch.py
+++ b/bot/runtime_capital_provenance_alias_convergence_v229_patch.py
@@ -2,22 +2,25 @@
 
 Production evidence on 2026-08-25 showed a canonical capital publication rejected
 as ``incomplete_broker_aggregation:2/3`` while the stalled-writer diagnostic
-reported ``valid_brokers=3`` and position sync remained 3/3.  The v209 zero
+reported ``valid_brokers=3`` and position sync remained 3/3. The v209 zero
 balance completeness repair is intentionally fail closed, but its provenance
 reader returned the first loaded stall-guard alias even when that alias did not
-own the current thread's active refresh context.  A second alias could therefore
+own the current thread's active refresh context. A second alias could therefore
 hold the real same-cycle ``live_brokers`` evidence while v209 saw an empty/default
 status and declined the legitimate zero-balance entry.
 
-v229 changes only provenance selection.  It inspects every known stall-guard
-alias, considers only aliases whose thread-local refresh context is actively in
-flight on the publishing thread, deduplicates identical module objects, and
-merges evidence conservatively.  Exclusion or disagreement always wins over a
-live observation.  The existing v209 rules remain authoritative: only an exact
+v229 changes provenance selection. It inspects every known stall-guard alias,
+considers only aliases whose thread-local refresh context is actively in flight
+on the publishing thread, deduplicates identical module objects, and merges
+evidence conservatively. Exclusion or disagreement always wins over a live
+observation. The existing v209 rules remain authoritative: only an exact
 same-cycle live zero may restore a missing broker key; positive balances are
-never synthesized; timeout/error/stale/unknown brokers remain excluded; capital
-amounts, freshness, completeness thresholds, writer/nonce/risk/kill-switch,
-order/fill and activation gates are unchanged.
+never synthesized; timeout/error/stale/unknown brokers remain excluded.
+
+After its provenance hooks attach, v229 installs v230 so every distinct loaded
+CapitalAuthority publisher alias receives the same v209 augmentation boundary.
+Capital amounts, freshness, completeness thresholds, writer/nonce/risk/
+kill-switch, order/fill and activation gates remain unchanged.
 """
 from __future__ import annotations
 
@@ -62,7 +65,6 @@ def _row_scalar(row: Any) -> float | None:
 
 
 def _active_guard_statuses() -> list[tuple[str, ModuleType, dict[str, Any]]]:
-    """Return only same-thread guard aliases with an active refresh context."""
     rows: list[tuple[str, ModuleType, dict[str, Any]]] = []
     seen: set[int] = set()
     for name in _GUARD_NAMES:
@@ -82,10 +84,7 @@ def _active_guard_statuses() -> list[tuple[str, ModuleType, dict[str, Any]]]:
             LOGGER.warning(
                 "CAPITAL_PROVENANCE_ALIAS_V229_READ_FAILED marker=%s alias=%s error=%s:%s "
                 "trading_fail_closed=true",
-                MARKER,
-                name,
-                type(exc).__name__,
-                exc,
+                MARKER, name, type(exc).__name__, exc,
             )
             continue
         rows.append((name, module, status))
@@ -93,7 +92,6 @@ def _active_guard_statuses() -> list[tuple[str, ModuleType, dict[str, Any]]]:
 
 
 def _merged_active_guard_status() -> dict[str, Any]:
-    """Merge active alias evidence with exclusion/conflict taking precedence."""
     rows = _active_guard_statuses()
     if not rows:
         return {}
@@ -107,7 +105,6 @@ def _merged_active_guard_status() -> dict[str, Any]:
 
     for alias, _module, status in rows:
         used_fallback = used_fallback or bool(status.get("used_fallback", False))
-
         for raw_key, raw_row in dict(status.get("brokers", {}) or {}).items():
             broker = _key(raw_key)
             if broker and broker not in fallbacks:
@@ -144,7 +141,6 @@ def _merged_active_guard_status() -> dict[str, Any]:
             row["alias"] = alias
             live[broker] = row
 
-    # Safety rule: any active exclusion or cross-alias disagreement wins.
     for broker in set(excluded) | conflicts:
         live.pop(broker, None)
 
@@ -167,11 +163,7 @@ def _merged_active_guard_status() -> dict[str, Any]:
         LOGGER.warning(
             "CAPITAL_PROVENANCE_ALIAS_V229_MERGED marker=%s aliases=%s live=%s excluded=%s conflicts=%s "
             "exclusion_wins=true stale_aliases_ignored=true capital_mutated=false trading_fail_closed=true",
-            MARKER,
-            list(result["active_aliases"]),
-            sorted(live),
-            sorted(excluded),
-            sorted(conflicts),
+            MARKER, list(result["active_aliases"]), sorted(live), sorted(excluded), sorted(conflicts),
         )
     return result
 
@@ -195,8 +187,6 @@ def _patch_v209() -> bool:
             active = _merged_active_guard_status()
             if active:
                 return active
-            # No same-thread active refresh provenance means v209 must not use a
-            # stale/default alias as evidence for a new zero-balance entry.
             return {}
 
         setattr(guard_v229, _PATCH_ATTR, True)
@@ -226,14 +216,8 @@ def _patch_v209() -> bool:
                     "snapshot_keys=%s live_keys=%s excluded_keys=%s candidate_missing=%s additions=%s "
                     "positive_balance_fabricated=false timeout_exclusions_preserved=true "
                     "freshness_extended=false completeness_threshold_unchanged=true trading_fail_closed=true",
-                    MARKER,
-                    expected,
-                    len(before_keys),
-                    before_keys,
-                    live_keys,
-                    excluded_keys,
-                    candidate_missing,
-                    list(additions),
+                    MARKER, expected, len(before_keys), before_keys, live_keys, excluded_keys,
+                    candidate_missing, list(additions),
                 )
             return augmented, additions
 
@@ -259,21 +243,35 @@ def _patch_release_manifest() -> bool:
         return False
 
 
+def _install_v230() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_capital_authority_alias_v230_patch")
+        installer = getattr(module, "install", None)
+        return bool(callable(installer) and installer())
+    except Exception as exc:
+        LOGGER.error(
+            "CAPITAL_AUTHORITY_ALIAS_V230_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        return False
+
+
 def install() -> bool:
     with _LOCK:
         v209_ok = _patch_v209()
         manifest_ok = _patch_release_manifest()
-        ready = bool(v209_ok and manifest_ok)
+        v230_ok = bool(v209_ok and manifest_ok and _install_v230())
+        ready = bool(v209_ok and manifest_ok and v230_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         LOGGER.critical(
             "RUNTIME_CAPITAL_PROVENANCE_ALIAS_V229 marker=%s ready=%s "
             "active_refresh_alias_only=true duplicate_module_dedup=true exclusion_wins=true "
             "alias_conflict_fail_closed=true same_cycle_live_zero_rule_preserved=true "
-            "positive_balance_fabricated=false stale_balance_reused=false freshness_extended=false "
-            "completeness_threshold_unchanged=true writer_nonce_risk_killswitch_order_fill_gates_unchanged=true "
-            "forced_activation=false safety_gates_bypassed=false",
-            MARKER,
-            str(ready).lower(),
+            "publisher_alias_v230=%s positive_balance_fabricated=false stale_balance_reused=false "
+            "freshness_extended=false completeness_threshold_unchanged=true "
+            "writer_nonce_risk_killswitch_order_fill_gates_unchanged=true forced_activation=false "
+            "safety_gates_bypassed=false",
+            MARKER, str(ready).lower(), str(v230_ok).lower(),
         )
         return ready
 
@@ -290,4 +288,5 @@ __all__ = [
     "_active_guard_statuses",
     "_merged_active_guard_status",
     "_patch_v209",
+    "_install_v230",
 ]

--- a/bot/tests/test_runtime_capital_authority_alias_v230.py
+++ b/bot/tests/test_runtime_capital_authority_alias_v230.py
@@ -1,0 +1,98 @@
+"""Regression tests for capital-authority publisher alias convergence v230."""
+from __future__ import annotations
+
+import sys
+import unittest
+from dataclasses import dataclass
+from types import ModuleType
+from unittest.mock import patch
+
+import bot.runtime_capital_authority_alias_v230_patch as v230
+import bot.runtime_zero_balance_completeness_v209_patch as v209
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    real_capital: float
+    broker_balances: dict[str, float]
+    broker_count: int
+    expected_brokers: int = 3
+
+
+def _authority_module(name: str) -> tuple[ModuleType, type]:
+    module = ModuleType(name)
+
+    class CapitalAuthority:
+        def __init__(self) -> None:
+            self.seen = None
+
+        def publish_snapshot(self, snapshot, writer_id):
+            self.seen = snapshot
+            return True
+
+    module.CapitalAuthority = CapitalAuthority
+    return module, CapitalAuthority
+
+
+class CapitalAuthorityAliasV230Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.snapshot = _Snapshot(
+            real_capital=345.97,
+            broker_balances={"kraken": 252.76, "coinbase": 93.21},
+            broker_count=2,
+        )
+
+    def test_distinct_authority_alias_classes_are_both_patched(self) -> None:
+        canonical, canonical_cls = _authority_module("bot.capital_authority")
+        alias, alias_cls = _authority_module("capital_authority")
+        with patch.dict(sys.modules, {"bot.capital_authority": canonical, "capital_authority": alias}, clear=False):
+            patched, loaded = v230._patch_loaded_aliases()
+        self.assertEqual(loaded, 2)
+        self.assertEqual(patched, 2)
+        self.assertTrue(getattr(canonical_cls.publish_snapshot, v230._PATCH_ATTR, False))
+        self.assertTrue(getattr(alias_cls.publish_snapshot, v230._PATCH_ATTR, False))
+
+    def test_duplicate_class_identity_is_deduplicated(self) -> None:
+        canonical, canonical_cls = _authority_module("bot.capital_authority")
+        alias = ModuleType("capital_authority")
+        alias.CapitalAuthority = canonical_cls
+        with patch.dict(sys.modules, {"bot.capital_authority": canonical, "capital_authority": alias}, clear=False):
+            rows = v230._loaded_authority_classes()
+        self.assertEqual(len(rows), 1)
+
+    def test_noncanonical_alias_publish_uses_v209_augmentation(self) -> None:
+        alias, alias_cls = _authority_module("capital_authority")
+        canonical, _ = _authority_module("bot.capital_authority")
+        augmented = _Snapshot(
+            real_capital=self.snapshot.real_capital,
+            broker_balances={**self.snapshot.broker_balances, "okx": 0.0},
+            broker_count=3,
+        )
+        with patch.dict(sys.modules, {"bot.capital_authority": canonical, "capital_authority": alias}, clear=False):
+            with patch.object(v209, "_augment_snapshot", return_value=(augmented, ("okx",))):
+                self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+                authority = alias_cls()
+                self.assertTrue(authority.publish_snapshot(self.snapshot, "writer"))
+        self.assertEqual(authority.seen.broker_count, 3)
+        self.assertEqual(authority.seen.broker_balances["okx"], 0.0)
+        self.assertEqual(authority.seen.real_capital, self.snapshot.real_capital)
+
+    def test_no_addition_leaves_snapshot_unchanged(self) -> None:
+        alias, alias_cls = _authority_module("capital_authority")
+        with patch.object(v209, "_augment_snapshot", return_value=(self.snapshot, ())):
+            self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+            authority = alias_cls()
+            self.assertTrue(authority.publish_snapshot(self.snapshot, "writer"))
+        self.assertIs(authority.seen, self.snapshot)
+
+    def test_augmentation_failure_fails_closed_with_original_snapshot(self) -> None:
+        alias, alias_cls = _authority_module("capital_authority")
+        with patch.object(v209, "_augment_snapshot", side_effect=RuntimeError("bad provenance")):
+            self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+            authority = alias_cls()
+            self.assertTrue(authority.publish_snapshot(self.snapshot, "writer"))
+        self.assertIs(authority.seen, self.snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Production evidence
The deployed V229 runtime at `2c2e28208860074fae5b9ebfdbc4536095b3492c` reports V209 and V229 ready, yet canonical capital publication still fails closed as `incomplete_broker_aggregation:2/3` while `valid_brokers=3`. The heartbeat is then denied by `capital_snapshot_stale` before any `BROKER_SUBMIT_ATTEMPT` occurs.

## Root cause
V209 wraps `publish_snapshot` only on `bot.capital_authority.CapitalAuthority`. NIJA can hold a separately loaded `capital_authority` module/class. V229 hardens V209's provenance reader, but if publication occurs through the unwrapped alias, neither V209 augmentation nor V229 diagnostics run on that real publisher.

## V230 fix
- Patch `publish_snapshot` on every distinct loaded CapitalAuthority class across `bot.capital_authority` and `capital_authority`.
- Deduplicate aliases that share the same class identity.
- Reuse V209 `_augment_snapshot`, after V229 has hardened its provenance reader.
- Reassert alias coverage every 5 seconds so late-loaded aliases are covered.
- Chain V230 directly from V229 so ordering remains V209 -> V229 -> V230.
- Register V230 in the runtime release manifest.
- Add regression coverage for distinct aliases, duplicate class identity, noncanonical publisher augmentation, unchanged snapshots, and fail-closed augmentation errors.

## Safety invariants
- Exact same-cycle live zero only.
- No positive balance fabrication.
- No stale/timeout/error/excluded/conflicting broker promotion.
- No capital-total mutation.
- No freshness TTL extension or completeness threshold reduction.
- No writer/nonce/risk/kill-switch bypass.
- No execution authority, order/fill proof, or LIVE_ACTIVE fabrication.

## Expected runtime proof after deploy
Look for `RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230 ... ready=true`; if a confirmed zero broker is the missing row, then `CAPITAL_AUTHORITY_ALIAS_V230_RESTORED` / V209 restoration should precede an accepted 3/3 capital publication. Only after capital is fresh should the heartbeat be allowed to proceed to real broker submission and the remaining EXCHANGE_MONITOR latch be reassessed.