### PR TITLE
Fix heartbeat terminal proof and Kraken contention convergence

### DIFF
--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -2,13 +2,15 @@
 
 Production proved the heartbeat passed the pipeline authority gate and router, then
 failed a second authority validation inside bot.broker_manager after the bounded v233
-grant expired.  The canonical startup-probe ContextVar was still the correct authority
-carrier; a wall-clock grant must not be extended merely to cover slow routing.
+grant expired.  The canonical startup-probe ContextVar is the preferred authority
+carrier, but the same-thread v233 grant is the bounded fallback when the ContextVar
+scope has already unwound before the broker-manager terminal.
 
-v244 wraps the actual live broker-manager submit methods.  It enters only when the
-canonical ContextVar already verifies HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE and current
-startup writer authority is reverified immediately at the terminal method.  The
-canonical authority bindings are anchored for that method call so its inner
+v244 wraps the actual live broker-manager submit methods.  It enters only when v236
+can resolve an already-verified HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE from either the
+canonical ContextVar or the still-live same-thread v233 grant, and current startup
+writer authority is reverified immediately at the terminal method.  The canonical
+authority bindings are anchored for that method call so its inner
 _reject_if_unauthorized_order_submit check observes the verified probe.
 
 Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
@@ -37,7 +39,40 @@ def _v236() -> ModuleType:
 
 
 def _verified_reason() -> str | None:
-    reason = getattr(_v236(), "_canonical_verified_probe")()
+    """Resolve only authority that was already verified upstream.
+
+    v236._verified_reason() prefers the same-thread, sub-second v233 grant and then
+    falls back to the canonical startup-probe ContextVar.  v244 previously called
+    only _canonical_verified_probe(), which lost the production heartbeat whenever
+    its ContextVar scope ended before the broker-manager method.  This resolver never
+    creates a grant and therefore cannot authorize an ordinary order by itself.
+    """
+    v236 = _v236()
+    resolver = getattr(v236, "_verified_reason", None)
+    if callable(resolver):
+        try:
+            resolved = resolver()
+        except Exception as exc:
+            LOGGER.warning(
+                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_RESOLVE_ERROR marker=%s "
+                "error=%s:%s trading_fail_closed=true",
+                MARKER, type(exc).__name__, exc,
+            )
+            resolved = None
+        value = resolved[0] if isinstance(resolved, tuple) and resolved else resolved
+        normalized = str(value or "").strip().upper()
+        if normalized in _ALLOWED:
+            return normalized
+
+    # Compatibility fallback for an older v236 shape.  This remains fail-closed
+    # and still requires the canonical ContextVar to be active.
+    canonical = getattr(v236, "_canonical_verified_probe", None)
+    if not callable(canonical):
+        return None
+    try:
+        reason = canonical()
+    except Exception:
+        return None
     normalized = str(reason or "").strip().upper()
     return normalized if normalized in _ALLOWED else None
 
@@ -68,9 +103,8 @@ def _wrap_method(current: Callable[..., Any], module: ModuleType, surface: str) 
             return current(self, *args, **kwargs)
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED marker=%s surface=%s "
-            "probe_reason=%s canonical_context_already_verified=true "
-            "startup_writer_reverified=true canonical_terminal_bindings=true "
-            "grant_ttl_not_extended=true ordinary_orders_unchanged=true "
+            "probe_reason=%s verified_upstream_authority=true startup_writer_reverified=true "
+            "canonical_terminal_bindings=true grant_ttl_not_extended=true ordinary_orders_unchanged=true "
             "lifecycle_nonce_risk_capital_broker_health_killswitch_min_notional_fill_gates_unchanged=true "
             "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
             MARKER, surface, reason,
@@ -99,7 +133,12 @@ def _patch_broker_manager_methods() -> tuple[bool, tuple[str, ...]]:
             setattr(cls, method_name, wrapped)
             if bool(getattr(getattr(cls, method_name, None), _PATCH_ATTR, False)):
                 patched.append(surface)
