### PR TITLE
Fix Kraken local contention and expose convergence blockers

### DIFF
--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -10671,6 +10671,29 @@ class KrakenBroker(BaseBroker):
             return 0.0
 
         except Exception as e:
+            # Process-local read-lock contention is not Kraken/API/auth/nonce
+            # unavailability.  Classify it before any broker-health mutation so
+            # the transient call fails closed without incrementing the balance
+            # error streak or entering EXIT-ONLY.  Reuse only a previously
+            # authenticated cached balance; never fabricate success/capital.
+            _local_read_lock_error = str(e or "").strip().lower()
+            if (
+                "kraken read lock busy" in _local_read_lock_error
+                or "krakenreadlockbusy" in _local_read_lock_error
+                or "local_read_lock_timeout" in _local_read_lock_error
+            ):
+                logger.warning(
+                    "KRAKEN_LOCAL_READ_CONTENTION_V243_EXCLUDED account=%s "
+                    "health_counter_unchanged=true availability_unchanged=true "
+                    "exit_only_unchanged=true current_read_fail_closed=true "
+                    "cached_balance_only=true exchange_unavailability_unproven=true error=%s",
+                    self.account_identifier,
+                    str(e)[:180],
+                )
+                if self._last_known_balance is not None:
+                    return self.balance_cache.get("kraken", self._last_known_balance)
+                return 0.0
+
             if self._demote_on_writer_authority_failure(e):
                 return 0.0
             _nonce_rebuild_cooldown_s = self._get_nonce_rebuild_retry_cooldown_seconds(e)

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("nija.runtime_post_import_convergence")
 _MARKER = "20260826-post-import-convergence-v242"
 _LOCK = threading.RLock()
 _STARTED = False
+_LAST_PREREQUISITES: dict[str, bool] = {}
 _CANONICAL = "bot.downstream_risk_governor_equity_repair_patch"
 _ALIAS = "nija_downstream_risk_governor_equity_repair_patch"
 
@@ -136,19 +137,47 @@ def _iteration() -> bool:
     v240 = _install_v240_heartbeat_terminal_lifecycle()
     v241 = _install_v241_kraken_local_contention_alias()
     v242 = _install_v242_kraken_local_contention_instance()
-    installs = [
-        _install_v154_recovery(), _install_v155_nonce_maturity(), _install_v157_runtime_quality(),
-        _install_v158_capital_margin(), _install_v161_capital_position_convergence(),
-        _install_v162_late_observation_fence(), _install_v163_activation_convergence(),
-        _install_v164_capital_publication_liveness(), _install_v165_capital_publication_scheduling(),
-        _install_v167_refresh_demand(), _install_v209_zero_balance_completeness(),
-        _install_v229_capital_provenance_alias(),
-    ]
+    prerequisites = {
+        "audit_patched": patched,
+        "v154_execution_recovery": _install_v154_recovery(),
+        "v155_nonce_maturity": _install_v155_nonce_maturity(),
+        "v157_runtime_quality": _install_v157_runtime_quality(),
+        "v158_capital_margin": _install_v158_capital_margin(),
+        "v161_capital_position": _install_v161_capital_position_convergence(),
+        "v162_late_observation_fence": _install_v162_late_observation_fence(),
+        "v163_activation_convergence": _install_v163_activation_convergence(),
+        "v164_capital_publication_liveness": _install_v164_capital_publication_liveness(),
+        "v165_capital_publication_scheduling": _install_v165_capital_publication_scheduling(),
+        "v167_refresh_demand": _install_v167_refresh_demand(),
+        "v209_zero_balance_completeness": _install_v209_zero_balance_completeness(),
+        "v224_exchange_reject_provenance": v224,
+        "v228_exchange_reject_dispatch_provenance": v228,
+        "v229_capital_provenance_alias": _install_v229_capital_provenance_alias(),
+        "v232_heartbeat_execution_quality": v232,
+        "v233_heartbeat_terminal_authority": v233,
+        "v234_kraken_read_lock_recovery": v234,
+        "v236_heartbeat_final_submit": v236,
+        "v237_kraken_contention_health": v237,
+        "v238_heartbeat_marker_convergence": v238,
+        "v239_all_account_profit_targets": v239,
+        "v240_heartbeat_terminal_lifecycle": v240,
+        "v241_kraken_contention_alias": v241,
+        "v242_kraken_contention_instance": v242,
+    }
+    global _LAST_PREREQUISITES
+    _LAST_PREREQUISITES = dict(prerequisites)
+    failed = tuple(name for name, value in prerequisites.items() if not value)
     os.environ["NIJA_RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED"] = "1"
     if changed:
         logger.warning("DOWNSTREAM_RISK_ALIAS_DRIFT_REPAIRED marker=%s canonical=%s alias=%s same=true", _MARKER, _CANONICAL, _ALIAS)
-    logger.debug("RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d audit_patched=%s v224=%s v228=%s v232=%s v233=%s v234=%s v236=%s v237=%s v238=%s v239=%s v240=%s v241=%s v242=%s", _MARKER, _policy(), required, patched, v224, v228, v232, v233, v234, v236, v237, v238, v239, v240, v241, v242)
-    return bool(v224 and v228 and v232 and v233 and v234 and v236 and v237 and v238 and v239 and v240 and v241 and v242 and all(installs))
+    logger.warning(
+        "RUNTIME_POST_IMPORT_CONVERGENCE marker=%s policy=%s min_brokers=%d ready=%s "
+        "failed_prerequisites=%s prerequisites=%s",
+        _MARKER, _policy(), required, str(not failed).lower(),
+        ",".join(failed) or "none",
+        ",".join(f"{name}={str(value).lower()}" for name, value in prerequisites.items()),
+    )
+    return not failed
 
 
 def _watchdog() -> None:
