### PR TITLE
Preserve verified heartbeat context at broker-manager terminal

### DIFF
--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -1,0 +1,144 @@
+"""Preserve verified startup-heartbeat context through live broker-manager submit (v244).
+
+Production proved the heartbeat passed the pipeline authority gate and router, then
+failed a second authority validation inside bot.broker_manager after the bounded v233
+grant expired.  The canonical startup-probe ContextVar was still the correct authority
+carrier; a wall-clock grant must not be extended merely to cover slow routing.
+
+v244 wraps the actual live broker-manager submit methods.  It enters only when the
+canonical ContextVar already verifies HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE and current
+startup writer authority is reverified immediately at the terminal method.  The
+canonical authority bindings are anchored for that method call so its inner
+_reject_if_unauthorized_order_submit check observes the verified probe.
+
+Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
+minimum notional, exchange acknowledgement, fill proof, and readiness remain unchanged.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_heartbeat_broker_manager_terminal_v244")
+MARKER = "20260826-heartbeat-broker-manager-terminal-v244"
+_FLAG = "NIJA_HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY"
+_PATCH_ATTR = "_nija_heartbeat_broker_manager_terminal_v244"
+_ALLOWED = {"HEARTBEAT_TRADE", "HEARTBEAT_TRADE_CLOSE"}
+_CLASSES = ("CoinbaseBroker", "KrakenBroker", "OKXBroker", "AlpacaBroker")
+_METHODS = ("place_market_order", "place_limit_order")
+
+
+def _v236() -> ModuleType:
+    return importlib.import_module("bot.runtime_heartbeat_final_submit_v236_patch")
+
+
+def _verified_reason() -> str | None:
+    reason = getattr(_v236(), "_canonical_verified_probe")()
+    normalized = str(reason or "").strip().upper()
+    return normalized if normalized in _ALLOWED else None
+
+
+def _writer_ready() -> bool:
+    return bool(getattr(_v236(), "_reverify_startup_write_authority")())
+
+
+def _wrap_method(current: Callable[..., Any], module: ModuleType, surface: str) -> Callable[..., Any]:
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def terminal_v244(self: Any, *args: Any, **kwargs: Any):
+        reason = _verified_reason()
+        if reason is None:
+            return current(self, *args, **kwargs)
+        v236 = _v236()
+        authority = getattr(v236, "_authority_module")()
+        scope = getattr(authority, "startup_execution_probe_scope", None) if authority else None
+        bindings = getattr(v236, "_canonical_terminal_bindings", None)
+        if not callable(scope) or not callable(bindings) or not _writer_ready():
+            LOGGER.warning(
+                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_DEFERRED marker=%s surface=%s "
+                "probe_reason=%s startup_writer_reverified=false trading_fail_closed=true",
+                MARKER, surface, reason,
+            )
+            return current(self, *args, **kwargs)
+        LOGGER.critical(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED marker=%s surface=%s "
+            "probe_reason=%s canonical_context_already_verified=true "
+            "startup_writer_reverified=true canonical_terminal_bindings=true "
+            "grant_ttl_not_extended=true ordinary_orders_unchanged=true "
+            "lifecycle_nonce_risk_capital_broker_health_killswitch_min_notional_fill_gates_unchanged=true "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            MARKER, surface, reason,
+        )
+        with scope(reason), bindings(module):
+            return current(self, *args, **kwargs)
+
+    setattr(terminal_v244, _PATCH_ATTR, True)
+    setattr(terminal_v244, "__wrapped__", current)
+    return terminal_v244
+
+
+def _patch_broker_manager_methods() -> tuple[bool, tuple[str, ...]]:
+    module = importlib.import_module("bot.broker_manager")
+    patched: list[str] = []
+    for class_name in _CLASSES:
+        cls = getattr(module, class_name, None)
+        if not isinstance(cls, type):
+            continue
+        for method_name in _METHODS:
+            current = getattr(cls, method_name, None)
+            if not callable(current):
+                continue
+            surface = f"{class_name}.{method_name}"
+            wrapped = _wrap_method(current, module, surface)
+            setattr(cls, method_name, wrapped)
+            if bool(getattr(getattr(cls, method_name, None), _PATCH_ATTR, False)):
+                patched.append(surface)
+    required = "CoinbaseBroker.place_market_order" in patched
+    return required, tuple(sorted(set(patched)))
+
+
+def install() -> bool:
+    try:
+        v240 = importlib.import_module("bot.runtime_heartbeat_terminal_lifecycle_v240_patch")
+        upstream_install = getattr(v240, "install", None)
+        upstream = bool(callable(upstream_install) and upstream_install())
+        methods_ready, surfaces = _patch_broker_manager_methods()
+        ready = bool(upstream and methods_ready)
+    except Exception as exc:
+        LOGGER.error(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        ready, surfaces = False, ()
+    os.environ[_FLAG] = "1" if ready else "0"
+    if ready:
+        LOGGER.critical(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
+            "coinbase_live_terminal_required=true canonical_context_required=true "
+            "startup_writer_reverification_required=true grant_ttl_not_extended=true "
+            "ordinary_orders_unchanged=true execution_proof_fabricated=false "
+            "forced_activation=false safety_gates_bypassed=false",
+            MARKER, ",".join(surfaces),
+        )
+    return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_wrap_method",
+    "_patch_broker_manager_methods",
+    "_verified_reason",
+    "_writer_ready",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -119,6 +119,7 @@ def _install_v239_all_account_profit_targets(): return _install_named("bot.runti
 def _install_v240_heartbeat_terminal_lifecycle(): return _install_named("bot.runtime_heartbeat_terminal_lifecycle_v240_patch", "v240_install_missing", "HEARTBEAT_TERMINAL_LIFECYCLE_V240_INSTALL_ERROR")
 def _install_v241_kraken_local_contention_alias(): return _install_named("bot.runtime_kraken_local_contention_alias_v241_patch", "v241_install_missing", "KRAKEN_LOCAL_CONTENTION_V241_INSTALL_ERROR")
 def _install_v242_kraken_local_contention_instance(): return _install_named("bot.runtime_kraken_local_contention_instance_v242_patch", "v242_install_missing", "KRAKEN_LOCAL_CONTENTION_V242_INSTALL_ERROR")
+def _install_v244_heartbeat_broker_manager_terminal(): return _install_named("bot.runtime_heartbeat_broker_manager_terminal_v244_patch", "v244_install_missing", "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR")
 
 
 def _iteration() -> bool:
@@ -137,6 +138,7 @@ def _iteration() -> bool:
     v240 = _install_v240_heartbeat_terminal_lifecycle()
     v241 = _install_v241_kraken_local_contention_alias()
     v242 = _install_v242_kraken_local_contention_instance()
+    v244 = _install_v244_heartbeat_broker_manager_terminal()
     prerequisites = {
         "audit_patched": patched,
         "v154_execution_recovery": _install_v154_recovery(),
@@ -163,6 +165,7 @@ def _iteration() -> bool:
         "v240_heartbeat_terminal_lifecycle": v240,
         "v241_kraken_contention_alias": v241,
         "v242_kraken_contention_instance": v242,
+        "v244_heartbeat_broker_manager_terminal": v244,
     }
     global _LAST_PREREQUISITES
     _LAST_PREREQUISITES = dict(prerequisites)
@@ -206,4 +209,4 @@ def install() -> bool:
         return ready
 
 
-__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_iteration", "_LAST_PREREQUISITES"]
+__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_install_v244_heartbeat_broker_manager_terminal", "_iteration", "_LAST_PREREQUISITES"]

--- a/bot/tests/test_runtime_heartbeat_broker_manager_terminal_v244.py
+++ b/bot/tests/test_runtime_heartbeat_broker_manager_terminal_v244.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import bot.runtime_heartbeat_broker_manager_terminal_v244_patch as patch
+
+
+def test_verified_heartbeat_is_reanchored_at_broker_manager(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    state = {"scope": False, "bindings": False, "calls": 0}
+
+    @contextmanager
+    def scope(reason):
+        assert reason == "HEARTBEAT_TRADE"
+        state["scope"] = True
+        try:
+            yield
+        finally:
+            state["scope"] = False
+
+    @contextmanager
+    def bindings(bound_module):
+        assert bound_module is module
+        state["bindings"] = True
+        try:
+            yield
+        finally:
+            state["bindings"] = False
+
+    fake_v236 = SimpleNamespace(
+        _authority_module=lambda: SimpleNamespace(startup_execution_probe_scope=scope),
+        _canonical_terminal_bindings=bindings,
+    )
+    monkeypatch.setattr(patch, "_v236", lambda: fake_v236)
+    monkeypatch.setattr(patch, "_verified_reason", lambda: "HEARTBEAT_TRADE")
+    monkeypatch.setattr(patch, "_writer_ready", lambda: True)
+
+    def submit(_self, value):
+        state["calls"] += 1
+        assert state["scope"] is True
+        assert state["bindings"] is True
+        return value
+
+    wrapped = patch._wrap_method(submit, module, "CoinbaseBroker.place_market_order")
+    assert wrapped(object(), "exchange-result") == "exchange-result"
+    assert state["calls"] == 1
+    assert state["scope"] is False
+    assert state["bindings"] is False
+
+
+def test_ordinary_boot_order_remains_blocked(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    monkeypatch.setattr(patch, "_verified_reason", lambda: None)
+    monkeypatch.setattr(
+        patch,
+        "_writer_ready",
+        lambda: pytest.fail("ordinary order must not reverify startup writer"),
+    )
+
+    def blocked(_self):
+        raise RuntimeError("broker order submission blocked (reason=lifecycle_phase:BOOT)")
+
+    wrapped = patch._wrap_method(blocked, module, "CoinbaseBroker.place_market_order")
+    with pytest.raises(RuntimeError, match="lifecycle_phase:BOOT"):
+        wrapped(object())
+
+
+def test_verified_probe_without_current_writer_remains_fail_closed(monkeypatch):
+    module = ModuleType("bot.broker_manager")
+    monkeypatch.setattr(patch, "_verified_reason", lambda: "HEARTBEAT_TRADE")
+    monkeypatch.setattr(patch, "_writer_ready", lambda: False)
+    fake_v236 = SimpleNamespace(
+        _authority_module=lambda: SimpleNamespace(startup_execution_probe_scope=lambda _reason: None),
+        _canonical_terminal_bindings=lambda _module: None,
+    )
+    monkeypatch.setattr(patch, "_v236", lambda: fake_v236)
+
+    def blocked(_self):
+        raise RuntimeError("broker order submission blocked (reason=lifecycle_phase:BOOT)")
+
+    wrapped = patch._wrap_method(blocked, module, "CoinbaseBroker.place_market_order")
+    with pytest.raises(RuntimeError, match="lifecycle_phase:BOOT"):
+        wrapped(object())


### PR DESCRIPTION
## Production evidence
The genuine HEARTBEAT_TRADE passed pipeline authority and routing, then failed the second authority validation inside `bot.broker_manager` with `lifecycle_phase:BOOT`. The v233 wall-clock grant had expired during slow routing even though the canonical startup-probe ContextVar remained active.

## Fix
- wrap the actual live broker-manager submit methods, including `CoinbaseBroker.place_market_order`
- require an already-verified canonical HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE ContextVar
- reverify current startup writer authority immediately at the terminal method
- re-anchor canonical authority bindings only for that method call
- install/reassert v244 through post-import convergence

## Safety
- does not extend the v233 TTL
- ordinary BOOT orders remain blocked
- heartbeat calls without current startup writer authority remain blocked
- does not mutate lifecycle, nonce, risk, capital, broker health, kill switch, notional, exchange acknowledgement, fill, readiness, or activation proof
- genuine exchange acceptance/fill remains required

## Expected runtime proof
- `HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED`
- terminal `broker_manager` validator allows only the verified heartbeat
- a real Coinbase order acknowledgement/fill publishes the genuine execution marker
- nonce and execution readiness converge normally