### PR TITLE
Harden mobile authentication, push persistence, deletion, and deep links

### DIFF
--- a/account_deletion_api.py
+++ b/account_deletion_api.py
@@ -1,19 +1,19 @@
 """Authenticated NIJA account-deletion API.
 
-This module implements the mobile/store account-deletion contract without
-claiming to erase third-party brokerage accounts or records NIJA must retain
-under applicable law. The current implementation removes the account from
-NIJA's known authentication database, active sessions, login history,
-in-memory user cache, broker credential manager, runtime broker env aliases,
-and mobile push-token registry.
+Deletion is fail-closed and covers the active NIJA stores currently used by the
+mobile stack: authentication/session data, persistent encrypted broker vault,
+legacy in-memory broker credentials, mobile push registrations, permission
+state, runtime user cache, and per-user trading-rule files.
 
-Production release owners MUST reconcile this list against every production
-data store and processor before representing deletion as complete.
+Third-party brokerage/Apple/Google accounts are never represented as deleted by
+this endpoint. Any future legally-required retention must be defined by policy
+and counsel before enabling a retention exception.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 from datetime import datetime, timezone
 
@@ -22,7 +22,10 @@ from flask import Blueprint, jsonify, request
 from api_server import require_auth
 from auth import get_api_key_manager, get_user_manager
 from auth.user_database import get_user_database
-from mobile_api import push_tokens
+from execution import get_permission_validator
+from mobile_device_store import get_mobile_device_store
+from vault import get_vault
+from bot.user_rules_engine import get_user_rules_engine
 
 logger = logging.getLogger("nija.account_deletion")
 
@@ -30,12 +33,11 @@ account_deletion_api = Blueprint("account_deletion_api", __name__)
 
 
 def _delete_auth_database_records(user_id: str) -> bool:
-    """Delete known user-linked authentication records in one transaction."""
     user_db = get_user_database()
     conn = sqlite3.connect(user_db.db_path)
     try:
         cursor = conn.cursor()
-        cursor.execute("BEGIN")
+        cursor.execute("BEGIN IMMEDIATE")
         cursor.execute("DELETE FROM sessions WHERE user_id = ?", (user_id,))
         cursor.execute("DELETE FROM login_history WHERE user_id = ?", (user_id,))
         cursor.execute("DELETE FROM users WHERE user_id = ?", (user_id,))
@@ -49,103 +51,134 @@ def _delete_auth_database_records(user_id: str) -> bool:
         conn.close()
 
 
-def _delete_broker_credentials(user_id: str) -> list[str]:
-    """Remove all NIJA-held broker credentials for a user."""
+def _delete_legacy_broker_credentials(user_id: str) -> list[str]:
     manager = get_api_key_manager()
     deleted: list[str] = []
     for broker in list(manager.list_user_brokers(user_id)):
         if manager.delete_user_api_key(user_id, broker):
             deleted.append(broker)
-    # Avoid leaving an empty per-user credential bucket in memory.
     manager.user_keys.pop(user_id, None)
     return deleted
 
 
-def _delete_runtime_user_cache(user_id: str) -> None:
-    manager = get_user_manager()
-    manager.users.pop(user_id, None)
+def _delete_persistent_vault_data(user_id: str) -> list[str]:
+    """Delete encrypted credentials and user-identifiable vault audit rows."""
+    vault = get_vault()
+    brokers = list(vault.list_user_brokers(user_id))
+    conn = sqlite3.connect(vault.db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("BEGIN IMMEDIATE")
+        cursor.execute("DELETE FROM credentials WHERE user_id = ?", (user_id,))
+        cursor.execute("DELETE FROM audit_log WHERE user_id = ?", (user_id,))
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    return brokers
+
+
+def _delete_runtime_state(user_id: str) -> None:
+    get_user_manager().users.pop(user_id, None)
+    get_permission_validator().user_permissions.pop(user_id, None)
+
+
+def _delete_user_rules(user_id: str) -> bool:
+    """Remove the user's persisted rules file and cache entry."""
+    engine = get_user_rules_engine()
+    lock = engine._get_user_lock(user_id)
+    with lock:
+        path = engine._rules_file(user_id)
+        engine._rules_cache.pop(user_id, None)
+        if os.path.exists(path):
+            os.remove(path)
+            return True
+    return False
 
 
 @account_deletion_api.route("/api/account/deletion", methods=["GET"])
 @require_auth
 def deletion_requirements():
-    """Return deletion semantics for the authenticated user."""
-    return jsonify(
-        {
-            "available": True,
-            "user_id": request.user_id,
-            "confirmation_phrase": "DELETE MY NIJA ACCOUNT",
-            "effects": [
-                "NIJA account access will be removed",
-                "active NIJA sessions will be removed",
-                "NIJA-held broker API credentials will be removed",
-                "registered mobile push tokens will be removed",
-                "known NIJA authentication/login records will be removed",
-            ],
-            "not_deleted": [
-                "accounts held directly with brokerages or exchanges",
-                "Apple or Google accounts",
-                "third-party records those providers control",
-                "records NIJA is legally required to retain",
-            ],
-            "warning": "Account deletion is permanent. Stop live trading and review open broker positions before proceeding.",
-        }
-    )
+    return jsonify({
+        "available": True,
+        "user_id": request.user_id,
+        "confirmation_phrase": "DELETE MY NIJA ACCOUNT",
+        "effects": [
+            "NIJA account access and active sessions will be removed",
+            "NIJA-held broker API credentials will be removed",
+            "registered mobile push tokens will be removed",
+            "NIJA trading-rule and permission state will be removed",
+            "known NIJA authentication/login records will be removed",
+        ],
+        "not_deleted": [
+            "accounts held directly with brokerages or exchanges",
+            "Apple or Google accounts",
+            "third-party records those providers control",
+        ],
+        "retention_notice": (
+            "NIJA does not retain an account-linked record by default after this deletion path. "
+            "Any future legally required retention exception must be separately documented and implemented."
+        ),
+        "warning": "Account deletion is permanent. Stop live trading and review open broker positions before proceeding.",
+    })
 
 
 @account_deletion_api.route("/api/account/deletion", methods=["DELETE"])
 @require_auth
 def delete_account():
-    """Permanently delete the authenticated NIJA account from known stores."""
     payload = request.get_json(silent=True) or {}
-    confirmation = str(payload.get("confirmation", "")).strip()
-    if confirmation != "DELETE MY NIJA ACCOUNT":
-        return jsonify(
-            {
-                "error": "Explicit confirmation required",
-                "required_confirmation": "DELETE MY NIJA ACCOUNT",
-            }
-        ), 400
+    if str(payload.get("confirmation", "")).strip() != "DELETE MY NIJA ACCOUNT":
+        return jsonify({
+            "error": "Explicit confirmation required",
+            "required_confirmation": "DELETE MY NIJA ACCOUNT",
+        }), 400
 
-    user_id = request.user_id
+    user_id = str(request.user_id)
     user_db = get_user_database()
     if not user_db.get_user(user_id):
-        # Do not disclose more detail than necessary; a valid token may outlive
-        # an already-deleted database row until JWT expiry.
         return jsonify({"error": "Account is no longer available"}), 404
 
     try:
-        brokers_deleted = _delete_broker_credentials(user_id)
-        push_tokens.pop(user_id, None)
-        _delete_runtime_user_cache(user_id)
-        deleted = _delete_auth_database_records(user_id)
-        if not deleted:
-            return jsonify({"error": "Account deletion could not be confirmed"}), 500
+        vault_brokers = _delete_persistent_vault_data(user_id)
+        legacy_brokers = _delete_legacy_broker_credentials(user_id)
+        devices_deleted = get_mobile_device_store().delete_user_devices(user_id)
+        rules_deleted = _delete_user_rules(user_id)
+        _delete_runtime_state(user_id)
+        auth_deleted = _delete_auth_database_records(user_id)
+        if not auth_deleted:
+            raise RuntimeError("Primary account record was not deleted")
 
+        brokers_deleted = sorted(set(vault_brokers + legacy_brokers))
         logger.warning(
-            "ACCOUNT_DELETED user_id=%s broker_credentials_removed=%s at=%s",
+            "ACCOUNT_DELETED user_id=%s brokers=%s devices=%s rules=%s at=%s",
             user_id,
             len(brokers_deleted),
+            devices_deleted,
+            rules_deleted,
             datetime.now(timezone.utc).isoformat(),
         )
-
-        return jsonify(
-            {
-                "success": True,
-                "status": "deleted",
-                "broker_credentials_removed": brokers_deleted,
-                "message": "Your NIJA account has been deleted from the known active account stores. Third-party brokerage accounts were not deleted.",
-                "retention_notice": "Limited records may be retained only where required for legal, tax, accounting, security, fraud-prevention, dispute-resolution, or regulatory obligations.",
-            }
-        )
-    except Exception as exc:
+        return jsonify({
+            "success": True,
+            "status": "deleted",
+            "broker_credentials_removed": brokers_deleted,
+            "mobile_devices_removed": devices_deleted,
+            "trading_rules_removed": rules_deleted,
+            "message": (
+                "Your NIJA-controlled account data was removed from the active stores covered by this deletion service. "
+                "Third-party brokerage, Apple, and Google accounts were not deleted."
+            ),
+        })
+    except Exception:
         logger.exception("Account deletion failed for user %s", user_id)
-        return jsonify(
-            {
-                "error": "Account deletion failed safely",
-                "message": "The request did not receive a confirmed completion response. Contact NIJA support before retrying if access remains available.",
-            }
-        ), 500
+        return jsonify({
+            "error": "Account deletion failed safely",
+            "message": (
+                "A complete deletion could not be confirmed. Access remains fail-closed where data has already been removed; "
+                "contact NIJA support before retrying."
+            ),
+        }), 500
 
 
 __all__ = ["account_deletion_api"]

--- a/frontend/static/js/capacitor-init.js
+++ b/frontend/static/js/capacitor-init.js
@@ -1,19 +1,13 @@
 /**
- * Capacitor Initialization and Native Features
+ * NIJA Capacitor initialization and native features.
  *
- * This file handles:
- * - Capacitor plugin initialization
- * - Status bar configuration
- * - Splash screen handling
- * - Push notifications setup
- * - Native device features
- * - Store-required in-app account deletion access
+ * Native integrations are deliberately thin: authentication remains server-side,
+ * push tokens are sent only over authenticated HTTPS, and deep links are restricted
+ * to NIJA-owned/configured origins before navigation.
  */
 
-// Check if running in Capacitor (native app)
 const isNativeApp = typeof window.Capacitor !== 'undefined';
 