@@ -167,8 +196,14 @@ def install() -> bool:
         if not _STARTED:
             _STARTED = True
             threading.Thread(target=_watchdog, name="RuntimePostImportConvergence", daemon=True).start()
-        logger.critical("RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d alias_same=true v224=true v228=true v232=true v233=true v234=true v236=true v237=true v238=true v239=true v240=true v241=true v242=true ready=%s", _MARKER, _policy(), _required_broker_count(), str(ready).lower())
+        failed = tuple(name for name, value in _LAST_PREREQUISITES.items() if not value)
+        logger.critical(
+            "RUNTIME_POST_IMPORT_CONVERGENCE_INSTALLED marker=%s policy=%s min_brokers=%d "
+            "alias_same=true ready=%s failed_prerequisites=%s",
+            _MARKER, _policy(), _required_broker_count(), str(ready).lower(),
+            ",".join(failed) or "none",
+        )
         return ready
 
 
-__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_iteration"]
+__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_iteration", "_LAST_PREREQUISITES"]

--- a/bot/tests/test_kraken_local_contention_v243.py
+++ b/bot/tests/test_kraken_local_contention_v243.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import bot.broker_manager as broker_manager
+
+
+def test_local_kraken_read_contention_does_not_mutate_health():
+    broker = broker_manager.KrakenBroker.__new__(broker_manager.KrakenBroker)
+    broker.api = object()
+    broker._gateway_url = ""
+    broker._last_known_balance = 154.49
+    broker._balance_last_updated = None
+    broker._kraken_balance_cache_ttl = 0.0
+    broker.balance_cache = {"kraken": 154.49}
+    broker._balance_fetch_errors = 44
+    broker._is_available = True
+    broker.exit_only_mode = False
+    broker.kraken_health = "OK"
+    broker.account_identifier = "PLATFORM"
+
+    def busy(*_args, **_kwargs):
+        raise RuntimeError("Kraken read lock busy (local_read_lock_timeout)")
+
+    broker._kraken_private_call = busy
+
+    assert broker_manager.KrakenBroker.get_account_balance(broker, verbose=False) == 154.49
+    assert broker._balance_fetch_errors == 44
+    assert broker._is_available is True
+    assert broker.exit_only_mode is False
+    assert broker.kraken_health == "OK"
+
+
+def test_local_kraken_read_contention_without_cache_returns_zero_without_health_mutation():
+    broker = broker_manager.KrakenBroker.__new__(broker_manager.KrakenBroker)
+    broker.api = object()
+    broker._gateway_url = ""
+    broker._last_known_balance = None
+    broker._balance_last_updated = None
+    broker._kraken_balance_cache_ttl = 0.0
+    broker.balance_cache = {}
+    broker._balance_fetch_errors = 2
+    broker._is_available = True
+    broker.exit_only_mode = False
+    broker.kraken_health = "OK"
+    broker.account_identifier = "PLATFORM"
+    broker._kraken_private_call = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        RuntimeError("KrakenReadLockBusy")
+    )
+
+    assert broker_manager.KrakenBroker.get_account_balance(broker, verbose=False) == 0.0
+    assert broker._balance_fetch_errors == 2
+    assert broker._is_available is True
+    assert broker.exit_only_mode is False
+    assert broker.kraken_health == "OK"

--- a/bot/tests/test_runtime_post_import_convergence_patch.py
+++ b/bot/tests/test_runtime_post_import_convergence_patch.py
@@ -39,3 +39,21 @@ def test_downstream_risk_alias_drift_is_repaired(monkeypatch):
     assert patch._canonicalize_alias() is True
     assert sys.modules[patch._ALIAS] is canonical
     assert patch._canonicalize_alias() is False
+
+
+def test_iteration_reports_hidden_failed_prerequisite(monkeypatch):
+    monkeypatch.setattr(patch, "_canonicalize_alias", lambda: False)
+    monkeypatch.setattr(patch, "_apply_broker_threshold", lambda: 1)
+    monkeypatch.setattr(patch, "_patch_quiescence_audit", lambda: True)
+
+    installers = [
+        name for name in dir(patch)
+        if name.startswith("_install_v") and callable(getattr(patch, name))
+    ]
+    for name in installers:
+        monkeypatch.setattr(patch, name, lambda: True)
+    monkeypatch.setattr(patch, "_install_v155_nonce_maturity", lambda: False)
+
+    assert patch._iteration() is False
+    assert patch._LAST_PREREQUISITES["v155_nonce_maturity"] is False
+    assert patch._LAST_PREREQUISITES["v242_kraken_contention_instance"] is True


### PR DESCRIPTION
## Summary
- classify process-local Kraken read-lock contention inside the live balance method before any health counter, availability, or EXIT-ONLY mutation
- preserve fail-closed behavior and reuse only a previously authenticated cached balance
- expose every older and current post-import convergence prerequisite plus the exact false prerequisite names
- add regression tests for the 44 -> 45 error escalation and concealed prerequisite reporting

## Safety
- no synthetic balance or success
- no execution/nonce/readiness proof fabrication
- genuine exchange, API, auth, nonce, HTTP, and order errors remain authoritative
- current lock-contended read remains failed/cached-only

## Expected runtime proof
- `KRAKEN_LOCAL_READ_CONTENTION_V243_EXCLUDED ... health_counter_unchanged=true exit_only_unchanged=true`
- no `Kraken marked unavailable ... 45 consecutive errors` from that same local-contention event
- `RUNTIME_POST_IMPORT_CONVERGENCE ... failed_prerequisites=<exact names|none>`
- normal nonce lease maturity and genuine heartbeat execution marker then drive `nonce_ready` and `execution_ready`