### PR TITLE
Restore authoritative position-fetch recovery dispatch

### DIFF
--- a/bot/platform_position_sync_v108_patch.py
+++ b/bot/platform_position_sync_v108_patch.py
@@ -23,7 +23,10 @@ v108 breaks that liveness cycle without weakening safety:
   bootstrap, risk, kill-switch, or execution readiness is synthesized.
 
 This module deliberately does not add another ``builtins.__import__`` wrapper.
-A short-lived monitor patches MABM once it is loaded, then exits.
+A short-lived monitor patches MABM once it is loaded, then exits.  The MABM
+refresh hook is identified by its exact function owner rather than a copied
+``functools.wraps`` marker so later wrapper churn cannot silently detach the
+position-sync recovery dispatcher.
 """
 from __future__ import annotations
 
@@ -229,6 +232,31 @@ def dispatch_platform_position_sync(manager: Any, *, trigger: str) -> int:
     return started
 
 
+def _is_exact_refresh_hook(candidate: Any) -> bool:
+    """Return True only for the real v108 MABM refresh wrapper."""
+    if not callable(candidate) or not bool(getattr(candidate, _PATCH_ATTR, False)):
+        return False
+    owner = getattr(candidate, "__globals__", {}) or {}
+    return bool(
+        str(owner.get("MARKER", "")) == MARKER
+        and str(owner.get("__name__", "")).endswith("platform_position_sync_v108_patch")
+    )
+
+
+def _chain_has_exact_refresh_hook(callable_obj: Any) -> bool:
+    """Ignore markers copied by functools.wraps and prove v108 is in-chain."""
+    seen: set[int] = set()
+    current = callable_obj
+    for _ in range(32):
+        if not callable(current) or id(current) in seen:
+            return False
+        seen.add(id(current))
+        if _is_exact_refresh_hook(current):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
+
+
 def _patch_mabm(module: ModuleType) -> bool:
     cls = getattr(module, "MultiAccountBrokerManager", None)
     if not isinstance(cls, type):
@@ -236,10 +264,24 @@ def _patch_mabm(module: ModuleType) -> bool:
     current = getattr(cls, "refresh_capital_authority", None)
     if not callable(current):
         return False
-    if bool(getattr(current, _PATCH_ATTR, False)):
+    if _chain_has_exact_refresh_hook(current):
         return True
 
-    @wraps(current)
+    copied_marker = bool(getattr(current, _PATCH_ATTR, False))
+    if copied_marker:
+        try:
+            delattr(current, _PATCH_ATTR)
+        except Exception:
+            LOGGER.warning(
+                "PLATFORM_POSITION_SYNC_V108_COPIED_MARKER_CLEAR_FAILED marker=%s module=%s fail_closed=true",
+                MARKER,
+                module.__name__,
+            )
+            return False
+
+    original = current
+
+    @wraps(original)
     def refresh_capital_authority_v108(self: Any, *args: Any, **kwargs: Any):
         trigger = str(kwargs.get("trigger", args[0] if args else "refresh_capital_authority"))
         try:
@@ -252,15 +294,16 @@ def _patch_mabm(module: ModuleType) -> bool:
                 type(exc).__name__,
                 exc,
             )
-        return current(self, *args, **kwargs)
+        return original(self, *args, **kwargs)
 
     setattr(refresh_capital_authority_v108, _PATCH_ATTR, True)
-    setattr(refresh_capital_authority_v108, "__wrapped__", current)
+    setattr(refresh_capital_authority_v108, "__wrapped__", original)
     cls.refresh_capital_authority = refresh_capital_authority_v108  # type: ignore[assignment]
     LOGGER.critical(
-        "PLATFORM_POSITION_SYNC_V108_MABM_PATCHED marker=%s module=%s dispatch_before_capital_refresh=true capital_ready_dependency=false safety_gates_unchanged=true",
+        "PLATFORM_POSITION_SYNC_V108_MABM_PATCHED marker=%s module=%s dispatch_before_capital_refresh=true capital_ready_dependency=false exact_owner=true copied_marker_false_positive_blocked=true reasserted=%s safety_gates_unchanged=true",
         MARKER,
         module.__name__,
+        str(copied_marker).lower(),
     )
     return True
 
@@ -309,7 +352,7 @@ def install() -> bool:
         os.environ["NIJA_PLATFORM_POSITION_SYNC_V108_INSTALLED"] = "1"
         _INSTALLED = True
         LOGGER.critical(
-            "PLATFORM_POSITION_SYNC_V108_INSTALLED marker=%s direct_platform_dispatch=true capital_ready_dependency=false single_flight=true bounded_retry=true import_hook=false synthetic_empty_snapshot=false",
+            "PLATFORM_POSITION_SYNC_V108_INSTALLED marker=%s direct_platform_dispatch=true capital_ready_dependency=false single_flight=true bounded_retry=true import_hook=false synthetic_empty_snapshot=false exact_refresh_hook_owner=true",
             MARKER,
         )
         return True
@@ -328,5 +371,7 @@ __all__ = [
     "dispatch_platform_position_sync",
     "_connected_unsynced_platform_brokers",
     "_retry_policy",
+    "_is_exact_refresh_hook",
+    "_chain_has_exact_refresh_hook",
     "_patch_mabm",
 ]

--- a/bot/runtime_position_fetch_proof_v182_patch.py
+++ b/bot/runtime_position_fetch_proof_v182_patch.py
@@ -11,7 +11,9 @@ call chain.
 v182 repairs only that wrapper/proof handoff.  It identifies the exact v98
 wrapper by its function-owner globals, reasserts it on the canonical startup
 adopter when missing, makes platform discovery require both adoption and fetch
-proof, and fail-closes a worker that returns adopted without fetch proof.
+proof, fail-closes a worker that returns adopted without fetch proof, and
+reasserts the exact v108 MABM refresh dispatcher so a broker missing proof gets
+a real authoritative retry after later wrapper churn.
 
 No position, connectivity, capital, writer/nonce authority, kill switch, risk
 state, activation state, or execution permission is fabricated or promoted.
@@ -242,6 +244,46 @@ def _patch_worker() -> bool:
         return False
 
 
+def _reassert_v108_dispatch_hook() -> tuple[bool, str]:
+    """Restore the exact v108 MABM refresh dispatcher after wrapper churn."""
+    try:
+        v108 = _v108_module()
+        patch_loaded = getattr(v108, "_patch_loaded", None)
+        if not callable(patch_loaded):
+            return False, "v108_patch_loaded_unavailable"
+        ready = bool(patch_loaded())
+        if not ready:
+            return False, "v108_mabm_not_loaded_or_patch_failed"
+
+        exact = getattr(v108, "_chain_has_exact_refresh_hook", None)
+        if not callable(exact):
+            return False, "v108_exact_refresh_verifier_unavailable"
+
+        verified = False
+        for module_name in ("bot.multi_account_broker_manager", "multi_account_broker_manager"):
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+            cls = getattr(module, "MultiAccountBrokerManager", None)
+            current = getattr(cls, "refresh_capital_authority", None) if isinstance(cls, type) else None
+            if callable(current) and bool(exact(current)):
+                verified = True
+                break
+        if not verified:
+            return False, "exact_v108_refresh_hook_not_verified"
+
+        LOGGER.critical(
+            "POSITION_FETCH_PROOF_V182_V108_DISPATCH_REASSERTED marker=%s "
+            "exact_refresh_owner=true copied_marker_false_positive_blocked=true "
+            "authoritative_retry_only=true synthetic_success=false safety_gates_bypassed=false",
+            MARKER,
+        )
+        return True, "exact_v108_refresh_hook_ready"
+    except Exception as exc:
+        return False, f"v108_dispatch_reassert_error:{type(exc).__name__}:{exc}"
+
+
 def _patch_release_manifest() -> bool:
     try:
         manifest = importlib.import_module("bot.runtime_release_manifest_patch")
@@ -259,25 +301,28 @@ def install() -> bool:
         v98_ok, v98_detail = _reassert_v98_adopter()
         discovery_ok = _patch_discovery()
         worker_ok = _patch_worker()
+        dispatch_ok, dispatch_detail = _reassert_v108_dispatch_hook()
         manifest_ok = _patch_release_manifest()
-        ready = bool(v98_ok and discovery_ok and worker_ok and manifest_ok)
+        ready = bool(v98_ok and discovery_ok and worker_ok and dispatch_ok and manifest_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_POSITION_FETCH_PROOF_V182_FAILED marker=%s v98_ok=%s v98_detail=%s "
-                "discovery_ok=%s worker_ok=%s manifest_ok=%s trading_fail_closed=true",
+                "discovery_ok=%s worker_ok=%s dispatch_ok=%s dispatch_detail=%s manifest_ok=%s trading_fail_closed=true",
                 MARKER,
                 str(v98_ok).lower(),
                 v98_detail,
                 str(discovery_ok).lower(),
                 str(worker_ok).lower(),
+                str(dispatch_ok).lower(),
+                dispatch_detail,
                 str(manifest_ok).lower(),
             )
             return False
         LOGGER.critical(
             "RUNTIME_POSITION_FETCH_PROOF_V182 marker=%s ready=true exact_v98_owner_required=true "
-            "adopted_and_fetch_proof_required=true copied_marker_false_positive_blocked=true "
-            "synthetic_success=false forced_activation=false safety_gates_bypassed=false",
+            "adopted_and_fetch_proof_required=true exact_v108_refresh_hook_required=true "
+            "copied_marker_false_positive_blocked=true synthetic_success=false forced_activation=false safety_gates_bypassed=false",
             MARKER,
         )
         return True
@@ -297,5 +342,6 @@ __all__ = [
     "_connected_platform_brokers_requiring_proof",
     "_patch_discovery",
     "_patch_worker",
+    "_reassert_v108_dispatch_hook",
     "_patch_release_manifest",
 ]

--- a/tests/test_position_fetch_refresh_hook_v254.py
+++ b/tests/test_position_fetch_refresh_hook_v254.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import bot.platform_position_sync_v108_patch as v108
+import bot.runtime_position_fetch_proof_v182_patch as v182
+
+
+def test_v108_reasserts_exact_refresh_hook_when_marker_was_only_copied(monkeypatch):
+    calls: list[str] = []
+
+    def later_wrapper(self, *args, **kwargs):
+        return "refresh-ok"
+
+    # Simulate functools.wraps copying v108's marker onto a later wrapper even
+    # though the exact v108 owner is no longer in the active call chain.
+    setattr(later_wrapper, v108._PATCH_ATTR, True)
+
+    fake_module = ModuleType("bot.multi_account_broker_manager")
+
+    class MultiAccountBrokerManager:
+        refresh_capital_authority = later_wrapper
+
+    fake_module.MultiAccountBrokerManager = MultiAccountBrokerManager
+
+    assert v108._chain_has_exact_refresh_hook(later_wrapper) is False
+    monkeypatch.setattr(
+        v108,
+        "dispatch_platform_position_sync",
+        lambda manager, *, trigger: calls.append(trigger) or 1,
+    )
+
+    assert v108._patch_mabm(fake_module) is True
+    active = MultiAccountBrokerManager.refresh_capital_authority
+    assert v108._chain_has_exact_refresh_hook(active) is True
+
+    manager = MultiAccountBrokerManager()
+    assert manager.refresh_capital_authority(trigger="v254-test") == "refresh-ok"
+    assert calls == ["v254-test"]
+
+
+def test_v108_does_not_double_wrap_when_exact_hook_is_present(monkeypatch):
+    fake_module = ModuleType("bot.multi_account_broker_manager")
+
+    class MultiAccountBrokerManager:
+        def refresh_capital_authority(self, *args, **kwargs):
+            return "ok"
+
+    fake_module.MultiAccountBrokerManager = MultiAccountBrokerManager
+    monkeypatch.setattr(v108, "dispatch_platform_position_sync", lambda *args, **kwargs: 0)
+
+    assert v108._patch_mabm(fake_module) is True
+    first = MultiAccountBrokerManager.refresh_capital_authority
+    assert v108._chain_has_exact_refresh_hook(first) is True
+
+    assert v108._patch_mabm(fake_module) is True
+    assert MultiAccountBrokerManager.refresh_capital_authority is first
+
+
+def test_v182_reasserts_and_verifies_v108_refresh_dispatch(monkeypatch):
+    fake_mabm_module = ModuleType("bot.multi_account_broker_manager")
+
+    class MultiAccountBrokerManager:
+        def refresh_capital_authority(self, *args, **kwargs):
+            return None
+
+    fake_mabm_module.MultiAccountBrokerManager = MultiAccountBrokerManager
+    active_refresh = MultiAccountBrokerManager.refresh_capital_authority
+
+    fake_v108 = SimpleNamespace(
+        _patch_loaded=lambda: True,
+        _chain_has_exact_refresh_hook=lambda candidate: candidate is active_refresh,
+    )
+    monkeypatch.setattr(v182, "_v108_module", lambda: fake_v108)
+
+    real_import = v182.importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bot.multi_account_broker_manager":
+            return fake_mabm_module
+        if name == "multi_account_broker_manager":
+            raise ImportError(name)
+        return real_import(name)
+
+    monkeypatch.setattr(v182.importlib, "import_module", fake_import)
+
+    ready, detail = v182._reassert_v108_dispatch_hook()
+    assert ready is True
+    assert detail == "exact_v108_refresh_hook_ready"
+
+
+def test_v182_fails_closed_when_v108_refresh_dispatch_cannot_be_reasserted(monkeypatch):
+    fake_v108 = SimpleNamespace(
+        _patch_loaded=lambda: False,
+        _chain_has_exact_refresh_hook=lambda candidate: False,
+    )
+    monkeypatch.setattr(v182, "_v108_module", lambda: fake_v108)
+
+    ready, detail = v182._reassert_v108_dispatch_hook()
+    assert ready is False
+    assert detail == "v108_mabm_not_loaded_or_patch_failed"


### PR DESCRIPTION
## Summary
- make the v108 MABM capital-refresh hook verify its exact wrapper owner instead of trusting a marker copied by `functools.wraps`
- reassert and verify that exact v108 refresh dispatcher from the v182 position-fetch proof repair
- keep Coinbase/other platform brokers fail-closed until a real authoritative position fetch publishes `_startup_position_sync_fetch_ok=True`
- add regression tests for copied-marker wrapper churn, exact-hook idempotence, v182 reassertion, and fail-closed reassert failure

## Production evidence
Deployment `a3c8745ed1e49c4de426d62d13df9198502c412a` showed v96 reporting all three platform brokers adopted while v146 repeatedly corrected readiness to false. Kraken and OKX emitted independent v98 fetch proof; Coinbase did not. The same runtime showed no v108 recovery-worker log despite v182 being ready. This repair restores that missing liveness path without fabricating position sync, heartbeat, nonce, execution authority, or activation state.

## Safety
No writer, nonce, risk, kill-switch, capital, broker-health, minimum-notional, order, fill, or activation gate is bypassed. The genuine heartbeat execution marker remains owned by `TradingStrategy._persist_heartbeat_marker`.