### PR TITLE
Fix authority/nonce truth convergence and Kraken position-sync wakeup (v231)

### DIFF
--- a/bot/runtime_authority_nonce_truth_convergence_v231_patch.py
+++ b/bot/runtime_authority_nonce_truth_convergence_v231_patch.py
@@ -1,0 +1,284 @@
+"""Converge current writer-authority and nonce truth without weakening safety.
+
+Production on 2026-08-25 exposed two coupled readiness defects:
+
+* authority_heartbeat could mark ``nonce_ready`` from the absence of the legacy
+  KRAKEN_NONCE_LEASE_REQUIRED environment variable even while a connected Kraken
+  platform broker was present; and
+* preactivation_readiness_convergence_v16 used one combined writer+nonce probe
+  for both ``authority_ready`` and ``nonce_ready``. A legitimate pending Kraken
+  nonce proof could therefore erase a separately proven current writer authority
+  heartbeat when v133 synchronized current proof truth.
+
+v231 keeps those facts independent. Writer authority is reconstructed only from
+current distributed-writer authority, a fresh writer heartbeat, and a clear kill
+switch. Nonce readiness remains the existing v16/current runtime nonce proof; if
+Kraken is connected, no Coinbase-only shortcut is permitted. Execution readiness
+requires both independent proofs.
+
+When position synchronization is still false after a healthy authority heartbeat,
+v231 wakes the existing v161 authoritative position-sync monitor immediately.
+It never marks position_sync_ready itself and never converts a failed/timeout
+broker read into success.
+
+No capital, broker connectivity, balance, position, nonce, writer, risk,
+kill-switch, order/fill or LIVE activation proof is fabricated. All existing
+fail-closed gates remain authoritative.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_authority_nonce_truth_convergence_v231")
+MARKER = "20260825-runtime-authority-nonce-truth-convergence-v231"
+RELEASE_ID = "20260825-runtime-convergence-v231"
+_READY_FLAG = "NIJA_RUNTIME_AUTHORITY_NONCE_TRUTH_V231_READY"
+_PATCH_ATTR = "_nija_runtime_authority_nonce_truth_v231"
+_LOCK = threading.RLock()
+_INSTALLED = False
+
+
+def _v16():
+    return importlib.import_module("preactivation_readiness_convergence_v16_patch")
+
+
+def _tsm():
+    return importlib.import_module("bot.trading_state_machine")
+
+
+def _readiness():
+    return importlib.import_module("bot.readiness_table")
+
+
+def _current_writer_authority_proof() -> tuple[bool, str]:
+    """Return writer authority independently of Kraken nonce maturity."""
+    v16 = _v16()
+    tsm = _tsm()
+
+    token = str(os.environ.get("NIJA_WRITER_FENCING_TOKEN", "") or "").strip()
+    generation = str(os.environ.get("NIJA_WRITER_LEASE_GENERATION", "") or "").strip()
+    if not token or not generation:
+        return False, f"writer_identity_missing:token={bool(token)} generation={generation or 'missing'}"
+
+    heartbeat_probe = getattr(v16, "_heartbeat_ready", None)
+    if not callable(heartbeat_probe):
+        return False, "writer_heartbeat_probe_missing"
+    heartbeat_ok, heartbeat_detail = heartbeat_probe()
+    if not bool(heartbeat_ok):
+        return False, str(heartbeat_detail or "writer_heartbeat_not_ready")
+
+    authority_gate = getattr(tsm, "_distributed_writer_authority_gate", None)
+    if not callable(authority_gate):
+        return False, "distributed_writer_authority_gate_missing"
+    authority_ok, authority_detail = authority_gate()
+    if not bool(authority_ok):
+        return False, str(authority_detail or "distributed_writer_authority_not_ready")
+
+    kill_probe = getattr(v16, "_kill_switch_clear", None)
+    if not callable(kill_probe):
+        return False, "kill_switch_probe_missing"
+    kill_ok, kill_detail = kill_probe()
+    if not bool(kill_ok):
+        return False, str(kill_detail or "kill_switch_not_clear")
+
+    return True, f"writer_authority_current;{heartbeat_detail or 'heartbeat_fresh'}"
+
+
+def _kraken_nonce_required() -> bool:
+    """Use canonical runtime broker topology, never legacy env absence."""
+    tsm = _tsm()
+    required = getattr(tsm, "_kraken_nonce_gates_required", None)
+    if not callable(required):
+        # Fail closed if topology cannot be classified.
+        return True
+    try:
+        return bool(required())
+    except Exception:
+        return True
+
+
+def _patch_v16_proof_collection() -> bool:
+    v16 = _v16()
+    current = getattr(v16, "_collect_proofs", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def collect_v231():
+        proofs, details = current()
+        proofs = dict(proofs or {})
+        details = dict(details or {})
+
+        # Preserve the existing v16 nonce proof. It already flows through the
+        # canonical runtime writer/nonce gate and must remain false while a
+        # connected Kraken lease is pending. Only authority is decoupled from it.
+        nonce_ready = bool(proofs.get("nonce_ready", False))
+        authority_ready, authority_detail = _current_writer_authority_proof()
+        execution_pipeline = bool(details.get("execution_pipeline_wired", False))
+        risk_ready = bool(proofs.get("risk_ready", False))
+
+        proofs["authority_ready"] = bool(authority_ready)
+        proofs["nonce_ready"] = bool(nonce_ready)
+        proofs["execution_ready"] = bool(
+            execution_pipeline and risk_ready and authority_ready and nonce_ready
+        )
+        details["v231_writer_authority"] = authority_detail
+        details["v231_kraken_nonce_required"] = _kraken_nonce_required()
+        details["v231_nonce_ready"] = nonce_ready
+        return proofs, details
+
+    setattr(collect_v231, _PATCH_ATTR, True)
+    setattr(collect_v231, "__wrapped__", current)
+    v16._collect_proofs = collect_v231
+    return True
+
+
+def _correct_heartbeat_nonce_truth() -> tuple[bool, str]:
+    """Undo only the legacy Coinbase-only nonce shortcut when Kraken is active."""
+    if not _kraken_nonce_required():
+        return True, "kraken_nonce_not_applicable"
+
+    # Re-use the canonical v16 nonce proof after v231 collection patching.
+    try:
+        proofs, _details = _v16()._collect_proofs()
+        nonce_ready = bool(dict(proofs or {}).get("nonce_ready", False))
+    except Exception as exc:
+        nonce_ready = False
+        LOGGER.warning(
+            "AUTHORITY_NONCE_V231_NONCE_PROBE_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+
+    readiness = _readiness()
+    table = dict(readiness.snapshot())
+    if nonce_ready:
+        if not bool(table.get("nonce_ready", False)):
+            readiness.mark_ready("nonce_ready")
+        return True, "kraken_nonce_current_proof_true"
+
+    if bool(table.get("nonce_ready", False)):
+        readiness.revoke_ready("nonce_ready", reason="v231_active_kraken_nonce_proof_false")
+        LOGGER.warning(
+            "AUTHORITY_NONCE_V231_FALSE_COINBASE_SHORTCUT_REVOKED marker=%s "
+            "kraken_active=true nonce_ready=false proof_fabricated=false trading_fail_closed=true",
+            MARKER,
+        )
+    return False, "kraken_nonce_current_proof_false"
+
+
+def _wake_position_sync_if_needed() -> bool:
+    """Dispatch the existing authoritative v161 reconciler; never publish success."""
+    try:
+        table = dict(_readiness().snapshot())
+        if bool(table.get("position_sync_ready", False)):
+            return False
+        v161 = importlib.import_module("bot.runtime_capital_position_convergence_v161_patch")
+        iteration = getattr(v161, "_position_monitor_iteration", None)
+        if not callable(iteration):
+            return False
+        started, published = iteration()
+        LOGGER.info(
+            "POSITION_SYNC_V231_WAKE marker=%s workers_started=%s readiness_published=%s "
+            "authoritative_adopter_only=true synthetic_success=false",
+            MARKER,
+            started,
+            str(bool(published)).lower(),
+        )
+        return bool(started or published)
+    except Exception as exc:
+        LOGGER.warning(
+            "POSITION_SYNC_V231_WAKE_FAILED marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+def _patch_authority_heartbeat() -> bool:
+    heartbeat = importlib.import_module("bot.authority_heartbeat")
+    cls = getattr(heartbeat, "AuthorityHeartbeatMonitor", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "_tick", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    @wraps(current)
+    def tick_v231(self: Any) -> None:
+        current(self)
+        # Only reconcile readiness after a genuinely healthy current authority
+        # heartbeat. Failure/lockdown paths remain untouched.
+        authority_ok, _detail = _current_writer_authority_proof()
+        if not authority_ok:
+            return
+        _correct_heartbeat_nonce_truth()
+        _wake_position_sync_if_needed()
+
+    setattr(tick_v231, _PATCH_ATTR, True)
+    setattr(tick_v231, "__wrapped__", current)
+    cls._tick = tick_v231
+    return True
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_authority_nonce_truth_v231"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    global _INSTALLED
+    with _LOCK:
+        v16_ok = _patch_v16_proof_collection()
+        heartbeat_ok = _patch_authority_heartbeat()
+        manifest_ok = _register_manifest()
+        ready = bool(v16_ok and heartbeat_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        _INSTALLED = ready
+        LOGGER.critical(
+            "RUNTIME_AUTHORITY_NONCE_TRUTH_V231 marker=%s ready=%s "
+            "authority_nonce_split=true active_kraken_topology_authoritative=true "
+            "legacy_coinbase_nonce_shortcut_corrected=true position_sync_immediate_wakeup=true "
+            "nonce_gates_unchanged=true writer_gates_unchanged=true kill_switch_unchanged=true "
+            "risk_gates_unchanged=true execution_proof_fabricated=false forced_activation=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            str(ready).lower(),
+        )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_current_writer_authority_proof",
+    "_kraken_nonce_required",
+    "_correct_heartbeat_nonce_truth",
+    "_wake_position_sync_if_needed",
+    "_patch_v16_proof_collection",
+    "_patch_authority_heartbeat",
+]

--- a/bot/runtime_capital_authority_alias_v230_patch.py
+++ b/bot/runtime_capital_authority_alias_v230_patch.py
@@ -13,6 +13,10 @@ provenance reader is hardened by V229 before V230 is installed from V229. Thus
 only a same-cycle live exact zero can restore a missing broker entry; positive,
 stale, timeout, error, excluded or conflicting observations remain fail closed.
 
+After V230's publisher aliases are converged, V231 is installed to keep current
+writer-authority truth independent from Kraken nonce maturity and to remove the
+legacy Coinbase-only nonce shortcut when Kraken is an active connected broker.
+
 V230 never fabricates positive capital, changes capital totals, freshness TTL,
 completeness thresholds, writer/nonce/risk/kill-switch state, execution proof,
 order/fill proof, or activation state.
@@ -116,11 +120,28 @@ def _register_manifest() -> bool:
         return False
 
 
+def _install_v231() -> bool:
+    """Install authority/nonce truth convergence after V230 is established."""
+    try:
+        module = importlib.import_module("bot.runtime_authority_nonce_truth_convergence_v231_patch")
+        installer = getattr(module, "install", None)
+        return bool(callable(installer) and installer())
+    except Exception as exc:
+        LOGGER.error(
+            "RUNTIME_AUTHORITY_NONCE_TRUTH_V231_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _worker() -> None:
     while True:
         try:
             _patch_loaded_aliases()
             _register_manifest()
+            _install_v231()
         except Exception as exc:
             LOGGER.warning(
                 "CAPITAL_AUTHORITY_ALIAS_V230_REASSERT_ERROR marker=%s error=%s:%s "
@@ -142,7 +163,10 @@ def install() -> bool:
         importlib.import_module("bot.capital_authority")
         patched, loaded = _patch_loaded_aliases()
         manifest_ok = _register_manifest()
-        ready = bool(loaded >= 1 and patched == loaded and manifest_ok)
+        base_ready = bool(loaded >= 1 and patched == loaded and manifest_ok)
+        # Install V231 only after V230's own publisher safety boundary is ready.
+        v231_ok = bool(base_ready and _install_v231())
+        ready = bool(base_ready and v231_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if ready and (_THREAD is None or not _THREAD.is_alive()):
             _THREAD = threading.Thread(
@@ -154,11 +178,12 @@ def install() -> bool:
         LOGGER.critical(
             "RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230 marker=%s ready=%s loaded_alias_classes=%d "
             "patched_alias_classes=%d duplicate_identity_dedup=true v209_v229_required=true "
-            "exact_same_cycle_zero_only=true positive_balance_fabricated=false stale_balance_reused=false "
+            "v231_authority_nonce_truth=%s exact_same_cycle_zero_only=true "
+            "positive_balance_fabricated=false stale_balance_reused=false "
             "freshness_extended=false completeness_threshold_unchanged=true "
             "writer_nonce_risk_killswitch_order_fill_gates_unchanged=true forced_activation=false "
             "safety_gates_bypassed=false",
-            MARKER, str(ready).lower(), loaded, patched,
+            MARKER, str(ready).lower(), loaded, patched, str(v231_ok).lower(),
         )
         return ready
 
@@ -174,4 +199,5 @@ __all__ = [
     "install_import_hook",
     "_loaded_authority_classes",
     "_patch_loaded_aliases",
+    "_install_v231",
 ]

--- a/bot/tests/test_runtime_authority_nonce_truth_convergence_v231.py
+++ b/bot/tests/test_runtime_authority_nonce_truth_convergence_v231.py
@@ -1,0 +1,123 @@
+"""Regression tests for runtime authority/nonce truth convergence v231."""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import bot.runtime_authority_nonce_truth_convergence_v231_patch as v231
+
+
+class _FakeReadiness:
+    def __init__(self, table=None):
+        self.table = dict(table or {})
+        self.revocations = []
+
+    def snapshot(self):
+        return dict(self.table)
+
+    def mark_ready(self, key):
+        self.table[key] = True
+
+    def revoke_ready(self, key, reason=""):
+        self.table[key] = False
+        self.revocations.append((key, reason))
+
+
+class AuthorityNonceTruthV231Tests(unittest.TestCase):
+    def test_collect_keeps_current_authority_true_while_nonce_is_pending(self) -> None:
+        def original_collect():
+            return (
+                {
+                    "authority_ready": False,
+                    "nonce_ready": False,
+                    "execution_ready": False,
+                    "risk_ready": True,
+                },
+                {"execution_pipeline_wired": True},
+            )
+
+        fake_v16 = SimpleNamespace(_collect_proofs=original_collect)
+        with patch.object(v231, "_v16", return_value=fake_v16), \
+             patch.object(v231, "_current_writer_authority_proof", return_value=(True, "current")), \
+             patch.object(v231, "_kraken_nonce_required", return_value=True):
+            self.assertTrue(v231._patch_v16_proof_collection())
+            proofs, details = fake_v16._collect_proofs()
+
+        self.assertTrue(proofs["authority_ready"])
+        self.assertFalse(proofs["nonce_ready"])
+        self.assertFalse(proofs["execution_ready"])
+        self.assertTrue(details["v231_kraken_nonce_required"])
+
+    def test_execution_requires_both_authority_and_nonce(self) -> None:
+        def original_collect():
+            return (
+                {
+                    "authority_ready": False,
+                    "nonce_ready": True,
+                    "execution_ready": False,
+                    "risk_ready": True,
+                },
+                {"execution_pipeline_wired": True},
+            )
+
+        fake_v16 = SimpleNamespace(_collect_proofs=original_collect)
+        with patch.object(v231, "_v16", return_value=fake_v16), \
+             patch.object(v231, "_current_writer_authority_proof", return_value=(True, "current")), \
+             patch.object(v231, "_kraken_nonce_required", return_value=True):
+            self.assertTrue(v231._patch_v16_proof_collection())
+            proofs, _ = fake_v16._collect_proofs()
+
+        self.assertTrue(proofs["authority_ready"])
+        self.assertTrue(proofs["nonce_ready"])
+        self.assertTrue(proofs["execution_ready"])
+
+    def test_active_kraken_revokes_false_coinbase_nonce_shortcut(self) -> None:
+        readiness = _FakeReadiness({"nonce_ready": True})
+        fake_v16 = SimpleNamespace(
+            _collect_proofs=lambda: ({"nonce_ready": False}, {})
+        )
+        with patch.object(v231, "_kraken_nonce_required", return_value=True), \
+             patch.object(v231, "_readiness", return_value=readiness), \
+             patch.object(v231, "_v16", return_value=fake_v16):
+            ok, detail = v231._correct_heartbeat_nonce_truth()
+
+        self.assertFalse(ok)
+        self.assertEqual(detail, "kraken_nonce_current_proof_false")
+        self.assertFalse(readiness.table["nonce_ready"])
+        self.assertEqual(
+            readiness.revocations,
+            [("nonce_ready", "v231_active_kraken_nonce_proof_false")],
+        )
+
+    def test_no_kraken_leaves_nonce_not_applicable(self) -> None:
+        readiness = _FakeReadiness({"nonce_ready": False})
+        with patch.object(v231, "_kraken_nonce_required", return_value=False), \
+             patch.object(v231, "_readiness", return_value=readiness):
+            ok, detail = v231._correct_heartbeat_nonce_truth()
+        self.assertTrue(ok)
+        self.assertEqual(detail, "kraken_nonce_not_applicable")
+        self.assertFalse(readiness.table["nonce_ready"])
+
+    def test_position_sync_wakeup_dispatches_existing_v161_monitor_only(self) -> None:
+        readiness = _FakeReadiness({"position_sync_ready": False})
+        iteration = Mock(return_value=(1, True))
+        fake_v161 = SimpleNamespace(_position_monitor_iteration=iteration)
+
+        real_import = v231.importlib.import_module
+
+        def import_side_effect(name):
+            if name == "bot.runtime_capital_position_convergence_v161_patch":
+                return fake_v161
+            return real_import(name)
+
+        with patch.object(v231, "_readiness", return_value=readiness), \
+             patch.object(v231.importlib, "import_module", side_effect=import_side_effect):
+            self.assertTrue(v231._wake_position_sync_if_needed())
+
+        iteration.assert_called_once_with()
+        self.assertFalse(readiness.table["position_sync_ready"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Production logs on 2026-08-25 showed a real readiness truth mismatch:

- authority heartbeat proved current writer authority and marked `authority_ready=True`;
- heartbeat then marked `nonce_ready=True` using a legacy "Coinbase-only" shortcut based only on an absent env flag;
- Kraken was actually connected and still pending authoritative position sync;
- v133 immediately revoked authority/nonce because v16 used one combined writer+nonce proof for both readiness keys.

## Fix

Adds v231 runtime authority/nonce truth convergence:

- separates current distributed writer authority from Kraken nonce maturity;
- preserves existing nonce proof as authoritative and requires nonce for execution readiness;
- uses canonical runtime Kraken topology instead of `KRAKEN_NONCE_LEASE_REQUIRED` absence;
- corrects any transient false Coinbase-only `nonce_ready` publication when Kraken is active;
- immediately wakes the existing v161 authoritative position-sync monitor when position sync is pending;
- never marks position sync successful itself;
- chains v231 from the existing v230 convergence installer;
- adds regression tests for authority/nonce separation, active-Kraken nonce behavior, execution gating, and position-sync wakeup.

## Safety contract

No capital, balance, broker connectivity, position, writer, nonce, risk, kill-switch, order/fill, execution, or LIVE activation proof is fabricated. Existing fail-closed gates remain authoritative. No forced activation or safety bypass is introduced.