### PR TITLE
V231: re-anchor V230 outside replayed capital gates

### DIFF
--- a/bot/runtime_capital_authority_alias_v230_patch.py
+++ b/bot/runtime_capital_authority_alias_v230_patch.py
@@ -13,6 +13,19 @@ provenance reader is hardened by V229 before V230 is installed from V229. Thus
 only a same-cycle live exact zero can restore a missing broker entry; positive,
 stale, timeout, error, excluded or conflicting observations remain fail closed.
 
+Wrapper-order hardening
+-----------------------
+Production at 05:30 UTC showed both V230 aliases patched yet V170 still rejected
+raw 2/3 snapshots before any V229 diagnostic/restoration ran. The cause was
+``functools.wraps`` marker inheritance: when a later wrapper (for example V170)
+wrapped V230, it copied V230's custom marker into its own ``__dict__``. The old
+idempotence test used ``getattr(current, _PATCH_ATTR)`` and therefore mistook the
+outer non-V230 wrapper for the active V230 boundary. V230 now tracks the exact
+wrapper function objects it owns in a WeakSet. If another wrapper is replayed
+outside V230, the reassert worker detects that the current method is not a direct
+V230 wrapper and re-anchors augmentation outside it. This preserves every inner
+safety/rejection gate while ensuring completeness augmentation runs first.
+
 V230 never fabricates positive capital, changes capital totals, freshness TTL,
 completeness thresholds, writer/nonce/risk/kill-switch state, execution proof,
 order/fill proof, or activation state.
@@ -25,9 +38,10 @@ import os
 import sys
 import threading
 import time
+import weakref
 from functools import wraps
 from types import ModuleType
-from typing import Any
+from typing import Any, Callable
 
 LOGGER = logging.getLogger("nija.runtime_capital_authority_alias_v230")
 MARKER = "20260825-runtime-capital-authority-alias-v230"
@@ -37,6 +51,7 @@ _PATCH_ATTR = "_nija_runtime_capital_authority_alias_v230"
 _LOCK = threading.RLock()
 _THREAD: threading.Thread | None = None
 _AUTHORITY_NAMES = ("bot.capital_authority", "capital_authority")
+_DIRECT_WRAPPERS: weakref.WeakSet[Callable[..., Any]] = weakref.WeakSet()
 
 
 def _loaded_authority_classes() -> list[tuple[str, type]]:
@@ -55,12 +70,27 @@ def _loaded_authority_classes() -> list[tuple[str, type]]:
     return rows
 
 
+def _is_direct_wrapper(method: Any) -> bool:
+    """Return True only when *method itself* is a V230-owned outer wrapper.
+
+    Do not trust a copied custom attribute here. ``functools.wraps`` propagates
+    the wrapped function's ``__dict__`` to a new outer wrapper, which is exactly
+    the production ordering failure this check prevents.
+    """
+    try:
+        return method in _DIRECT_WRAPPERS
+    except TypeError:
+        return False
+
+
 def _patch_class(alias: str, cls: type) -> bool:
     current = getattr(cls, "publish_snapshot", None)
     if not callable(current):
         return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
+    if _is_direct_wrapper(current):
         return True
+
+    inherited_marker = bool(getattr(current, _PATCH_ATTR, False))
 
     @wraps(current)
     def publish_v230(self: Any, snapshot: Any, writer_id: str) -> bool:
@@ -91,8 +121,19 @@ def _patch_class(alias: str, cls: type) -> bool:
 
     setattr(publish_v230, _PATCH_ATTR, True)
     setattr(publish_v230, "__wrapped__", current)
+    _DIRECT_WRAPPERS.add(publish_v230)
     cls.publish_snapshot = publish_v230
-    return True
+
+    if inherited_marker:
+        LOGGER.warning(
+            "CAPITAL_AUTHORITY_ALIAS_V230_REANCHORED marker=%s alias=%s "
+            "copied_marker_detected=true outer_wrapper_repaired=true "
+            "augmentation_runs_before_inner_gates=true completeness_threshold_unchanged=true "
+            "trading_fail_closed=true",
+            MARKER,
+            alias,
+        )
+    return _is_direct_wrapper(cls.publish_snapshot)
 
 
 def _patch_loaded_aliases() -> tuple[int, int]:
