### PR TITLE
Fix startup lifecycle rejection provenance v247

### DIFF
--- a/bot/exchange_reject_dispatch_provenance_v228_patch.py
+++ b/bot/exchange_reject_dispatch_provenance_v228_patch.py
@@ -1,4 +1,4 @@
-"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232).
+"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232/v247).
 
 Production on 2026-08-25 showed the canonical EXCHANGE_MONITOR stop holding a
 5/5 rejection window while the runtime was otherwise converged.  The execution
@@ -25,6 +25,17 @@ non-exchange results too.  Generic messages such as ``OKX order failed`` and
 that a broker submit reached an exchange or that an exchange returned a reject.
 A concrete exchange response such as ``Kraken AddOrder rejected: ...`` remains
 unclassified here and continues to count normally.
+
+V247 closes the startup-heartbeat lifecycle provenance gap.  A terminal
+execution-authority validator can legitimately fail closed with
+``lifecycle_phase:BOOT`` / ``lifecycle_phase_not_live`` before any broker submit
+has occurred.  Those canonical lifecycle denials are local pre-dispatch outcomes,
+not exchange rejections, so they must not poison the exchange rejection-rate
+window.  This change is deliberately prospective: it never deletes an existing
+same-process rejection sample whose provenance is unknown.  Because the rolling
+window itself is not persisted, the next clean process starts with an empty
+window and v226 can independently recover a persisted historical EXCHANGE_MONITOR
+latch only after all of its existing safety proofs pass.
 
 This patch never clears a kill switch, resets a rejection window, marks
 readiness, grants execution authority, fabricates broker ACK/fill proof, changes
@@ -67,6 +78,11 @@ _NON_EXCHANGE_MARKERS = (
     "runtime authority convergence lost",
     "seak halted",
     "trading blocked",
+    # V247: canonical startup lifecycle denials happen before broker submit.
+    # Keep these exact authority-state tokens out of exchange telemetry while
+    # leaving unclassified broker/exchange rejection strings untouched.
+    "lifecycle_phase:boot",
+    "lifecycle_phase_not_live",
     "exchangekillswitch: exchange health red",
     "exchange health red — trade blocked",
     "liquidityintelligenceengine",
@@ -138,8 +154,8 @@ def _patch_execution_pipeline() -> bool:
                 "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s "
                 "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
                 "exchange_order_provenance=false route_guard_provenance_v232=true "
-                "kill_switch_unchanged=true execution_authority_unchanged=true "
-                "safety_gates_bypassed=false",
+                "lifecycle_provenance_v247=true kill_switch_unchanged=true "
+                "execution_authority_unchanged=true safety_gates_bypassed=false",
                 MARKER,
                 str(symbol)[:64],
                 str(side)[:32],
@@ -205,10 +221,10 @@ def install() -> bool:
     LOGGER.critical(
         "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s ready=true "
         "local_predispatch_rejects_excluded=true route_guard_provenance_v232=true "
-        "real_exchange_path_unchanged=true rejection_thresholds_unchanged=true "
-        "rejection_window_not_cleared=true kill_switch_unchanged=true "
-        "execution_authority_unchanged=true forced_activation=false "
-        "safety_gates_bypassed=false",
+        "lifecycle_provenance_v247=true real_exchange_path_unchanged=true "
+        "rejection_thresholds_unchanged=true rejection_window_not_cleared=true "
+        "kill_switch_unchanged=true execution_authority_unchanged=true "
+        "forced_activation=false safety_gates_bypassed=false",
         MARKER,
     )
     return True

--- a/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
+++ b/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
@@ -34,6 +34,17 @@ def test_non_exchange_classifier_covers_predispatch_failures():
         assert v228._is_non_exchange_rejection(reason) is True
 
 
+def test_v247_classifier_covers_startup_lifecycle_denials_without_exchange_proof():
+    reasons = (
+        "lifecycle_phase:BOOT",
+        "Execution blocked: lifecycle_phase:BOOT",
+        "lifecycle_phase_not_live",
+        "ExecutionAuthority reject: lifecycle_phase_not_live",
+    )
+    for reason in reasons:
+        assert v228._is_non_exchange_rejection(reason) is True
+
+
 def test_v232_classifier_covers_route_guard_soft_failures_without_exchange_proof():
     reasons = (
         "broker_dispatch_failed:kraken:none_result",
@@ -65,6 +76,21 @@ def test_dispatch_disabled_does_not_mutate_exchange_rejection_window(tmp_path, m
         symbol="BTC-USD",
         side="buy",
         reason="dispatch_disabled: dispatch.enabled=false",
+    )
+
+    assert list(protector._order_results) == []
+
+
+def test_v247_boot_lifecycle_denial_does_not_mutate_exchange_rejection_window(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(execution_pipeline, "get_exchange_kill_switch_protector", lambda: protector)
+    assert v228._patch_execution_pipeline()
+
+    execution_pipeline.ExecutionPipeline._emit_execution_rejection_telemetry(
+        _pipeline_stub(),
+        symbol="BTC-USD",
+        side="buy",
+        reason="Execution blocked: lifecycle_phase:BOOT",
     )
 
     assert list(protector._order_results) == []


### PR DESCRIPTION
## Production blocker
The active startup heartbeat can fail closed at a terminal authority check with `lifecycle_phase:BOOT` / `lifecycle_phase_not_live` before broker submission. Those local lifecycle denials were not covered by v228 and could enter the ExchangeKillSwitchProtector rejection window, sustaining the 5/5 EXCHANGE_MONITOR latch that then prevents v240 from completing the verified startup heartbeat.

## Fix
- Classify the exact canonical startup lifecycle denial tokens as local/pre-dispatch outcomes.
- Keep them out of exchange rejection-rate telemetry.
- Preserve genuine exchange rejects unchanged.
- Do not clear or rewrite any existing same-process rejection window.
- Preserve v226's fail-closed recovery contract: after a clean process restart the non-persisted rolling window is empty, and only the existing persisted-latch + non-order-health + writer + structural proofs can clear the historical EXCHANGE_MONITOR stop.

## Regression coverage
- BOOT lifecycle denial classification.
- BOOT lifecycle telemetry does not mutate `_order_results`.
- Genuine Kraken exchange rejection still mutates `_order_results`.

No risk, nonce, capital, writer, ECEL, minimum-notional, broker ACK/fill, or activation gate is bypassed.