-    required = "CoinbaseBroker.place_market_order" in patched
+    # Kraken is the production heartbeat route that exposed this gap.  Keep the
+    # existing Coinbase requirement and require the Kraken market terminal too.
+    required = all(
+        surface in patched
+        for surface in ("CoinbaseBroker.place_market_order", "KrakenBroker.place_market_order")
+    )
     return required, tuple(sorted(set(patched)))
 
 
@@ -120,7 +159,8 @@ def install() -> bool:
     if ready:
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
-            "coinbase_live_terminal_required=true canonical_context_required=true "
+            "coinbase_live_terminal_required=true kraken_live_terminal_required=true "
+            "verified_v233_grant_fallback=true canonical_context_preferred=true "
             "startup_writer_reverification_required=true grant_ttl_not_extended=true "
             "ordinary_orders_unchanged=true execution_proof_fabricated=false "
             "forced_activation=false safety_gates_bypassed=false",

--- a/bot/runtime_kraken_local_contention_health_v237_patch.py
+++ b/bot/runtime_kraken_local_contention_health_v237_patch.py
@@ -1,10 +1,12 @@
 """Keep process-local Kraken read-lock contention out of broker failure health (v237).
 
 A KrakenReadLockBusy read still fails closed, but it is not evidence that Kraken,
-credentials, nonce, or the account are unhealthy.  Patch every loaded live KrakenBroker
-identity and restore only the exact pre-call health fields when v234 proves contention
-occurred during that call.  Genuine exchange/API/auth/nonce/order/HTTP failures remain
-authoritative.
+credentials, nonce, or the account are unhealthy. Patch every loaded KrakenBroker
+identity that owns the balance path and restore only the exact pre-call health fields
+when v234 proves contention occurred during that call. The canonical balance/private
+read owner is ``bot.broker_manager.KrakenBroker``; broker_integration exposes an adapter
+layer and is not a valid readiness prerequisite for this guard. Genuine
+exchange/API/auth/nonce/order/HTTP failures remain authoritative.
 """
 from __future__ import annotations
 
@@ -141,7 +143,7 @@ def _patch_balance_class(cls: type) -> bool:
 
 def _patch_kraken_balance_health() -> bool:
     classes: dict[int, type] = {}
-    live_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -150,11 +152,15 @@ def _patch_kraken_balance_health() -> bool:
             except Exception:
                 continue
         cls = getattr(module, "KrakenBroker", None)
-        if isinstance(cls, type):
+        if isinstance(cls, type) and callable(getattr(cls, "get_account_balance", None)):
             classes[id(cls)] = cls
-            if str(getattr(module, "__name__", name)) == "bot.broker_integration":
-                live_found = True
-    return bool(classes and live_found and all(_patch_balance_class(cls) for cls in classes.values()))
+            if str(getattr(module, "__name__", name)) == "bot.broker_manager":
+                canonical_manager_found = True
+    return bool(
+        classes
+        and canonical_manager_found
+        and all(_patch_balance_class(cls) for cls in classes.values())
+    )
 
 
 def install() -> bool:
@@ -170,7 +176,7 @@ def install() -> bool:
         ready = False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
-        LOGGER.critical("KRAKEN_LOCAL_CONTENTION_V237_READY marker=%s ready=true all_live_kraken_aliases=true local_read_lock_only=true broker_failure_streak_excluded=true direct_balance_health_protected=true current_read_fail_closed=true genuine_exchange_errors_unchanged=true execution_authority_unchanged=true nonce_policy_unchanged=true forced_trade=false safety_gates_bypassed=false", MARKER)
+        LOGGER.critical("KRAKEN_LOCAL_CONTENTION_V237_READY marker=%s ready=true canonical_broker_manager=true local_read_lock_only=true broker_failure_streak_excluded=true direct_balance_health_protected=true current_read_fail_closed=true genuine_exchange_errors_unchanged=true execution_authority_unchanged=true nonce_policy_unchanged=true forced_trade=false safety_gates_bypassed=false", MARKER)
     return ready
 
 

