### PR TITLE
Fix Kraken runtime truth and heartbeat venue routing

### DIFF
--- a/bot/authority_heartbeat.py
+++ b/bot/authority_heartbeat.py
@@ -88,6 +88,26 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "enabled", "on"}
 
 
+def _kraken_nonce_gates_required_now() -> bool:
+    """Return current Kraken nonce applicability from canonical broker topology.
+
+    A missing legacy ``KRAKEN_NONCE_LEASE_REQUIRED`` variable is not evidence
+    of Coinbase-only operation.  Preserve an explicit legacy affirmative as a
+    strict operator override, then ask the trading state machine to classify
+    the registered live platform brokers.  Any probe failure remains
+    fail-closed and therefore cannot fabricate nonce readiness.
+    """
+    if _env_truthy("KRAKEN_NONCE_LEASE_REQUIRED"):
+        return True
+    try:
+        from bot import trading_state_machine as _tsm
+
+        probe = getattr(_tsm, "_kraken_nonce_gates_required", None)
+        return bool(probe()) if callable(probe) else True
+    except Exception:
+        return True
+
+
 def _backoff_wait_s(consecutive_failures: int) -> float:
     """Compute exponential backoff wait time for a given failure count.
 
@@ -809,17 +829,15 @@ class AuthorityHeartbeatMonitor:
                         "[AUTHORITY_GRANTED] authority_heartbeat_tick_passed — "
                         "marked authority_ready=True in readiness_table"
                     )
-                # For Coinbase-only deployments the Kraken nonce lease is not
-                # required.  Mark nonce_ready so prereqs_ready can be satisfied.
+                # For genuinely Coinbase-only deployments the Kraken nonce
+                # lease is not required.  Runtime broker topology, not absence
+                # of a legacy env variable, is authoritative.
                 if not _rt_table.get("nonce_ready", False):
-                    _kraken_nonce_required = os.environ.get(
-                        "KRAKEN_NONCE_LEASE_REQUIRED", ""
-                    ).strip()
-                    if not _kraken_nonce_required:
+                    if not _kraken_nonce_gates_required_now():
                         _rt_mark("nonce_ready")
                         logger.info(
                             "AUTHORITY_HEARTBEAT: marked nonce_ready=True "
-                            "(Coinbase-only mode — Kraken nonce not required)"
+                            "(canonical topology has no active Kraken platform broker)"
                         )
             except Exception as _rt_exc:
                 logger.debug(

--- a/bot/broker_manager.py
+++ b/bot/broker_manager.py
@@ -8004,6 +8004,19 @@ class BinanceBroker(BaseBroker):
         return ['BTCUSDT', 'ETHUSDT', 'SOLUSDT', 'XRPUSDT', 'ADAUSDT']
 
 
+def _is_local_kraken_read_contention(error: BaseException) -> bool:
+    """Return whether *error* proves process-local Kraken read-lock contention."""
+    normalized = str(error or "").strip().lower()
+    return any(
+        token in normalized
+        for token in (
+            "kraken read lock busy",
+            "krakenreadlockbusy",
+            "local_read_lock_timeout",
+        )
+    )
+
+
 class KrakenBroker(BaseBroker):
     """
     Kraken Pro Exchange integration for cryptocurrency spot trading.
@@ -10676,12 +10689,7 @@ class KrakenBroker(BaseBroker):
             # the transient call fails closed without incrementing the balance
             # error streak or entering EXIT-ONLY.  Reuse only a previously
             # authenticated cached balance; never fabricate success/capital.
