### PR TITLE
Fix position proof liveness and heartbeat worker context

### DIFF
--- a/bot/position_sync_failure_truth_v98_patch.py
+++ b/bot/position_sync_failure_truth_v98_patch.py
@@ -5,11 +5,15 @@ successfully timing out on a later authoritative refresh. startup_position_sync
 caught the timeout and returned without clearing ``_startup_position_sync_adopted``,
 so aggregate sync/readiness incorrectly remained true.
 
-v98 moves the invariant to the canonical startup-sync boundary: every fresh
-broker reconciliation revokes prior sync success before calling ``get_positions``.
-Only a successful authoritative snapshot may set the broker back to synchronized.
+v98 keeps the invariant at the canonical startup-sync boundary: a completed
+failed refresh revokes prior sync success, while a previously proven snapshot is
+not revoked merely because a new bounded refresh is still in flight. The wrapper
+observes the real broker ``get_positions`` call through a transparent proxy, so
+only an authoritative returned snapshot may refresh proof and any exception,
+missing fetch, or reconciliation failure fails closed.
+
 No broker connectivity, risk, nonce, writer, capital, or order-dispatch gate is
-weakened or synthesized.
+weakened or synthesized by this patch.
 """
 from __future__ import annotations
 
@@ -52,6 +56,39 @@ def _revoke_previous_success(broker: Any) -> None:
     os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "0"
 
 
+class _FetchProofProxy:
+    """Transparent broker proxy that observes the authoritative fetch outcome."""
+
+    __slots__ = ("_broker", "fetch_attempted", "fetch_ok", "fetch_error")
+
+    def __init__(self, broker: Any) -> None:
+        object.__setattr__(self, "_broker", broker)
+        object.__setattr__(self, "fetch_attempted", False)
+        object.__setattr__(self, "fetch_ok", None)
+        object.__setattr__(self, "fetch_error", None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_broker"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"_broker", "fetch_attempted", "fetch_ok", "fetch_error"}:
+            object.__setattr__(self, name, value)
+            return
+        setattr(object.__getattribute__(self, "_broker"), name, value)
+
+    def get_positions(self, *args: Any, **kwargs: Any) -> Any:
+        object.__setattr__(self, "fetch_attempted", True)
+        try:
+            result = object.__getattribute__(self, "_broker").get_positions(*args, **kwargs)
+        except BaseException as exc:
+            object.__setattr__(self, "fetch_ok", False)
+            object.__setattr__(self, "fetch_error", f"{type(exc).__name__}:{exc}")
+            raise
+        object.__setattr__(self, "fetch_ok", True)
+        object.__setattr__(self, "fetch_error", None)
+        return result
+
+
 def _patch_startup_sync(module: ModuleType) -> bool:
     current = getattr(module, "_adopt_broker_positions", None)
     if not callable(current):
@@ -62,9 +99,16 @@ def _patch_startup_sync(module: ModuleType) -> bool:
     @wraps(current)
     def adopt_broker_positions_v98(broker: Any, broker_name: str, eps: Any) -> int:
         previous = bool(getattr(broker, "_startup_position_sync_adopted", False))
-        _revoke_previous_success(broker)
+        previous_fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None) is True
+        proxy = _FetchProofProxy(broker)
+
+        # Do not revoke a previously authoritative snapshot merely because a
+        # maintenance refresh has started. The active v95 transport call is
+        # bounded; if it actually fails, the post-call proof below revokes the
+        # stale success immediately. This removes the Coinbase readiness flap
+        # without converting an error or timeout into success.
         try:
-            result = int(current(broker, broker_name, eps) or 0)
+            result = int(current(proxy, broker_name, eps) or 0)
         except BaseException as exc:
             _revoke_previous_success(broker)
             try:
@@ -82,39 +126,42 @@ def _patch_startup_sync(module: ModuleType) -> bool:
             )
             raise
 
+        fetch_attempted = bool(proxy.fetch_attempted)
+        fetch_ok = proxy.fetch_ok is True
         synced = bool(getattr(broker, "_startup_position_sync_adopted", False))
-        fetch_ok = getattr(broker, "_startup_position_sync_fetch_ok", None)
 
-        # The canonical adopter is the authority boundary: it sets ``adopted``
-        # only after the returned snapshot (including a genuine empty snapshot)
-        # has been fully reconciled.  Publish the corresponding fetch proof here
-        # after the pre-fetch revocation above.  Preserve an explicit False from
-        # an inner transport wrapper; a masked fetch failure must never be turned
-        # into an authoritative empty snapshot.
-        if synced and fetch_ok is not False:
+        if not fetch_attempted or not fetch_ok:
+            _revoke_previous_success(broker)
+            try:
+                setattr(broker, "_startup_position_sync_fetch_ok", False)
+                reason = proxy.fetch_error or "authoritative_fetch_not_completed"
+                setattr(broker, "_startup_position_sync_error", reason)
+            except Exception:
+                pass
+            synced = False
+        elif synced:
             try:
                 setattr(broker, "_startup_position_sync_fetch_ok", True)
                 setattr(broker, "_startup_position_sync_error", None)
             except Exception:
-                synced = False
+                _revoke_previous_success(broker)
                 try:
-                    setattr(broker, "_startup_position_sync_adopted", False)
-                    setattr(broker, "_startup_position_sync_symbols", tuple())
+                    setattr(broker, "_startup_position_sync_fetch_ok", False)
+                    setattr(broker, "_startup_position_sync_error", "fetch_proof_publish_failed")
                 except Exception:
                     pass
+                synced = False
                 LOGGER.exception(
-                    "POSITION_SYNC_V98_FETCH_PROOF_PUBLISH_FAILED marker=%s "
-                    "broker=%s fail_closed=true",
+                    "POSITION_SYNC_V98_FETCH_PROOF_PUBLISH_FAILED marker=%s broker=%s fail_closed=true",
                     MARKER,
                     broker_name,
                 )
-        elif synced:
-            # An explicit fetch failure is stronger than a legacy adopter that
-            # accepted a compatibility-layer ``[]`` fallback.
-            synced = False
+        else:
+            # The transport returned authoritatively but reconciliation did not
+            # complete. Keep the fetch fact, but never preserve readiness.
             try:
-                setattr(broker, "_startup_position_sync_adopted", False)
-                setattr(broker, "_startup_position_sync_symbols", tuple())
+                setattr(broker, "_startup_position_sync_fetch_ok", True)
+                setattr(broker, "_startup_position_sync_error", "authoritative_fetch_reconciliation_incomplete")
             except Exception:
                 pass
 
@@ -122,15 +169,19 @@ def _patch_startup_sync(module: ModuleType) -> bool:
             os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] = "0"
             os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] = "0"
             LOGGER.warning(
-                "POSITION_SYNC_V98_UNSYNCED marker=%s broker=%s previous_synced=%s stale_success_reused=false activation_blocked=true",
+                "POSITION_SYNC_V98_UNSYNCED marker=%s broker=%s previous_synced=%s previous_fetch_ok=%s "
+                "fetch_attempted=%s fetch_ok=%s stale_success_reused=false activation_blocked=true",
                 MARKER,
                 broker_name,
                 str(previous).lower(),
+                str(previous_fetch_ok).lower(),
+                str(fetch_attempted).lower(),
+                str(fetch_ok).lower(),
             )
         else:
             LOGGER.info(
-                "POSITION_SYNC_V98_FETCH_PROOF_READY marker=%s broker=%s "
-                "authoritative_snapshot=true positions_adopted=true",
+                "POSITION_SYNC_V98_FETCH_PROOF_READY marker=%s broker=%s authoritative_snapshot=true "
+                "positions_adopted=true prior_proof_preserved_only_while_inflight=true",
                 MARKER,
                 broker_name,
             )
@@ -140,7 +191,8 @@ def _patch_startup_sync(module: ModuleType) -> bool:
     setattr(adopt_broker_positions_v98, "__wrapped__", current)
     module._adopt_broker_positions = adopt_broker_positions_v98
     LOGGER.critical(
-        "POSITION_SYNC_FAILURE_TRUTH_V98_PATCHED marker=%s module=%s file=%s prefetch_revocation=true fail_closed=true",
+        "POSITION_SYNC_FAILURE_TRUTH_V98_PATCHED marker=%s module=%s file=%s "
+        "completed_failure_revocation=true inflight_prior_proof_preserved=true fail_closed=true",
         MARKER,
         getattr(module, "__name__", "<unknown>"),
         getattr(module, "__file__", None),
@@ -179,7 +231,8 @@ def install_import_hook() -> bool:
 
         os.environ["NIJA_POSITION_SYNC_FAILURE_TRUTH_V98_INSTALLED"] = "1"
         LOGGER.critical(
-            "POSITION_SYNC_FAILURE_TRUTH_V98_INSTALLED marker=%s prefetch_revocation=true stale_success_reuse=false safety_gates_unchanged=true",
+            "POSITION_SYNC_FAILURE_TRUTH_V98_INSTALLED marker=%s completed_failure_revocation=true "
+            "inflight_prior_proof_preserved=true stale_success_reuse=false safety_gates_unchanged=true",
             MARKER,
         )
         return True
@@ -189,4 +242,10 @@ def install() -> bool:
     return install_import_hook()
 
 
-__all__ = ["MARKER", "install", "install_import_hook", "_patch_startup_sync"]
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_patch_startup_sync",
+    "_FetchProofProxy",
+]

--- a/bot/runtime_execution_context_handoff_v246_patch.py
+++ b/bot/runtime_execution_context_handoff_v246_patch.py
@@ -1,0 +1,141 @@
+"""Preserve call-scoped execution authority across the pipeline ACK worker.
+
+Production on 2026-08-27 proved the startup heartbeat was independently verified,
+passed the pipeline authority gate, and armed the bounded v233 terminal grant.  The
+pipeline then dispatched routing work through ``ThreadPoolExecutor``.  Python
+ContextVars are not inherited by new executor threads, so the broker terminal saw a
+plain BOOT lifecycle and rejected the same verified startup probe.
+
+v246 repairs only that handoff.  The execution-pipeline module receives a local
+``concurrent`` proxy whose ThreadPoolExecutor captures ``contextvars.copy_context()``
+for each submitted call and runs that call inside the copied context.  The stdlib
+executor is not modified globally.  No startup-probe context is created here: an
+ordinary order with no verified context remains ordinary in the worker.
+
+Lifecycle state, writer/lease authority, nonce, risk, capital, broker health, kill
+switch, ECEL, minimum notional, exchange acknowledgement, fill proof, and activation
+proof are unchanged and remain fail closed.
+"""
+from __future__ import annotations
+
+import concurrent as _stdlib_concurrent
+import contextvars
+import importlib
+import logging
+import os
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_execution_context_handoff_v246")
+MARKER = "20260827-runtime-execution-context-handoff-v246"
+_FLAG = "NIJA_RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_READY"
+_PATCH_ATTR = "_nija_runtime_execution_context_handoff_v246"
+
+
+class _ContextPropagatingThreadPoolExecutor(_stdlib_concurrent.futures.ThreadPoolExecutor):
+    """ThreadPoolExecutor that copies only the caller's existing ContextVars."""
+
+    def submit(self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any):
+        ctx = contextvars.copy_context()
+        return super().submit(ctx.run, fn, *args, **kwargs)
+
+
+class _FuturesProxy:
+    def __init__(self, original: Any) -> None:
+        self._original = original
+        self.ThreadPoolExecutor = _ContextPropagatingThreadPoolExecutor
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._original, name)
+
+
+class _ConcurrentProxy:
+    def __init__(self, original: ModuleType) -> None:
+        self._original = original
+        self.futures = _FuturesProxy(original.futures)
+        setattr(self, _PATCH_ATTR, True)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._original, name)
+
+
+def _execution_pipeline_module() -> ModuleType:
+    return importlib.import_module("bot.execution_pipeline")
+
+
+def _patch_execution_pipeline(module: ModuleType | None = None) -> bool:
+    target = module or _execution_pipeline_module()
+    current = getattr(target, "concurrent", None)
+    if current is None or not hasattr(current, "futures"):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    # Keep the replacement local to bot.execution_pipeline.  In particular, do
+    # not mutate concurrent.futures.ThreadPoolExecutor process-wide.
+    setattr(target, "concurrent", _ConcurrentProxy(current))
+    patched = getattr(target, "concurrent", None)
+    return bool(
+        getattr(patched, _PATCH_ATTR, False)
+        and getattr(getattr(patched, "futures", None), "ThreadPoolExecutor", None)
+        is _ContextPropagatingThreadPoolExecutor
+        and _stdlib_concurrent.futures.ThreadPoolExecutor
+        is not _ContextPropagatingThreadPoolExecutor
+    )
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    except Exception:
+        return False
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    installers = getattr(manifest, "_INSTALLERS", None)
+    if not isinstance(required, dict):
+        return False
+    required["runtime_execution_context_handoff_v246"] = _FLAG
+    own = ("bot.runtime_execution_context_handoff_v246_patch", "install_import_hook")
+    if isinstance(installers, tuple) and own not in installers:
+        manifest._INSTALLERS = tuple(installers) + (own,)
+    return True
+
+
+def install() -> bool:
+    try:
+        pipeline_ready = _patch_execution_pipeline()
+        manifest_ready = _register_manifest()
+        ready = bool(pipeline_ready and manifest_ready)
+    except Exception as exc:
+        LOGGER.error(
+            "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_INSTALL_ERROR marker=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        ready = False
+    os.environ[_FLAG] = "1" if ready else "0"
+    if ready:
+        LOGGER.critical(
+            "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246 marker=%s ready=true "
+            "pipeline_thread_context_propagated=true stdlib_executor_unchanged=true "
+            "startup_probe_context_created=false existing_context_only=true ordinary_orders_unchanged=true "
+            "lifecycle_writer_nonce_risk_capital_broker_health_killswitch_ecel_min_notional_fill_gates_unchanged=true "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+        )
+    return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_patch_execution_pipeline",
+    "_register_manifest",
+    "_ContextPropagatingThreadPoolExecutor",
+]