--- a/bot/runtime_kraken_local_contention_instance_v242_patch.py
+++ b/bot/runtime_kraken_local_contention_instance_v242_patch.py
@@ -2,10 +2,11 @@
 
 Production on 2026-08-26 showed v241/v242 installed while get_account_balance() still
 incremented direct failure counters and entered EXIT-ONLY after KrakenReadLockBusy.
-The live KrakenBroker is defined in ``bot.broker_integration``; earlier v242 only
-searched broker_manager aliases, so the actual instance could remain unpatched.
+The private read and balance owner is ``bot.broker_manager.KrakenBroker``; the
+``bot.broker_integration`` module exposes ``KrakenBrokerAdapter`` at a different layer
+and must not be required as proof that this instance guard is active.
 
-v242 patches every loaded KrakenBroker class alias at BOTH boundaries:
+v242 patches every loaded canonical/legacy KrakenBroker class alias at BOTH boundaries:
 1. _kraken_private_call records a monotonic instance-local sequence only when the
    raised exception is provably KrakenReadLockBusy/local read-lock contention.
 2. get_account_balance/connect snapshot health before the call. If that exact instance
@@ -192,7 +193,7 @@ def _patch_class(cls: type) -> bool:
 def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
     classes: dict[int, type] = {}
     modules: list[str] = []
-    live_integration_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -201,14 +202,20 @@ def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
             except Exception:
                 continue
         cls = getattr(module, "KrakenBroker", None)
-        if isinstance(cls, type):
+        if (
+            isinstance(cls, type)
+            and callable(getattr(cls, "_kraken_private_call", None))
+            and callable(getattr(cls, "get_account_balance", None))
+        ):
             classes[id(cls)] = cls
             module_name = str(getattr(module, "__name__", name))
             modules.append(module_name)
-            if module_name == "bot.broker_integration":
-                live_integration_found = True
+            if module_name == "bot.broker_manager":
+                canonical_manager_found = True
     patched = sum(1 for cls in classes.values() if _patch_class(cls))
