### PR TITLE
Install rejection provenance before heartbeat worker

### DIFF
--- a/bot/runtime_execution_context_handoff_v246_patch.py
+++ b/bot/runtime_execution_context_handoff_v246_patch.py
@@ -12,6 +12,14 @@ for each submitted call and runs that call inside the copied context.  The stdli
 executor is not modified globally.  No startup-probe context is created here: an
 ordinary order with no verified context remains ordinary in the worker.
 
+Production later proved a startup ordering race: v246 could be ready before the
+v228/v247 exchange-rejection provenance wrapper had attached to ExecutionPipeline.
+That left a short interval where local startup/lifecycle failures could be counted as
+exchange rejection samples.  v246 now requires the existing v228 installer to be
+active before enabling the heartbeat worker context handoff.  It does not clear any
+rejection samples or deactivate a kill switch; a clean process must still satisfy
+v226's independent persisted-latch recovery proof.
+
 Lifecycle state, writer/lease authority, nonce, risk, capital, broker health, kill
 switch, ECEL, minimum notional, exchange acknowledgement, fill proof, and activation
 proof are unchanged and remain fail closed.
@@ -63,6 +71,41 @@ def _execution_pipeline_module() -> ModuleType:
     return importlib.import_module("bot.execution_pipeline")
 
 