--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -13,6 +13,11 @@ writer authority is reverified immediately at the terminal method.  The canonica
 authority bindings are anchored for that method call so its inner
 _reject_if_unauthorized_order_submit check observes the verified probe.
 
+v246 is installed from this already-authoritative heartbeat convergence slot.  It
+copies existing ContextVars into ExecutionPipeline's timeout worker so the verified
+startup probe is not lost merely because routing crosses a ThreadPoolExecutor
+boundary.  v246 creates no authority and does not patch the stdlib executor globally.
+
 Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
 minimum notional, exchange acknowledgement, fill proof, and readiness remain unchanged.
 """
@@ -39,14 +44,7 @@ def _v236() -> ModuleType:
 
 
 def _verified_reason() -> str | None:
-    """Resolve only authority that was already verified upstream.
-
-    v236._verified_reason() prefers the same-thread, sub-second v233 grant and then
-    falls back to the canonical startup-probe ContextVar.  v244 previously called
-    only _canonical_verified_probe(), which lost the production heartbeat whenever
-    its ContextVar scope ended before the broker-manager method.  This resolver never
-    creates a grant and therefore cannot authorize an ordinary order by itself.
-    """
+    """Resolve only authority that was already verified upstream."""
     v236 = _v236()
     resolver = getattr(v236, "_verified_reason", None)
     if callable(resolver):
@@ -64,8 +62,6 @@ def _verified_reason() -> str | None:
         if normalized in _ALLOWED:
             return normalized
 
-    # Compatibility fallback for an older v236 shape.  This remains fail-closed
-    # and still requires the canonical ContextVar to be active.
     canonical = getattr(v236, "_canonical_verified_probe", None)
     if not callable(canonical):
         return None
@@ -133,13 +129,25 @@ def _patch_broker_manager_methods() -> tuple[bool, tuple[str, ...]]:
             setattr(cls, method_name, wrapped)
             if bool(getattr(getattr(cls, method_name, None), _PATCH_ATTR, False)):
                 patched.append(surface)
-    # Kraken is the production heartbeat route that exposed this gap.  Keep the
-    # existing Coinbase requirement and require the Kraken market terminal too.
     required = all(
         surface in patched
         for surface in ("CoinbaseBroker.place_market_order", "KrakenBroker.place_market_order")
     )
     return required, tuple(sorted(set(patched)))
+
+
+def _install_v246_context_handoff() -> bool:
+    try:
+        module = importlib.import_module("bot.runtime_execution_context_handoff_v246_patch")
+        installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
+        return bool(callable(installer) and installer())
+    except Exception as exc:
+        LOGGER.error(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V246_INSTALL_ERROR marker=%s "
+            "error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        return False
 
 
 def install() -> bool:
@@ -148,21 +156,22 @@ def install() -> bool:
         upstream_install = getattr(v240, "install", None)
         upstream = bool(callable(upstream_install) and upstream_install())
         methods_ready, surfaces = _patch_broker_manager_methods()
-        ready = bool(upstream and methods_ready)
+        context_handoff_ready = _install_v246_context_handoff()
+        ready = bool(upstream and methods_ready and context_handoff_ready)
     except Exception as exc:
         LOGGER.error(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
-        ready, surfaces = False, ()
+        ready, surfaces, context_handoff_ready = False, (), False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
             "coinbase_live_terminal_required=true kraken_live_terminal_required=true "
             "verified_v233_grant_fallback=true canonical_context_preferred=true "
-            "startup_writer_reverification_required=true grant_ttl_not_extended=true "
-            "ordinary_orders_unchanged=true execution_proof_fabricated=false "
+            "pipeline_context_handoff_v246=true startup_writer_reverification_required=true "
+            "grant_ttl_not_extended=true ordinary_orders_unchanged=true execution_proof_fabricated=false "
             "forced_activation=false safety_gates_bypassed=false",
             MARKER, ",".join(surfaces),
         )
@@ -179,6 +188,7 @@ __all__ = [
     "install_import_hook",
     "_wrap_method",
     "_patch_broker_manager_methods",
+    "_install_v246_context_handoff",
     "_verified_reason",
     "_writer_ready",
 ]

--- a/tests/test_position_sync_failure_truth_v98_liveness.py
+++ b/tests/test_position_sync_failure_truth_v98_liveness.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import bot.position_sync_failure_truth_v98_patch as v98
+
+
+class _Broker:
+    def __init__(self, result=None, error: BaseException | None = None):
+        self.connected = True
+        self.position_tracker = SimpleNamespace(get_all_positions=lambda: [])
+        self._startup_position_sync_adopted = True
+        self._startup_position_sync_fetch_ok = True
+        self._startup_position_sync_symbols = tuple()
+        self._startup_position_sync_error = None
+        self._result = [] if result is None else result
+        self._error = error
+
+    def get_positions(self):
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _module_with_adopter(observed: list[tuple[bool, bool | None]] | None = None) -> ModuleType:
+    module = ModuleType("bot.startup_position_sync")
+
+    def adopter(broker, broker_name, eps):
+        if observed is not None:
+            observed.append(
+                (
+                    bool(getattr(broker, "_startup_position_sync_adopted", False)),
+                    getattr(broker, "_startup_position_sync_fetch_ok", None),
+                )
+            )
+        try:
+            positions = broker.get_positions()
+        except Exception:
+            # Mirrors startup_position_sync: transport failures are logged and
+            # converted to a non-success return at this legacy boundary.
+            return 0
+        if not positions:
+            broker._startup_position_sync_adopted = True
+            broker._startup_position_sync_symbols = tuple()
+            return 0
+        broker._startup_position_sync_adopted = True
+        broker._startup_position_sync_symbols = tuple(
+            sorted(str(item.get("symbol", "")) for item in positions if isinstance(item, dict))
+        )
+        return len(positions)
+
+    module._adopt_broker_positions = adopter
+    return module
+
+
+def test_valid_prior_proof_is_not_revoked_before_refresh_fetch_starts(monkeypatch):
+    observed: list[tuple[bool, bool | None]] = []
+    module = _module_with_adopter(observed)
+    monkeypatch.delenv("NIJA_POSITION_SYNC_ACTIVATION_READY", raising=False)
+    monkeypatch.delenv("NIJA_POSITION_SYNC_DISPATCH_READY", raising=False)
+
+    assert v98._patch_startup_sync(module) is True
+    broker = _Broker(result=[])
+
+    module._adopt_broker_positions(broker, "platform:coinbase", None)
+
+    assert observed == [(True, True)]
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_fetch_ok is True
+    assert broker._startup_position_sync_error is None
+
+
+def test_completed_fetch_failure_revokes_previous_success(monkeypatch):
+    module = _module_with_adopter()
+    monkeypatch.delenv("NIJA_POSITION_SYNC_ACTIVATION_READY", raising=False)
+    monkeypatch.delenv("NIJA_POSITION_SYNC_DISPATCH_READY", raising=False)
+
+    assert v98._patch_startup_sync(module) is True
+    broker = _Broker(error=TimeoutError("coinbase positions timed out"))
+
+    module._adopt_broker_positions(broker, "platform:coinbase", None)
+
+    assert broker._startup_position_sync_adopted is False
+    assert broker._startup_position_sync_fetch_ok is False
+    assert "TimeoutError" in str(broker._startup_position_sync_error)
+    assert v98.os.environ["NIJA_POSITION_SYNC_ACTIVATION_READY"] == "0"
+    assert v98.os.environ["NIJA_POSITION_SYNC_DISPATCH_READY"] == "0"
+
+
+def test_authoritative_empty_snapshot_refreshes_fetch_proof():
+    module = _module_with_adopter()
+    assert v98._patch_startup_sync(module) is True
+    broker = _Broker(result=[])
+    broker._startup_position_sync_adopted = False
+    broker._startup_position_sync_fetch_ok = None
+
+    module._adopt_broker_positions(broker, "platform:coinbase", None)
+
+    assert broker._startup_position_sync_adopted is True
+    assert broker._startup_position_sync_fetch_ok is True
+    assert broker._startup_position_sync_error is None

--- a/tests/test_runtime_execution_context_handoff_v246.py
+++ b/tests/test_runtime_execution_context_handoff_v246.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import concurrent.futures
+import contextvars
+from types import SimpleNamespace
+
+import bot.runtime_execution_context_handoff_v246_patch as v246
+
+
+def test_executor_propagates_existing_contextvar():
+    probe = contextvars.ContextVar("probe", default="none")
+    token = probe.set("HEARTBEAT_TRADE")
+    try:
+        with v246._ContextPropagatingThreadPoolExecutor(max_workers=1) as pool:
+            assert pool.submit(probe.get).result(timeout=2.0) == "HEARTBEAT_TRADE"
+    finally:
+        probe.reset(token)
+
+
+def test_executor_does_not_invent_context():
+    probe = contextvars.ContextVar("probe_default", default="none")
+    with v246._ContextPropagatingThreadPoolExecutor(max_workers=1) as pool:
+        assert pool.submit(probe.get).result(timeout=2.0) == "none"
+
+
+def test_stdlib_executor_is_not_globally_replaced():
+    assert concurrent.futures.ThreadPoolExecutor is not v246._ContextPropagatingThreadPoolExecutor
+
+
+def test_patch_is_local_to_execution_pipeline_module():
+    fake_concurrent = SimpleNamespace(futures=concurrent.futures)
+    fake_pipeline = SimpleNamespace(concurrent=fake_concurrent)
+
+    assert v246._patch_execution_pipeline(fake_pipeline) is True
+    assert fake_pipeline.concurrent.futures.ThreadPoolExecutor is v246._ContextPropagatingThreadPoolExecutor
+    assert concurrent.futures.ThreadPoolExecutor is not v246._ContextPropagatingThreadPoolExecutor
+
+
+def test_patch_is_idempotent():
+    fake_concurrent = SimpleNamespace(futures=concurrent.futures)
+    fake_pipeline = SimpleNamespace(concurrent=fake_concurrent)
+
+    assert v246._patch_execution_pipeline(fake_pipeline) is True
+    patched = fake_pipeline.concurrent
+    assert v246._patch_execution_pipeline(fake_pipeline) is True
+    assert fake_pipeline.concurrent is patched
+
+
+def test_manifest_registration_is_bounded(monkeypatch):
+    required = {}
+    installers = tuple()
+    fake_manifest = SimpleNamespace(_REQUIRED_FLAGS=required, _INSTALLERS=installers)
+    real_import = v246.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.runtime_release_manifest_patch":
+            return fake_manifest
+        return real_import(name)
+
+    monkeypatch.setattr(v246.importlib, "import_module", fake_import)
+    assert v246._register_manifest() is True
+    assert required["runtime_execution_context_handoff_v246"] == v246._FLAG
+    assert fake_manifest._INSTALLERS.count(
+        ("bot.runtime_execution_context_handoff_v246_patch", "install_import_hook")
+    ) == 1
+    assert v246._register_manifest() is True
+    assert fake_manifest._INSTALLERS.count(
+        ("bot.runtime_execution_context_handoff_v246_patch", "install_import_hook")
+    ) == 1


### PR DESCRIPTION
Production logs on 2026-08-27 exposed two independent startup-liveness defects while NIJA remained fail-closed.

1. Coinbase position proof flapped true -> false because the v98 wrapper revoked an already-authoritative snapshot before a bounded maintenance refresh had actually failed. The fix preserves proven state only while the new refresh is in flight, and still revokes on a real exception, missing authoritative fetch, or incomplete reconciliation.

2. After position sync became 3/3 green, the heartbeat reached ECEL, routing, and the verified v233 startup authority bridge, but the final Coinbase broker terminal rejected it as lifecycle_phase:BOOT. The cause is ExecutionPipeline's ACK timeout ThreadPoolExecutor: Python ContextVars are not inherited by new executor threads, so the already-verified startup-probe scope was lost at the worker boundary. v246 copies the caller's existing ContextVars into that local pipeline worker only. It creates no authority, does not extend the v233 TTL, does not alter lifecycle state, and does not patch ThreadPoolExecutor globally.

Regression coverage includes position proof preservation/revocation, authoritative empty snapshots, ContextVar propagation, no-context behavior, stdlib executor isolation, idempotent installation, and bounded manifest registration.

No writer, nonce, capital, risk, kill-switch, broker-health, ECEL, minimum-notional, exchange-acknowledgement, fill, freshness, or activation gate is bypassed.