### PR TITLE
Finish mobile production hardening and lock permanent app ID

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,12 +1,12 @@
 {
-  "appId": "com.nija.trading",
+  "appId": "com.nijaaitrading.app",
   "appName": "NIJA",
   "webDir": "frontend",
   "bundledWebRuntime": true,
   "server": {
     "androidScheme": "https",
     "iosScheme": "https",
-    "hostname": "nija.app"
+    "hostname": "nijaaitrading.com"
   },
   "plugins": {
     "SplashScreen": {

--- a/mobile/android/config/AndroidManifest.xml.template
+++ b/mobile/android/config/AndroidManifest.xml.template
@@ -1,40 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.nija.trading">
+    package="com.nijaaitrading.app">
 
-    <!-- Permissions -->
-
-    <!-- Internet access for API calls (REQUIRED) -->
     <uses-permission android:name="android.permission.INTERNET" />
-
-    <!-- Network state for connectivity checks -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-
-    <!-- Push notifications (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <!-- Vibration for haptic feedback -->
     <uses-permission android:name="android.permission.VIBRATE" />
-
-    <!-- Camera for QR code scanning (OPTIONAL) -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
-
-    <!-- Storage for saving reports (OPTIONAL) -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29" />
-
-    <!-- Biometric authentication -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-
-    <!-- Wake lock for background updates -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <!-- Request legacy external storage for Android 10 -->
     <application
         android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
@@ -47,7 +27,6 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true">
 
-        <!-- Main Activity -->
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
@@ -62,17 +41,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep linking (optional) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https"
-                      android:host="nija.app" />
+                <data android:scheme="https" android:host="nijaaitrading.com" />
+                <data android:scheme="https" android:host="www.nijaaitrading.com" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="nija" />
             </intent-filter>
         </activity>
 
-        <!-- Firebase Cloud Messaging Service -->
         <service
             android:name=".FirebaseMessagingService"
             android:exported="false">
@@ -81,21 +65,8 @@
             </intent-filter>
         </service>
 
-        <!-- Default notification channel ID -->
-        <meta-data
-            android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="@string/default_notification_channel_id" />
-
-        <!-- Default notification icon -->
-        <meta-data
-            android:name="com.google.firebase.messaging.default_notification_icon"
-            android:resource="@drawable/ic_notification" />
-
-        <!-- Default notification color -->
-        <meta-data
-            android:name="com.google.firebase.messaging.default_notification_color"
-            android:resource="@color/colorAccent" />
-
+        <meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="@string/default_notification_channel_id" />
+        <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/ic_notification" />
+        <meta-data android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/colorAccent" />
     </application>
-
 </manifest>

--- a/mobile/deep_links/apple-app-site-association.template
+++ b/mobile/deep_links/apple-app-site-association.template
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "APPLE_TEAM_ID.com.nijaaitrading.app"
+        ],
+        "components": [
+          { "/": "/*", "comment": "Route NIJA HTTPS links into the native app." }
+        ]
+      }
+    ]
+  }
+}

--- a/mobile/deep_links/assetlinks.json.template
+++ b/mobile/deep_links/assetlinks.json.template
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.nijaaitrading.app",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_GOOGLE_PLAY_OR_RELEASE_CERT_SHA256"
+      ]
+    }
+  }
+]

--- a/mobile/ios/config/NIJA.entitlements.template
+++ b/mobile/ios/config/NIJA.entitlements.template
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:nijaaitrading.com</string>
+        <string>applinks:www.nijaaitrading.com</string>
+    </array>
+</dict>
+</plist>

--- a/setup-mobile.sh
+++ b/setup-mobile.sh
@@ -1,156 +1,67 @@
 #!/bin/bash
 
 # NIJA Mobile App Setup Script
-# This script helps initialize the Capacitor mobile app
+# Permanent application identifier: com.nijaaitrading.app
 
-set -e  # Exit on error
+set -e
 
 echo "======================================"
 echo "NIJA Mobile App Setup"
 echo "======================================"
-echo ""
 
-# Check prerequisites
-echo "Checking prerequisites..."
-
-# Check Node.js
-if ! command -v node &> /dev/null; then
-    echo "❌ Node.js is not installed. Please install Node.js 18+ from https://nodejs.org/"
+if ! command -v node >/dev/null 2>&1; then
+    echo "Node.js 18+ is required"
     exit 1
 fi
-
 NODE_VERSION=$(node -v | cut -d 'v' -f 2 | cut -d '.' -f 1)
 if [ "$NODE_VERSION" -lt 18 ]; then
-    echo "❌ Node.js version is too old. Please upgrade to Node.js 18+"
+    echo "Node.js 18+ is required"
+    exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm is required"
     exit 1
 fi
 
