### PR TITLE
Require v224 synthetic rejection guard before startup repairs

### DIFF
--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -12,14 +12,20 @@ stale rejection recovery, and heartbeat recovery-liveness repairs before normal
 runtime modules can instantiate or use the hard-stop singleton. These repairs
 never clear an unproven stop or grant trading authority.
 
-Production on 2026-08-27 proved that merely listing dispatch provenance among the
-early repairs was not sufficient: other repair imports could run before v228 had
-patched the canonical execution telemetry boundary.  A heartbeat/startup path
-could therefore create current-process rejection samples during that ordering
-window.  The sanitizer now installs v217 first to protect kill-switch persistence,
-then requires v228/v247 dispatch/lifecycle provenance before importing any of the
-remaining early repair chain.  If v228 is unavailable or not ready, downstream
-early repairs are not imported and the runtime remains fail closed.
+Production on 2026-08-27 first proved that merely listing dispatch provenance
+among the early repairs was not sufficient: other repair imports could run
+before v228 had patched the canonical execution telemetry boundary. V249 moved
+v228 immediately behind v217.
+
+A later clean-start observation proved one smaller ordering window remained.
+The persisted global stop is already active during startup, and v224 is the
+protector-boundary guard that rejects every synthetic ``exec-reject:pipeline:*``
+result while that stop is active. Leaving v224 in the downstream repair list
+allowed startup imports between v228 and v224 to append current-process samples
+before the protector boundary was guarded. V250 therefore makes both v228 and
+v224 mandatory provenance barriers immediately after v217. If either cannot
+attach, no remaining early repair is imported and the runtime remains fail
+closed.
 """
 
 from __future__ import annotations
@@ -59,9 +65,10 @@ _EARLY_SAFETY_REPAIRS_ATTEMPTED = False
 _EARLY_SAFETY_REPAIRS_READY = False
 
 # v217 must remain first because installing v228 imports ExecutionPipeline, whose
-# import graph can touch kill-switch code.  Immediately after v217, v228 is a hard
-# prerequisite for every remaining early repair import.  This is the earliest safe
-# point at which the execution rejection boundary can be protected.
+# import graph can touch kill-switch code. Immediately after v217, v228 protects
+# the rejection-emission boundary and v224 protects the ExchangeKillSwitchProtector
+# boundary for synthetic pipeline rejects while the persisted global stop is
+# active. Both are hard prerequisites for every remaining early repair import.
 _EARLY_KILL_SWITCH_PROVENANCE = (
     "kill_switch_early_provenance_v217_patch",
     "KILL_SWITCH_EARLY_V217",
@@ -69,6 +76,10 @@ _EARLY_KILL_SWITCH_PROVENANCE = (
 _REQUIRED_REJECTION_PROVENANCE = (
     "exchange_reject_dispatch_provenance_v228_patch",
     "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228",
+)
+_REQUIRED_SYNTHETIC_STOP_PROVENANCE = (
+    "exchange_reject_provenance_v224_patch",
+    "EXCHANGE_REJECT_PROVENANCE_V224",
 )
 _REMAINING_EARLY_REPAIRS = (
     (
@@ -82,10 +93,6 @@ _REMAINING_EARLY_REPAIRS = (
     (
         "exchange_rejection_sample_guard_v222_patch",
         "EXCHANGE_REJECTION_SAMPLE_GUARD_V222",
-    ),
-    (
-        "exchange_reject_provenance_v224_patch",
-        "EXCHANGE_REJECT_PROVENANCE_V224",
     ),
     (
         "runtime_kraken_capital_admission_v227_patch",
@@ -161,11 +168,13 @@ def _install_early_safety_repairs() -> bool:
     """Install hard-stop root repairs before normal runtime imports.
 
     v217 is installed first so v228 can safely import/patch ExecutionPipeline
