### PR TITLE
Keep unconfirmed ACK timeouts out of exchange reject telemetry

### DIFF
--- a/bot/exchange_reject_dispatch_provenance_v228_patch.py
+++ b/bot/exchange_reject_dispatch_provenance_v228_patch.py
@@ -1,4 +1,4 @@
-"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232/v247).
+"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232/v247/v253).
 
 Production on 2026-08-25 showed the canonical EXCHANGE_MONITOR stop holding a
 5/5 rejection window while the runtime was otherwise converged.  The execution
@@ -37,6 +37,20 @@ window itself is not persisted, the next clean process starts with an empty
 window and v226 can independently recover a persisted historical EXCHANGE_MONITOR
 latch only after all of its existing safety proofs pass.
 
+V253 closes an execution-outcome provenance mismatch observed on 2026-08-28.
+``ExecutionPipeline._reconcile_ack_timeout`` deliberately returns
+``confirmed_order_rejected:ack_timeout_no_confirmed_fill...`` when no confirmed
+broker acknowledgement/fill can be established inside the bounded ACK window.
+The existing soft-reject classifier already treats that and
+``terminal_reject_status:unfilled`` as operational/unconfirmed outcomes, but v228
+had not excluded those exact strings from exchange-rejection telemetry.  Five
+such synthetic results could therefore satisfy the 5/5 rejection-rate threshold
+without proving that an exchange rejected five submitted orders.  V253 excludes
+only those exact unconfirmed ACK/unfilled soft outcomes.  It does not treat them
+as success, does not establish execution/fill proof, does not clear an existing
+same-process window or kill switch, and does not suppress concrete exchange
+rejection responses.
+
 This patch never clears a kill switch, resets a rejection window, marks
 readiness, grants execution authority, fabricates broker ACK/fill proof, changes
 minimum notional/risk rules, or forces LIVE_ACTIVE.  A persisted historical
@@ -57,13 +71,15 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.exchange_reject_dispatch_provenance_v228")
 MARKER = "20260825-exchange-reject-dispatch-provenance-v228"
+V253_MARKER = "20260828-soft-timeout-rejection-provenance-v253"
 _FLAG = "NIJA_EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY"
 _PATCH_ATTR = "_nija_exchange_reject_dispatch_provenance_v228"
 _LOCK = threading.RLock()
 _THREAD: threading.Thread | None = None
 
 # These are outcomes that can be produced without a broker order ever reaching
-# an exchange.  They must never contribute to the exchange rejection-rate gate.
+# an exchange, or without any confirmed exchange rejection response. They must
+# never contribute to the exchange rejection-rate gate.
 _NON_EXCHANGE_MARKERS = (
     "dispatch_disabled",
     "executionauthority reject",
@@ -121,6 +137,12 @@ _NON_EXCHANGE_MARKERS = (
     "broker_dispatch_exception",
     "okx order failed",
     "all operations failed",
+    # V253: bounded ACK reconciliation could not establish a confirmed exchange
+    # ACK/fill/reject. These are explicitly soft/unconfirmed outcomes elsewhere
+    # in the pipeline and must not be promoted into exchange-rejection samples.
+    "confirmed_order_rejected:ack_timeout",
+    "ack_timeout_no_confirmed_fill",
+    "terminal_reject_status:unfilled",
 )
 
 
@@ -151,12 +173,14 @@ def _patch_execution_pipeline() -> bool:
     ) -> Any:
         if _is_non_exchange_rejection(reason):
             LOGGER.critical(
-                "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s "
+                "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s v253_marker=%s "
                 "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
                 "exchange_order_provenance=false route_guard_provenance_v232=true "
-                "lifecycle_provenance_v247=true kill_switch_unchanged=true "
-                "execution_authority_unchanged=true safety_gates_bypassed=false",
+                "lifecycle_provenance_v247=true soft_timeout_provenance_v253=true "
+                "kill_switch_unchanged=true execution_authority_unchanged=true "
+                "execution_proof_fabricated=false safety_gates_bypassed=false",
                 MARKER,
+                V253_MARKER,
                 str(symbol)[:64],
                 str(side)[:32],
                 str(reason)[:512],
@@ -192,9 +216,10 @@ def _worker() -> None:
             _register_manifest_if_loaded()
         except Exception as exc:
             LOGGER.warning(
-                "EXCHANGE_REJECT_V228_REASSERT_ERROR marker=%s err=%s:%s "
+                "EXCHANGE_REJECT_V228_REASSERT_ERROR marker=%s v253_marker=%s err=%s:%s "
                 "trading_fail_closed=true",
                 MARKER,
+                V253_MARKER,
                 type(exc).__name__,
                 exc,
             )
@@ -219,13 +244,15 @@ def install() -> bool:
             )
             _THREAD.start()
     LOGGER.critical(
-        "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s ready=true "
+        "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s v253_marker=%s ready=true "
         "local_predispatch_rejects_excluded=true route_guard_provenance_v232=true "
-        "lifecycle_provenance_v247=true real_exchange_path_unchanged=true "
-        "rejection_thresholds_unchanged=true rejection_window_not_cleared=true "
-        "kill_switch_unchanged=true execution_authority_unchanged=true "
+        "lifecycle_provenance_v247=true soft_timeout_provenance_v253=true "
+        "real_exchange_path_unchanged=true rejection_thresholds_unchanged=true "
+        "rejection_window_not_cleared=true kill_switch_unchanged=true "
+        "execution_authority_unchanged=true execution_proof_fabricated=false "
         "forced_activation=false safety_gates_bypassed=false",
         MARKER,
+        V253_MARKER,
     )
     return True
 