-echo "✅ Node.js $(node -v) found"
-
-# Check npm
-if ! command -v npm &> /dev/null; then
-    echo "❌ npm is not installed"
-    exit 1
-fi
-
-echo "✅ npm $(npm -v) found"
-
-# Install npm dependencies
-echo ""
-echo "Installing npm dependencies..."
 npm install
 
-echo "✅ Dependencies installed"
-
-# Initialize Capacitor
-echo ""
-echo "Initializing Capacitor..."
-
 if [ ! -d "ios" ]; then
-    echo "Adding iOS platform..."
     npm run cap:add:ios
-    echo "✅ iOS platform added"
-else
-    echo "✅ iOS platform already exists"
 fi
-
 if [ ! -d "android" ]; then
-    echo "Adding Android platform..."
     npm run cap:add:android
-    echo "✅ Android platform added"
-else
-    echo "✅ Android platform already exists"
 fi
-
-# Sync web assets
-echo ""
-echo "Syncing web assets with native projects..."
 npm run cap:sync
-echo "✅ Assets synced"
 
-# Check backend API availability (optional)
-echo ""
-echo "Checking backend API availability..."
 API_URL="${API_BASE_URL:-http://localhost:5000}"
-if command -v curl &> /dev/null; then
+if command -v curl >/dev/null 2>&1; then
     if curl -s -o /dev/null -w "%{http_code}" "$API_URL/health" | grep -q "200"; then
-        echo "✅ Backend API is reachable at $API_URL"
+        echo "Backend API reachable at $API_URL"
     else
-        echo "⚠️  Warning: Backend API not reachable at $API_URL"
-        echo "   Make sure the backend is running before testing the mobile app"
+        echo "Warning: backend API not reachable at $API_URL"
     fi
-else
-    echo "⚠️  curl not found - skipping API check"
 fi
 
-# Platform-specific instructions
 echo ""
-echo "======================================"
-echo "Platform-Specific Setup"
-echo "======================================"
+echo "Permanent app ID: com.nijaaitrading.app"
 echo ""
-
-# iOS setup
 if [ -d "ios" ]; then
-    echo "📱 iOS Setup:"
-    echo ""
-    echo "1. Ensure you have Xcode installed (macOS only)"
-    echo "2. Open the iOS project:"
-    echo "   npm run cap:open:ios"
-    echo ""
-    echo "3. In Xcode:"
-    echo "   - Select the App target"
-    echo "   - Update the Bundle Identifier (com.nija.trading)"
-    echo "   - Select your development team for code signing"
-    echo "   - Add required capabilities (Push Notifications, Background Modes)"
-    echo ""
-    echo "4. Update Info.plist with privacy descriptions"
-    echo "   (See mobile/ios/README.md for required keys)"
-    echo ""
+    echo "iOS:"
+    echo "  1. Open with: npm run cap:open:ios"
+    echo "  2. Confirm Bundle Identifier is com.nijaaitrading.app"
+    echo "  3. Select the Apple development team"
+    echo "  4. Enable Push Notifications and Associated Domains"
+    echo "  5. Add applinks:nijaaitrading.com and applinks:www.nijaaitrading.com"
+    echo "  6. Apply mobile/ios/config/NIJA.entitlements.template to the App target"
 fi
-
-# Android setup
 if [ -d "android" ]; then
-    echo "🤖 Android Setup:"
-    echo ""
-    echo "1. Ensure you have Android Studio installed"
-    echo "2. Open the Android project:"
-    echo "   npm run cap:open:android"
-    echo ""
-    echo "3. In Android Studio:"
-    echo "   - Update applicationId in app/build.gradle (com.nija.trading)"
-    echo "   - Generate a release keystore for signing"
-    echo "   - Add required permissions in AndroidManifest.xml"
-    echo ""
-    echo "4. Generate signing keystore:"
-    echo "   keytool -genkey -v -keystore android/release.keystore \\"
-    echo "     -alias nija-release -keyalg RSA -keysize 2048 -validity 10000"
-    echo ""
+    echo "Android:"
+    echo "  1. Open with: npm run cap:open:android"
+    echo "  2. Confirm applicationId/namespace is com.nijaaitrading.app"
+    echo "  3. Apply mobile/android/config/AndroidManifest.xml.template"
+    echo "  4. Host /.well-known/assetlinks.json after the Play signing SHA-256 is known"
+    echo "  5. Configure Firebase and release signing when credentials are available"
 fi
 
 echo ""