-    without weakening kill-switch persistence provenance.  v228/v247 is then a
-    mandatory ordering barrier: no remaining early repair module is imported
-    until the canonical rejection telemetry boundary is protected.
+    without weakening kill-switch persistence provenance. v228 then protects the
+    telemetry emission boundary, and v224 immediately protects the canonical
+    ExchangeKillSwitchProtector boundary against synthetic pipeline rejects while
+    a persisted global stop is active. No downstream early repair module is
+    imported until all three protections are attached.
 
-    Failure is deliberately fail-closed.  This helper never clears a stop or a
+    Failure is deliberately fail-closed. This helper never clears a stop or a
     rejection window, marks execution ready, grants authority, or forces a trade.
     """
     global _EARLY_SAFETY_REPAIRS_ATTEMPTED, _EARLY_SAFETY_REPAIRS_READY
@@ -178,23 +187,36 @@ def _install_early_safety_repairs() -> bool:
     v217_module, v217_label = _EARLY_KILL_SWITCH_PROVENANCE
     if not _install_one_early_repair(v217_module, v217_label):
         logger.critical(
-            "EARLY_SAFETY_REPAIR_CHAIN_BLOCKED marker=20260827-earliest-rejection-provenance-v249 "
+            "EARLY_SAFETY_REPAIR_CHAIN_BLOCKED marker=20260827-earliest-synthetic-rejection-boundary-v250 "
             "reason=kill_switch_early_provenance_unready downstream_imports_skipped=true "
-            "dispatch_provenance_ready=false rejection_window_cleared=false "
-            "kill_switch_unchanged=true execution_authority_unchanged=true "
-            "forced_activation=false safety_gates_bypassed=false trading_fail_closed=true"
+            "dispatch_provenance_ready=false synthetic_stop_provenance_ready=false "
+            "rejection_window_cleared=false kill_switch_unchanged=true "
+            "execution_authority_unchanged=true forced_activation=false "
+            "safety_gates_bypassed=false trading_fail_closed=true"
         )
         return False
 
     v228_module, v228_label = _REQUIRED_REJECTION_PROVENANCE
     if not _install_one_early_repair(v228_module, v228_label):
         logger.critical(
-            "EARLY_SAFETY_REPAIR_CHAIN_BLOCKED marker=20260827-earliest-rejection-provenance-v249 "
+            "EARLY_SAFETY_REPAIR_CHAIN_BLOCKED marker=20260827-earliest-synthetic-rejection-boundary-v250 "
             "reason=exchange_reject_dispatch_provenance_unready downstream_imports_skipped=true "
             "dispatch_provenance_ready=false lifecycle_provenance_v247=false "
-            "rejection_window_cleared=false kill_switch_unchanged=true "
-            "execution_authority_unchanged=true forced_activation=false "
-            "safety_gates_bypassed=false trading_fail_closed=true"
+            "synthetic_stop_provenance_ready=false rejection_window_cleared=false "
+            "kill_switch_unchanged=true execution_authority_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false trading_fail_closed=true"
+        )
+        return False
+
+    v224_module, v224_label = _REQUIRED_SYNTHETIC_STOP_PROVENANCE
+    if not _install_one_early_repair(v224_module, v224_label):
+        logger.critical(
+            "EARLY_SAFETY_REPAIR_CHAIN_BLOCKED marker=20260827-earliest-synthetic-rejection-boundary-v250 "
+            "reason=exchange_reject_synthetic_stop_provenance_unready downstream_imports_skipped=true "
+            "dispatch_provenance_ready=true lifecycle_provenance_v247=true "
+            "synthetic_stop_provenance_ready=false rejection_window_cleared=false "
+            "kill_switch_unchanged=true execution_authority_unchanged=true "
+            "forced_activation=false safety_gates_bypassed=false trading_fail_closed=true"
         )
         return False
 
@@ -206,12 +228,13 @@ def _install_early_safety_repairs() -> bool:
     _EARLY_SAFETY_REPAIRS_READY = all_ready
     os.environ["NIJA_EARLY_SAFETY_REPAIRS_READY"] = "1" if all_ready else "0"
     logger.critical(
-        "EARLIEST_REJECTION_PROVENANCE_V249_READY marker=20260827-earliest-rejection-provenance-v249 "
+        "EARLIEST_SYNTHETIC_REJECTION_BOUNDARY_V250_READY "
+        "marker=20260827-earliest-synthetic-rejection-boundary-v250 "
         "ready=%s kill_switch_provenance_v217=true dispatch_provenance_v228=true "
-        "lifecycle_provenance_v247=true dispatch_provenance_before_downstream_repairs=true "
-        "rejection_window_cleared=false kill_switch_unchanged=true "
-        "execution_authority_unchanged=true forced_activation=false "
-        "safety_gates_bypassed=false trading_fail_closed=%s",
+        "lifecycle_provenance_v247=true synthetic_stop_provenance_v224=true "
+        "v224_before_downstream_repairs=true rejection_window_cleared=false "
+        "kill_switch_unchanged=true execution_authority_unchanged=true "
+        "forced_activation=false safety_gates_bypassed=false trading_fail_closed=%s",
         str(all_ready).lower(),
         str(not all_ready).lower(),
     )
@@ -277,7 +300,8 @@ def install_import_hook() -> bool:
 
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. v217 is intentionally first. v228 immediately
-# follows and must be ready before v218/v221/v222/v224/v225/v226/v227 are imported.
-# No startup path here clears a rejection sample or an active kill switch.
+# follows, then v224 must protect the synthetic pipeline-reject boundary before
+# v218/v221/v222/v225/v226/v227 are imported. No startup path here clears a
+# rejection sample or an active kill switch.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/tests/test_earliest_rejection_provenance_v249.py
+++ b/tests/test_earliest_rejection_provenance_v249.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the v249 earliest rejection-provenance barrier."""
+"""Regression coverage for earliest rejection-provenance startup barriers."""
 
 from __future__ import annotations
 
