### PR TITLE
Keep activation snapshot fallback behind canonical proof

### DIFF
--- a/bot/runtime_activation_snapshot_proof_truth_v251_patch.py
+++ b/bot/runtime_activation_snapshot_proof_truth_v251_patch.py
@@ -1,0 +1,222 @@
+"""Keep activation-snapshot fallback aligned with canonical readiness proof (v251).
+
+Production on 2026-08-27 showed the capital snapshot bridge reporting that its
+local concrete gates had passed and calling TradingStateMachine's compatibility
+force route while canonical readiness still had ``execution_ready=False``.  The
+compatibility route correctly refused the transition, but the premature request
+created contradictory activation diagnostics and proof churn while the genuine
+heartbeat order result was still outstanding.
+
+This patch does not activate trading.  It only wraps the bridge's legacy
+``_concrete_activation_gates_pass`` fallback predicate so that a compatibility
+activation request cannot be issued until the canonical readiness table is
+complete.  When heartbeat verification is required, the canonical heartbeat
+marker must also be present, stage-sufficient, and fresh.  The wrapper is
+periodically reasserted because older convergence installers can replace or
+rebind the bridge helper later in startup.
+
+No readiness flag, nonce, execution proof, heartbeat marker, kill switch, writer
+lease, broker result, order result, or trading state is mutated here.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_activation_snapshot_proof_truth_v251")
+MARKER = "20260827-activation-snapshot-proof-truth-v251"
+_FLAG = "NIJA_ACTIVATION_SNAPSHOT_PROOF_TRUTH_V251_READY"
+_PATCH_ATTR = "_nija_activation_snapshot_proof_truth_v251"
+_IMPORT_FLAG = "_NIJA_ACTIVATION_SNAPSHOT_PROOF_TRUTH_V251_IMPORT_HOOK"
+_LOCK = threading.RLock()
+_THREAD: threading.Thread | None = None
+_IMPORT_LOCAL = threading.local()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return str(os.environ.get(name, default)).strip().lower() in _TRUE
+
+
+def _import(*names: str) -> ModuleType | None:
+    for name in names:
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    for name in names:
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if isinstance(module, ModuleType):
+            return module
+    return None
+
+
+def _canonical_readiness_complete() -> tuple[bool, str]:
+    module = _import("bot.readiness_table", "readiness_table")
+    if module is None:
+        return False, "readiness_table_unavailable"
+    snapshot_fn = getattr(module, "snapshot", None)
+    if not callable(snapshot_fn):
+        return False, "readiness_snapshot_unavailable"
+    try:
+        snapshot = dict(snapshot_fn() or {})
+    except Exception as exc:
+        return False, f"readiness_snapshot_error:{type(exc).__name__}:{exc}"
+    if not snapshot:
+        return False, "readiness_snapshot_empty"
+    pending = sorted(str(key) for key, value in snapshot.items() if not bool(value))
+    if pending:
+        return False, f"readiness_incomplete:{','.join(pending)}"
+    return True, "readiness_complete"
+
+
+def _canonical_heartbeat_proof(tsm_module: Any) -> tuple[bool, str]:
+    required = _truthy("HEARTBEAT_REQUIRED_FIRST_ACTIVATION") or _truthy("HEARTBEAT_TRADE")
+    if not required:
+        return True, "heartbeat_not_required"
+    status = getattr(tsm_module, "_heartbeat_verification_status", None)
+    if not callable(status):
+        return False, "heartbeat_verifier_unavailable"
+    try:
+        ok, detail, _meta = status()
+    except Exception as exc:
+        return False, f"heartbeat_verifier_error:{type(exc).__name__}:{exc}"
+    if not bool(ok):
+        return False, f"heartbeat_verification:{str(detail or 'not_verified')}"
+    return True, "heartbeat_verified"
+
+
+def _patch_bridge() -> bool:
+    bridge = _import("bot.activation_snapshot_bridge_patch", "activation_snapshot_bridge_patch")
+    if bridge is None:
+        return False
+    current = getattr(bridge, "_concrete_activation_gates_pass", None)
+    if not callable(current):
+        return False
+    if getattr(current, _PATCH_ATTR, False):
+        return True
+
+    @wraps(current)
+    def proof_truth_guard(tsm_module: Any) -> tuple[bool, str]:
+        ok, detail = current(tsm_module)
+        if not bool(ok):
+            return False, str(detail or "bridge_gate_blocked")
+
+        readiness_ok, readiness_detail = _canonical_readiness_complete()
+        if not readiness_ok:
+            LOGGER.info(
+                "ACTIVATION_SNAPSHOT_V251_PROOF_PENDING marker=%s blocker=%s "
+                "force_compat_not_called=true readiness_mutated=false nonce_mutated=false "
+                "execution_proof_fabricated=false heartbeat_marker_written=false "
+                "kill_switch_unchanged=true forced_activation=false trading_fail_closed=true",
+                MARKER,
+                readiness_detail,
+            )
+            return False, readiness_detail
+
+        heartbeat_ok, heartbeat_detail = _canonical_heartbeat_proof(tsm_module)
+        if not heartbeat_ok:
+            LOGGER.info(
+                "ACTIVATION_SNAPSHOT_V251_PROOF_PENDING marker=%s blocker=%s "
+                "canonical_readiness_complete=true force_compat_not_called=true "
+                "readiness_mutated=false nonce_mutated=false execution_proof_fabricated=false "
+                "heartbeat_marker_written=false kill_switch_unchanged=true "
+                "forced_activation=false trading_fail_closed=true",
+                MARKER,
+                heartbeat_detail,
+            )
+            return False, heartbeat_detail
+
+        return True, "canonical_readiness_and_heartbeat_proof_current"
+
+    setattr(proof_truth_guard, _PATCH_ATTR, True)
+    setattr(proof_truth_guard, "__wrapped__", current)
+    bridge._concrete_activation_gates_pass = proof_truth_guard
+    return True
+
+
+def _worker() -> None:
+    while True:
+        try:
+            _patch_bridge()
+        except Exception as exc:
+            LOGGER.warning(
+                "ACTIVATION_SNAPSHOT_V251_REASSERT_ERROR marker=%s err=%s:%s "
+                "trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+        time.sleep(1.0)
+
+
+def install() -> bool:
+    global _THREAD
+    with _LOCK:
+        # The target may not yet be imported.  Install the import hook and worker
+        # first; readiness means the protection mechanism is armed, not that the
+        # activation bridge is already loaded.
+        if not getattr(builtins, _IMPORT_FLAG, False):
+            original_import = builtins.__import__
+
+            @wraps(original_import)
+            def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+                result = original_import(name, globals, locals, fromlist, level)
+                if getattr(_IMPORT_LOCAL, "active", False):
+                    return result
+                text = str(name or "")
+                if "activation_snapshot_bridge" in text or "trading_state_machine" in text or "readiness_table" in text:
+                    _IMPORT_LOCAL.active = True
+                    try:
+                        _patch_bridge()
+                    finally:
+                        _IMPORT_LOCAL.active = False
+                return result
+
+            builtins.__import__ = guarded_import
+            setattr(builtins, _IMPORT_FLAG, True)
+
+        _patch_bridge()
+        if _THREAD is None or not _THREAD.is_alive():
+            _THREAD = threading.Thread(
+                target=_worker,
+                name="ActivationSnapshotProofTruthV251",
+                daemon=True,
+            )
+            _THREAD.start()
+        os.environ[_FLAG] = "1"
+
+    LOGGER.critical(
+        "ACTIVATION_SNAPSHOT_PROOF_TRUTH_V251_READY marker=%s ready=true "
+        "canonical_readiness_required=true canonical_heartbeat_required_when_configured=true "
+        "self_reasserting=true readiness_mutated=false nonce_mutated=false "
+        "execution_proof_fabricated=false heartbeat_marker_written=false "
+        "kill_switch_unchanged=true writer_lease_unchanged=true broker_results_unchanged=true "
+        "forced_activation=false safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_canonical_readiness_complete",
+    "_canonical_heartbeat_proof",
+    "_patch_bridge",
+]

--- a/bot/strict_live_startup_sanitizer.py
+++ b/bot/strict_live_startup_sanitizer.py
@@ -8,9 +8,10 @@ replace distributed ownership with a process-local assertion.
 The earliest startup path also installs the kill-switch provenance, failure
 classification, durable guarded-replay, exchange rejection sample,
 exchange-rejection provenance, dispatch provenance, Kraken capital admission,
-stale rejection recovery, and heartbeat recovery-liveness repairs before normal
-runtime modules can instantiate or use the hard-stop singleton. These repairs
-never clear an unproven stop or grant trading authority.
+stale rejection recovery, heartbeat recovery-liveness, and activation proof
+truth repairs before normal runtime modules can instantiate or use the hard-stop
+or activation singletons. These repairs never clear an unproven stop or grant
+trading authority.
 
 Production on 2026-08-27 first proved that merely listing dispatch provenance
 among the early repairs was not sufficient: other repair imports could run
@@ -105,6 +106,10 @@ _REMAINING_EARLY_REPAIRS = (
     (
         "runtime_heartbeat_killswitch_clear_wakeup_v225_patch",
         "HEARTBEAT_KILLSWITCH_CLEAR_WAKEUP_V225",
+    ),
+    (
+        "runtime_activation_snapshot_proof_truth_v251_patch",
+        "ACTIVATION_SNAPSHOT_PROOF_TRUTH_V251",
     ),
 )
 
@@ -301,7 +306,7 @@ def install_import_hook() -> bool:
 # This must run before sanitize imports or the broader trading runtime can create
 # the global KillSwitch singleton. v217 is intentionally first. v228 immediately
 # follows, then v224 must protect the synthetic pipeline-reject boundary before
-# v218/v221/v222/v225/v226/v227 are imported. No startup path here clears a
+# v218/v221/v222/v225/v226/v227/v251 are imported. No startup path here clears a
 # rejection sample or an active kill switch.
 _install_early_safety_repairs()
 sanitize("module_import")

--- a/tests/test_activation_snapshot_proof_truth_v251.py
+++ b/tests/test_activation_snapshot_proof_truth_v251.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+PATCH = Path(__file__).resolve().parents[1] / "bot" / "runtime_activation_snapshot_proof_truth_v251_patch.py"
+spec = importlib.util.spec_from_file_location("activation_snapshot_proof_truth_v251_under_test", PATCH)
+assert spec and spec.loader
+v251 = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = v251
+spec.loader.exec_module(v251)
+
+
+def test_readiness_incomplete_blocks_bridge_fallback(monkeypatch):
+    readiness = types.ModuleType("bot.readiness_table")
+    readiness.snapshot = lambda: {
+        "broker_connected": True,
+        "capital_ready": True,
+        "authority_ready": True,
+        "nonce_ready": True,
+        "execution_ready": False,
+    }
+    monkeypatch.setitem(sys.modules, "bot.readiness_table", readiness)
+    monkeypatch.setitem(sys.modules, "readiness_table", readiness)
+
+    bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    bridge._concrete_activation_gates_pass = lambda _tsm: (True, "")
+    monkeypatch.setitem(sys.modules, "bot.activation_snapshot_bridge_patch", bridge)
+    monkeypatch.setitem(sys.modules, "activation_snapshot_bridge_patch", bridge)
+
+    tsm = types.SimpleNamespace(_heartbeat_verification_status=lambda: (True, "", {}))
+    monkeypatch.setenv("HEARTBEAT_TRADE", "true")
+
+    assert v251._patch_bridge() is True
+    ok, detail = bridge._concrete_activation_gates_pass(tsm)
+
+    assert ok is False
+    assert detail == "readiness_incomplete:execution_ready"
+
+
+def test_missing_genuine_heartbeat_marker_blocks_fallback(monkeypatch):
+    readiness = types.ModuleType("bot.readiness_table")
+    readiness.snapshot = lambda: {
+        "broker_connected": True,
+        "capital_ready": True,
+        "authority_ready": True,
+        "nonce_ready": True,
+        "execution_ready": True,
+    }
+    monkeypatch.setitem(sys.modules, "bot.readiness_table", readiness)
+    monkeypatch.setitem(sys.modules, "readiness_table", readiness)
+
+    bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    bridge._concrete_activation_gates_pass = lambda _tsm: (True, "")
+    monkeypatch.setitem(sys.modules, "bot.activation_snapshot_bridge_patch", bridge)
+    monkeypatch.setitem(sys.modules, "activation_snapshot_bridge_patch", bridge)
+
+    tsm = types.SimpleNamespace(
+        _heartbeat_verification_status=lambda: (False, "marker_missing", {"required_stage": "ORDER_VERIFY"})
+    )
+    monkeypatch.setenv("HEARTBEAT_REQUIRED_FIRST_ACTIVATION", "true")
+
+    assert v251._patch_bridge() is True
+    ok, detail = bridge._concrete_activation_gates_pass(tsm)
+
+    assert ok is False
+    assert detail == "heartbeat_verification:marker_missing"
+
+
+def test_complete_readiness_and_genuine_heartbeat_allow_existing_compat_route(monkeypatch):
+    readiness = types.ModuleType("bot.readiness_table")
+    readiness.snapshot = lambda: {
+        "broker_connected": True,
+        "capital_ready": True,
+        "authority_ready": True,
+        "nonce_ready": True,
+        "execution_ready": True,
+    }
+    monkeypatch.setitem(sys.modules, "bot.readiness_table", readiness)
+    monkeypatch.setitem(sys.modules, "readiness_table", readiness)
+
+    bridge = types.ModuleType("bot.activation_snapshot_bridge_patch")
+    bridge._concrete_activation_gates_pass = lambda _tsm: (True, "")
+    monkeypatch.setitem(sys.modules, "bot.activation_snapshot_bridge_patch", bridge)
+    monkeypatch.setitem(sys.modules, "activation_snapshot_bridge_patch", bridge)
+
+    tsm = types.SimpleNamespace(
+        _heartbeat_verification_status=lambda: (
+            True,
+            "",
+            {"stage": "ORDER_VERIFY", "verified_at_epoch": 123.0},
+        )
+    )
+    monkeypatch.setenv("HEARTBEAT_TRADE", "true")
+
+    assert v251._patch_bridge() is True
+    ok, detail = bridge._concrete_activation_gates_pass(tsm)
+
+    assert ok is True
+    assert detail == "canonical_readiness_and_heartbeat_proof_current"
+
+
+def test_v251_does_not_fabricate_activation_or_proof():
+    source = PATCH.read_text(encoding="utf-8")
+    forbidden = (
+        "force_activate_bypass(",
+        "_force_live_active_transition(",
+        "execution_ready\"] = True",
+        "nonce_ready\"] = True",
+        "heartbeat_verified.flag\").write",
+        "get_kill_switch().deactivate(",
+    )
+    assert all(token not in source for token in forbidden)
+    assert "execution_proof_fabricated=false" in source
+    assert "heartbeat_marker_written=false" in source
+    assert "forced_activation=false" in source
+    assert "safety_gates_bypassed=false" in source


### PR DESCRIPTION
Production deployment `aff8e0987b1473f57ab0e56e6a204cddfb7753b2` cleared the historical exchange kill switch and allowed the heartbeat trade to reach Coinbase submission, but activation still churned in `LIVE_PENDING_CONFIRMATION`: the snapshot bridge logged `all_concrete_gates_passed` and invoked the compatibility force route while canonical readiness still had `execution_ready=False`. The state machine correctly refused that request, and nonce proof was then revoked by current-proof reconciliation.

v251 keeps that legacy fallback aligned with canonical truth:

- wraps the activation snapshot bridge fallback gate;
- requires the canonical readiness table to be complete before the compatibility activation request can be issued;
- when heartbeat verification is configured, requires the canonical heartbeat marker to be present, stage-sufficient, and fresh;
- self-reasserts the wrapper so later import/rebind activity cannot reopen the unguarded fallback;
- installs during strict live startup;
- adds regression coverage for incomplete execution readiness, missing heartbeat proof, successful current proof, and no proof/safety fabrication.

This does **not** mark `execution_ready` or `nonce_ready`, write the heartbeat marker, clear a kill switch, alter broker results, grant writer authority, or force `LIVE_ACTIVE`. The real Coinbase heartbeat order result and canonical execution/nonce proofs still have to complete normally.