@@ -153,7 +194,8 @@ def install() -> bool:
             _THREAD.start()
         LOGGER.critical(
             "RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230 marker=%s ready=%s loaded_alias_classes=%d "
-            "patched_alias_classes=%d duplicate_identity_dedup=true v209_v229_required=true "
+            "patched_alias_classes=%d duplicate_identity_dedup=true direct_wrapper_identity=true "
+            "wraps_marker_inheritance_safe=true v209_v229_required=true "
             "exact_same_cycle_zero_only=true positive_balance_fabricated=false stale_balance_reused=false "
             "freshness_extended=false completeness_threshold_unchanged=true "
             "writer_nonce_risk_killswitch_order_fill_gates_unchanged=true forced_activation=false "
@@ -173,5 +215,7 @@ __all__ = [
     "install",
     "install_import_hook",
     "_loaded_authority_classes",
+    "_is_direct_wrapper",
+    "_patch_class",
     "_patch_loaded_aliases",
 ]

--- a/bot/tests/test_runtime_capital_authority_alias_v230.py
+++ b/bot/tests/test_runtime_capital_authority_alias_v230.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 import unittest
 from dataclasses import dataclass
+from functools import wraps
 from types import ModuleType
 from unittest.mock import patch
 
@@ -49,8 +50,8 @@ class CapitalAuthorityAliasV230Tests(unittest.TestCase):
             patched, loaded = v230._patch_loaded_aliases()
         self.assertEqual(loaded, 2)
         self.assertEqual(patched, 2)
-        self.assertTrue(getattr(canonical_cls.publish_snapshot, v230._PATCH_ATTR, False))
-        self.assertTrue(getattr(alias_cls.publish_snapshot, v230._PATCH_ATTR, False))
+        self.assertTrue(v230._is_direct_wrapper(canonical_cls.publish_snapshot))
+        self.assertTrue(v230._is_direct_wrapper(alias_cls.publish_snapshot))
 
     def test_duplicate_class_identity_is_deduplicated(self) -> None:
         canonical, canonical_cls = _authority_module("bot.capital_authority")
@@ -76,6 +77,49 @@ class CapitalAuthorityAliasV230Tests(unittest.TestCase):
         self.assertEqual(authority.seen.broker_count, 3)
         self.assertEqual(authority.seen.broker_balances["okx"], 0.0)
         self.assertEqual(authority.seen.real_capital, self.snapshot.real_capital)
+
+    def test_outer_wraps_marker_copy_is_reanchored_before_completeness_gate(self) -> None:
+        """A replayed outer gate must not hide V230 behind a copied marker."""
+        alias, alias_cls = _authority_module("capital_authority")
+        augmented = _Snapshot(
+            real_capital=self.snapshot.real_capital,
+            broker_balances={**self.snapshot.broker_balances, "okx": 0.0},
+            broker_count=3,
+        )
+        with patch.object(v209, "_augment_snapshot", return_value=(augmented, ("okx",))):
+            self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+            v230_inner = alias_cls.publish_snapshot
+
+            @wraps(v230_inner)
+            def replayed_completeness_gate(self, snapshot, writer_id):
+                if int(getattr(snapshot, "broker_count", 0) or 0) < 3:
+                    return False
+                return v230_inner(self, snapshot, writer_id)
+
+            # functools.wraps copied V230's marker even though this function is
+            # not V230's augmentation boundary. This reproduces production.
+            alias_cls.publish_snapshot = replayed_completeness_gate
+            self.assertTrue(getattr(alias_cls.publish_snapshot, v230._PATCH_ATTR, False))
+            self.assertFalse(v230._is_direct_wrapper(alias_cls.publish_snapshot))
+
+            # Reassertion must wrap outside the replayed gate so the 2/3 raw
+            # snapshot becomes a truthful 3/3 snapshot before the gate checks it.
+            self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+            self.assertTrue(v230._is_direct_wrapper(alias_cls.publish_snapshot))
+            authority = alias_cls()
+            self.assertTrue(authority.publish_snapshot(self.snapshot, "writer"))
+
+        self.assertEqual(authority.seen.broker_count, 3)
+        self.assertEqual(authority.seen.broker_balances["okx"], 0.0)
+        self.assertEqual(authority.seen.real_capital, self.snapshot.real_capital)
+
+    def test_direct_wrapper_reassert_is_idempotent(self) -> None:
+        alias, alias_cls = _authority_module("capital_authority")
+        self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+        first = alias_cls.publish_snapshot
+        self.assertTrue(v230._patch_class("capital_authority", alias_cls))
+        self.assertIs(alias_cls.publish_snapshot, first)
+        self.assertTrue(v230._is_direct_wrapper(alias_cls.publish_snapshot))
 
     def test_no_addition_leaves_snapshot_unchanged(self) -> None:
         alias, alias_cls = _authority_module("capital_authority")

--- a/scripts/run_unittest_baseline.py
+++ b/scripts/run_unittest_baseline.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import sys
+import threading
 import unittest
 from urllib.parse import unquote
 
 
 FailureKey = tuple[str, str]
 _KINDS = {"FAIL", "ERROR"}
+_TEST_ONLY_RESTART_THREAD_NAMES = frozenset({
+    "terminal-writer-loss-forced-restart",
+})
 
 
 def _parse_baseline(path: Path) -> set[FailureKey]:
@@ -37,6 +41,53 @@ def _parse_baseline(path: Path) -> set[FailureKey]:
         entries.add(entry)
         test_ids.add(entry[1])
     return entries
+
+
+def _reset_terminal_writer_loss_test_state() -> None:
+    """Prevent one unit test's terminal-loss proof from killing later tests.
+
+    Production correctly arms an ``os._exit(75)`` timer after terminal writer
+    loss. Unit tests intentionally exercise that path, but the daemon Timer can
+    outlive the test method and terminate the entire shared unittest process
+    several tests later. Cancel only the explicitly named forced-restart timer
+    and invoke the latch module's documented test-only reset hook between test
+    cases. Production code and restart behavior are unchanged.
+    """
+    for thread in tuple(threading.enumerate()):
+        if thread.name not in _TEST_ONLY_RESTART_THREAD_NAMES:
+            continue
+        cancel = getattr(thread, "cancel", None)
+        if callable(cancel):
+            try:
+                cancel()
+            except Exception:
+                pass
+
+    seen: set[int] = set()
+    for module_name in (
+        "bot.terminal_writer_loss_latch",
+        "terminal_writer_loss_latch",
+    ):
+        module = sys.modules.get(module_name)
+        if module is None or id(module) in seen:
+            continue
+        seen.add(id(module))
+        reset = getattr(module, "reset_for_test", None)
+        if callable(reset):
+            try:
+                reset()
+            except Exception:
+                pass
+
+
+class _IsolatedTextTestResult(unittest.TextTestResult):
+    """Text result that clears process-level restart state after every test."""
+
+    def stopTest(self, test: unittest.case.TestCase) -> None:  # noqa: N802
+        try:
+            super().stopTest(test)
+        finally:
+            _reset_terminal_writer_loss_test_state()
 
 
 def _observed_failures(result: unittest.TestResult) -> set[FailureKey]:
@@ -67,11 +118,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"CI_BASELINE_INVALID: {exc}", file=sys.stderr)
         return 2
 