@@ -23,14 +23,14 @@ def _load_sanitizer_without_autorun(fake_import):
         return real_import(name, globals, locals, fromlist, level)
 
     namespace = {
-        "__name__": "nija_test_strict_live_startup_sanitizer_v249",
+        "__name__": "nija_test_strict_live_startup_sanitizer_v250",
         "__builtins__": dict(vars(builtins), __import__=guarded_import),
     }
     exec(compile(source, str(SANITIZER), "exec"), namespace)
     return namespace
 
 
-def test_v217_then_v228_precede_every_remaining_early_repair(monkeypatch):
+def test_v217_v228_v224_precede_every_remaining_early_repair(monkeypatch):
     calls = []
 
     def fake_import(name, _fromlist):
@@ -41,17 +41,18 @@ def test_v217_then_v228_precede_every_remaining_early_repair(monkeypatch):
     monkeypatch.delenv("NIJA_EARLY_SAFETY_REPAIRS_READY", raising=False)
 
     assert ns["_install_early_safety_repairs"]() is True
-    assert calls[:2] == [
+    assert calls[:3] == [
         "bot.kill_switch_early_provenance_v217_patch",
         "bot.exchange_reject_dispatch_provenance_v228_patch",
+        "bot.exchange_reject_provenance_v224_patch",
     ]
-    assert calls[2:] == [
+    assert calls[3:] == [
         f"bot.{module_name}" for module_name, _label in ns["_REMAINING_EARLY_REPAIRS"]
     ]
     assert ns["os"].environ["NIJA_EARLY_SAFETY_REPAIRS_READY"] == "1"
 
 
-def test_v228_failure_blocks_all_downstream_early_imports(monkeypatch):
+def test_v228_failure_blocks_v224_and_all_downstream_early_imports(monkeypatch):
     calls = []
 
     def fake_import(name, _fromlist):
@@ -68,6 +69,33 @@ def test_v228_failure_blocks_all_downstream_early_imports(monkeypatch):
         "bot.kill_switch_early_provenance_v217_patch",
         "bot.exchange_reject_dispatch_provenance_v228_patch",
     ]
+    assert "bot.exchange_reject_provenance_v224_patch" not in calls
+    assert ns["os"].environ["NIJA_EARLY_SAFETY_REPAIRS_READY"] == "0"
+
+
+def test_v224_failure_blocks_all_downstream_early_imports(monkeypatch):
+    calls = []
+
+    def fake_import(name, _fromlist):
+        calls.append(name)
+        if name == "bot.exchange_reject_provenance_v224_patch":
+            return SimpleNamespace(install_import_hook=lambda: False)
+        return SimpleNamespace(install_import_hook=lambda: True)
+
+    ns = _load_sanitizer_without_autorun(fake_import)
+    monkeypatch.delenv("NIJA_EARLY_SAFETY_REPAIRS_READY", raising=False)
+
+    assert ns["_install_early_safety_repairs"]() is False
+    assert calls == [
+        "bot.kill_switch_early_provenance_v217_patch",
+        "bot.exchange_reject_dispatch_provenance_v228_patch",
+        "bot.exchange_reject_provenance_v224_patch",
+    ]
+    assert not any(
+        name == f"bot.{module_name}"
+        for module_name, _label in ns["_REMAINING_EARLY_REPAIRS"]
+        for name in calls
+    )
     assert ns["os"].environ["NIJA_EARLY_SAFETY_REPAIRS_READY"] == "0"
 
 
@@ -86,14 +114,13 @@ def test_v217_failure_prevents_pipeline_import_and_remains_fail_closed(monkeypat
     assert ns["_install_early_safety_repairs"]() is False
     assert calls == ["bot.kill_switch_early_provenance_v217_patch"]
     assert "bot.exchange_reject_dispatch_provenance_v228_patch" not in calls
+    assert "bot.exchange_reject_provenance_v224_patch" not in calls
     assert ns["os"].environ["NIJA_EARLY_SAFETY_REPAIRS_READY"] == "0"
 
 
 def test_no_rejection_window_or_force_activation_mutation_is_introduced():
     source = SANITIZER.read_text(encoding="utf-8")
 
-    # v249 is an ordering barrier only. It must never gain a shortcut that clears
-    # rejection history, deactivates a kill switch, or grants live authority.
     forbidden = (
         "clear_rejection_window(",
         "deactivate_kill_switch(",
@@ -106,3 +133,4 @@ def test_no_rejection_window_or_force_activation_mutation_is_introduced():
     assert "kill_switch_unchanged=true" in source
     assert "forced_activation=false" in source
     assert "safety_gates_bypassed=false" in source
+    assert "synthetic_stop_provenance_v224=true" in source


### PR DESCRIPTION
Production runtime after merge commit 39bd3553 still showed `current_process_rejection_samples_present:5` even though v228/v247 were ready. The remaining startup window is between v228 and v224: v228 protects the ExecutionPipeline telemetry boundary, while v224 protects the canonical ExchangeKillSwitchProtector boundary from synthetic `exec-reject:pipeline:*` samples while a persisted global stop is already active.

This v250 change makes the startup provenance barrier:

1. v217 kill-switch persistence provenance
2. v228/v247 dispatch/lifecycle provenance
3. v224 synthetic pipeline-reject provenance
4. only then the remaining early repair/recovery imports

If v217, v228, or v224 cannot attach, downstream startup repairs are not imported and the runtime remains fail closed.

This does not clear rejection samples, reset the exchange kill switch, grant authority, fabricate execution/nonce/order/fill proof, or force LIVE_ACTIVE. The existing five samples remain untouched. A clean process must show an empty current-process rejection window before v226 can independently recover a truly historical persisted EXCHANGE_MONITOR latch.

Regression coverage now verifies v217→v228→v224 ordering and fail-closed behavior for each mandatory barrier.