### PR TITLE
V232: keep route soft failures out of exchange rejection telemetry

### DIFF
--- a/bot/exchange_reject_dispatch_provenance_v228_patch.py
+++ b/bot/exchange_reject_dispatch_provenance_v228_patch.py
@@ -1,4 +1,4 @@
-"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228).
+"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232).
 
 Production on 2026-08-25 showed the canonical EXCHANGE_MONITOR stop holding a
 5/5 rejection window while the runtime was otherwise converged.  The execution
@@ -7,13 +7,24 @@ pipeline can return failures before a broker order is sent (for example
 through ``_on_order_rejected``.  The pipeline's synthetic telemetry order ID
 alone does not prove that an exchange saw or rejected an order.
 
-v228 patches only the telemetry emission boundary.  Known local, authority,
+V228 patches only the telemetry emission boundary.  Known local, authority,
 state-machine, liquidity, routing, risk, ECEL, disconnected-adapter and other
 pre-dispatch failures are logged as non-exchange outcomes and are not appended
 to ExchangeKillSwitchProtector's order-rejection window.  Errors that are not
 classified as local continue through the existing path unchanged, so genuine
 broker/exchange rejection telemetry, thresholds and fail-closed behavior remain
 intact.
+
+V232 closes a remaining route-guard provenance gap discovered after capital and
+position readiness converged. ``execution_route_integrity_patch`` deliberately
+classifies several route/adapter outcomes as soft dispatch failures, but those
+same strings could still be forwarded to this exchange-rejection telemetry
+boundary.  V232 therefore treats those unproven route/adapter outcomes as
+non-exchange results too.  Generic messages such as ``OKX order failed`` and
+``all operations failed`` are excluded because, by themselves, they do not prove
+that a broker submit reached an exchange or that an exchange returned a reject.
+A concrete exchange response such as ``Kraken AddOrder rejected: ...`` remains
+unclassified here and continues to count normally.
 
 This patch never clears a kill switch, resets a rejection window, marks
 readiness, grants execution authority, fabricates broker ACK/fill proof, changes
@@ -81,6 +92,19 @@ _NON_EXCHANGE_MARKERS = (
     "ecel reject:",
     "orderfeasibility deny",
     "postguard deny",
+    # V232: execution_route_integrity_patch classifies these as soft/local
+    # route outcomes.  None of these strings alone proves broker submission or
+    # an exchange-level reject response.
+    "broker_dispatch_failed",
+    "empty_order_result",
+    "empty order result",
+    "execution_route_mismatch",
+    "brokerrouteguard deny",
+    "broker disabled",
+    "adapter_exception",
+    "broker_dispatch_exception",
+    "okx order failed",
+    "all operations failed",
 )
 
 
@@ -113,8 +137,9 @@ def _patch_execution_pipeline() -> bool:
             LOGGER.critical(
                 "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s "
                 "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
-                "exchange_order_provenance=false kill_switch_unchanged=true "
-                "execution_authority_unchanged=true safety_gates_bypassed=false",
+                "exchange_order_provenance=false route_guard_provenance_v232=true "
+                "kill_switch_unchanged=true execution_authority_unchanged=true "
+                "safety_gates_bypassed=false",
                 MARKER,
                 str(symbol)[:64],
                 str(side)[:32],
@@ -179,10 +204,11 @@ def install() -> bool:
             _THREAD.start()
     LOGGER.critical(
         "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s ready=true "
-        "local_predispatch_rejects_excluded=true real_exchange_path_unchanged=true "
-        "rejection_thresholds_unchanged=true rejection_window_not_cleared=true "
-        "kill_switch_unchanged=true execution_authority_unchanged=true "
-        "forced_activation=false safety_gates_bypassed=false",
+        "local_predispatch_rejects_excluded=true route_guard_provenance_v232=true "
+        "real_exchange_path_unchanged=true rejection_thresholds_unchanged=true "
+        "rejection_window_not_cleared=true kill_switch_unchanged=true "
+        "execution_authority_unchanged=true forced_activation=false "
+        "safety_gates_bypassed=false",
         MARKER,
     )
     return True

--- a/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
+++ b/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
@@ -34,6 +34,22 @@ def test_non_exchange_classifier_covers_predispatch_failures():
         assert v228._is_non_exchange_rejection(reason) is True
 
 
+def test_v232_classifier_covers_route_guard_soft_failures_without_exchange_proof():
+    reasons = (
+        "broker_dispatch_failed:kraken:none_result",
+        "broker_dispatch_failed:coinbase:empty_order_result",
+        "empty order result from adapter",
+        "execution_route_mismatch:selected=kraken:actual=coinbase:symbol=BTC-USD",
+        "BrokerRouteGuard deny: broker disabled for live execution selected=okx",
+        "adapter_exception: TimeoutError",
+        "broker_dispatch_exception: RuntimeError",
+        "OKX order failed",
+        "all operations failed",
+    )
+    for reason in reasons:
+        assert v228._is_non_exchange_rejection(reason) is True
+
+
 def test_classifier_does_not_swallow_unclassified_exchange_rejects():
     assert v228._is_non_exchange_rejection("Kraken AddOrder rejected: EOrder:Insufficient margin") is False
     assert v228._is_non_exchange_rejection("Coinbase order rejected: UNKNOWN_EXCHANGE_FAILURE") is False
@@ -49,6 +65,21 @@ def test_dispatch_disabled_does_not_mutate_exchange_rejection_window(tmp_path, m
         symbol="BTC-USD",
         side="buy",
         reason="dispatch_disabled: dispatch.enabled=false",
+    )
+
+    assert list(protector._order_results) == []
+
+
+def test_v232_route_soft_failure_does_not_mutate_exchange_rejection_window(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(execution_pipeline, "get_exchange_kill_switch_protector", lambda: protector)
+    assert v228._patch_execution_pipeline()
+
+    execution_pipeline.ExecutionPipeline._emit_execution_rejection_telemetry(
+        _pipeline_stub(),
+        symbol="BTC-USD",
+        side="buy",
+        reason="broker_dispatch_failed:kraken:empty_order_result",
     )
 
     assert list(protector._order_results) == []


### PR DESCRIPTION
Production evidence on 2026-08-25 shows capital and position readiness converged (`total_capital≈346.35`, Kraken/Coinbase/OKX position sync all true), but trading remains fail-closed because EXCHANGE_MONITOR holds a 5/5 rejection kill-switch window.

Root cause: route/adapter soft failures can reach the execution rejection telemetry boundary without proof that a broker submission reached an exchange. `execution_route_integrity_patch` explicitly treats outcomes such as `broker_dispatch_failed`, empty adapter results, route mismatches, adapter exceptions, and generic `OKX order failed` / `all operations failed` messages as soft route failures, but V228 did not classify all of those strings as non-exchange telemetry.

Fix:
- Extend V228's non-exchange classifier to the route-guard soft-failure taxonomy.
- Keep concrete exchange responses (for example `Kraken AddOrder rejected: ...`) on the existing rejection path.
- Do not clear or reset the current rejection window in code.
- Do not alter kill-switch thresholds, writer/nonce/risk/capital gates, broker health, min-notional, order/fill proof, or activation rules.
- Add regression tests proving route/adapter soft failures do not mutate the exchange rejection window while genuine exchange rejects still do.

Expected deploy behavior:
1. V232-capable V228 reports `route_guard_provenance_v232=true`.
2. A fresh process has no inherited in-memory rejection samples; if the persisted 5/5 stop is historical and all V226 proofs pass, V226 may clear that persisted latch under its existing one-shot policy.
3. New local route failures remain excluded from exchange rejection telemetry.
4. Any genuine new broker/exchange rejection storm can still trip EXCHANGE_MONITOR normally.
5. NIJA must still re-earn authority, nonce, execution, broker ACK/fill proof, and LIVE_ACTIVE before being called 100/100.