+    _reset_terminal_writer_loss_test_state()
     suite = unittest.defaultTestLoader.discover(
         start_dir=args.start_dir,
         pattern=args.pattern,
     )
-    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    runner = unittest.TextTestRunner(
+        verbosity=2,
+        resultclass=_IsolatedTextTestResult,
+    )
+    result = runner.run(suite)
+    _reset_terminal_writer_loss_test_state()
+
     observed = _observed_failures(result)
     unexpected = observed - baseline
     resolved = baseline - observed


### PR DESCRIPTION
Production evidence on 2026-08-25 05:30 UTC shows V230 loaded on both CapitalAuthority aliases, but canonical capital publication still fails closed at incomplete_broker_aggregation:2/3. The failure occurs before V229/V209 diagnostics or zero-row restoration run.

Root cause: functools.wraps copies V230's custom patch marker into later outer wrappers (notably replayed V170). V230 previously treated that inherited marker as proof that its augmentation boundary was still outermost, so its reassert worker did not re-anchor. V170 could then reject the raw 2/3 snapshot before V230 had a chance to restore a same-cycle live exact-zero broker row.

Fix:
- Track exact V230-owned wrapper function identities with a WeakSet instead of trusting inherited marker attributes.
- Re-anchor V230 outside later replayed wrappers when marker inheritance is detected.
- Preserve all inner completeness, freshness, writer, nonce, risk, kill-switch, order, fill, and activation gates.
- Keep exact-same-cycle-zero-only behavior; no positive balance fabrication, no stale reuse, no threshold changes.
- Add regression coverage reproducing the outer functools.wraps marker-copy sequence and verifying augmentation runs before the completeness gate.

Expected production proof after deploy:
1. RUNTIME_CAPITAL_AUTHORITY_ALIAS_V230 reports direct_wrapper_identity=true and wraps_marker_inheritance_safe=true.
2. If replay ordering exists, CAPITAL_AUTHORITY_ALIAS_V230_REANCHORED appears.
3. For a legitimate zero-balance third venue, CAPITAL_COMPLETENESS_V229_DIAGNOSTIC and CAPITAL_AUTHORITY_ALIAS_V230_RESTORED / ZERO_BALANCE_COMPLETENESS_V209_RESTORED appear.
4. Capital publication becomes accepted 3/3 without changing total capital.
5. Only after fresh capital and other gates pass should heartbeat dispatch proceed.