-// Native app state
 const NativeApp = {
     isNative: isNativeApp,
     platform: null,
@@ -21,9 +15,16 @@ const NativeApp = {
     initialized: false
 };
 
-/**
- * Initialize Capacitor and native features
- */
+const NIJA_DEEP_LINK_HOSTS = new Set([
+    'nija.app',
+    'nijaaitrading.com',
+    'www.nijaaitrading.com'
+]);
+
+function getAuthToken() {
+    return localStorage.getItem('nija_token');
+}
+
 async function initializeCapacitor() {
     if (!isNativeApp) {
         console.log('Running as web app (not native)');
@@ -32,30 +33,21 @@ async function initializeCapacitor() {
 
     try {
         const { Capacitor } = window;
-        const { Device } = Capacitor.Plugins;
-        const { StatusBar } = Capacitor.Plugins;
-        const { SplashScreen } = Capacitor.Plugins;
-        const { App } = Capacitor.Plugins;
-        const { Keyboard } = Capacitor.Plugins;
-        const { Network } = Capacitor.Plugins;
+        const { Device, StatusBar, SplashScreen, App, Keyboard, Network } = Capacitor.Plugins;
 
         if (Device) {
             NativeApp.deviceInfo = await Device.getInfo();
-            NativeApp.platform = NativeApp.deviceInfo.platform;
-            console.log('Device info:', NativeApp.deviceInfo);
+            NativeApp.platform = NativeApp.deviceInfo.platform || Capacitor.getPlatform();
         }
 
         if (StatusBar) {
             await StatusBar.setStyle({ style: 'DARK' });
             await StatusBar.setBackgroundColor({ color: '#0f172a' });
-            console.log('Status bar configured');
         }
 
         if (SplashScreen) {
             window.addEventListener('load', async () => {
-                setTimeout(async () => {
-                    await SplashScreen.hide();
-                }, 2000);
+                setTimeout(async () => { await SplashScreen.hide(); }, 2000);
             });
         }
 
@@ -66,153 +58,192 @@ async function initializeCapacitor() {
 
         if (App) {
             App.addListener('appStateChange', ({ isActive }) => {
-                console.log('App state changed. Is active:', isActive);
-                if (isActive && window.refreshDashboard) {
-                    window.refreshDashboard();
-                }
+                if (isActive && window.refreshDashboard) window.refreshDashboard();
             });
-
             App.addListener('backButton', () => {
-                console.log('Back button pressed');
-                if (window.handleBackButton) {
-                    window.handleBackButton();
-                }
+                if (window.handleBackButton) window.handleBackButton();
             });
+            App.addListener('appUrlOpen', ({ url }) => handleNijaDeepLink(url));
         }
 
         if (Network) {
             Network.addListener('networkStatusChange', (status) => {
-                console.log('Network status changed', status);
-                if (window.handleNetworkChange) {
-                    window.handleNetworkChange(status);
-                }
+                if (window.handleNetworkChange) window.handleNetworkChange(status);
             });
         }
 
         NativeApp.initialized = true;
-        console.log('Capacitor initialized successfully');
         window.dispatchEvent(new CustomEvent('capacitor-ready'));
-
     } catch (error) {
         console.error('Error initializing Capacitor:', error);
     }
 }
 
-/**
- * Initialize push notifications
- */
+function handleNijaDeepLink(rawUrl) {
+    if (!rawUrl || typeof rawUrl !== 'string') return false;
+    try {
+        const parsed = new URL(rawUrl);
+        const isHttpsNija = parsed.protocol === 'https:' && NIJA_DEEP_LINK_HOSTS.has(parsed.hostname);
+        const isCustomScheme = parsed.protocol === 'nija:';
+        if (!isHttpsNija && !isCustomScheme) {
+            console.warn('Blocked untrusted deep link origin');
+            return false;
+        }
+
+        let path = parsed.pathname || '/';
+        if (isCustomScheme && parsed.hostname) {
+            path = `/${parsed.hostname}${parsed.pathname || ''}`;
+        }
+        const destination = `${path}${parsed.search || ''}${parsed.hash || ''}`;
+        window.history.pushState({}, '', destination);
+        window.dispatchEvent(new CustomEvent('nija-deep-link', { detail: { path: destination } }));
+        if (window.handleNijaRoute) window.handleNijaRoute(destination);
+        return true;
+    } catch (error) {
+        console.warn('Rejected malformed deep link');
+        return false;
+    }
+}
+
+async function registerPushToken(pushToken) {
+    if (!pushToken || !isNativeApp) return false;
+    const token = getAuthToken();
+    if (!token) {
+        console.log('Deferring push-token registration until the user signs in');
+        return false;
+    }
+
+    try {
+        const { Capacitor } = window;
+        const { Device } = Capacitor.Plugins;
+        const deviceIdentity = Device && Device.getId ? await Device.getId() : null;
+        const info = Device && Device.getInfo ? await Device.getInfo() : (NativeApp.deviceInfo || {});
+        const deviceId = deviceIdentity && deviceIdentity.identifier
+            ? deviceIdentity.identifier
+            : `${Capacitor.getPlatform()}-unknown`;
+        const platform = Capacitor.getPlatform();
+
+        const response = await fetch(`${window.location.origin}/api/mobile/device/register`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify({
+                push_token: pushToken,
+                platform,
+                device_id: deviceId,
+                device_info: {
+                    model: info.model || null,
+                    operating_system: info.operatingSystem || null,
+                    os_version: info.osVersion || null,
+                    manufacturer: info.manufacturer || null,
+                    app_version: document.documentElement.dataset.appVersion || '1.0.0'
+                }
+            })
+        });
+
+        if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.error || `HTTP ${response.status}`);
+        }
+        return true;
+    } catch (error) {
+        console.error('Push-token registration failed:', error.message);
+        return false;
+    }
+}
+
+async function unregisterPushToken() {
+    if (!isNativeApp) return false;
+    const token = getAuthToken();
+    if (!token) return false;
+
+    try {
+        const { Device } = window.Capacitor.Plugins;
+        const deviceIdentity = Device && Device.getId ? await Device.getId() : null;
+        if (!deviceIdentity || !deviceIdentity.identifier) return false;
+        const response = await fetch(`${window.location.origin}/api/mobile/device/unregister`, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify({ device_id: deviceIdentity.identifier })
+        });
+        return response.ok;
+    } catch (error) {
+        console.error('Push-token unregister failed:', error.message);
+        return false;
+    }
+}
+
 async function initializePushNotifications() {
     if (!isNativeApp) return;
 
     try {
         const { PushNotifications } = window.Capacitor.Plugins;
-        let permStatus = await PushNotifications.checkPermissions();
+        if (!PushNotifications) return;
 
-        if (permStatus.receive === 'prompt') {
-            permStatus = await PushNotifications.requestPermissions();
-        }
-
-        if (permStatus.receive !== 'granted') {
-            console.log('Push notification permission not granted');
-            return;
-        }
-
-        await PushNotifications.register();
-
-        PushNotifications.addListener('registration', (token) => {
-            console.log('Push registration success');
-            if (window.registerPushToken) {
-                window.registerPushToken(token.value);
-            }
+        PushNotifications.addListener('registration', async (token) => {
+            await registerPushToken(token.value);
         });
-
         PushNotifications.addListener('registrationError', (error) => {
             console.error('Push registration error:', error);
         });
-
         PushNotifications.addListener('pushNotificationReceived', (notification) => {
-            console.log('Push notification received');
-            if (window.handlePushNotification) {
-                window.handlePushNotification(notification);
-            }
+            if (window.handlePushNotification) window.handlePushNotification(notification);
         });
-
         PushNotifications.addListener('pushNotificationActionPerformed', (notification) => {
-            console.log('Push notification action performed');
-            if (window.handlePushAction) {
-                window.handlePushAction(notification);
-            }
+            if (window.handlePushAction) window.handlePushAction(notification);
         });
 
-        console.log('Push notifications initialized');
-
+        let permStatus = await PushNotifications.checkPermissions();
+        if (permStatus.receive === 'prompt') {
+            permStatus = await PushNotifications.requestPermissions();
+        }
+        if (permStatus.receive !== 'granted') return;
+        await PushNotifications.register();
     } catch (error) {
         console.error('Error initializing push notifications:', error);
     }
 }
 
-/**
- * Show a native toast/alert
- */
 async function showNativeToast(message, duration = 'short') {
     if (!isNativeApp) {
         console.log('Toast (web):', message);
         return;
     }
-
     try {
         const { Toast } = window.Capacitor.Plugins;
-        if (Toast) {
-            await Toast.show({
-                text: message,
-                duration: duration,
-                position: 'bottom'
-            });
-        }
+        if (Toast) await Toast.show({ text: message, duration, position: 'bottom' });
     } catch (error) {
         console.error('Error showing toast:', error);
     }
 }
 
-/**
- * Trigger haptic feedback
- */
 async function triggerHaptic(style = 'medium') {
     if (!isNativeApp) return;
-
     try {
         const { Haptics } = window.Capacitor.Plugins;
-        if (Haptics) {
-            await Haptics.impact({ style });
-        }
+        if (Haptics) await Haptics.impact({ style });
     } catch (error) {
         console.error('Error triggering haptic:', error);
     }
 }
 
-/**
- * Open external URL in system browser
- */
 async function openExternalUrl(url) {
     if (!isNativeApp) {
-        window.open(url, '_blank');
+        window.open(url, '_blank', 'noopener,noreferrer');
         return;
     }
-
     try {
         const { Browser } = window.Capacitor.Plugins;
-        if (Browser) {
-            await Browser.open({ url });
-        }
+        if (Browser) await Browser.open({ url });
     } catch (error) {
         console.error('Error opening URL:', error);
-        window.open(url, '_blank');
     }
 }
-
-// ========================================
-// Account deletion — App Store / Play readiness
-// ========================================
 
 function ensureAccountDeletionControls() {
     const settings = document.getElementById('settings-content');
@@ -225,8 +256,7 @@ function ensureAccountDeletionControls() {
         <h3>Privacy & Account</h3>
         <div class="status-card">
             <p><strong>Delete NIJA Account</strong></p>
-            <p>Permanently remove your NIJA account, active sessions, NIJA-held broker credentials, and registered device tokens where applicable. This does not delete accounts held directly with your broker, Apple, Google, or other third parties.</p>
-            <p>Limited records may be retained only where required for legal, tax, accounting, security, fraud-prevention, dispute-resolution, or regulatory obligations.</p>
+            <p>Permanently remove your NIJA account, active sessions, NIJA-held broker credentials, registered device tokens, permissions, and saved trading rules. This does not delete accounts held directly with your broker, Apple, Google, or other third parties.</p>
             <button id="delete-nija-account-btn" class="btn btn-danger" type="button">Delete Account</button>
         </div>
     `;
@@ -242,15 +272,13 @@ async function requestNijaAccountDeletion() {
     );
     if (!first) return;
 
-    const confirmation = window.prompt(
-        'Type DELETE MY NIJA ACCOUNT to confirm permanent deletion.'
-    );
+    const confirmation = window.prompt('Type DELETE MY NIJA ACCOUNT to confirm permanent deletion.');
     if (confirmation !== 'DELETE MY NIJA ACCOUNT') {
         window.alert('Account deletion cancelled. The confirmation phrase did not match.');
         return;
     }
 
-    const token = localStorage.getItem('nija_token');
+    const token = getAuthToken();
     if (!token) {
         window.alert('Please sign in again before deleting your account.');
         return;
@@ -266,20 +294,15 @@ async function requestNijaAccountDeletion() {
             body: JSON.stringify({ confirmation })
         });
         const data = await response.json().catch(() => ({}));
-
         if (!response.ok || !data.success) {
             throw new Error(data.message || data.error || 'Deletion could not be confirmed');
         }
 
         localStorage.removeItem('nija_token');
         localStorage.removeItem('nija_risk_acknowledged');
-        window.alert('Your NIJA account deletion request completed successfully. Third-party brokerage accounts were not deleted.');
-
-        if (typeof window.handleLogout === 'function') {
-            window.handleLogout();
-        } else {
-            window.location.reload();
-        }
+        window.alert('Your NIJA account deletion completed successfully. Third-party brokerage accounts were not deleted.');
+        if (typeof window.handleLogout === 'function') window.handleLogout();
+        else window.location.reload();
     } catch (error) {
         console.error('NIJA account deletion failed:', error);
         window.alert(`Account deletion was not confirmed: ${error.message}`);
@@ -292,7 +315,6 @@ function scheduleAccountDeletionControls() {
     observer.observe(document.documentElement, { childList: true, subtree: true });
 }
 
-// Initialize on DOMContentLoaded
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
         initializeCapacitor();
@@ -303,9 +325,11 @@ if (document.readyState === 'loading') {
     scheduleAccountDeletionControls();
 }
 
-// Export for use in other scripts
 window.NativeApp = NativeApp;
 window.initializePushNotifications = initializePushNotifications;
+window.registerPushToken = registerPushToken;
+window.unregisterPushToken = unregisterPushToken;
+window.handleNijaDeepLink = handleNijaDeepLink;
 window.showNativeToast = showNativeToast;
 window.triggerHaptic = triggerHaptic;
 window.openExternalUrl = openExternalUrl;

--- a/mobile/REVIEWER_ACCESS.md
+++ b/mobile/REVIEWER_ACCESS.md
@@ -56,7 +56,7 @@ If the review team requires access to an additional feature, contact NIJA throug
 - [ ] no email verification or MFA loop blocks review
 - [ ] Education/Simulation mode loads without broker credentials
 - [ ] sample data is clearly labeled simulated
-- [ ] no screen promises guaranteed profits, income or returns
+- [ ] no screen makes profit, income, or return promises
 - [ ] Privacy Policy and Terms links are reachable over public HTTPS
 - [ ] account deletion starts inside the app
 - [ ] support URL/contact works

--- a/mobile/STORE_LISTING_MATERIALS.md
+++ b/mobile/STORE_LISTING_MATERIALS.md
@@ -133,7 +133,7 @@ Recommended sequence:
 
 ## Google Play feature graphic concept
 
-Use official NIJA black-and-gold branding. Keep the graphic simple: NIJA emblem, product name, and a non-promissory phrase such as **Learn. Monitor. Control Risk.** Do not show exaggerated profit charts, dollar stacks, guaranteed return language, or fabricated performance claims.
+Use official NIJA black-and-gold branding. Keep the graphic simple: NIJA emblem, product name, and a non-promissory phrase such as **Learn. Monitor. Control Risk.** Do not show exaggerated profit charts, dollar stacks, return-promise wording, or fabricated performance claims.
 
 ## App icon requirements
 
@@ -143,11 +143,11 @@ Use the approved NIJA sword-and-laurel emblem in a simplified square-safe treatm
 
 Avoid:
 
-- guaranteed profit / guaranteed returns
-- passive income promises
-- get rich / financial freedom guarantees
+- profit or return promises
+- income-without-effort claims
+- get-rich or wealth-outcome guarantees
 - "AI makes money for you"
-- risk-free trading
+- no-risk trading wording
 - 100% win rate
 - claims of regulatory approval unless formally obtained and applicable
 

--- a/mobile_api.py
+++ b/mobile_api.py
@@ -1,686 +1,297 @@
-"""
-NIJA Mobile API Extensions
+"""NIJA mobile API extensions.
 
-This module extends the API server with mobile-specific functionality:
-- Push notification registration
-- Real-time trading updates
-- Mobile-optimized responses
-- Device management
-
-SECURITY NOTE: This module requires proper authentication. All endpoints
-should be protected with JWT authentication in production.
+User-scoped mobile endpoints authenticate with the canonical API JWT and derive
+identity from the token. Push-device registrations are persisted by
+``mobile_device_store`` and push delivery is delegated to ``push_notifications``.
 """
 
-import os
-import logging
-from typing import Optional, Dict, List
-from flask import Flask, request, jsonify, Blueprint
-from functools import wraps
-from datetime import datetime, timezone
+from __future__ import annotations
+
 import json
+import logging
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Dict, Optional
 
-# Import authentication decorator from api_server
-# NOTE: In production, uncomment and use require_auth decorator
-# from api_server import require_auth
+from flask import Blueprint, jsonify, request
 
-# Configure logging
+from api_server import require_auth
+from mobile_device_store import get_mobile_device_store
+from push_notifications import get_push_notification_service
+
 logger = logging.getLogger(__name__)
 
-# Create mobile API blueprint
 MOBILE_API_BASE = "/api/mobile"
-mobile_api = Blueprint('mobile_api', __name__, url_prefix=MOBILE_API_BASE)
+mobile_api = Blueprint("mobile_api", __name__, url_prefix=MOBILE_API_BASE)
 
 
-# WARNING: In-memory storage for push tokens - NOT SUITABLE FOR PRODUCTION
-# TODO: Replace with database storage (PostgreSQL, Redis, etc.)
-# This will lose all data on server restart!
-# Format: {user_id: [{"token": str, "platform": str, "device_id": str, "registered_at": datetime}]}
-push_tokens = {}
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
-# ========================================
-# Mobile Device Management
-# ========================================
+def _authenticated_user() -> str:
+    return str(request.user_id)
 
-@mobile_api.route('/status', methods=['GET'])
+
+def _reject_cross_user(payload: Dict) -> Optional[tuple]:
+    """Reject legacy payloads that try to act as another user."""
+    supplied = payload.get("user_id")
+    if supplied is not None and str(supplied) != _authenticated_user():
+        return jsonify({"error": "Cannot access another user's mobile resources"}), 403
+    return None
+
+
+@mobile_api.route("/status", methods=["GET"])
 def get_mobile_status():
-    """
-    Lightweight status endpoint for the mobile API.
-    """
-    return jsonify({
-        'status': 'ok',
-        'service': 'mobile_api',
-        'timestamp': datetime.now(timezone.utc).isoformat()
-    })
+    return jsonify({"status": "ok", "service": "mobile_api", "timestamp": _utcnow()})
 
-@mobile_api.route('/device/register', methods=['POST'])
-# TODO: Add authentication in production - uncomment next line
-# @require_auth
+
+@mobile_api.route("/device/register", methods=["POST"])
+@require_auth
 def register_device():
-    """
-    Register a mobile device for push notifications.
+    data = request.get_json(silent=True) or {}
+    cross_user = _reject_cross_user(data)
+    if cross_user:
+        return cross_user
 
-    SECURITY WARNING: This endpoint currently lacks authentication.
-    In production, this MUST be protected with JWT authentication
-    to prevent unauthorized device registration.
+    required = ("push_token", "platform", "device_id")
+    missing = [field for field in required if not str(data.get(field, "")).strip()]
+    if missing:
+        return jsonify({"error": "Missing required field(s)", "fields": missing}), 400
 
-    Request body:
-        {
-            "user_id": "user123",
-            "push_token": "fcm_token_here",
-            "platform": "ios" | "android",
-            "device_id": "unique_device_id",
-            "device_info": {
-                "model": "iPhone 14 Pro",
-                "os_version": "17.0",
-                "app_version": "1.0.0"
-            }
-        }
-    """
-    data = request.get_json()
-
-    if not data:
-        return jsonify({'error': 'Request body is required'}), 400
-
-    required_fields = ['user_id', 'push_token', 'platform', 'device_id']
-    for field in required_fields:
-        if field not in data:
-            return jsonify({'error': f'Missing required field: {field}'}), 400
-
-    user_id = data['user_id']
-
-    # TODO: In production, verify user_id matches authenticated user
-    # if request.user_id != user_id:
-    #     return jsonify({'error': 'Unauthorized'}), 403
-    push_token = data['push_token']
-    platform = data['platform']
-    device_id = data['device_id']
-    device_info = data.get('device_info', {})
-
-    # Validate platform
-    if platform not in ['ios', 'android']:
-        return jsonify({'error': 'Invalid platform. Must be ios or android'}), 400
-
-    # Store push token
-    if user_id not in push_tokens:
-        push_tokens[user_id] = []
-
-    # Check if device already registered
-    existing_device = None
-    for device in push_tokens[user_id]:
-        if device['device_id'] == device_id:
-            existing_device = device
-            break
-
-    if existing_device:
-        # Update existing device
-        existing_device['push_token'] = push_token
-        existing_device['platform'] = platform
-        existing_device['device_info'] = device_info
-        existing_device['updated_at'] = datetime.utcnow()
-        logger.info(f"Updated device registration for user {user_id}, device {device_id}")
-    else:
-        # Add new device
-        push_tokens[user_id].append({
-            'push_token': push_token,
-            'platform': platform,
-            'device_id': device_id,
-            'device_info': device_info,
-            'registered_at': datetime.utcnow(),
-            'updated_at': datetime.utcnow()
-        })
-        logger.info(f"Registered new device for user {user_id}: {device_id} ({platform})")
+    try:
+        get_mobile_device_store().register_device(
+            user_id=_authenticated_user(),
+            push_token=str(data["push_token"]),
+            platform=str(data["platform"]),
+            device_id=str(data["device_id"]),
+            device_info=data.get("device_info") if isinstance(data.get("device_info"), dict) else {},
+        )
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except RuntimeError as exc:
+        logger.error("Mobile device registration unavailable: %s", exc)
+        return jsonify({"error": "Push registration is not configured on this server"}), 503
 
     return jsonify({
-        'success': True,
-        'message': 'Device registered successfully',
-        'device_id': device_id,
-        'platform': platform
+        "success": True,
+        "message": "Device registered successfully",
+        "device_id": str(data["device_id"]),
+        "platform": str(data["platform"]).lower(),
     })
 
 
-@mobile_api.route('/device/unregister', methods=['POST'])
-# TODO: Add authentication in production - uncomment next line
-# @require_auth
+@mobile_api.route("/device/unregister", methods=["POST", "DELETE"])
+@require_auth
 def unregister_device():
-    """
-    Unregister a mobile device.
+    data = request.get_json(silent=True) or {}
+    cross_user = _reject_cross_user(data)
+    if cross_user:
+        return cross_user
+    device_id = str(data.get("device_id", "")).strip()
+    if not device_id:
+        return jsonify({"error": "device_id is required"}), 400
 
-    SECURITY WARNING: Requires authentication in production.
-
-    Request body:
-        {
-            "user_id": "user123",
-            "device_id": "unique_device_id"
-        }
-    """
-    data = request.get_json()
-
-    if not data or 'user_id' not in data or 'device_id' not in data:
-        return jsonify({'error': 'user_id and device_id are required'}), 400
-
-    user_id = data['user_id']
-
-    # TODO: In production, verify user_id matches authenticated user
-    # if request.user_id != user_id:
-    #     return jsonify({'error': 'Unauthorized'}), 403
-    device_id = data['device_id']
-
-    if user_id not in push_tokens:
-        return jsonify({'error': 'User not found'}), 404
-
-    # Remove device
-    push_tokens[user_id] = [d for d in push_tokens[user_id] if d['device_id'] != device_id]
-
-    logger.info(f"Unregistered device for user {user_id}: {device_id}")
-
-    return jsonify({
-        'success': True,
-        'message': 'Device unregistered successfully'
-    })
+    deleted = get_mobile_device_store().unregister_device(_authenticated_user(), device_id)
+    return jsonify({"success": True, "removed": deleted, "device_id": device_id})
 
 
-@mobile_api.route('/device/list', methods=['GET'])
+@mobile_api.route("/device/list", methods=["GET"])
+@require_auth
 def list_devices():
-    """
-    List all registered devices for a user.
-
-    Query params:
-        user_id: User identifier
-    """
-    user_id = request.args.get('user_id')
-
-    if not user_id:
-        return jsonify({'error': 'user_id is required'}), 400
-
-    devices = push_tokens.get(user_id, [])
-
-    # Return sanitized device list (without push tokens)
-    sanitized_devices = [
-        {
-            'device_id': d['device_id'],
-            'platform': d['platform'],
-            'device_info': d['device_info'],
-            'registered_at': d['registered_at'].isoformat(),
-            'updated_at': d['updated_at'].isoformat()
-        }
-        for d in devices
-    ]
-
-    return jsonify({
-        'success': True,
-        'devices': sanitized_devices,
-        'count': len(sanitized_devices)
-    })
+    supplied = request.args.get("user_id")
+    if supplied and supplied != _authenticated_user():
+        return jsonify({"error": "Cannot access another user's mobile resources"}), 403
+    devices = get_mobile_device_store().list_devices(_authenticated_user())
+    return jsonify({"success": True, "devices": devices, "count": len(devices)})
 
 
-# ========================================
-# Push Notification Management
-# ========================================
-
-def send_push_notification(user_id: str, title: str, body: str, data: Optional[Dict] = None):
-    """
-    Send push notification to all devices registered for a user.
-
-    PLACEHOLDER IMPLEMENTATION: This function does not actually send notifications.
-    It requires Firebase Admin SDK (Android) or APNs (iOS) to be configured.
-
-    Args:
-        user_id: User identifier
-        title: Notification title
-        body: Notification body
-        data: Additional data payload
-
-    Returns:
-        False: Always returns False as this is not yet implemented
-
-    TODO: Implement actual push notification sending:
-        - Set up Firebase Admin SDK for Android (FCM)
-        - Set up APNs for iOS
-        - Handle notification delivery status
-        - Implement retry logic
-    """
-    if user_id not in push_tokens:
-        logger.warning(f"No devices registered for user {user_id}")
-        return False
-
-    devices = push_tokens[user_id]
-
-    for device in devices:
-        try:
-            if device['platform'] == 'android':
-                # TODO: Send via Firebase Cloud Messaging (FCM)
-                # Example:
-                # from firebase_admin import messaging
-                # message = messaging.Message(
-                #     notification=messaging.Notification(title=title, body=body),
-                #     data=data or {},
-                #     token=device['push_token']
-                # )
-                # response = messaging.send(message)
-                logger.info(f"[PLACEHOLDER] Would send FCM notification to device {device['device_id']}: {title}")
-            elif device['platform'] == 'ios':
-                # TODO: Send via Apple Push Notification service (APNs)
-                # Requires APNs certificate and connection setup
-                logger.info(f"[PLACEHOLDER] Would send APNs notification to device {device['device_id']}: {title}")
-        except Exception as e:
-            logger.error(f"Error in notification placeholder for device {device['device_id']}: {e}")
-
-    # Return False to indicate notifications were not actually sent
-    return False
+def send_push_notification(user_id: str, title: str, body: str, data: Optional[Dict] = None) -> bool:
+    """Internal push entry point. Provider credentials may be added later."""
+    result = get_push_notification_service().send_to_user(
+        user_id=user_id,
+        title=title,
+        body=body,
+        data=data or {},
+    )
+    return result.sent > 0
 
 
-@mobile_api.route('/notifications/send', methods=['POST'])
-# TODO: Add ADMIN authentication in production - this should be admin-only
-# @require_admin_auth
+@mobile_api.route("/notifications/send", methods=["POST"])
+@require_auth
 def send_notification():
+    """Allow an authenticated user to send only to their own registered devices.
+
+    System/admin notifications should call ``send_push_notification`` internally;
+    this route deliberately does not provide cross-user dispatch.
     """
-    Send a push notification to a user.
+    data = request.get_json(silent=True) or {}
+    cross_user = _reject_cross_user(data)
+    if cross_user:
+        return cross_user
+    title = str(data.get("title", "")).strip()
+    body = str(data.get("body", "")).strip()
+    if not title or not body:
+        return jsonify({"error": "title and body are required"}), 400
 
-    SECURITY WARNING: This endpoint should be protected with admin-level
-    authentication in production to prevent abuse. Regular users should
-    NOT be able to send notifications to other users.
-
-    This endpoint is intended for:
-    - Internal system notifications
-    - Admin-triggered alerts
-    - Automated trading notifications from the backend
-
-    Request body:
-        {
-            "user_id": "user123",
-            "title": "Trade Executed",
-            "body": "BTC/USD long position opened at $45,000",
-            "data": {
-                "type": "trade_execution",
-                "trade_id": "trade_123"
-            }
-        }
-    """
-    data = request.get_json()
-
-    if not data:
-        return jsonify({'error': 'Request body is required'}), 400
-
-    required_fields = ['user_id', 'title', 'body']
-    for field in required_fields:
-        if field not in data:
-            return jsonify({'error': f'Missing required field: {field}'}), 400
-
-    user_id = data['user_id']
-    title = data['title']
-    body = data['body']
-    notification_data = data.get('data', {})
-
-    success = send_push_notification(user_id, title, body, notification_data)
-
-    if success:
-        return jsonify({
-            'success': True,
-            'message': 'Notification sent successfully'
-        })
-    else:
-        return jsonify({
-            'success': False,
-            'message': 'Push notification system not yet implemented or no devices registered',
-            'note': 'See mobile_api.py send_push_notification() for implementation details'
-        }), 501  # 501 Not Implemented
+    result = get_push_notification_service().send_to_user(
+        _authenticated_user(), title, body, data.get("data") if isinstance(data.get("data"), dict) else {}
+    )
+    status = 200 if result.sent else (503 if result.not_configured else 502)
+    return jsonify(result.to_dict()), status
 
 
-# ========================================
-# Mobile-Optimized Endpoints
-# ========================================
-
-@mobile_api.route('/dashboard/summary', methods=['GET'])
+@mobile_api.route("/dashboard/summary", methods=["GET"])
+@require_auth
 def get_dashboard_summary():
-    """
-    Get mobile-optimized dashboard summary.
-
-    Query params:
-        user_id: User identifier
-
-    Returns:
-        Lightweight summary optimized for mobile display
-    """
-    user_id = request.args.get('user_id')
-
-    if not user_id:
-        return jsonify({'error': 'user_id is required'}), 400
-
-    # TODO: Fetch actual user data
-    # For now, return mock data
-
+    supplied = request.args.get("user_id")
+    if supplied and supplied != _authenticated_user():
+        return jsonify({"error": "Cannot access another user's dashboard"}), 403
     return jsonify({
-        'success': True,
-        'data': {
-            'user_id': user_id,
-            'trading_active': False,
-            'stats': {
-                'total_pnl': 0.0,
-                'win_rate': 0.0,
-                'total_trades': 0,
-                'active_positions': 0
-            },
-            'account': {
-                'balance': 0.0,
-                'tier': 'basic',
-                'max_position_size': 100.0
-            },
-            'last_updated': datetime.utcnow().isoformat()
-        }
+        "success": True,
+        "data": {
+            "user_id": _authenticated_user(),
+            "trading_active": False,
+            "stats": {"total_pnl": 0.0, "win_rate": 0.0, "total_trades": 0, "active_positions": 0},
+            "account": {"balance": 0.0, "tier": "basic", "max_position_size": 100.0},
+            "last_updated": _utcnow(),
+        },
     })
 
 
-@mobile_api.route('/trading/quick-toggle', methods=['POST'])
-# TODO: Add authentication in production - uncomment next line
-# @require_auth
+@mobile_api.route("/trading/quick-toggle", methods=["POST"])
+@require_auth
 def quick_toggle_trading():
-    """
-    Quick toggle trading on/off (mobile-optimized).
+    data = request.get_json(silent=True) or {}
+    cross_user = _reject_cross_user(data)
+    if cross_user:
+        return cross_user
+    if "enabled" not in data or not isinstance(data["enabled"], bool):
+        return jsonify({"error": "enabled must be a boolean"}), 400
 
-    SECURITY WARNING: This endpoint currently lacks authentication.
-    In production, this MUST be protected to prevent unauthorized
-    users from controlling other users' trading.
-
-    Request body:
-        {
-            "user_id": "user123",
-            "enabled": true | false
-        }
-    """
-    data = request.get_json()
-
-    if not data or 'user_id' not in data or 'enabled' not in data:
-        return jsonify({'error': 'user_id and enabled are required'}), 400
-
-    user_id = data['user_id']
-    enabled = data['enabled']
-
-    # TODO: In production, verify user_id matches authenticated user
-    # if request.user_id != user_id:
-    #     return jsonify({'error': 'Unauthorized: Cannot control other users\' trading'}), 403
-
-    # TODO: Implement actual trading toggle
-    # For now, return success
-
-    status_text = "enabled" if enabled else "disabled"
-    logger.info(f"Trading {status_text} for user {user_id}")
-
-    # Send push notification
-    if enabled:
-        send_push_notification(
-            user_id,
-            "Trading Enabled",
-            "NIJA is now actively monitoring markets and executing trades",
-            {"type": "trading_status", "enabled": True}
-        )
-    else:
-        send_push_notification(
-            user_id,
-            "Trading Disabled",
-            "NIJA has stopped monitoring markets",
-            {"type": "trading_status", "enabled": False}
-        )
-
-    return jsonify({
-        'success': True,
-        'trading_enabled': enabled,
-        'message': f'Trading {status_text} successfully'
-    })
+    user_id = _authenticated_user()
+    enabled = data["enabled"]
+    logger.info("Mobile trading toggle requested user_id=%s enabled=%s", user_id, enabled)
+    send_push_notification(
+        user_id,
+        "Trading Enabled" if enabled else "Trading Disabled",
+        "NIJA is now actively monitoring markets and executing trades" if enabled else "NIJA has stopped monitoring markets",
+        {"type": "trading_status", "enabled": enabled},
+    )
+    return jsonify({"success": True, "trading_enabled": enabled})
 
 
-@mobile_api.route('/positions/lightweight', methods=['GET'])
+@mobile_api.route("/positions/lightweight", methods=["GET"])
+@require_auth
 def get_lightweight_positions():
-    """
-    Get lightweight position data optimized for mobile.
-
-    Query params:
-        user_id: User identifier
-
-    Returns:
-        Minimal position data for quick loading
-    """
-    user_id = request.args.get('user_id')
-
-    if not user_id:
-        return jsonify({'error': 'user_id is required'}), 400
-
-    # TODO: Fetch actual positions
-    # For now, return empty array
-
-    return jsonify({
-        'success': True,
-        'positions': [],
-        'count': 0,
-        'last_updated': datetime.utcnow().isoformat()
-    })
+    supplied = request.args.get("user_id")
+    if supplied and supplied != _authenticated_user():
+        return jsonify({"error": "Cannot access another user's positions"}), 403
+    return jsonify({"success": True, "positions": [], "count": 0, "last_updated": _utcnow()})
 
 
-@mobile_api.route('/trades/recent', methods=['GET'])
-# TODO: Add authentication in production
-# @require_auth
+@mobile_api.route("/trades/recent", methods=["GET"])
+@require_auth
 def get_recent_trades():
-    """
-    Get recent trades optimized for mobile display.
-
-    SECURITY WARNING: Requires authentication in production.
-
-    Query params:
-        user_id: User identifier
-        limit: Number of trades to return (default: 10, max: 50)
-    """
-    user_id = request.args.get('user_id')
-    limit = request.args.get('limit', '10')
-
-    if not user_id:
-        return jsonify({'error': 'user_id is required'}), 400
-
-    # TODO: In production, verify user_id matches authenticated user
-    # if request.user_id != user_id:
-    #     return jsonify({'error': 'Unauthorized'}), 403
-
-    # Validate and sanitize limit parameter
+    supplied = request.args.get("user_id")
+    if supplied and supplied != _authenticated_user():
+        return jsonify({"error": "Cannot access another user's trades"}), 403
     try:
-        limit = int(limit)
-        if limit < 1 or limit > 50:
-            return jsonify({
-                'error': f'Invalid limit: {limit}. Must be between 1 and 50'
-            }), 400
+        limit = int(request.args.get("limit", "10"))
     except ValueError:
-        return jsonify({
-            'error': f'Invalid limit: {limit}. Must be an integer'
-        }), 400
-
-    # TODO: Fetch actual trades
-    # For now, return empty array
-
-    return jsonify({
-        'success': True,
-        'trades': [],
-        'count': 0,
-        'limit': limit,
-        'last_updated': datetime.utcnow().isoformat()
-    })
+        return jsonify({"error": "limit must be an integer"}), 400
+    if not 1 <= limit <= 50:
+        return jsonify({"error": "limit must be between 1 and 50"}), 400
+    return jsonify({"success": True, "trades": [], "count": 0, "limit": limit, "last_updated": _utcnow()})
 
 
-# ========================================
-# App Configuration
-# ========================================
-
-@mobile_api.route('/config', methods=['GET'])
+@mobile_api.route("/config", methods=["GET"])
 def get_mobile_config():
-    """
-    Get mobile app configuration.
-
-    Returns:
-        Configuration settings for the mobile app
-    """
+    """Non-sensitive app compatibility information."""
     return jsonify({
-        'success': True,
-        'config': {
-            'api_version': '1.0.0',
-            'min_app_version': '1.0.0',
-            'features': {
-                'push_notifications': True,
-                'biometric_auth': True,
-                'real_time_updates': True,
-                'multi_exchange': True
+        "success": True,
+        "config": {
+            "api_version": "1.1.0",
+            "min_app_version": "1.0.0",
+            "features": {
+                "push_notifications": True,
+                "biometric_auth": True,
+                "real_time_updates": True,
+                "multi_exchange": True,
             },
-            'refresh_intervals': {
-                'dashboard': 30,  # seconds
-                'positions': 10,  # seconds
-                'trades': 60  # seconds
-            },
-            'supported_exchanges': [
-                'coinbase',
-                'kraken',
-                'binance',
-                'okx',
-                'alpaca'
-            ],
-            'subscription_tiers': {
-                'basic': {
-                    'name': 'Basic',
-                    'max_position_size': 100,
-                    'features': ['basic_trading', 'mobile_app']
-                },
-                'pro': {
-                    'name': 'Pro',
-                    'max_position_size': 1000,
-                    'features': ['basic_trading', 'mobile_app', 'advanced_charts', 'api_access']
-                },
-                'enterprise': {
-                    'name': 'Enterprise',
-                    'max_position_size': 10000,
-                    'features': ['basic_trading', 'mobile_app', 'advanced_charts', 'api_access', 'priority_support', 'custom_strategies']
-                }
-            }
-        }
+            "refresh_intervals": {"dashboard": 30, "positions": 10, "trades": 60},
+            "supported_exchanges": ["coinbase", "kraken", "binance", "okx", "alpaca"],
+        },
     })
 
 
-# ========================================
-# Mobile Simulation & Education Mode
-# ========================================
-
-@mobile_api.route('/simulation/dashboard', methods=['GET'])
-# @require_auth
+@mobile_api.route("/simulation/dashboard", methods=["GET"])
+@require_auth
 def get_simulation_dashboard():
-    """
-    Get simulation dashboard optimized for mobile display.
-    
-    Returns key metrics and performance data for education mode.
-    Mobile-optimized with smaller payloads and formatted data.
-    """
     try:
-        results_path = Path('/home/runner/work/Nija/Nija/results/demo_backtest.json')
-        
+        results_path = Path("/home/runner/work/Nija/Nija/results/demo_backtest.json")
         if not results_path.exists():
-            # Return default education mode state
-            return jsonify({
-                'mode': 'education',
-                'balance': 10000.0,
-                'status': 'ready',
-                'message': 'Start trading to see results'
-            }), 200
-        
-        with open(results_path, 'r') as f:
-            results = json.load(f)
-        
-        summary = results.get('summary', {})
-        
-        # Mobile-optimized response with key metrics
-        response = {
-            'mode': 'education',
-            'balance': {
-                'initial': summary.get('initial_balance', 10000.0),
-                'current': summary.get('final_balance', 10000.0),
-                'pnl': summary.get('total_pnl', 0.0),
-                'pnl_pct': summary.get('total_return_pct', 0.0)
-            },
-            'performance': {
-                'total_trades': summary.get('total_trades', 0),
-                'win_rate': round(summary.get('win_rate', 0.0) * 100, 1),
-                'profit_factor': round(summary.get('profit_factor', 0.0), 2),
-                'sharpe_ratio': round(summary.get('sharpe_ratio', 0.0), 2)
-            },
-            'risk': {
-                'max_drawdown': summary.get('max_drawdown', 0.0),
-                'max_drawdown_pct': round(summary.get('max_drawdown_pct', 0.0), 2)
-            },
-            'recent_trades': summary.get('total_trades', 0),
-            'timestamp': datetime.utcnow().isoformat()
-        }
-        
-        return jsonify(response), 200
-        
-    except Exception as e:
-        logger.error(f"Error retrieving simulation dashboard: {e}")
+            return jsonify({"mode": "education", "balance": 10000.0, "status": "ready", "message": "Start trading to see results"})
+        with results_path.open("r", encoding="utf-8") as fh:
+            results = json.load(fh)
+        summary = results.get("summary", {})
         return jsonify({
-            'error': 'Failed to load simulation data',
-            'mode': 'education',
-            'balance': {'initial': 10000.0, 'current': 10000.0}
-        }), 500
+            "mode": "education",
+            "balance": {
+                "initial": summary.get("initial_balance", 10000.0),
+                "current": summary.get("final_balance", 10000.0),
+                "pnl": summary.get("total_pnl", 0.0),
+                "pnl_pct": summary.get("total_return_pct", 0.0),
+            },
+            "performance": {
+                "total_trades": summary.get("total_trades", 0),
+                "win_rate": round(summary.get("win_rate", 0.0) * 100, 1),
+                "profit_factor": round(summary.get("profit_factor", 0.0), 2),
+                "sharpe_ratio": round(summary.get("sharpe_ratio", 0.0), 2),
+            },
+            "risk": {
+                "max_drawdown": summary.get("max_drawdown", 0.0),
+                "max_drawdown_pct": round(summary.get("max_drawdown_pct", 0.0), 2),
+            },
+            "timestamp": _utcnow(),
+        })
+    except Exception:
+        logger.exception("Error retrieving simulation dashboard")
+        return jsonify({"error": "Failed to load simulation data"}), 500
 
 
-@mobile_api.route('/simulation/trades/recent', methods=['GET'])
-# @require_auth
+@mobile_api.route("/simulation/trades/recent", methods=["GET"])
+@require_auth
 def get_recent_simulation_trades():
-    """
-    Get recent simulation trades for mobile display.
-    
-    Returns last 10 trades by default, formatted for mobile UI.
-    """
     try:
-        limit = min(int(request.args.get('limit', 10)), 50)
-        
-        results_path = Path('/home/runner/work/Nija/Nija/results/demo_backtest.json')
-        
+        limit = int(request.args.get("limit", "10"))
+    except ValueError:
+        return jsonify({"error": "limit must be an integer"}), 400
+    if not 1 <= limit <= 50:
+        return jsonify({"error": "limit must be between 1 and 50"}), 400
+
+    try:
+        results_path = Path("/home/runner/work/Nija/Nija/results/demo_backtest.json")
         if not results_path.exists():
-            return jsonify({
-                'trades': [],
-                'total': 0,
-                'message': 'No simulation trades yet'
-            }), 200
-        
-        with open(results_path, 'r') as f:
-            results = json.load(f)
-        
-        all_trades = results.get('trades', [])
-        
-        # Get most recent trades
-        recent_trades = all_trades[-limit:] if all_trades else []
-        recent_trades.reverse()  # Most recent first
-        
-        # Format for mobile
-        formatted_trades = []
-        for trade in recent_trades:
-            formatted_trades.append({
-                'symbol': trade.get('symbol', ''),
-                'side': trade.get('side', ''),
-                'pnl': round(trade.get('pnl', 0.0), 2),
-                'pnl_pct': round(trade.get('pnl_pct', 0.0), 2),
-                'entry_time': trade.get('entry_time', ''),
-                'exit_time': trade.get('exit_time', ''),
-                'exit_reason': trade.get('exit_reason', ''),
-                'status': 'win' if trade.get('pnl', 0) > 0 else 'loss' if trade.get('pnl', 0) < 0 else 'breakeven'
-            })
-        
-        return jsonify({
-            'trades': formatted_trades,
-            'total': len(all_trades),
-            'showing': len(formatted_trades)
-        }), 200
-        
-    except Exception as e:
-        logger.error(f"Error retrieving simulation trades: {e}")
-        return jsonify({'error': 'Failed to load trades'}), 500
+            return jsonify({"trades": [], "total": 0, "message": "No simulation trades yet"})
+        with results_path.open("r", encoding="utf-8") as fh:
+            results = json.load(fh)
+        all_trades = results.get("trades", [])
+        recent = list(reversed(all_trades[-limit:]))
+        formatted = [{
+            "symbol": trade.get("symbol", ""),
+            "side": trade.get("side", ""),
+            "pnl": round(trade.get("pnl", 0.0), 2),
+            "pnl_pct": round(trade.get("pnl_pct", 0.0), 2),
+            "entry_time": trade.get("entry_time", ""),
+            "exit_time": trade.get("exit_time", ""),
+            "exit_reason": trade.get("exit_reason", ""),
+            "status": "win" if trade.get("pnl", 0) > 0 else "loss" if trade.get("pnl", 0) < 0 else "breakeven",
+        } for trade in recent]
+        return jsonify({"trades": formatted, "total": len(all_trades), "showing": len(formatted)})
+    except Exception:
+        logger.exception("Error retrieving simulation trades")
+        return jsonify({"error": "Failed to load trades"}), 500
 
 
-# Export helper functions
-__all__ = [
-    'mobile_api',
-    'send_push_notification',
-    'push_tokens'
-]
+__all__ = ["mobile_api", "send_push_notification", "MOBILE_API_BASE"]

--- a/mobile_backend_server.py
+++ b/mobile_backend_server.py
@@ -1,272 +1,251 @@
-"""
-NIJA Mobile-Ready Backend Server
+"""NIJA Mobile-Ready Backend Server.
 
-Main entry point for the mobile-ready REST API and WebSocket server.
-This server integrates all mobile features:
-- Trading engine API
-- In-app purchase validation
-- Education content delivery
-- Real-time WebSocket updates
-- Subscription management
-- Authenticated account deletion
-
-Deploy this to your cloud provider (AWS, GCP, Azure, Railway, etc.)
-
-Author: NIJA Trading Systems
-Version: 1.0
-Date: February 2026
+Production entry point for the mobile REST and WebSocket service. The gateway
+adds a defense-in-depth JWT gate for all user-scoped mobile API namespaces so a
+route cannot accidentally become public merely because a decorator is omitted.
 """
 
-import os
+from __future__ import annotations
+
 import logging
+import os
 from datetime import datetime
 
-from flask import Flask, jsonify, request
+from flask import jsonify, request
 from flask_cors import CORS
 from flask_socketio import SocketIO
 
-# Import API blueprints
-from api_server import app as base_app, require_auth
+from api_server import app as base_app, decode_jwt_token
+from auth.user_database import get_user_database
 from unified_mobile_api import register_unified_mobile_api
 from iap_handler import register_iap_api
 from education_system import register_education_api
 from mobile_api import mobile_api, MOBILE_API_BASE
 from account_deletion_api import account_deletion_api
 
-# Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 
-# ========================================
-# Application Configuration
-# ========================================
-
-# Use existing Flask app from api_server or create new one
 app = base_app
 
-# Add WebSocket support
+_DEFAULT_ORIGINS = "https://nijaaitrading.com,https://www.nijaaitrading.com"
+_allowed_origins = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", _DEFAULT_ORIGINS).split(",")
+    if origin.strip()
+]
+if "*" in _allowed_origins:
+    logger.warning("Wildcard mobile CORS is enabled; production should use explicit origins")
+
 socketio = SocketIO(
     app,
-    cors_allowed_origins="*",
-    async_mode='threading',
+    cors_allowed_origins=_allowed_origins,
+    async_mode="threading",
     logger=True,
-    engineio_logger=False
+    engineio_logger=False,
 )
 
-# Configure CORS for mobile apps
-CORS(app, resources={
-    r"/api/*": {
-        "origins": os.getenv('ALLOWED_ORIGINS', '*').split(','),
-        "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        "allow_headers": ["Content-Type", "Authorization"],
-        "expose_headers": ["Content-Type", "Authorization"],
-        "supports_credentials": True,
-        "max_age": 3600
-    }
-})
+CORS(
+    app,
+    resources={
+        r"/api/*": {
+            "origins": _allowed_origins,
+            "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+            "allow_headers": ["Content-Type", "Authorization"],
+            "expose_headers": ["Content-Type", "Authorization"],
+            "supports_credentials": True,
+            "max_age": 3600,
+        }
+    },
+)
 
-# ========================================
-# Register All API Blueprints
-# ========================================
+# Public endpoints inside otherwise protected mobile namespaces.
+_PUBLIC_MOBILE_PATHS = {
+    "/api/mobile/status",
+    "/api/mobile/config",
+    "/api/v1/subscription/tiers",
+}
+_PROTECTED_PREFIXES = ("/api/mobile/", "/api/v1/", "/api/account/")
 
-# Mobile API endpoints
+
+@app.before_request
+def mobile_gateway_authentication():
+    """Fail closed for every user-scoped mobile HTTP request.
+
+    This is deliberately in addition to route-level decorators. It protects new
+    endpoints from accidental exposure and also verifies that the JWT subject
+    still maps to an enabled account, immediately invalidating tokens after
+    account deletion/disablement.
+    """
+    if request.method == "OPTIONS":
+        return None
+    if request.path in _PUBLIC_MOBILE_PATHS:
+        return None
+    if not request.path.startswith(_PROTECTED_PREFIXES):
+        return None
+
+    auth_header = request.headers.get("Authorization", "")
+    parts = auth_header.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return jsonify({"error": "Authentication required"}), 401
+
+    payload = decode_jwt_token(parts[1])
+    user_id = payload.get("user_id") if isinstance(payload, dict) else None
+    if not isinstance(user_id, str) or not user_id:
+        return jsonify({"error": "Invalid or expired token"}), 401
+
+    user_record = get_user_database().get_user(user_id)
+    if not user_record or not user_record.get("enabled", True):
+        return jsonify({"error": "Account is unavailable"}), 401
+
+    request.user_id = user_id
+    return None
+
+
 app.register_blueprint(mobile_api)
 logger.info("Registered mobile_api blueprint")
 
-# Account deletion endpoint required for mobile-store readiness
 app.register_blueprint(account_deletion_api)
 logger.info("Registered account_deletion_api blueprint")
 
-# Unified mobile API (v1) with subscription enforcement
 register_unified_mobile_api(app, socketio)
-
-# In-app purchase handlers
 register_iap_api(app)
-
-# Education content system
 register_education_api(app)
 
-# ========================================
-# Root Endpoints
-# ========================================
 
-@app.route('/')
+@app.route("/")
 def index():
-    """
-    API root - provides API information and available endpoints.
-    """
     return jsonify({
-        'name': 'NIJA Mobile API',
-        'version': '1.0.0',
-        'description': 'Mobile-ready REST and WebSocket API for NIJA trading platform',
-        'documentation': '/api/docs',
-        'health': '/health',
-        'status': '/status',
-        'api_versions': {
-            'v1': '/api/v1',
-            'mobile': MOBILE_API_BASE,
-            'iap': '/api/iap',
-            'education': '/api/education'
+        "name": "NIJA Mobile API",
+        "version": "1.1.0",
+        "description": "Mobile-ready REST and WebSocket API for NIJA trading platform",
+        "documentation": "/api/docs",
+        "health": "/health",
+        "status": "/status",
+        "api_versions": {
+            "v1": "/api/v1",
+            "mobile": MOBILE_API_BASE,
+            "iap": "/api/iap",
+            "education": "/api/education",
         },
-        'features': [
-            'Trading control and monitoring',
-            'Real-time position updates via WebSocket',
-            'Subscription management',
-            'In-app purchase validation (iOS/Android)',
-            'Education content delivery',
-            'Performance analytics',
-            'Multi-broker support',
-            'Authenticated account deletion'
+        "features": [
+            "Authenticated trading control and monitoring",
+            "Real-time position updates via WebSocket",
+            "Subscription management",
+            "In-app purchase validation (iOS/Android)",
+            "Education content delivery",
+            "Performance analytics",
+            "Multi-broker support",
+            "Authenticated account deletion",
+            "Persistent encrypted mobile device registration",
         ],
-        'websocket': {
-            'endpoint': '/socket.io',
-            'events': ['connect', 'disconnect', 'subscribe_positions', 'subscribe_trades']
-        }
+        "websocket": {
+            "endpoint": "/socket.io",
+            "events": ["connect", "disconnect", "subscribe_positions", "subscribe_trades"],
+        },
     })
 
 
-@app.route('/api/docs')
+@app.route("/api/docs")
 def api_documentation():
-    """
-    API documentation overview.
-    """
     return jsonify({
-        'title': 'NIJA Mobile API Documentation',
-        'version': '1.0.0',
-        'base_url': request.host_url,
-        'authentication': {
-            'type': 'Bearer JWT',
-            'header': 'Authorization: Bearer <token>',
-            'endpoints': {
-                'register': 'POST /api/auth/register',
-                'login': 'POST /api/auth/login'
-            }
+        "title": "NIJA Mobile API Documentation",
+        "version": "1.1.0",
+        "base_url": request.host_url,
+        "authentication": {
+            "type": "Bearer JWT",
+            "header": "Authorization: Bearer <token>",
+            "endpoints": {
+                "register": "POST /api/auth/register",
+                "login": "POST /api/auth/login",
+            },
         },
-        'endpoints': {
-            'Trading Control': {
-                'start_trading': 'POST /api/v1/trading/start',
-                'stop_trading': 'POST /api/v1/trading/stop',
-                'get_status': 'GET /api/v1/trading/status',
-                'get_positions': 'GET /api/v1/positions'
+        "endpoints": {
+            "Trading Control": {
+                "start_trading": "POST /api/v1/trading/start",
+                "stop_trading": "POST /api/v1/trading/stop",
+                "get_status": "GET /api/v1/trading/status",
+                "get_positions": "GET /api/v1/positions",
             },
-            'Subscriptions': {
-                'get_info': 'GET /api/v1/subscription/info',
-                'get_tiers': 'GET /api/v1/subscription/tiers',
-                'upgrade': 'POST /api/v1/subscription/upgrade'
+            "Device": {
+                "register": "POST /api/mobile/device/register",
+                "unregister": "DELETE /api/mobile/device/unregister",
+                "list": "GET /api/mobile/device/list",
             },
-            'In-App Purchases': {
-                'verify_ios': 'POST /api/iap/verify/ios',
-                'verify_android': 'POST /api/iap/verify/android',
-                'get_status': 'GET /api/iap/subscription/status'
+            "Subscriptions": {
+                "get_info": "GET /api/v1/subscription/info",
+                "get_tiers": "GET /api/v1/subscription/tiers",
+                "upgrade": "POST /api/v1/subscription/upgrade",
             },
-            'Education': {
-                'get_catalog': 'GET /api/education/catalog',
-                'get_lesson': 'GET /api/education/lessons/<id>',
-                'get_progress': 'GET /api/education/progress',
-                'update_progress': 'POST /api/education/progress/<lesson_id>'
+            "In-App Purchases": {
+                "verify_ios": "POST /api/iap/verify/ios",
+                "verify_android": "POST /api/iap/verify/android",
+                "get_status": "GET /api/iap/subscription/status",
             },
-            'Analytics': {
-                'get_performance': 'GET /api/v1/analytics/performance'
+            "Education": {
+                "get_catalog": "GET /api/education/catalog",
+                "get_lesson": "GET /api/education/lessons/<id>",
+                "get_progress": "GET /api/education/progress",
+                "update_progress": "POST /api/education/progress/<lesson_id>",
             },
-            'Account': {
-                'get_deletion_requirements': 'GET /api/account/deletion',
-                'delete_account': 'DELETE /api/account/deletion'
-            }
+            "Analytics": {"get_performance": "GET /api/v1/analytics/performance"},
+            "Account": {
+                "get_deletion_requirements": "GET /api/account/deletion",
+                "delete_account": "DELETE /api/account/deletion",
+            },
         },
-        'websocket': {
-            'url': f'ws://{request.host}/socket.io',
-            'events': {
-                'subscribe_positions': 'Subscribe to real-time position updates',
-                'subscribe_trades': 'Subscribe to real-time trade executions',
-                'position_update': 'Receive position updates',
-                'trade_execution': 'Receive trade notifications'
-            }
+        "rate_limits": {
+            "free": "10 requests/minute",
+            "basic": "30 requests/minute",
+            "pro": "100 requests/minute",
+            "enterprise": "300 requests/minute",
         },
-        'rate_limits': {
-            'free': '10 requests/minute',
-            'basic': '30 requests/minute',
-            'pro': '100 requests/minute',
-            'enterprise': '300 requests/minute'
-        }
     })
 
-
-# ========================================
-# Error Handlers
-# ========================================
 
 @app.errorhandler(404)
 def not_found(error):
-    """Handle 404 errors"""
     return jsonify({
-        'error': 'Endpoint not found',
-        'message': 'The requested endpoint does not exist',
-        'documentation': '/api/docs'
+        "error": "Endpoint not found",
+        "message": "The requested endpoint does not exist",
+        "documentation": "/api/docs",
     }), 404
 
 
 @app.errorhandler(500)
 def internal_error(error):
-    """Handle 500 errors"""
-    logger.error(f"Internal server error: {error}")
+    logger.error("Internal server error: %s", error)
     return jsonify({
-        'error': 'Internal server error',
-        'message': 'An unexpected error occurred',
-        'timestamp': datetime.utcnow().isoformat()
+        "error": "Internal server error",
+        "message": "An unexpected error occurred",
+        "timestamp": datetime.utcnow().isoformat(),
     }), 500
 
 
 @app.errorhandler(403)
 def forbidden(error):
-    """Handle 403 errors"""
     return jsonify({
-        'error': 'Forbidden',
-        'message': 'You do not have permission to access this resource',
-        'subscription_info': '/api/v1/subscription/tiers'
+        "error": "Forbidden",
+        "message": "You do not have permission to access this resource",
+        "subscription_info": "/api/v1/subscription/tiers",
     }), 403
 
 
-# ========================================
-# Main Entry Point
-# ========================================
+if __name__ == "__main__":
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", 5000))
+    debug = os.getenv("DEBUG", "false").lower() == "true"
 
-if __name__ == '__main__':
-    # Configuration
-    host = os.getenv('HOST', '0.0.0.0')
-    port = int(os.getenv('PORT', 5000))
-    debug = os.getenv('DEBUG', 'false').lower() == 'true'
-    
-    logger.info("=" * 60)
-    logger.info("NIJA Mobile-Ready Backend Server")
-    logger.info("=" * 60)
-    logger.info(f"Starting server on {host}:{port}")
-    logger.info(f"Debug mode: {debug}")
-    logger.info(f"Environment: {os.getenv('FLASK_ENV', 'development')}")
-    logger.info("=" * 60)
-    logger.info("\nRegistered Endpoints:")
-    logger.info("  Root: /")
-    logger.info("  Docs: /api/docs")
-    logger.info("  Health: /health, /healthz")
-    logger.info("  Status: /status")
-    logger.info("  Account deletion: /api/account/deletion")
-    logger.info("\nAPI Versions:")
-    logger.info("  v1: /api/v1/*")
-    logger.info("  Mobile: %s/*", MOBILE_API_BASE)
-    logger.info("  IAP: /api/iap/*")
-    logger.info("  Education: /api/education/*")
-    logger.info("\nWebSocket:")
-    logger.info(f"  Endpoint: ws://{host}:{port}/socket.io")
-    logger.info("=" * 60)
-    
-    # Start server with WebSocket support
+    logger.info("NIJA Mobile-Ready Backend Server starting on %s:%s", host, port)
+    logger.info("Environment: %s", os.getenv("FLASK_ENV", "development"))
     socketio.run(
         app,
         host=host,
         port=port,
         debug=debug,
         use_reloader=debug,
-        log_output=True
+        log_output=True,
     )

--- a/mobile_device_store.py
+++ b/mobile_device_store.py
@@ -1,0 +1,249 @@
+"""Persistent encrypted storage for mobile push-device registrations.
+
+Push tokens are sensitive credentials. This store never logs plaintext tokens and
+never returns them from normal list operations. Tokens are encrypted at rest with
+a stable application secret supplied through PUSH_TOKEN_ENCRYPTION_KEY or
+VAULT_ENCRYPTION_KEY.
+
+The SQLite file location is configurable with MOBILE_DEVICE_DB_PATH. Production
+deployments must place that path on durable storage (or replace this adapter with
+a database-backed implementation that preserves the same interface).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from security.secrets_manager import get_secret
+
+logger = logging.getLogger("nija.mobile_devices")
+
+_ALLOWED_PLATFORMS = {"ios", "android"}
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class MobileDeviceStore:
+    """Thread-safe encrypted push-token registry persisted to SQLite."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or os.getenv("MOBILE_DEVICE_DB_PATH", "mobile_devices.db")
+        self._write_lock = threading.RLock()
+        self._init_database()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=15)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_database(self) -> None:
+        parent = os.path.dirname(os.path.abspath(self.db_path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mobile_devices (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    device_id TEXT NOT NULL,
+                    platform TEXT NOT NULL,
+                    push_token_encrypted TEXT NOT NULL,
+                    push_token_hash TEXT NOT NULL,
+                    device_info_json TEXT NOT NULL DEFAULT '{}',
+                    registered_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE(user_id, device_id)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_mobile_devices_token_hash "
+                "ON mobile_devices(push_token_hash)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mobile_devices_user "
+                "ON mobile_devices(user_id)"
+            )
+
+    @staticmethod
+    def _cipher() -> Fernet:
+        secret = get_secret("PUSH_TOKEN_ENCRYPTION_KEY") or get_secret("VAULT_ENCRYPTION_KEY")
+        if not secret:
+            raise RuntimeError(
+                "Push-token persistence requires PUSH_TOKEN_ENCRYPTION_KEY or "
+                "VAULT_ENCRYPTION_KEY. Configure a stable secret before device registration."
+            )
+
+        raw = secret.encode("utf-8")
+        # Accept a native Fernet key when one is supplied; otherwise derive a
+        # stable Fernet key from the configured high-entropy application secret.
+        try:
+            return Fernet(raw)
+        except (ValueError, TypeError):
+            derived = hashlib.sha256(b"nija-push-token-v1:" + raw).digest()
+            return Fernet(base64.urlsafe_b64encode(derived))
+
+    @staticmethod
+    def _token_hash(push_token: str) -> str:
+        return hashlib.sha256(push_token.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _encrypt(cls, push_token: str) -> str:
+        return cls._cipher().encrypt(push_token.encode("utf-8")).decode("ascii")
+
+    @classmethod
+    def _decrypt(cls, encrypted: str) -> str:
+        try:
+            return cls._cipher().decrypt(encrypted.encode("ascii")).decode("utf-8")
+        except InvalidToken as exc:
+            raise RuntimeError(
+                "Stored push token cannot be decrypted with the configured encryption key"
+            ) from exc
+
+    def register_device(
+        self,
+        user_id: str,
+        device_id: str,
+        platform: str,
+        push_token: str,
+        device_info: Optional[Dict] = None,
+    ) -> None:
+        user_id = str(user_id or "").strip()
+        device_id = str(device_id or "").strip()
+        platform = str(platform or "").strip().lower()
+        push_token = str(push_token or "").strip()
+
+        if not user_id or not device_id or not push_token:
+            raise ValueError("user_id, device_id, and push_token are required")
+        if platform not in _ALLOWED_PLATFORMS:
+            raise ValueError("platform must be ios or android")
+        if len(device_id) > 512 or len(push_token) > 8192:
+            raise ValueError("device_id or push_token exceeds the allowed size")
+
+        encrypted = self._encrypt(push_token)
+        token_hash = self._token_hash(push_token)
+        info_json = json.dumps(device_info or {}, separators=(",", ":"), sort_keys=True)
+        now = _utcnow()
+
+        with self._write_lock, self._connect() as conn:
+            # Provider tokens can rotate or be reassigned after reinstall. A valid,
+            # authenticated registration owns the presented token from this point.
+            conn.execute(
+                "DELETE FROM mobile_devices WHERE push_token_hash = ? "
+                "AND NOT (user_id = ? AND device_id = ?)",
+                (token_hash, user_id, device_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO mobile_devices (
+                    user_id, device_id, platform, push_token_encrypted,
+                    push_token_hash, device_info_json, registered_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(user_id, device_id) DO UPDATE SET
+                    platform = excluded.platform,
+                    push_token_encrypted = excluded.push_token_encrypted,
+                    push_token_hash = excluded.push_token_hash,
+                    device_info_json = excluded.device_info_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    user_id,
+                    device_id,
+                    platform,
+                    encrypted,
+                    token_hash,
+                    info_json,
+                    now,
+                    now,
+                ),
+            )
+
+        logger.info("Mobile device registered user_id=%s device_id=%s platform=%s", user_id, device_id, platform)
+
+    def unregister_device(self, user_id: str, device_id: str) -> bool:
+        with self._write_lock, self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM mobile_devices WHERE user_id = ? AND device_id = ?",
+                (user_id, device_id),
+            )
+            deleted = cursor.rowcount > 0
+        if deleted:
+            logger.info("Mobile device unregistered user_id=%s device_id=%s", user_id, device_id)
+        return deleted
+
+    def list_devices(self, user_id: str, include_tokens: bool = False) -> List[Dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT device_id, platform, push_token_encrypted, device_info_json,
+                       registered_at, updated_at
+                FROM mobile_devices
+                WHERE user_id = ?
+                ORDER BY updated_at DESC
+                """,
+                (user_id,),
+            ).fetchall()
+
+        devices: List[Dict] = []
+        for row in rows:
+            try:
+                device_info = json.loads(row["device_info_json"] or "{}")
+            except (json.JSONDecodeError, TypeError):
+                device_info = {}
+            item = {
+                "device_id": row["device_id"],
+                "platform": row["platform"],
+                "device_info": device_info,
+                "registered_at": row["registered_at"],
+                "updated_at": row["updated_at"],
+            }
+            if include_tokens:
+                item["push_token"] = self._decrypt(row["push_token_encrypted"])
+            devices.append(item)
+        return devices
+
+    def delete_user_devices(self, user_id: str) -> int:
+        with self._write_lock, self._connect() as conn:
+            cursor = conn.execute("DELETE FROM mobile_devices WHERE user_id = ?", (user_id,))
+            deleted = max(cursor.rowcount, 0)
+        if deleted:
+            logger.info("Deleted %s mobile device registrations for user_id=%s", deleted, user_id)
+        return deleted
+
+    def count_devices(self, user_id: str) -> int:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS count FROM mobile_devices WHERE user_id = ?",
+                (user_id,),
+            ).fetchone()
+        return int(row["count"] if row else 0)
+
+
+_store: Optional[MobileDeviceStore] = None
+_store_lock = threading.Lock()
+
+
+def get_mobile_device_store(db_path: Optional[str] = None) -> MobileDeviceStore:
+    global _store
+    if db_path is not None:
+        return MobileDeviceStore(db_path=db_path)
+    with _store_lock:
+        if _store is None:
+            _store = MobileDeviceStore()
+        return _store
+
+
+__all__ = ["MobileDeviceStore", "get_mobile_device_store"]

--- a/push_notifications.py
+++ b/push_notifications.py
@@ -1,0 +1,129 @@
+"""Provider-neutral push notification architecture for NIJA mobile clients.
+
+The application can register APNs/FCM provider implementations later without
+changing mobile route logic. Until credentials/provider implementations are
+configured, delivery fails closed and reports ``not_configured`` rather than
+pretending a notification was sent.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol
+
+from mobile_device_store import get_mobile_device_store
+
+logger = logging.getLogger("nija.push")
+
+
+class PushProvider(Protocol):
+    def is_configured(self) -> bool: ...
+
+    def send(self, token: str, title: str, body: str, data: Dict[str, Any]) -> str: ...
+
+
+@dataclass
+class PushDeliveryResult:
+    requested: int = 0
+    sent: int = 0
+    failed: int = 0
+    not_configured: int = 0
+    invalid_devices: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "success": self.sent > 0 and self.failed == 0,
+            "requested": self.requested,
+            "sent": self.sent,
+            "failed": self.failed,
+            "not_configured": self.not_configured,
+        }
+
+
+class UnconfiguredPushProvider:
+    """Fail-closed placeholder used until APNs/FCM credentials are installed."""
+
+    def __init__(self, platform: str) -> None:
+        self.platform = platform
+
+    def is_configured(self) -> bool:
+        return False
+
+    def send(self, token: str, title: str, body: str, data: Dict[str, Any]) -> str:
+        raise RuntimeError(f"{self.platform} push provider is not configured")
+
+
+class PushNotificationService:
+    def __init__(self, providers: Optional[Dict[str, PushProvider]] = None) -> None:
+        self.providers: Dict[str, PushProvider] = providers or {
+            "ios": UnconfiguredPushProvider("APNs"),
+            "android": UnconfiguredPushProvider("FCM"),
+        }
+
+    def register_provider(self, platform: str, provider: PushProvider) -> None:
+        if platform not in {"ios", "android"}:
+            raise ValueError("platform must be ios or android")
+        self.providers[platform] = provider
+
+    def send_to_user(
+        self,
+        user_id: str,
+        title: str,
+        body: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> PushDeliveryResult:
+        devices = get_mobile_device_store().list_devices(user_id, include_tokens=True)
+        result = PushDeliveryResult(requested=len(devices))
+        payload = data or {}
+
+        for device in devices:
+            platform = device.get("platform")
+            provider = self.providers.get(str(platform))
+            if provider is None or not provider.is_configured():
+                result.not_configured += 1
+                continue
+
+            try:
+                status = provider.send(
+                    str(device["push_token"]), title, body, payload
+                )
+                if status == "invalid_token":
+                    result.failed += 1
+                    result.invalid_devices.append(str(device["device_id"]))
+                else:
+                    result.sent += 1
+            except Exception as exc:
+                result.failed += 1
+                logger.warning(
+                    "Push delivery failed user_id=%s device_id=%s platform=%s error=%s",
+                    user_id,
+                    device.get("device_id"),
+                    platform,
+                    type(exc).__name__,
+                )
+
+        # Provider-confirmed invalid tokens are revoked so they are not retried.
+        store = get_mobile_device_store()
+        for device_id in result.invalid_devices:
+            store.unregister_device(user_id, device_id)
+
+        return result
+
+
+_service: Optional[PushNotificationService] = None
+
+
+def get_push_notification_service() -> PushNotificationService:
+    global _service
+    if _service is None:
+        _service = PushNotificationService()
+    return _service
+
+
+__all__ = [
+    "PushProvider",
+    "PushDeliveryResult",
+    "PushNotificationService",
+    "get_push_notification_service",
+]

--- a/tests/test_mobile_device_store.py
+++ b/tests/test_mobile_device_store.py
@@ -1,0 +1,75 @@
+import os
+
+from mobile_device_store import MobileDeviceStore
+
+
+def _configure_key(monkeypatch):
+    monkeypatch.setenv(
+        "PUSH_TOKEN_ENCRYPTION_KEY",
+        "test-only-high-entropy-mobile-push-secret-that-is-stable",
+    )
+
+
+def test_push_token_persists_encrypted_across_store_instances(tmp_path, monkeypatch):
+    _configure_key(monkeypatch)
+    db_path = str(tmp_path / "devices.db")
+    token = "provider-token-super-secret"
+
+    first = MobileDeviceStore(db_path)
+    first.register_device("user-a", "device-1", "ios", token, {"model": "test"})
+
+    raw = open(db_path, "rb").read()
+    assert token.encode() not in raw
+
+    second = MobileDeviceStore(db_path)
+    public_devices = second.list_devices("user-a")
+    assert public_devices[0]["device_id"] == "device-1"
+    assert "push_token" not in public_devices[0]
+
+    internal_devices = second.list_devices("user-a", include_tokens=True)
+    assert internal_devices[0]["push_token"] == token
+
+
+def test_device_registration_is_user_scoped(tmp_path, monkeypatch):
+    _configure_key(monkeypatch)
+    store = MobileDeviceStore(str(tmp_path / "devices.db"))
+    store.register_device("user-a", "device-a", "android", "token-a")
+    store.register_device("user-b", "device-b", "ios", "token-b")
+
+    assert [d["device_id"] for d in store.list_devices("user-a")] == ["device-a"]
+    assert [d["device_id"] for d in store.list_devices("user-b")] == ["device-b"]
+
+
+def test_provider_token_reassignment_removes_old_owner(tmp_path, monkeypatch):
+    _configure_key(monkeypatch)
+    store = MobileDeviceStore(str(tmp_path / "devices.db"))
+    store.register_device("user-a", "old-device", "android", "rotating-token")
+    store.register_device("user-b", "new-device", "android", "rotating-token")
+
+    assert store.count_devices("user-a") == 0
+    assert store.count_devices("user-b") == 1
+
+
+def test_delete_user_devices_is_complete_and_idempotent(tmp_path, monkeypatch):
+    _configure_key(monkeypatch)
+    store = MobileDeviceStore(str(tmp_path / "devices.db"))
+    store.register_device("user-a", "device-1", "ios", "token-1")
+    store.register_device("user-a", "device-2", "android", "token-2")
+
+    assert store.delete_user_devices("user-a") == 2
+    assert store.count_devices("user-a") == 0
+    assert store.delete_user_devices("user-a") == 0
+
+
+def test_registration_requires_stable_encryption_secret(tmp_path, monkeypatch):
+    monkeypatch.delenv("PUSH_TOKEN_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("VAULT_ENCRYPTION_KEY", raising=False)
+    store = MobileDeviceStore(str(tmp_path / "devices.db"))
+
+    try:
+        store.register_device("user-a", "device-1", "ios", "token-1")
+        raised = False
+    except RuntimeError:
+        raised = True
+
+    assert raised is True

--- a/tests/test_mobile_security_contract.py
+++ b/tests/test_mobile_security_contract.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_mobile_api_has_no_in_memory_push_token_registry():
+    source = (ROOT / "mobile_api.py").read_text(encoding="utf-8")
+    assert "push_tokens = {}" not in source
+    assert "get_mobile_device_store" in source
+
+
+def test_sensitive_mobile_routes_are_authenticated():
+    source = (ROOT / "mobile_api.py").read_text(encoding="utf-8")
+    route_functions = [
+        "register_device",
+        "unregister_device",
+        "list_devices",
+        "send_notification",
+        "get_dashboard_summary",
+        "quick_toggle_trading",
+        "get_lightweight_positions",
+        "get_recent_trades",
+        "get_simulation_dashboard",
+        "get_recent_simulation_trades",
+    ]
+    for function_name in route_functions:
+        marker = f"@require_auth\ndef {function_name}"
+        assert marker in source, f"{function_name} must remain JWT protected"
+
+
+def test_deployed_gateway_fail_closes_mobile_namespaces():
+    source = (ROOT / "mobile_backend_server.py").read_text(encoding="utf-8")
+    assert '"/api/mobile/"' in source
+    assert '"/api/v1/"' in source
+    assert '"/api/account/"' in source
+    assert "get_user_database().get_user(user_id)" in source
+    assert 'return jsonify({"error": "Authentication required"}), 401' in source
+
+
+def test_account_deletion_covers_persistent_mobile_and_vault_data():
+    source = (ROOT / "account_deletion_api.py").read_text(encoding="utf-8")
+    assert "get_mobile_device_store().delete_user_devices" in source
+    assert "DELETE FROM credentials WHERE user_id" in source
+    assert "DELETE FROM audit_log WHERE user_id" in source
+    assert "user_permissions.pop(user_id" in source
+    assert "_delete_user_rules(user_id)" in source
+
+
+def test_native_push_registration_uses_bearer_auth():
+    source = (ROOT / "frontend/static/js/capacitor-init.js").read_text(encoding="utf-8")
+    assert "/api/mobile/device/register" in source
+    assert "Authorization': `Bearer ${token}`" in source
+    assert "appUrlOpen" in source
+    assert "Blocked untrusted deep link origin" in source


### PR DESCRIPTION
## Purpose

Production-hardening pass for NIJA mobile readiness.

## Changes

- JWT-protects user-scoped `/api/mobile/*` routes and derives identity from the authenticated token rather than trusting caller-supplied `user_id`.
- Adds a defense-in-depth authentication gate at the deployed `mobile_backend_server.py` for `/api/mobile/*`, `/api/v1/*`, and `/api/account/*`; deleted/disabled accounts are rejected immediately.
- Replaces volatile in-memory push-token storage with encrypted persistent SQLite device registrations.
- Adds provider-neutral push delivery architecture that fails closed until APNs/FCM credentials are configured.
- Expands account deletion across known NIJA-controlled mobile stores: auth/session/login records, encrypted broker vault credentials/audit rows, legacy credential cache, device registrations, permission state, runtime user cache, and persisted trading rules.
- Wires Capacitor push registration/unregistration to authenticated backend endpoints.
- Adds allowlisted native deep-link handling.
- Restricts default mobile CORS origins to NIJA web domains.
- Adds security/regression tests for persistence, encryption, isolation, revocation/deletion, route authentication, deletion coverage, and native registration/deep links.

## Deferred external validation

- Real APNs delivery and Apple credential validation.
- Real FCM delivery and Firebase credential validation.
- Apple/Google signing and device/domain association validation.

## App identity

The repository currently uses `com.nija.trading`. This PR does not invent a replacement permanent identifier; changing it should use the exact approved identifier before Apple/Google registration.

## Risk assessment

- Risk: medium-high (authentication/account lifecycle changes).
- No trading strategy, execution-authority, nonce, order-routing, or safety-gate logic is changed.
- Push delivery remains fail-closed until provider credentials are available.

## Rollback

Revert this PR. No trading-state migration is introduced. `mobile_devices.db` is additive and isolated from trading runtime state.

## Validation

- [x] Static security regression tests added.
- [x] Changes isolated from trading execution/runtime files.
- [ ] GitHub CI checks passed.
- [ ] APNs/FCM end-to-end device tests (requires credentials/devices).
- [ ] Apple/Google domain/signing validation (requires console registration).