-            _local_read_lock_error = str(e or "").strip().lower()
-            if (
-                "kraken read lock busy" in _local_read_lock_error
-                or "krakenreadlockbusy" in _local_read_lock_error
-                or "local_read_lock_timeout" in _local_read_lock_error
-            ):
+            if _is_local_kraken_read_contention(e):
                 logger.warning(
                     "KRAKEN_LOCAL_READ_CONTENTION_V243_EXCLUDED account=%s "
                     "health_counter_unchanged=true availability_unchanged=true "
@@ -12297,6 +12305,16 @@ class KrakenBroker(BaseBroker):
             return positions
 
         except Exception as e:
+            if _is_local_kraken_read_contention(e):
+                logger.warning(
+                    "KRAKEN_LOCAL_READ_CONTENTION_V245_POSITION_EXCLUDED account=%s "
+                    "health_counter_unchanged=true availability_unchanged=true "
+                    "exit_only_unchanged=true position_snapshot_fail_closed=true "
+                    "exchange_unavailability_unproven=true error=%s",
+                    self.account_identifier,
+                    str(e)[:180],
+                )
+                return []
             self._demote_on_writer_authority_failure(e)
             logger.error(f"Error fetching Kraken positions: {e}")
             return []

--- a/bot/nija_core_loop.py
+++ b/bot/nija_core_loop.py
@@ -7795,6 +7795,31 @@ def run_trading_loop(strategy: Any, cycle_secs: int = 150) -> None:
                                 _pool_dispatched = True
 
                                 _accepted_count = sum(1 for v in _pool_accepted.values() if v)
+                                # A successfully accepted first broker-pool batch is
+                                # the async equivalent of entering run_scan_phase.
+                                # Record that lifecycle edge immediately so startup
+                                # authority convergence does not wait on a scan-start
+                                # watchdog that the authority gate itself prevents a
+                                # worker from reaching.  This is telemetry only: it
+                                # grants no execution authority and does not mark the
+                                # scan complete.
+                                if _accepted_count > 0 and cycle == 1:
+                                    try:
+                                        from bot.entrypoint_writer_authority import (
+                                            get_entrypoint_writer_authority,
+                                        )
+                                        get_entrypoint_writer_authority().record_scan_started()
+                                        logger.critical(
+                                            "SCAN_ASYNC_DISPATCH_STARTED cycle=%d accepted=%d",
+                                            cycle,
+                                            _accepted_count,
+                                        )
+                                    except Exception as _scan_start_err:
+                                        logger.warning(
+                                            "SCAN_ASYNC_DISPATCH_TELEMETRY_FAILED cycle=%d err=%s",
+                                            cycle,
+                                            _scan_start_err,
+                                        )
                                 logger.critical(
                                     "🚀 [BROKER_POOL] Dispatched %d/%d broker workers | "
                                     "cycle=%d brokers=%s",

--- a/bot/runtime_kraken_local_contention_alias_v241_patch.py
+++ b/bot/runtime_kraken_local_contention_alias_v241_patch.py
@@ -100,6 +100,7 @@ def _patch_class(cls: type) -> bool:
 def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
     classes: dict[int, type] = {}
     modules: list[str] = []
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -110,9 +111,14 @@ def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
         cls = getattr(module, "KrakenBroker", None)
         if isinstance(cls, type):
             classes[id(cls)] = cls
-            modules.append(str(getattr(module, "__name__", name)))
+            module_name = str(getattr(module, "__name__", name))
+            modules.append(module_name)
+            if module_name == "bot.broker_manager":
+                canonical_manager_found = True
     patched = sum(1 for cls in classes.values() if _patch_class(cls))
-    return bool(classes and patched == len(classes)), patched, tuple(sorted(set(modules)))
+    return bool(
+        classes and canonical_manager_found and patched == len(classes)
+    ), patched, tuple(sorted(set(modules)))
 
 
 def install() -> bool:

--- a/bot/runtime_kraken_local_contention_health_v237_patch.py
+++ b/bot/runtime_kraken_local_contention_health_v237_patch.py
@@ -141,7 +141,7 @@ def _patch_balance_class(cls: type) -> bool:
 
 def _patch_kraken_balance_health() -> bool:
     classes: dict[int, type] = {}
-    live_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -152,9 +152,17 @@ def _patch_kraken_balance_health() -> bool:
         cls = getattr(module, "KrakenBroker", None)
         if isinstance(cls, type):
             classes[id(cls)] = cls
-            if str(getattr(module, "__name__", name)) == "bot.broker_integration":
-                live_found = True
-    return bool(classes and live_found and all(_patch_balance_class(cls) for cls in classes.values()))
+            # The live ``KrakenBroker`` class belongs to
+            # ``bot.broker_manager``.  ``bot.broker_integration`` has a
+            # differently shaped ``KrakenBrokerAdapter`` and must not be used
+            # as proof that the manager class exists.
+            if str(getattr(module, "__name__", name)) == "bot.broker_manager":
+                canonical_manager_found = True
+    return bool(
+        classes
+        and canonical_manager_found
+        and all(_patch_balance_class(cls) for cls in classes.values())
+    )
 
 
 def install() -> bool:

--- a/bot/runtime_kraken_local_contention_instance_v242_patch.py
+++ b/bot/runtime_kraken_local_contention_instance_v242_patch.py
@@ -192,7 +192,7 @@ def _patch_class(cls: type) -> bool:
 def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
     classes: dict[int, type] = {}
     modules: list[str] = []
-    live_integration_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -205,10 +205,16 @@ def _patch_aliases() -> tuple[bool, int, tuple[str, ...]]:
             classes[id(cls)] = cls
             module_name = str(getattr(module, "__name__", name))
             modules.append(module_name)
-            if module_name == "bot.broker_integration":
-                live_integration_found = True
+            # The production class is ``bot.broker_manager.KrakenBroker``.
+            # The integration module defines ``KrakenBrokerAdapter`` instead;
+            # looking for ``KrakenBroker`` there kept the entire v234/v237/
+            # v241/v242 readiness chain false despite effective protection.
+            if module_name == "bot.broker_manager":
+                canonical_manager_found = True
     patched = sum(1 for cls in classes.values() if _patch_class(cls))
-    return bool(classes and live_integration_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
+    return bool(
+        classes and canonical_manager_found and patched == len(classes)
+    ), patched, tuple(sorted(set(modules)))
 
 
 def install() -> bool:
@@ -228,7 +234,7 @@ def install() -> bool:
     if ready:
         LOGGER.critical(
             "KRAKEN_LOCAL_CONTENTION_V242_READY marker=%s ready=true patched_classes=%d modules=%s "
-            "live_broker_integration_required=true instance_local_busy_sequence=true private_call_boundary=true "
+            "canonical_broker_manager_required=true instance_local_busy_sequence=true private_call_boundary=true "
             "balance_health_guard=true connect_health_guard=true exact_precall_health_only=true "
             "current_call_fail_closed=true genuine_exchange_api_auth_nonce_http_order_failures_unchanged=true "
             "execution_authority_unchanged=true forced_trade=false safety_gates_bypassed=false",

--- a/bot/runtime_kraken_read_lock_recovery_v234_patch.py
+++ b/bot/runtime_kraken_read_lock_recovery_v234_patch.py
@@ -136,7 +136,7 @@ def _patch_class(cls: type) -> bool:
 def _patch_all_kraken_classes() -> tuple[bool, int, tuple[str, ...]]:
     classes: dict[int, type] = {}
     modules: list[str] = []
-    live_found = False
+    canonical_manager_found = False
     for name in _MODULES:
         module = sys.modules.get(name)
         if not isinstance(module, ModuleType):
@@ -149,10 +149,15 @@ def _patch_all_kraken_classes() -> tuple[bool, int, tuple[str, ...]]:
             classes[id(cls)] = cls
             module_name = str(getattr(module, "__name__", name))
             modules.append(module_name)
-            if module_name == "bot.broker_integration":
-                live_found = True
+            # ``KrakenBroker`` is defined by the canonical broker-manager
+            # module.  ``bot.broker_integration`` exposes
+            # ``KrakenBrokerAdapter`` instead, so requiring a KrakenBroker
+            # class there makes this installer permanently report false even
+            # after the real live class has been patched.
+            if module_name == "bot.broker_manager":
+                canonical_manager_found = True
     patched = sum(1 for cls in classes.values() if _patch_class(cls))
-    return bool(classes and live_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
+    return bool(classes and canonical_manager_found and patched == len(classes)), patched, tuple(sorted(set(modules)))
 
 
 def _patch_broker_manager(module: ModuleType | None = None) -> bool:

--- a/bot/tests/test_heartbeat_market_discovery.py
+++ b/bot/tests/test_heartbeat_market_discovery.py
@@ -219,6 +219,76 @@ class TestHeartbeatEmptyMarketFallback(unittest.TestCase):
                 marker_payload = json.loads(marker_file.read())
                 self.assertEqual(marker_payload.get("stage"), "ORDER_VERIFY")
 
+    def test_heartbeat_uses_canonical_ready_venue_not_cached_degraded_broker(self):
+        """A cached Kraken broker cannot override Coinbase-only readiness."""
+        from bot.trading_strategy import TradingStrategy
+
+        kraken = SimpleNamespace(
+            NAME="kraken",
+            connected=True,
+            exit_only_mode=False,
+            _last_known_balance=250.0,
+        )
+        coinbase = SimpleNamespace(
+            NAME="coinbase",
+            connected=True,
+            exit_only_mode=False,
+            _last_known_balance=95.0,
+        )
+
+        strategy = self._make_strategy_with_broker(kraken)
+        strategy.multi_account_manager = SimpleNamespace(
+            platform_brokers={"kraken": kraken, "coinbase": coinbase}
+        )
+
+        with patch.dict(
+            "os.environ",
+            {"NIJA_EXECUTION_READY_VENUES": "coinbase,okx"},
+            clear=False,
+        ):
+            selected = strategy._get_heartbeat_broker()
+
+        self.assertIs(selected, coinbase)
+        self.assertIs(strategy.broker, coinbase)
+
+    def test_heartbeat_fails_closed_when_ready_venue_object_is_missing(self):
+        """Published readiness never falls back to a degraded cached venue."""
+        kraken = SimpleNamespace(
+            NAME="kraken",
+            connected=True,
+            exit_only_mode=False,
+            _last_known_balance=250.0,
+        )
+        strategy = self._make_strategy_with_broker(kraken)
+
+        with patch.dict(
+            "os.environ",
+            {"NIJA_EXECUTION_READY_VENUES": "coinbase"},
+            clear=False,
+        ):
+            selected = strategy._get_heartbeat_broker()
+
+        self.assertIsNone(selected)
+
+    def test_heartbeat_fails_closed_when_published_ready_set_is_empty(self):
+        """An authoritative empty ready set is not treated as unpublished."""
+        kraken = SimpleNamespace(
+            NAME="kraken",
+            connected=True,
+            exit_only_mode=False,
+            _last_known_balance=250.0,
+        )
+        strategy = self._make_strategy_with_broker(kraken)
+
+        with patch.dict(
+            "os.environ",
+            {"NIJA_EXECUTION_READY_VENUES": ""},
+            clear=False,
+        ):
+            selected = strategy._get_heartbeat_broker()
+
+        self.assertIsNone(selected)
+
     def test_heartbeat_fill_verify_blocks_without_fill(self):
         broker = MagicMock()
         broker.connected = True

--- a/bot/tests/test_kraken_contention_canonical_topology_v245.py
+++ b/bot/tests/test_kraken_contention_canonical_topology_v245.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from bot import runtime_kraken_local_contention_alias_v241_patch as v241
+from bot import runtime_kraken_local_contention_health_v237_patch as v237
+from bot import runtime_kraken_local_contention_instance_v242_patch as v242
+from bot import runtime_kraken_read_lock_recovery_v234_patch as v234
+
+
+class _CanonicalKrakenBroker:
+    def _kraken_private_call(self, *_args, **_kwargs):
+        return {"result": {}}
+
+    def get_account_balance(self):
+        return 0.0
+
+    def connect(self):
+        return True
+
+
+def _install_test_topology(monkeypatch) -> None:
+    canonical = ModuleType("bot.broker_manager")
+    canonical.KrakenBroker = _CanonicalKrakenBroker
+    integration = ModuleType("bot.broker_integration")
+    integration.KrakenBrokerAdapter = type("KrakenBrokerAdapter", (), {})
+
+    monkeypatch.setitem(sys.modules, "bot.broker_manager", canonical)
+    monkeypatch.setitem(sys.modules, "broker_manager", canonical)
+    monkeypatch.setitem(sys.modules, "bot.broker_integration", integration)
+    monkeypatch.setitem(sys.modules, "broker_integration", integration)
+
+
+def test_v234_accepts_canonical_broker_manager_topology(monkeypatch):
+    _install_test_topology(monkeypatch)
+
+    ready, patched, modules = v234._patch_all_kraken_classes()
+
+    assert ready is True
+    assert patched == 1
+    assert "bot.broker_manager" in modules
+
+
+def test_v237_accepts_canonical_broker_manager_topology(monkeypatch):
+    _install_test_topology(monkeypatch)
+
+    assert v237._patch_kraken_balance_health() is True
+
+
+def test_v241_accepts_canonical_broker_manager_topology(monkeypatch):
+    _install_test_topology(monkeypatch)
+
+    ready, patched, modules = v241._patch_aliases()
+
+    assert ready is True
+    assert patched == 1
+    assert "bot.broker_manager" in modules
+
+
+def test_v242_accepts_canonical_broker_manager_topology(monkeypatch):
+    _install_test_topology(monkeypatch)
+
+    ready, patched, modules = v242._patch_aliases()
+
+    assert ready is True
+    assert patched == 1
+    assert "bot.broker_manager" in modules

--- a/bot/tests/test_kraken_local_contention_v243.py
+++ b/bot/tests/test_kraken_local_contention_v243.py
@@ -51,3 +51,25 @@ def test_local_kraken_read_contention_without_cache_returns_zero_without_health_
     assert broker._is_available is True
     assert broker.exit_only_mode is False
     assert broker.kraken_health == "OK"
+
+
+def test_local_kraken_position_contention_skips_authority_demotion():
+    broker = broker_manager.KrakenBroker.__new__(broker_manager.KrakenBroker)
+    broker.api = object()
+    broker.account_identifier = "PLATFORM"
+    broker._balance_fetch_errors = 2
+    broker._is_available = True
+    broker.exit_only_mode = False
+    broker.kraken_health = "OK"
+    broker._kraken_private_call = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        RuntimeError("Kraken read lock busy after 3.00s for Balance")
+    )
+    broker._demote_on_writer_authority_failure = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("local contention must not enter authority demotion")
+    )
+
+    assert broker_manager.KrakenBroker.get_positions(broker) == []
+    assert broker._balance_fetch_errors == 2
+    assert broker._is_available is True
+    assert broker.exit_only_mode is False
+    assert broker.kraken_health == "OK"

--- a/bot/tests/test_live_pending_to_live_active_regression.py
+++ b/bot/tests/test_live_pending_to_live_active_regression.py
@@ -37,6 +37,7 @@ import os
 import time
 import threading
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from bot.startup_coordinator import (
@@ -162,6 +163,35 @@ class TestAuthorityReadyBootstrap(unittest.TestCase):
 
         if result:
             self.assertTrue(readiness_table.snapshot().get("nonce_ready", False))
+
+    def test_connected_kraken_requires_nonce_without_legacy_env(self) -> None:
+        """Canonical connected topology overrides a missing legacy nonce flag."""
+        import bot.trading_state_machine as tsm
+
+        os.environ.pop("KRAKEN_NONCE_LEASE_REQUIRED", None)
+        manager = SimpleNamespace(
+            platform_brokers={"kraken": SimpleNamespace(connected=True)}
+        )
+
+        with patch.object(tsm, "_get_mabm_instance", return_value=manager):
+            self.assertTrue(tsm._kraken_nonce_gates_required())
+
+    def test_authority_bootstrap_does_not_mark_nonce_for_connected_kraken(self) -> None:
+        """Writer authority alone cannot satisfy an active Kraken nonce gate."""
+        import bot.trading_state_machine as tsm
+
+        os.environ.pop("KRAKEN_NONCE_LEASE_REQUIRED", None)
+        manager = SimpleNamespace(
+            platform_brokers={"kraken": SimpleNamespace(connected=True)}
+        )
+
+        with patch.object(
+            tsm, "_distributed_writer_authority_gate", return_value=(True, "")
+        ), patch.object(tsm, "_get_mabm_instance", return_value=manager):
+            self.assertTrue(tsm._is_authority_ready())
+
+        self.assertTrue(readiness_table.snapshot().get("authority_ready", False))
+        self.assertFalse(readiness_table.snapshot().get("nonce_ready", False))
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +343,29 @@ class TestAuthorityHeartbeatMarksReadiness(unittest.TestCase):
         self.assertFalse(
             readiness_table.snapshot().get("nonce_ready", False),
             "nonce_ready must NOT be auto-set when KRAKEN_NONCE_LEASE_REQUIRED is set",
+        )
+
+    def test_tick_does_not_infer_coinbase_only_from_missing_legacy_env(self) -> None:
+        """An active Kraken topology keeps nonce readiness fail-closed."""
+        monitor = self._make_monitor()
+        os.environ.pop("KRAKEN_NONCE_LEASE_REQUIRED", None)
+
+        with patch(
+            "bot.authority_heartbeat._check_authority_once",
+            return_value=(True, ""),
+        ), patch(
+            "bot.authority_heartbeat._write_heartbeat_marker",
+        ), patch.object(
+            monitor, "_write_heartbeat_to_redis", return_value=None, create=True
+        ), patch(
+            "bot.authority_heartbeat._kraken_nonce_gates_required_now",
+            return_value=True,
+        ):
+            monitor._tick()
+
+        self.assertFalse(
+            readiness_table.snapshot().get("nonce_ready", False),
+            "missing legacy env must not fabricate Coinbase-only nonce readiness",
         )
 
     def test_failed_tick_does_not_mark_authority_ready(self) -> None:

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -616,7 +616,10 @@ def _kraken_nonce_gates_required() -> bool:
     Kraken is not an active connected platform broker. In that case, enforcing
     Kraken nonce gates can block dispatch unnecessarily.
     """
-    if _env_truthy("NIJA_FORCE_KRAKEN_NONCE_GATES", "false"):
+    if (
+        _env_truthy("NIJA_FORCE_KRAKEN_NONCE_GATES", "false")
+        or _env_truthy("KRAKEN_NONCE_LEASE_REQUIRED", "false")
+    ):
         return True
 
     try:
@@ -3287,10 +3290,9 @@ def _is_authority_ready() -> bool:
             except ImportError:
                 from readiness_table import mark_ready as _rt_mark  # type: ignore[import]
             _rt_mark("authority_ready")
-            # Also mark nonce_ready for Coinbase-only mode (Kraken nonce not
-            # required), which unblocks the prereqs_ready check inside the
-            # coordinator's _reconcile_runtime_authority_locked().
-            if not os.environ.get("KRAKEN_NONCE_LEASE_REQUIRED", "").strip():
+            # Also mark nonce_ready only when canonical runtime topology proves
+            # that no active Kraken platform broker requires nonce authority.
+            if not _kraken_nonce_gates_required():
                 _rt_mark("nonce_ready")
             logger.critical(
                 "[AUTHORITY_GRANTED] writer_authority_gate_passed — "

--- a/bot/trading_strategy.py
+++ b/bot/trading_strategy.py
@@ -1131,7 +1131,7 @@ class TradingStrategy:
             way, market discovery failure never blocks heartbeat execution.
         """
         # ── Resolve broker ─────────────────────────────────────────────────
-        broker = self._get_active_broker()
+        broker = self._get_heartbeat_broker()
         if broker is None:
             logger.error("❌ Heartbeat trade: no active broker available")
             return False
@@ -1561,6 +1561,83 @@ class TradingStrategy:
         if status:
             logger.warning("No entry-eligible broker available: %s", status)
         return None
+
+    def _get_heartbeat_broker(self) -> Optional[Any]:
+        """Return a canonically execution-ready broker for startup proof.
+
+        ``NIJA_EXECUTION_READY_VENUES`` is published by the authoritative
+        three-venue readiness reconciler.  When it is present, a startup
+        ORDER_VERIFY/FILL_VERIFY probe must not reuse a merely connected or
+        legacy-balance-eligible cached broker outside that set.  Ordinary entry
+        routing remains unchanged and the method fails closed if none of the
+        published ready venues can be resolved to a live broker object.
+        """
+        readiness_published = "NIJA_EXECUTION_READY_VENUES" in os.environ
+        ready_raw = os.environ.get("NIJA_EXECUTION_READY_VENUES", "")
+        ready_venues = {
+            venue.strip().lower()
+            for venue in ready_raw.split(",")
+            if venue.strip()
+        }
+        if not readiness_published:
+            return self._get_active_broker()
+        if not ready_venues:
+            logger.error(
+                "Heartbeat broker selection failed closed: ready_venues=none "
+                "status=canonical_readiness_has_no_ready_venues"
+            )
+            return None
+
+        candidates: Dict[Any, Any] = {}
+        if self.multi_account_manager is not None:
+            try:
+                candidates.update(
+                    getattr(self.multi_account_manager, "platform_brokers", {}) or {}
+                )
+            except Exception as exc:
+                logger.debug("Heartbeat MABM broker lookup failed: %s", exc)
+        if self.broker_manager is not None:
+            try:
+                candidates.update(getattr(self.broker_manager, "brokers", {}) or {})
+                primary = self.broker_manager.get_primary_broker()
+                if primary is not None:
+                    candidates.setdefault(
+                        getattr(primary, "broker_type", "primary"), primary
+                    )
+            except Exception as exc:
+                logger.debug("Heartbeat BrokerManager lookup failed: %s", exc)
+        if self.broker is not None:
+            candidates.setdefault(
+                getattr(self.broker, "broker_type", "cached"), self.broker
+            )
+
+        ready_candidates = {
+            raw_key: broker
+            for raw_key, broker in candidates.items()
+            if broker is not None
+            and self._broker_key_from_obj(broker) in ready_venues
+        }
+        selected, name, status = self._select_entry_broker(ready_candidates)
+        if selected is None:
+            logger.error(
+                "Heartbeat broker selection failed closed: ready_venues=%s status=%s",
+                ",".join(sorted(ready_venues)),
+                status or "no_matching_broker_objects",
+            )
+            return None
+
+        self.broker = selected
+        if self.broker_manager is not None:
+            try:
+                self.broker_manager.active_broker = selected
+            except Exception:
+                pass
+        logger.info(
+            "HEARTBEAT_CANONICAL_VENUE_SELECTED venue=%s ready_venues=%s",
+            name,
+            ",".join(sorted(ready_venues)),
+        )
+        return selected
 
     @staticmethod
     def _position_symbol(position: Any) -> str:

--- a/three_venue_execution_readiness.py
+++ b/three_venue_execution_readiness.py
@@ -759,28 +759,6 @@ def publish_once(*, force: bool = False) -> dict[str, Any]:
 
 def reconcile_execution_readiness(*, trigger: str = "manual", force: bool = False) -> dict[str, Any]:
     payload = publish_once(force=force)
-    runtime_enabled = _truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY")
-    if (
-        payload["writer_ready"]
-        and payload["capital_ready"]
-        and payload["any_venue_ready"]
-        and not runtime_enabled
-    ):
-        state = payload.get("writer_state", {})
-        logger.critical(
-            "WRITER_AUTHORITY_STATE_MACHINE_BUG marker=%s trigger=%s "
-            "lease=%s token=%s heartbeat_healthy=%s core_loop_alive=%s "
-            "capital_ready=%s ready_venues=%s runtime_execution_authority=%s auto_repair=true",
-            MARKER,
-            trigger,
-            state.get("lease_acquired"),
-            state.get("fencing_token"),
-            state.get("heartbeat_healthy"),
-            state.get("core_loop_alive"),
-            payload["capital_ready"],
-            ",".join(payload["ready_venues"]) or "none",
-            runtime_enabled,
-        )
     if payload["writer_ready"]:
         try:
             repair = importlib.import_module("bot.runtime_authority_convergence_repair_patch")
@@ -799,6 +777,33 @@ def reconcile_execution_readiness(*, trigger: str = "manual", force: bool = Fals
                     MARKER,
                     trigger,
                 )
+    # Diagnose only after the bounded convergence repair has had a chance to
+    # commit through the canonical state machine.  Previously this marker was
+    # emitted before every successful repair and falsely described a transient
+    # pre-repair observation as a persistent state-machine defect.
+    runtime_enabled = _truthy("NIJA_RUNTIME_EXECUTION_AUTHORITY")
+    if (
+        payload["writer_ready"]
+        and payload["capital_ready"]
+        and payload["any_venue_ready"]
+        and not runtime_enabled
+    ):
+        state = payload.get("writer_state", {})
+        logger.critical(
+            "WRITER_AUTHORITY_STATE_MACHINE_BUG marker=%s trigger=%s "
+            "lease=%s token=%s heartbeat_healthy=%s core_loop_alive=%s "
+            "capital_ready=%s ready_venues=%s runtime_execution_authority=%s "
+            "auto_repair_attempted=true",
+            MARKER,
+            trigger,
+            state.get("lease_acquired"),
+            state.get("fencing_token"),
+            state.get("heartbeat_healthy"),
+            state.get("core_loop_alive"),
+            payload["capital_ready"],
+            ",".join(payload["ready_venues"]) or "none",
+            runtime_enabled,
+        )
     return payload
 
 


### PR DESCRIPTION
## Summary
- classify and recover process-local Kraken read-lock contention without fabricating broker health
- converge authority/nonce truth on the active Kraken topology
- route startup heartbeat verification through a canonical execution-ready venue instead of degraded cached Kraken
- preserve fail-closed lifecycle, nonce, writer, risk, kill-switch, capital, and order gates

## Validation
- 84 authority/lifecycle tests passed
- 16 heartbeat routing tests passed
- Python compilation passed
- diff checks and unsafe-bypass scan passed

Production deploy is triggered by merge to `main`.