+def _install_exchange_rejection_provenance() -> bool:
+    """Require v228/v247 before heartbeat worker execution can be enabled.
+
+    v228 owns the canonical pre-dispatch rejection classifier and includes the
+    v247 lifecycle provenance rules.  Installing it here closes the startup
+    ordering gap without mutating the protector's existing rejection window or
+    changing any kill-switch recovery policy.
+    """
+    try:
+        module = importlib.import_module("bot.exchange_reject_dispatch_provenance_v228_patch")
+        installer = getattr(module, "install", None)
+        if not callable(installer):
+            installer = getattr(module, "install_import_hook", None)
+        if not callable(installer):
+            return False
+        ready = bool(installer())
+        if not ready:
+            LOGGER.warning(
+                "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_PROVENANCE_WAIT marker=%s "
+                "v228_ready=false rejection_window_cleared=false kill_switch_unchanged=true "
+                "trading_fail_closed=true",
+                MARKER,
+            )
+        return ready
+    except Exception as exc:
+        LOGGER.warning(
+            "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_PROVENANCE_ERROR marker=%s error=%s:%s "
+            "rejection_window_cleared=false kill_switch_unchanged=true trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _patch_execution_pipeline(module: ModuleType | None = None) -> bool:
     target = module or _execution_pipeline_module()
     current = getattr(target, "concurrent", None)
@@ -102,9 +145,10 @@ def _register_manifest() -> bool:
 
 def install() -> bool:
     try:
-        pipeline_ready = _patch_execution_pipeline()
+        provenance_ready = _install_exchange_rejection_provenance()
+        pipeline_ready = _patch_execution_pipeline() if provenance_ready else False
         manifest_ready = _register_manifest()
-        ready = bool(pipeline_ready and manifest_ready)
+        ready = bool(provenance_ready and pipeline_ready and manifest_ready)
     except Exception as exc:
         LOGGER.error(
             "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_INSTALL_ERROR marker=%s error=%s:%s "
@@ -113,15 +157,26 @@ def install() -> bool:
             type(exc).__name__,
             exc,
         )
+        provenance_ready = False
         ready = False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
         LOGGER.critical(
             "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246 marker=%s ready=true "
+            "exchange_reject_dispatch_provenance_v228=true lifecycle_provenance_v247=true "
             "pipeline_thread_context_propagated=true stdlib_executor_unchanged=true "
             "startup_probe_context_created=false existing_context_only=true ordinary_orders_unchanged=true "
+            "rejection_window_cleared=false kill_switch_unchanged=true "
             "lifecycle_writer_nonce_risk_capital_broker_health_killswitch_ecel_min_notional_fill_gates_unchanged=true "
             "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+        )
+    elif not provenance_ready:
+        LOGGER.critical(
+            "RUNTIME_EXECUTION_CONTEXT_HANDOFF_V246_BLOCKED marker=%s ready=false "
+            "reason=exchange_reject_dispatch_provenance_unready rejection_window_cleared=false "
+            "kill_switch_unchanged=true execution_proof_fabricated=false forced_activation=false "
+            "safety_gates_bypassed=false trading_fail_closed=true",
             MARKER,
         )
     return ready
@@ -135,6 +190,7 @@ __all__ = [
     "MARKER",
     "install",
     "install_import_hook",
+    "_install_exchange_rejection_provenance",
     "_patch_execution_pipeline",
     "_register_manifest",
     "_ContextPropagatingThreadPoolExecutor",

--- a/tests/test_runtime_execution_context_handoff_v246.py
+++ b/tests/test_runtime_execution_context_handoff_v246.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextvars
+import os
 from types import SimpleNamespace
 
 import bot.runtime_execution_context_handoff_v246_patch as v246
@@ -44,6 +45,59 @@ def test_patch_is_idempotent():
     patched = fake_pipeline.concurrent
     assert v246._patch_execution_pipeline(fake_pipeline) is True
     assert fake_pipeline.concurrent is patched
+
+
+def test_provenance_installer_is_required(monkeypatch):
+    calls = []
+    fake_v228 = SimpleNamespace(install=lambda: calls.append("v228") or True)
+    real_import = v246.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.exchange_reject_dispatch_provenance_v228_patch":
+            return fake_v228
+        return real_import(name)
+
+    monkeypatch.setattr(v246.importlib, "import_module", fake_import)
+    assert v246._install_exchange_rejection_provenance() is True
+    assert calls == ["v228"]
+
+
+def test_provenance_failure_keeps_v246_fail_closed(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(v246, "_install_exchange_rejection_provenance", lambda: calls.append("provenance") or False)
+    monkeypatch.setattr(v246, "_patch_execution_pipeline", lambda: calls.append("pipeline") or True)
+    monkeypatch.setattr(v246, "_register_manifest", lambda: calls.append("manifest") or True)
+
+    old = os.environ.get(v246._FLAG)
+    try:
+        assert v246.install() is False
+        assert os.environ.get(v246._FLAG) == "0"
+        assert calls == ["provenance", "manifest"]
+    finally:
+        if old is None:
+            os.environ.pop(v246._FLAG, None)
+        else:
+            os.environ[v246._FLAG] = old
+
+
+def test_install_orders_provenance_before_pipeline(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(v246, "_install_exchange_rejection_provenance", lambda: calls.append("provenance") or True)
+    monkeypatch.setattr(v246, "_patch_execution_pipeline", lambda: calls.append("pipeline") or True)
+    monkeypatch.setattr(v246, "_register_manifest", lambda: calls.append("manifest") or True)
+
+    old = os.environ.get(v246._FLAG)
+    try:
+        assert v246.install() is True
+        assert os.environ.get(v246._FLAG) == "1"
+        assert calls == ["provenance", "pipeline", "manifest"]
+    finally:
+        if old is None:
+            os.environ.pop(v246._FLAG, None)
+        else:
+            os.environ[v246._FLAG] = old
 
 
 def test_manifest_registration_is_bounded(monkeypatch):


### PR DESCRIPTION
Production deployment 997a33c showed v246 becoming ready before the v228/v247 exchange-rejection provenance wrapper was attached. Within that startup interval the ExchangeKillSwitchProtector already held five current-process rejection samples, so v226 correctly refused persisted-latch recovery and NIJA remained in EMERGENCY_STOP.

This change makes v246 require the existing v228/v247 provenance installer before enabling the execution-pipeline heartbeat worker context handoff. It closes the startup ordering race without clearing the rejection window, changing rejection thresholds, deactivating the kill switch, granting authority, fabricating execution proof, or forcing activation.

A clean process is still required. If the persisted EXCHANGE_MONITOR 5/5 latch is historical and the new process has no genuine exchange rejection samples, v226 can recover it only after its existing writer/structural/non-order health proofs pass. Genuine exchange rejects remain counted normally.

Regression tests verify provenance is installed before the pipeline worker, provenance failure keeps v246 fail-closed, ContextVar propagation remains intact, no context is invented, and the stdlib executor remains unchanged.