@@ -236,6 +263,7 @@ def install_import_hook() -> bool:
 
 __all__ = [
     "MARKER",
+    "V253_MARKER",
     "install",
     "install_import_hook",
     "_is_non_exchange_rejection",

--- a/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
+++ b/bot/tests/test_exchange_reject_dispatch_provenance_v228.py
@@ -61,9 +61,20 @@ def test_v232_classifier_covers_route_guard_soft_failures_without_exchange_proof
         assert v228._is_non_exchange_rejection(reason) is True
 
 
+def test_v253_classifier_covers_unconfirmed_ack_and_unfilled_soft_outcomes():
+    reasons = (
+        "confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s",
+        "ack_timeout_no_confirmed_fill",
+        "terminal_reject_status:unfilled",
+    )
+    for reason in reasons:
+        assert v228._is_non_exchange_rejection(reason) is True
+
+
 def test_classifier_does_not_swallow_unclassified_exchange_rejects():
     assert v228._is_non_exchange_rejection("Kraken AddOrder rejected: EOrder:Insufficient margin") is False
     assert v228._is_non_exchange_rejection("Coinbase order rejected: UNKNOWN_EXCHANGE_FAILURE") is False
+    assert v228._is_non_exchange_rejection("Coinbase order rejected: request timeout at exchange") is False
 
 
 def test_dispatch_disabled_does_not_mutate_exchange_rejection_window(tmp_path, monkeypatch):
@@ -106,6 +117,21 @@ def test_v232_route_soft_failure_does_not_mutate_exchange_rejection_window(tmp_p
         symbol="BTC-USD",
         side="buy",
         reason="broker_dispatch_failed:kraken:empty_order_result",
+    )
+
+    assert list(protector._order_results) == []
+
+
+def test_v253_unconfirmed_ack_timeout_does_not_mutate_exchange_rejection_window(tmp_path, monkeypatch):
+    protector = _protector(tmp_path)
+    monkeypatch.setattr(execution_pipeline, "get_exchange_kill_switch_protector", lambda: protector)
+    assert v228._patch_execution_pipeline()
+
+    execution_pipeline.ExecutionPipeline._emit_execution_rejection_telemetry(
+        _pipeline_stub(),
+        symbol="BTC-USD",
+        side="buy",
+        reason="confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s",
     )
 
     assert list(protector._order_results) == []


### PR DESCRIPTION
Production deployment `fef27424f93650e8aa1b18fe132b6eb91e2b7d08` showed the EXCHANGE_MONITOR stop active again with a current-process 5/5 rejection window. v250/v228/v224 were still installed, so this was not the old startup-ordering regression.

The remaining provenance gap is in bounded ACK reconciliation. `ExecutionPipeline._reconcile_ack_timeout` returns `confirmed_order_rejected:ack_timeout_no_confirmed_fill...` when NIJA cannot establish a confirmed broker ACK/fill within the timeout. The existing soft-reject classifier already treats this and `terminal_reject_status:unfilled` as operational/unconfirmed outcomes, but v228 did not exclude those exact strings from exchange rejection telemetry. Because the telemetry order ID is synthetic, five such unconfirmed outcomes could satisfy the 5/5 exchange-rejection threshold without proving five exchange rejects.

v253:
- excludes only `confirmed_order_rejected:ack_timeout*`, `ack_timeout_no_confirmed_fill`, and `terminal_reject_status:unfilled` from the exchange rejection rolling window;
- keeps these outcomes failed/unconfirmed and does not create ACK, fill, execution, nonce, or activation proof;
- does not clear the current rejection window or kill switch;
- preserves v226's verified fresh-process recovery requirements;
- preserves concrete exchange rejections, including Kraken/Coinbase rejection responses and generic exchange-side timeout messages;
- adds regression coverage for both exclusion and genuine-reject preservation.

No thresholds, risk gates, writer authority, broker execution, kill-switch deactivation, or forced activation behavior is changed.