### PR TITLE
Prevent startup soft rejects poisoning exchange kill-switch telemetry

### DIFF
--- a/bot/exchange_kill_switch_internal_reject_guard_patch.py
+++ b/bot/exchange_kill_switch_internal_reject_guard_patch.py
@@ -10,7 +10,9 @@ from typing import Any
 
 logger = logging.getLogger("nija.exchange_kill_switch_internal_reject_guard")
 _MARKER = "EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_PATCHED marker=20260706a"
+_V254_MARKER = "20260828-soft-reject-telemetry-v254"
 _PATCHED_ATTR = "_nija_exchange_kill_switch_internal_reject_guard_20260706a"
+_TELEMETRY_PATCHED_ATTR = "_nija_early_soft_reject_telemetry_v254"
 _TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _INTERNAL_REJECT_PATTERNS = (
     "no_execution_venue_available",
@@ -23,6 +25,26 @@ _INTERNAL_REJECT_PATTERNS = (
     "venue registry",
 )
 
+# These outcomes do not prove that an exchange rejected a submitted order.  The
+# guard is loaded by sitecustomize and patches ExecutionPipeline on first import,
+# so the protection exists before deferred startup repair modules run.
+_SOFT_NON_EXCHANGE_REASON_PATTERNS = (
+    "execution gate pending",
+    "state_machine=emergency_stop",
+    "state_machine=live_pending_confirmation",
+    "state_machine=off",
+    "dispatch_disabled",
+    "runtime authority convergence lost",
+    "executionauthority reject",
+    "execution_authority_blocked",
+    "execution_authority_runtime",
+    "lifecycle_phase:boot",
+    "lifecycle_phase_not_live",
+    "terminal_reject_status:unfilled",
+    "confirmed_order_rejected:ack_timeout",
+    "ack_timeout_no_confirmed_fill",
+)
+
 
 def _truthy(name: str, default: str = "true") -> bool:
     return str(os.environ.get(name, default)).strip().lower() in _TRUE
@@ -31,6 +53,11 @@ def _truthy(name: str, default: str = "true") -> bool:
 def _internal_reject(*values: Any) -> bool:
     text = " ".join(str(v or "") for v in values).lower()
     return any(pattern in text for pattern in _INTERNAL_REJECT_PATTERNS)
+
+
+def _soft_non_exchange_reason(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return bool(text) and any(pattern in text for pattern in _SOFT_NON_EXCHANGE_REASON_PATTERNS)
 
 
 def _patch_module(module: ModuleType) -> bool:
@@ -57,9 +84,52 @@ def _patch_module(module: ModuleType) -> bool:
         return original(self, order_id, accepted, *args, **kwargs)
 
     setattr(record_order_result, _PATCHED_ATTR, True)
+    setattr(record_order_result, "__wrapped__", original)
     setattr(cls, "record_order_result", record_order_result)
     logger.warning("%s class=ExchangeKillSwitchProtector", _MARKER)
     print("[NIJA-PRINT] EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_PATCHED marker=20260706a", flush=True)
+    return True
+
+
+def _patch_execution_pipeline_module(module: ModuleType) -> bool:
+    cls = getattr(module, "ExecutionPipeline", None)
+    if not isinstance(cls, type):
+        return False
+    original = getattr(cls, "_emit_execution_rejection_telemetry", None)
+    if not callable(original):
+        return False
+    if getattr(original, _TELEMETRY_PATCHED_ATTR, False):
+        return True
+
+    @wraps(original)
+    def _emit_execution_rejection_telemetry_v254(
+        self: Any,
+        *,
+        symbol: str,
+        side: str,
+        reason: str,
+    ) -> Any:
+        if _soft_non_exchange_reason(reason):
+            logger.warning(
+                "EARLY_SOFT_REJECT_TELEMETRY_IGNORED marker=%s symbol=%s side=%s "
+                "reason=%s exchange_sample_mutated=false kill_switch_unchanged=true "
+                "execution_authority_unchanged=true execution_proof_fabricated=false",
+                _V254_MARKER,
+                str(symbol)[:64],
+                str(side)[:32],
+                str(reason)[:512],
+            )
+            return None
+        return original(self, symbol=symbol, side=side, reason=reason)
+
+    setattr(_emit_execution_rejection_telemetry_v254, _TELEMETRY_PATCHED_ATTR, True)
+    setattr(_emit_execution_rejection_telemetry_v254, "__wrapped__", original)
+    setattr(cls, "_emit_execution_rejection_telemetry", _emit_execution_rejection_telemetry_v254)
+    logger.warning(
+        "EARLY_SOFT_REJECT_TELEMETRY_GUARD_PATCHED marker=%s module=%s",
+        _V254_MARKER,
+        getattr(module, "__name__", "unknown"),
+    )
     return True
 
 
@@ -72,9 +142,19 @@ def _try_patch_loaded() -> bool:
     return patched
 
 
+def _try_patch_execution_pipeline_loaded() -> bool:
+    patched = False
+    for name in ("bot.execution_pipeline", "execution_pipeline"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_execution_pipeline_module(module) or patched
+    return patched
+
+
 def install_import_hook() -> None:
     os.environ.setdefault("NIJA_EXCHANGE_KILL_SWITCH_IGNORE_INTERNAL_ROUTING_REJECTS", "true")
     _try_patch_loaded()
+    _try_patch_execution_pipeline_loaded()
     if getattr(builtins, "_NIJA_EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_HOOK", False):
         return
     original_import = builtins.__import__
@@ -82,17 +162,22 @@ def install_import_hook() -> None:
     def guarded_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
         module = original_import(name, globals, locals, fromlist, level)
         try:
-            if name.endswith("exchange_kill_switch"):
-                _try_patch_loaded()
-            else:
-                _try_patch_loaded()
+            _try_patch_loaded()
+            _try_patch_execution_pipeline_loaded()
         except Exception as exc:
-            logger.warning("EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD hook failed name=%s error=%s", name, exc)
+            logger.warning(
+                "EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD hook failed name=%s error=%s",
+                name,
+                exc,
+            )
         return module
 
     builtins.__import__ = guarded_import
     setattr(builtins, "_NIJA_EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_HOOK", True)
-    logger.warning("EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_IMPORT_HOOK marker=20260706a")
+    logger.warning(
+        "EXCHANGE_KILL_SWITCH_INTERNAL_REJECT_GUARD_IMPORT_HOOK marker=20260706a v254_marker=%s",
+        _V254_MARKER,
+    )
 
 
 def install() -> None:

--- a/bot/execution_soft_reject_classification_patch.py
+++ b/bot/execution_soft_reject_classification_patch.py
@@ -9,7 +9,9 @@ from typing import Any
 
 logger = logging.getLogger("nija.execution_soft_reject_classification")
 _MARKER = "20260709af"
+_V254_MARKER = "20260828-soft-reject-telemetry-v254"
 _PATCHED_ATTR = "_nija_execution_soft_reject_classification_20260709af"
+_TELEMETRY_PATCHED_ATTR = "_nija_soft_reject_telemetry_v254"
 
 _SOFT_REJECT_MARKERS = (
     "execution gate pending",
@@ -32,46 +34,102 @@ def _is_soft_operational_reject(error: Any) -> bool:
     return any(marker in text for marker in _SOFT_REJECT_MARKERS)
 
 
+def _patch_telemetry_boundary(cls: type) -> bool:
+    """Keep known local/unconfirmed soft outcomes out of exchange rejection telemetry.
+
+    This is deliberately an early defense-in-depth boundary.  Soft outcomes are
+    still returned as failures to callers; they are simply not promoted into the
+    ExchangeKillSwitchProtector order-rejection window unless a concrete exchange
+    rejection is independently observed elsewhere.
+    """
+    current = getattr(cls, "_emit_execution_rejection_telemetry", None)
+    if not callable(current):
+        return False
+    if getattr(current, _TELEMETRY_PATCHED_ATTR, False):
+        return True
+
+    @wraps(current)
+    def _emit_execution_rejection_telemetry_v254(
+        self: Any,
+        *,
+        symbol: str,
+        side: str,
+        reason: str,
+    ) -> Any:
+        if _is_soft_operational_reject(reason):
+            logger.warning(
+                "EXECUTION_SOFT_REJECT_TELEMETRY_IGNORED marker=%s legacy_marker=%s "
+                "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
+                "kill_switch_unchanged=true execution_proof_fabricated=false",
+                _V254_MARKER,
+                _MARKER,
+                str(symbol)[:64],
+                str(side)[:32],
+                str(reason)[:512],
+            )
+            return None
+        return current(self, symbol=symbol, side=side, reason=reason)
+
+    setattr(_emit_execution_rejection_telemetry_v254, _TELEMETRY_PATCHED_ATTR, True)
+    setattr(_emit_execution_rejection_telemetry_v254, "__wrapped__", current)
+    setattr(cls, "_emit_execution_rejection_telemetry", _emit_execution_rejection_telemetry_v254)
+    return True
+
+
 def _patch_module(module: ModuleType) -> bool:
     cls = getattr(module, "ExecutionPipeline", None)
     if not isinstance(cls, type):
         return False
+
+    telemetry_ok = _patch_telemetry_boundary(cls)
     original = getattr(cls, "_on_order_rejected", None)
-    if not callable(original) or getattr(original, _PATCHED_ATTR, False):
-        return bool(getattr(original, _PATCHED_ATTR, False))
+    if not callable(original):
+        return False
+    if getattr(original, _PATCHED_ATTR, False):
+        return telemetry_ok
 
     @wraps(original)
     def _on_order_rejected_soft(self: Any, request: Any, error: str, *args: Any, **kwargs: Any):
         if _is_soft_operational_reject(error):
-            try:
-                emit = getattr(self, "_emit_execution_rejection_telemetry", None)
-                if callable(emit):
-                    emit(
-                        symbol=getattr(request, "symbol", "unknown"),
-                        side=getattr(request, "side", "unknown"),
-                        reason=error or "soft operational reject",
-                    )
-            except Exception:
-                pass
+            # Do not emit exchange-rejection telemetry for a local/unconfirmed
+            # operational outcome.  The v254 telemetry wrapper above provides a
+            # second guard in case another caller invokes the telemetry method
+            # directly with the same soft reason.
             logger.warning(
-                "EXECUTION_SOFT_REJECT_CLASSIFIED marker=%s symbol=%s side=%s error=%s action=no_ecel_systemerror",
+                "EXECUTION_SOFT_REJECT_CLASSIFIED marker=%s v254_marker=%s symbol=%s "
+                "side=%s error=%s action=no_ecel_systemerror_no_exchange_sample",
                 _MARKER,
+                _V254_MARKER,
                 getattr(request, "symbol", "unknown"),
                 getattr(request, "side", "unknown"),
                 error,
             )
             print(
-                f"[NIJA-PRINT] EXECUTION_SOFT_REJECT_CLASSIFIED marker={_MARKER} symbol={getattr(request, 'symbol', 'unknown')} action=no_ecel_systemerror",
+                f"[NIJA-PRINT] EXECUTION_SOFT_REJECT_CLASSIFIED marker={_MARKER} "
+                f"v254_marker={_V254_MARKER} symbol={getattr(request, 'symbol', 'unknown')} "
+                "action=no_ecel_systemerror_no_exchange_sample",
                 flush=True,
             )
             return None
         return original(self, request, error, *args, **kwargs)
 
     setattr(_on_order_rejected_soft, _PATCHED_ATTR, True)
+    setattr(_on_order_rejected_soft, "__wrapped__", original)
     setattr(cls, "_on_order_rejected", _on_order_rejected_soft)
-    logger.warning("EXECUTION_SOFT_REJECT_CLASSIFICATION_PATCHED marker=%s module=%s", _MARKER, getattr(module, "__name__", "unknown"))
-    print(f"[NIJA-PRINT] EXECUTION_SOFT_REJECT_CLASSIFICATION_PATCHED marker={_MARKER}", flush=True)
-    return True
+    logger.warning(
+        "EXECUTION_SOFT_REJECT_CLASSIFICATION_PATCHED marker=%s v254_marker=%s module=%s "
+        "telemetry_guard=%s",
+        _MARKER,
+        _V254_MARKER,
+        getattr(module, "__name__", "unknown"),
+        str(telemetry_ok).lower(),
+    )
+    print(
+        f"[NIJA-PRINT] EXECUTION_SOFT_REJECT_CLASSIFICATION_PATCHED marker={_MARKER} "
+        f"v254_marker={_V254_MARKER} telemetry_guard={str(telemetry_ok).lower()}",
+        flush=True,
+    )
+    return telemetry_ok
 
 
 def _patch_loaded() -> None:
@@ -81,7 +139,13 @@ def _patch_loaded() -> None:
             try:
                 _patch_module(module)
             except Exception as exc:
-                logger.warning("EXECUTION_SOFT_REJECT_CLASSIFICATION_FAILED marker=%s module=%s err=%s", _MARKER, name, exc)
+                logger.warning(
+                    "EXECUTION_SOFT_REJECT_CLASSIFICATION_FAILED marker=%s v254_marker=%s module=%s err=%s",
+                    _MARKER,
+                    _V254_MARKER,
+                    name,
+                    exc,
+                )
 
 
 def install_import_hook() -> None:
@@ -98,7 +162,11 @@ def install_import_hook() -> None:
 
     builtins.__import__ = importing
     setattr(builtins, "_NIJA_EXECUTION_SOFT_REJECT_CLASSIFICATION_HOOK_20260709AF", True)
-    logger.warning("EXECUTION_SOFT_REJECT_CLASSIFICATION_IMPORT_HOOK marker=%s installed=true", _MARKER)
+    logger.warning(
+        "EXECUTION_SOFT_REJECT_CLASSIFICATION_IMPORT_HOOK marker=%s v254_marker=%s installed=true",
+        _MARKER,
+        _V254_MARKER,
+    )
 
 
 def install() -> None:

--- a/bot/tests/test_exchange_kill_switch_internal_reject_guard_v254.py
+++ b/bot/tests/test_exchange_kill_switch_internal_reject_guard_v254.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot import exchange_kill_switch_internal_reject_guard_patch as guard
+
+
+class FakeExecutionPipeline:
+    def __init__(self):
+        self.telemetry_calls = []
+
+    def _emit_execution_rejection_telemetry(self, *, symbol, side, reason):
+        self.telemetry_calls.append({"symbol": symbol, "side": side, "reason": reason})
+        return "original"
+
+
+def _pipeline():
+    module = SimpleNamespace(ExecutionPipeline=FakeExecutionPipeline, __name__="bot.execution_pipeline")
+    assert guard._patch_execution_pipeline_module(module) is True
+    return module.ExecutionPipeline()
+
+
+def test_v254_classifier_marks_unconfirmed_ack_timeout_non_exchange():
+    assert guard._soft_non_exchange_reason(
+        "confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s"
+    ) is True
+    assert guard._soft_non_exchange_reason("terminal_reject_status:unfilled") is True
+
+
+def test_v254_classifier_preserves_concrete_exchange_reject():
+    assert guard._soft_non_exchange_reason(
+        "Kraken AddOrder rejected: EOrder:Insufficient margin"
+    ) is False
+
+
+def test_startup_guard_suppresses_ack_timeout_exchange_telemetry():
+    pipeline = _pipeline()
+    result = pipeline._emit_execution_rejection_telemetry(
+        symbol="BTC-USD",
+        side="buy",
+        reason="confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s",
+    )
+    assert result is None
+    assert pipeline.telemetry_calls == []
+
+
+def test_startup_guard_suppresses_lifecycle_and_dispatch_local_blocks():
+    pipeline = _pipeline()
+    for reason in (
+        "dispatch_disabled: dispatch.enabled=false",
+        "Execution blocked: lifecycle_phase:BOOT",
+        "Execution gate pending (state_machine=EMERGENCY_STOP)",
+    ):
+        assert pipeline._emit_execution_rejection_telemetry(
+            symbol="ETH-USD",
+            side="sell",
+            reason=reason,
+        ) is None
+    assert pipeline.telemetry_calls == []
+
+
+def test_startup_guard_allows_concrete_exchange_rejection_to_original_boundary():
+    pipeline = _pipeline()
+    result = pipeline._emit_execution_rejection_telemetry(
+        symbol="BTC-USD",
+        side="buy",
+        reason="Kraken AddOrder rejected: EOrder:Insufficient margin",
+    )
+    assert result == "original"
+    assert len(pipeline.telemetry_calls) == 1

--- a/bot/tests/test_execution_soft_reject_classification_patch.py
+++ b/bot/tests/test_execution_soft_reject_classification_patch.py
@@ -8,39 +8,80 @@ from bot import execution_soft_reject_classification_patch as patch
 class FakePipeline:
     def __init__(self):
         self.original_called = False
+        self.telemetry_calls = []
 
     def _emit_execution_rejection_telemetry(self, **kwargs):
-        self.telemetry = kwargs
+        self.telemetry_calls.append(kwargs)
 
     def _on_order_rejected(self, request, error):
         self.original_called = True
         raise SystemError("ECEL FAILURE — INVALID ORDER ESCAPED")
 
 
-def test_emergency_stop_reject_is_soft_not_ecel_failure():
+def _patched_pipeline():
     module = SimpleNamespace(ExecutionPipeline=FakePipeline, __name__="bot.execution_pipeline")
     assert patch._patch_module(module) is True
-    pipeline = module.ExecutionPipeline()
+    return module.ExecutionPipeline()
+
+
+def test_emergency_stop_reject_is_soft_not_ecel_failure_or_exchange_sample():
+    pipeline = _patched_pipeline()
     request = SimpleNamespace(symbol="A-USD", side="buy")
 
-    assert pipeline._on_order_rejected(request, "Execution gate pending (state_machine=EMERGENCY_STOP)") is None
+    assert pipeline._on_order_rejected(
+        request,
+        "Execution gate pending (state_machine=EMERGENCY_STOP)",
+    ) is None
     assert pipeline.original_called is False
+    assert pipeline.telemetry_calls == []
 
 
-def test_terminal_unfilled_reject_is_soft_not_ecel_failure():
-    module = SimpleNamespace(ExecutionPipeline=FakePipeline, __name__="bot.execution_pipeline")
-    assert patch._patch_module(module) is True
-    pipeline = module.ExecutionPipeline()
+def test_terminal_unfilled_reject_is_soft_not_ecel_failure_or_exchange_sample():
+    pipeline = _patched_pipeline()
     request = SimpleNamespace(symbol="AXS-USD", side="buy")
 
     assert pipeline._on_order_rejected(request, "terminal_reject_status:unfilled") is None
     assert pipeline.original_called is False
+    assert pipeline.telemetry_calls == []
+
+
+def test_ack_timeout_reject_is_soft_not_exchange_sample():
+    pipeline = _patched_pipeline()
+    request = SimpleNamespace(symbol="BTC-USD", side="buy")
+
+    assert pipeline._on_order_rejected(
+        request,
+        "confirmed_order_rejected:ack_timeout_no_confirmed_fill_within_30s",
+    ) is None
+    assert pipeline.original_called is False
+    assert pipeline.telemetry_calls == []
+
+
+def test_direct_soft_telemetry_call_is_suppressed_by_v254_boundary():
+    pipeline = _patched_pipeline()
+
+    assert pipeline._emit_execution_rejection_telemetry(
+        symbol="BTC-USD",
+        side="buy",
+        reason="ack_timeout_no_confirmed_fill",
+    ) is None
+    assert pipeline.telemetry_calls == []
+
+
+def test_unknown_direct_telemetry_still_reaches_original_boundary():
+    pipeline = _patched_pipeline()
+
+    pipeline._emit_execution_rejection_telemetry(
+        symbol="BTC-USD",
+        side="buy",
+        reason="Kraken AddOrder rejected: EOrder:Insufficient margin",
+    )
+    assert len(pipeline.telemetry_calls) == 1
+    assert "Kraken AddOrder rejected" in pipeline.telemetry_calls[0]["reason"]
 
 
 def test_unknown_reject_still_uses_original_path():
-    module = SimpleNamespace(ExecutionPipeline=FakePipeline, __name__="bot.execution_pipeline")
-    assert patch._patch_module(module) is True
-    pipeline = module.ExecutionPipeline()
+    pipeline = _patched_pipeline()
     request = SimpleNamespace(symbol="AXS-USD", side="buy")
 
     try:


### PR DESCRIPTION
## Purpose

Fix the production deadlock shown in the 2026-08-28 runtime log: the runtime is otherwise converged and broker-connected, but the EXCHANGE_MONITOR kill switch remains active on a 5/5 current-process rejection window, which blocks the heartbeat execution marker and leaves authority/nonce/execution proofs false.

## Root cause addressed

V253 correctly classifies `confirmed_order_rejected:ack_timeout_no_confirmed_fill...` and `terminal_reject_status:unfilled` as unconfirmed/operational outcomes, but that protection was primarily installed through a later runtime wrapper. The native/early soft-reject path could still emit those outcomes into `ExchangeKillSwitchProtector.record_order_result()` during startup before the later wrapper was in place.

## Changes

- Extend the existing sitecustomize-loaded internal-reject guard so it patches `ExecutionPipeline._emit_execution_rejection_telemetry` on first import.
- Suppress only known local/unconfirmed soft outcomes from exchange rejection telemetry, including ACK timeout without confirmed fill, terminal unfilled, startup lifecycle, emergency-stop, dispatch-disabled, and authority-local blocks.
- Harden `execution_soft_reject_classification_patch` so soft operational rejects do not emit exchange-rejection telemetry before returning.
- Add regression tests proving soft/unconfirmed outcomes do not reach telemetry while concrete exchange rejects (for example Kraken `AddOrder rejected`) still pass through unchanged.

## Safety properties

- Does NOT clear the current rejection window.
- Does NOT deactivate the kill switch.
- Does NOT change rejection thresholds/minimum samples.
- Does NOT treat ACK timeout as success or fill proof.
- Does NOT grant authority, nonce, execution proof, or LIVE_ACTIVE.
- Does NOT suppress concrete exchange rejection responses.
- Existing v226 stale-latch recovery remains the only bounded automatic recovery path after a clean process starts with an empty in-memory order window and all required safety proofs pass.

## Expected post-deploy sequence

1. New process begins with empty in-memory rejection window.
2. Early v254 guard prevents local/unconfirmed startup outcomes from poisoning that window.
3. If the persisted EXCHANGE_MONITOR stop is truly historical and all v226 checks pass, v226 may clear that stale latch once.
4. Normal heartbeat must then earn genuine execution marker, nonce proof, authority proof, and execution readiness.
5. Any concrete broker/exchange rejection still counts normally and can re-trigger the kill switch.

## Validation

CI should run the targeted regression tests plus normal repository checks. No trading strategy/backtest changes are required because execution selection/strategy behavior is unchanged.