### PR TITLE
Fix heartbeat proof bootstrap deadlock

### DIFF
--- a/bot/tests/test_heartbeat_marker_bootstrap_circuit_breaker.py
+++ b/bot/tests/test_heartbeat_marker_bootstrap_circuit_breaker.py
@@ -1,0 +1,32 @@
+"""Regression coverage for pre-proof heartbeat circuit-breaker behavior."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from bot import trading_state_machine as tsm
+
+
+def test_missing_bootstrap_marker_fails_closed_without_tripping_breaker() -> None:
+    with patch.object(tsm, "_heartbeat_verification_required", return_value=True), patch.object(
+        tsm,
+        "_heartbeat_verification_status",
+        return_value=(False, "marker_missing", {}),
+    ), patch.object(tsm, "_record_execution_anomaly") as record:
+        ready, reason = tsm._runtime_writer_nonce_ready()
+
+    assert ready is False
+    assert reason == "heartbeat_verification:marker_missing"
+    record.assert_not_called()
+
+
+def test_invalid_existing_marker_remains_circuit_breaker_anomaly() -> None:
+    with patch.object(tsm, "_heartbeat_verification_required", return_value=True), patch.object(
+        tsm,
+        "_heartbeat_verification_status",
+        return_value=(False, "marker_malformed:bad-json", {}),
+    ), patch.object(tsm, "_record_execution_anomaly") as record:
+        ready, reason = tsm._runtime_writer_nonce_ready()
+
+    assert ready is False
+    assert reason == "heartbeat_verification:marker_malformed:bad-json"
+    record.assert_called_once_with("heartbeat_verification", "marker_malformed:bad-json")

--- a/bot/tests/test_heartbeat_market_discovery_bound_v208.py
+++ b/bot/tests/test_heartbeat_market_discovery_bound_v208.py
@@ -10,6 +10,10 @@ from unittest.mock import patch
 from bot.runtime_heartbeat_probe_pipeline_bridge_v197_patch import (
     _wrap_heartbeat_market_discovery_method,
 )
+from bot.trading_strategy import (
+    _HEARTBEAT_DISCOVERY_FLIGHTS,
+    _bounded_heartbeat_market_discovery,
+)
 
 
 class _Broker:
@@ -24,6 +28,9 @@ class _Broker:
 
 
 class HeartbeatMarketDiscoveryBoundV208Tests(unittest.TestCase):
+    def tearDown(self) -> None:
+        _HEARTBEAT_DISCOVERY_FLIGHTS.clear()
+
     def test_heartbeat_thread_times_out_to_empty_markets(self) -> None:
         broker = _Broker()
         wrapped = _wrap_heartbeat_market_discovery_method(
@@ -64,6 +71,25 @@ class HeartbeatMarketDiscoveryBoundV208Tests(unittest.TestCase):
             method_name="get_available_markets",
         )
         self.assertEqual(wrapped(broker), ["BTC-USD", "ETH-USD"])
+
+    def test_call_site_timeout_covers_late_bound_broker_alias(self) -> None:
+        broker = _Broker()
+        with patch.dict(
+            os.environ,
+            {"NIJA_HEARTBEAT_MARKET_DISCOVERY_TIMEOUT_S": "0.5"},
+            clear=False,
+        ):
+            started = time.monotonic()
+            with self.assertRaisesRegex(TimeoutError, "market discovery timed out"):
+                _bounded_heartbeat_market_discovery(broker, "get_available_markets")
+            elapsed = time.monotonic() - started
+
+            with self.assertRaisesRegex(TimeoutError, "still in flight"):
+                _bounded_heartbeat_market_discovery(broker, "get_available_markets")
+
+        self.assertEqual(broker.calls, 1)
+        self.assertLess(elapsed, 1.25)
+        broker.release.set()
 
 
 if __name__ == "__main__":

--- a/bot/trading_state_machine.py
+++ b/bot/trading_state_machine.py
@@ -3315,10 +3315,16 @@ def _runtime_writer_nonce_ready() -> tuple[bool, str]:
     heartbeat_required = _heartbeat_verification_required()
     heartbeat_ok, heartbeat_err, _ = _heartbeat_verification_status()
     if heartbeat_required and not heartbeat_ok:
-        _record_execution_anomaly(
-            "heartbeat_verification",
-            heartbeat_err or "missing_or_stale",
-        )
+        # ``marker_missing`` is the expected bootstrap state before the genuine
+        # startup heartbeat reaches ORDER_VERIFY.  Counting readiness polling as
+        # repeated execution anomalies trips the circuit breaker before that
+        # probe can create its marker, producing a circular deadlock.  Malformed,
+        # stale, or insufficient markers remain anomalies and fail closed.
+        if heartbeat_err != "marker_missing":
+            _record_execution_anomaly(
+                "heartbeat_verification",
+                heartbeat_err or "missing_or_stale",
+            )
         return False, f"heartbeat_verification:{heartbeat_err or 'missing_or_stale'}"
 
     writer_ok, writer_err = _distributed_writer_authority_gate()

--- a/bot/trading_strategy.py
+++ b/bot/trading_strategy.py
@@ -105,6 +105,73 @@ except ImportError:
         logger.warning("MarketReadinessGate not available — startup market probe will run degraded")
 
 _HEARTBEAT_LOG_LIMITER = get_log_rate_limiter()
+_HEARTBEAT_DISCOVERY_LOCK = threading.Lock()
+_HEARTBEAT_DISCOVERY_FLIGHTS: Dict[tuple[int, str], threading.Thread] = {}
+
+
+def _heartbeat_market_discovery_timeout_s() -> float:
+    """Return the caller-owned timeout for heartbeat market discovery."""
+    try:
+        value = float(os.environ.get("NIJA_HEARTBEAT_MARKET_DISCOVERY_TIMEOUT_S", "5") or 5.0)
+    except (TypeError, ValueError):
+        value = 5.0
+    return max(0.5, min(30.0, value))
+
+
+def _bounded_heartbeat_market_discovery(broker: Any, method_name: str) -> Any:
+    """Run heartbeat market discovery once with a bounded, fail-safe wait.
+
+    Runtime patch v208 protects known broker classes, but late-bound aliases can
+    replace those class methods after installation.  Owning the timeout at the
+    heartbeat call site guarantees that a read-only discovery call cannot pin
+    the one heartbeat scheduler forever.  A timed-out worker remains registered
+    until it exits, preventing duplicate requests on later retries.
+    """
+    method = getattr(broker, method_name)
+    key = (id(broker), method_name)
+    result_queue: "queue.Queue[tuple[str, Any]]" = queue.Queue(maxsize=1)
+
+    with _HEARTBEAT_DISCOVERY_LOCK:
+        existing = _HEARTBEAT_DISCOVERY_FLIGHTS.get(key)
+        if existing is not None and existing.is_alive():
+            raise TimeoutError(f"heartbeat market discovery still in flight: {method_name}")
+        _HEARTBEAT_DISCOVERY_FLIGHTS.pop(key, None)
+
+        worker_ref: Dict[str, threading.Thread] = {}
+
+        def _runner() -> None:
+            try:
+                result_queue.put_nowait(("result", method()))
+            except BaseException as exc:
+                try:
+                    result_queue.put_nowait(("error", exc))
+                except queue.Full:
+                    pass
+            finally:
+                worker = worker_ref.get("worker")
+                with _HEARTBEAT_DISCOVERY_LOCK:
+                    if worker is not None and _HEARTBEAT_DISCOVERY_FLIGHTS.get(key) is worker:
+                        _HEARTBEAT_DISCOVERY_FLIGHTS.pop(key, None)
+
+        worker = threading.Thread(
+            target=_runner,
+            name=f"HeartbeatMarketDiscovery-Caller-{type(broker).__name__}-{method_name}",
+            daemon=True,
+        )
+        worker_ref["worker"] = worker
+        _HEARTBEAT_DISCOVERY_FLIGHTS[key] = worker
+        worker.start()
+
+    timeout_s = _heartbeat_market_discovery_timeout_s()
+    try:
+        kind, payload = result_queue.get(timeout=timeout_s)
+    except queue.Empty as exc:
+        raise TimeoutError(
+            f"heartbeat market discovery timed out after {timeout_s:.2f}s: {method_name}"
+        ) from exc
+    if kind == "error":
+        raise payload
+    return payload
 
 
 def _heartbeat_rate_limited_info(category: str, key: str, window_seconds: float, message: str, *args: Any) -> None:
@@ -1188,7 +1255,7 @@ class TradingStrategy:
                 else None
             )
             if _market_getter is not None:
-                available_markets = getattr(broker, _market_getter)()
+                available_markets = _bounded_heartbeat_market_discovery(broker, _market_getter)
                 _discovery_count = len(available_markets) if isinstance(available_markets, list) else 0
                 _heartbeat_rate_limited_info(
                     "heartbeat_market_discovery_count",


### PR DESCRIPTION
## Summary
- bound heartbeat market discovery at the strategy call site so late-bound broker aliases cannot pin the single heartbeat scheduler
- prevent the expected pre-proof `marker_missing` state from being counted as a repeated execution anomaly
- preserve fail-closed activation for malformed, stale, or insufficient heartbeat markers
- preserve genuine `ORDER_VERIFY`/`FILL_VERIFY`, writer, nonce, risk, kill-switch, and order gates

## Runtime evidence addressed
- `HeartbeatTrade` remained alive after authenticated balance hydration but never reached the BUY submit log
- readiness polling tripped `EXECUTION_CIRCUIT_BREAKER heartbeat_verification threshold=2 detail=marker_missing`
- activation stayed `LIVE_PENDING_CONFIRMATION` with `execution_ready=false`

## Validation
- Python compilation passed for all changed files
- 57 focused heartbeat/activation tests passed
- 42/43 broader authority tests passed; the lone failure is an unrelated pre-existing sub-microsecond float-string equality assertion in `test_heartbeat_authority_single_source.py`
- no safety bypass flags or secrets added

## Safety invariants
- no execution proof is fabricated
- no forced activation or forced trade
- missing marker remains fail-closed
- malformed/stale/insufficient markers still count toward the circuit breaker
- timed-out discovery is read-only and does not create duplicate discovery workers