-    return bool(classes and live_integration_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
+    return bool(
+        classes and canonical_manager_found and patched == len(classes)
+    ), patched, tuple(sorted(set(modules)))
 
 
 def install() -> bool:
@@ -228,7 +235,7 @@ def install() -> bool:
     if ready:
         LOGGER.critical(
             "KRAKEN_LOCAL_CONTENTION_V242_READY marker=%s ready=true patched_classes=%d modules=%s "
-            "live_broker_integration_required=true instance_local_busy_sequence=true private_call_boundary=true "
+            "canonical_broker_manager_required=true instance_local_busy_sequence=true private_call_boundary=true "
             "balance_health_guard=true connect_health_guard=true exact_precall_health_only=true "
             "current_call_fail_closed=true genuine_exchange_api_auth_nonce_http_order_failures_unchanged=true "
             "execution_authority_unchanged=true forced_trade=false safety_gates_bypassed=false",

--- a/bot/runtime_kraken_read_lock_recovery_v234_patch.py
+++ b/bot/runtime_kraken_read_lock_recovery_v234_patch.py
@@ -1,10 +1,15 @@
 """Recover from a permanently wedged process-local Kraken private-read lock.
 
-v234 observes KrakenReadLockBusy at every live KrakenBroker class identity.  A local
-read-lock timeout is not exchange/API/auth/nonce failure.  Reads remain fail-closed;
-mutating calls are never retried or lock-bypassed.  If repeated local contention is
-proven and no mutation is in flight, the process may recycle so the stale in-process
-lock is discarded safely.
+v234 observes KrakenReadLockBusy at every live KrakenBroker class identity that owns
+``_kraken_private_call``.  The canonical private-read owner is
+``bot.broker_manager.KrakenBroker`` (the same surface patched by v121); the
+``bot.broker_integration`` module exposes KrakenBrokerAdapter and must not be required
+as proof that the private-read recovery is installed.
+
+A local read-lock timeout is not exchange/API/auth/nonce failure. Reads remain
+fail-closed; mutating calls are never retried or lock-bypassed. If repeated local
+contention is proven and no mutation is in flight, the process may recycle so the
+stale in-process lock is discarded safely.
 """
 from __future__ import annotations
 
@@ -136,7 +141,7 @@ def _patch_class(cls: type) -> bool:
 def _patch_all_kraken_classes() -> tuple[bool, int, tuple[str, ...]]:
     classes: dict[int, type] = {}
     modules: list[str] = []
-    live_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -145,14 +150,16 @@ def _patch_all_kraken_classes() -> tuple[bool, int, tuple[str, ...]]:
             except Exception:
                 continue
         cls = getattr(module, "KrakenBroker", None)
-        if isinstance(cls, type):
+        # Only a class that actually owns the private-call boundary is relevant
+        # to v234. broker_integration's KrakenBrokerAdapter is a different layer.
+        if isinstance(cls, type) and callable(getattr(cls, "_kraken_private_call", None)):
             classes[id(cls)] = cls
             module_name = str(getattr(module, "__name__", name))
             modules.append(module_name)
-            if module_name == "bot.broker_integration":
-                live_found = True
+            if module_name == "bot.broker_manager":
+                canonical_manager_found = True
     patched = sum(1 for cls in classes.values() if _patch_class(cls))
-    return bool(classes and live_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
+    return bool(classes and canonical_manager_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
 
 
 def _patch_broker_manager(module: ModuleType | None = None) -> bool:
@@ -214,7 +221,7 @@ def install() -> bool:
             threading.Thread(target=_watchdog, name="KrakenReadLockRecoveryV234", daemon=True).start()
     LOGGER.critical(
         "RUNTIME_KRAKEN_READ_LOCK_RECOVERY_V234_READY marker=%s ready=true patched_classes=%d modules=%s "
-        "live_broker_integration_required=true recycle_after_s=%.2f quiet_reset_s=%.2f reset_requires_success=true "
+        "canonical_broker_manager_required=true recycle_after_s=%.2f quiet_reset_s=%.2f reset_requires_success=true "
         "process_local_lock_only=true mutating_calls_tracked=true lock_force_release=false lock_bypass=false "
         "balance_fabricated=false execution_authority_granted=false nonce_policy_unchanged=true "
         "local_contention_not_exchange_failure=true heartbeat_terminal_v235=true forced_trade=false safety_gates_bypassed=false",

--- a/bot/tests/test_kraken_contention_topology_convergence.py
+++ b/bot/tests/test_kraken_contention_topology_convergence.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import bot.runtime_kraken_local_contention_health_v237_patch as v237
+import bot.runtime_kraken_local_contention_instance_v242_patch as v242
+import bot.runtime_kraken_read_lock_recovery_v234_patch as v234
+
+
+def _manager_module_with_kraken() -> ModuleType:
+    module = ModuleType("bot.broker_manager")
+
+    class KrakenBroker:
+        def _kraken_private_call(self, method, *_args, **_kwargs):
+            return {"result": {}, "method": method}
+
+        def get_account_balance(self, *_args, **_kwargs):
+            return 1.0
+
+        def connect(self, *_args, **_kwargs):
+            return True
+
+    module.KrakenBroker = KrakenBroker
+    return module
+
+
+def test_v234_accepts_canonical_broker_manager_without_integration_kraken_class(monkeypatch):
+    module = _manager_module_with_kraken()
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", module)
+    monkeypatch.setattr(v234, "_MODULES", ("bot.broker_manager",))
+
+    ready, patched, modules = v234._patch_all_kraken_classes()
+
+    assert ready is True
+    assert patched == 1
+    assert modules == ("bot.broker_manager",)
+
+
+def test_v237_accepts_canonical_broker_manager_balance_owner(monkeypatch):
+    module = _manager_module_with_kraken()
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", module)
+    monkeypatch.setattr(v237, "_MODULES", ("bot.broker_manager",))
+
+    assert v237._patch_kraken_balance_health() is True
+
+
+def test_v242_accepts_canonical_broker_manager_instance_owner(monkeypatch):
+    module = _manager_module_with_kraken()
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", module)
+    monkeypatch.setattr(v242, "_MODULES", ("bot.broker_manager",))
+
+    ready, patched, modules = v242._patch_aliases()
+
+    assert ready is True
+    assert patched == 1
+    assert modules == ("bot.broker_manager",)

--- a/bot/tests/test_runtime_heartbeat_broker_manager_terminal_v244.py
+++ b/bot/tests/test_runtime_heartbeat_broker_manager_terminal_v244.py
@@ -8,6 +8,26 @@ import pytest
 import bot.runtime_heartbeat_broker_manager_terminal_v244_patch as patch
 
 
+def test_verified_reason_uses_live_v233_grant_when_canonical_scope_unwound(monkeypatch):
+    fake_v236 = SimpleNamespace(
+        _verified_reason=lambda: ("HEARTBEAT_TRADE", "v233_grant"),
+        _canonical_verified_probe=lambda: None,
+    )
+    monkeypatch.setattr(patch, "_v236", lambda: fake_v236)
+
+    assert patch._verified_reason() == "HEARTBEAT_TRADE"
+
+
+def test_verified_reason_remains_fail_closed_without_upstream_proof(monkeypatch):
+    fake_v236 = SimpleNamespace(
+        _verified_reason=lambda: (None, "none"),
+        _canonical_verified_probe=lambda: None,
+    )
+    monkeypatch.setattr(patch, "_v236", lambda: fake_v236)
+
+    assert patch._verified_reason() is None
+
+
 def test_verified_heartbeat_is_reanchored_at_broker_manager(monkeypatch):
     module = ModuleType("bot.broker_manager")
     state = {"scope": False, "bindings": False, "calls": 0}


### PR DESCRIPTION
Production log 2026-08-27 03:23Z exposed two concrete runtime gaps on deployed SHA 4f798c3a:

1. The verified startup heartbeat passed the pipeline bridge but was denied at `bot.broker_manager` with `lifecycle_phase:BOOT`. v244 only consulted the canonical ContextVar even though v236 already provides a bounded same-thread v233-grant fallback. This PR makes v244 consume only that already-verified upstream authority, re-verifies startup writer authority, and re-anchors the canonical scope at the broker-manager terminal. Ordinary orders and all risk/nonce/capital/kill-switch/fill gates remain unchanged.

2. Post-import convergence reported v234/v237/v241/v242 false while the source-level v243 guard correctly excluded Kraken local read contention from health mutation. v121 shows the private-read owner is `bot.broker_manager.KrakenBroker`; the older guards incorrectly required a `KrakenBroker` class under `bot.broker_integration`, which exposes an adapter layer instead. This PR aligns v234/v237/v242 readiness with the canonical broker-manager topology rather than suppressing those safety guards.

Tests added for the v233 grant fallback and the canonical Kraken contention topology.

Expected production proof after deploy:
- `HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED` before Kraken submit
- genuine exchange heartbeat acknowledgement/fill marker, then `execution_ready=true`
- `nonce_ready=true` only from genuine nonce proof
- `RUNTIME_POST_IMPORT_CONVERGENCE ... ready=true failed_prerequisites=none`
- local `KRAKEN_READ_LOCK_V212_BUSY` remains fail-closed without health/EXIT-ONLY mutation