-echo "======================================"
-echo "Next Steps"
-echo "======================================"
-echo ""
-echo "1. Configure your API endpoint in frontend/static/js/app.js"
-echo ""
-echo "2. Test on iOS (macOS only):"
-echo "   npm run ios:build"
-echo ""
-echo "3. Test on Android:"
-echo "   npm run android:build"
-echo ""
-echo "4. Read the build guide for detailed instructions:"
-echo "   cat mobile/BUILD_GUIDE.md"
-echo ""
-echo "5. For App Store submission, see:"
-echo "   mobile/ios/README.md"
-echo "   mobile/android/README.md"
-echo ""
-echo "======================================"
-echo "✅ Setup Complete!"
-echo "======================================"
-echo ""
-echo "For support, visit: https://github.com/dantelrharrell-debug/Nija/issues"
-echo ""
+echo "Store identity is locked. Do not change com.nijaaitrading.app after registration."

--- a/tests/test_mobile_production_hardening.py
+++ b/tests/test_mobile_production_hardening.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from mobile_device_store import MobileDeviceStore
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_permanent_mobile_identifier_is_locked():
+    config = json.loads((ROOT / "capacitor.config.json").read_text(encoding="utf-8"))
+    assert config["appId"] == "com.nijaaitrading.app"
+    assert config["server"]["hostname"] == "nijaaitrading.com"
+
+
+def test_android_manifest_uses_permanent_identifier_and_verified_domain():
+    manifest = (ROOT / "mobile/android/config/AndroidManifest.xml.template").read_text(encoding="utf-8")
+    assert 'package="com.nijaaitrading.app"' in manifest
+    assert 'android:host="nijaaitrading.com"' in manifest
+    assert 'android:autoVerify="true"' in manifest
+
+
+def test_ios_entitlements_include_associated_domains():
+    entitlements = (ROOT / "mobile/ios/config/NIJA.entitlements.template").read_text(encoding="utf-8")
+    assert "applinks:nijaaitrading.com" in entitlements
+    assert "applinks:www.nijaaitrading.com" in entitlements
+
+
+def test_mobile_api_user_scoped_routes_require_authentication():
+    source = (ROOT / "mobile_api.py").read_text(encoding="utf-8")
+    protected_handlers = [
+        "register_device",
+        "unregister_device",
+        "list_devices",
+        "send_notification",
+        "get_dashboard_summary",
+        "quick_toggle_trading",
+        "get_lightweight_positions",
+        "get_recent_trades",
+    ]
+    for handler in protected_handlers:
+        marker = f"@require_auth\ndef {handler}"
+        assert marker in source, f"{handler} must remain protected by @require_auth"
+    assert "push_tokens = {}" not in source
+    assert "get_mobile_device_store" in source
+
+
+def test_mobile_device_store_persists_encrypts_and_deletes(monkeypatch, tmp_path):
+    monkeypatch.setenv("PUSH_TOKEN_ENCRYPTION_KEY", "test-only-stable-secret-do-not-use-in-production")
+    db_path = tmp_path / "devices.db"
+    store = MobileDeviceStore(str(db_path))
+    store.register_device(
+        user_id="user-a",
+        device_id="device-a",
+        platform="android",
+        push_token="secret-provider-token",
+        device_info={"model": "test"},
+    )
+
+    listed = store.list_devices("user-a")
+    assert len(listed) == 1
+    assert "push_token" not in listed[0]
+    assert b"secret-provider-token" not in db_path.read_bytes()
+
+    reopened = MobileDeviceStore(str(db_path))
+    assert reopened.count_devices("user-a") == 1
+    assert reopened.list_devices("user-a", include_tokens=True)[0]["push_token"] == "secret-provider-token"
+    assert reopened.delete_user_devices("user-a") == 1
+    assert reopened.count_devices("user-a") == 0
+
+
+def test_account_deletion_covers_mobile_store_vault_permissions_and_rules():
+    source = (ROOT / "account_deletion_api.py").read_text(encoding="utf-8")
+    required = [
+        "get_mobile_device_store().delete_user_devices(user_id)",
+        "_delete_persistent_vault_data(user_id)",
+        "_delete_legacy_broker_credentials(user_id)",
+        "_delete_user_rules(user_id)",
+        "get_permission_validator().user_permissions.pop(user_id, None)",
+        "_delete_auth_database_records(user_id)",
+    ]
+    for marker in required:
+        assert marker in source


### PR DESCRIPTION
Completes the remaining GitHub-side mobile hardening work:

- locks permanent app ID to `com.nijaaitrading.app`
- updates Android package/deep-link domains
- adds iOS push + Associated Domains entitlement template
- adds Apple universal-link and Android asset-link templates
- keeps account/mobile authentication and persistent encrypted push-token implementation covered by regression tests
- adds tests for app identity, endpoint auth, encrypted persistent device storage, and deletion coverage

External values intentionally remain placeholders until platform credentials exist: Apple Team ID, Android/Play signing SHA-256, APNs/FCM credentials, and physical-device/domain verification.