### PR TITLE
Harden exchange rejection provenance at recorder boundary

### DIFF
--- a/bot/exchange_reject_dispatch_provenance_v228_patch.py
+++ b/bot/exchange_reject_dispatch_provenance_v228_patch.py
@@ -1,61 +1,18 @@
-"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v232/v247/v253).
+"""Keep local/pre-dispatch failures out of exchange rejection telemetry (v228/v256).
 
-Production on 2026-08-25 showed the canonical EXCHANGE_MONITOR stop holding a
-5/5 rejection window while the runtime was otherwise converged.  The execution
-pipeline can return failures before a broker order is sent (for example
-``dispatch_disabled: dispatch.enabled=false``) and later route those failures
-through ``_on_order_rejected``.  The pipeline's synthetic telemetry order ID
-alone does not prove that an exchange saw or rejected an order.
+The exchange rejection-rate kill switch must only be fed by outcomes that are not
+known to be local/pre-dispatch failures. Earlier v228/v232/v247/v253 classifiers
+protected the pipeline telemetry emitter, but production proved that wrapper
+ordering could still leave a same-process 5/5 rejection window. V256 therefore
+adds a second, independent guard at ExchangeKillSwitchProtector.record_order_result
+and carries the rejection reason through ExecutionPipeline._on_order_rejected.
 
-V228 patches only the telemetry emission boundary.  Known local, authority,
-state-machine, liquidity, routing, risk, ECEL, disconnected-adapter and other
-pre-dispatch failures are logged as non-exchange outcomes and are not appended
-to ExchangeKillSwitchProtector's order-rejection window.  Errors that are not
-classified as local continue through the existing path unchanged, so genuine
-broker/exchange rejection telemetry, thresholds and fail-closed behavior remain
-intact.
-
-V232 closes a remaining route-guard provenance gap discovered after capital and
-position readiness converged. ``execution_route_integrity_patch`` deliberately
-classifies several route/adapter outcomes as soft dispatch failures, but those
-same strings could still be forwarded to this exchange-rejection telemetry
-boundary.  V232 therefore treats those unproven route/adapter outcomes as
-non-exchange results too.  Generic messages such as ``OKX order failed`` and
-``all operations failed`` are excluded because, by themselves, they do not prove
-that a broker submit reached an exchange or that an exchange returned a reject.
-A concrete exchange response such as ``Kraken AddOrder rejected: ...`` remains
-unclassified here and continues to count normally.
-
-V247 closes the startup-heartbeat lifecycle provenance gap.  A terminal
-execution-authority validator can legitimately fail closed with
-``lifecycle_phase:BOOT`` / ``lifecycle_phase_not_live`` before any broker submit
-has occurred.  Those canonical lifecycle denials are local pre-dispatch outcomes,
-not exchange rejections, so they must not poison the exchange rejection-rate
-window.  This change is deliberately prospective: it never deletes an existing
-same-process rejection sample whose provenance is unknown.  Because the rolling
-window itself is not persisted, the next clean process starts with an empty
-window and v226 can independently recover a persisted historical EXCHANGE_MONITOR
-latch only after all of its existing safety proofs pass.
-
-V253 closes an execution-outcome provenance mismatch observed on 2026-08-28.
-``ExecutionPipeline._reconcile_ack_timeout`` deliberately returns
-``confirmed_order_rejected:ack_timeout_no_confirmed_fill...`` when no confirmed
-broker acknowledgement/fill can be established inside the bounded ACK window.
-The existing soft-reject classifier already treats that and
-``terminal_reject_status:unfilled`` as operational/unconfirmed outcomes, but v228
-had not excluded those exact strings from exchange-rejection telemetry.  Five
-such synthetic results could therefore satisfy the 5/5 rejection-rate threshold
-without proving that an exchange rejected five submitted orders.  V253 excludes
-only those exact unconfirmed ACK/unfilled soft outcomes.  It does not treat them
-as success, does not establish execution/fill proof, does not clear an existing
-same-process window or kill switch, and does not suppress concrete exchange
-rejection responses.
-
-This patch never clears a kill switch, resets a rejection window, marks
-readiness, grants execution authority, fabricates broker ACK/fill proof, changes
-minimum notional/risk rules, or forces LIVE_ACTIVE.  A persisted historical
-rejection stop must still satisfy v226's independent recovery proof after a
-process restart.
+Known local/authority/lifecycle/routing/risk/ECEL/soft-ACK failures remain failed
+operations, but they are not exchange rejection samples. Unclassified outcomes
+continue through the existing path unchanged, so genuine exchange rejections,
+thresholds, and fail-closed behavior are preserved. The patch never clears an
+existing window or kill switch and never fabricates execution, nonce, ACK, fill,
+or readiness proof.
 """
 from __future__ import annotations
 
@@ -65,6 +22,7 @@ import os
 import sys
 import threading
 import time
+from collections import deque
 from functools import wraps
 from types import ModuleType
 from typing import Any
@@ -72,14 +30,15 @@ from typing import Any
 LOGGER = logging.getLogger("nija.exchange_reject_dispatch_provenance_v228")
 MARKER = "20260825-exchange-reject-dispatch-provenance-v228"
 V253_MARKER = "20260828-soft-timeout-rejection-provenance-v253"
+V256_MARKER = "20260828-rejection-recorder-provenance-v256"
 _FLAG = "NIJA_EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY"
 _PATCH_ATTR = "_nija_exchange_reject_dispatch_provenance_v228"
+_REJECT_HANDLER_PATCH_ATTR = "_nija_exchange_reject_reason_context_v256"
+_RECORDER_PATCH_ATTR = "_nija_exchange_reject_recorder_provenance_v256"
 _LOCK = threading.RLock()
 _THREAD: threading.Thread | None = None
+_CONTEXT = threading.local()
 
-# These are outcomes that can be produced without a broker order ever reaching
-# an exchange, or without any confirmed exchange rejection response. They must
-# never contribute to the exchange rejection-rate gate.
 _NON_EXCHANGE_MARKERS = (
     "dispatch_disabled",
     "executionauthority reject",
@@ -94,9 +53,6 @@ _NON_EXCHANGE_MARKERS = (
     "runtime authority convergence lost",
     "seak halted",
     "trading blocked",
-    # V247: canonical startup lifecycle denials happen before broker submit.
-    # Keep these exact authority-state tokens out of exchange telemetry while
-    # leaving unclassified broker/exchange rejection strings untouched.
     "lifecycle_phase:boot",
     "lifecycle_phase_not_live",
     "exchangekillswitch: exchange health red",
@@ -124,9 +80,6 @@ _NON_EXCHANGE_MARKERS = (
     "ecel reject:",
     "orderfeasibility deny",
     "postguard deny",
-    # V232: execution_route_integrity_patch classifies these as soft/local
-    # route outcomes.  None of these strings alone proves broker submission or
-    # an exchange-level reject response.
     "broker_dispatch_failed",
     "empty_order_result",
     "empty order result",
@@ -137,9 +90,6 @@ _NON_EXCHANGE_MARKERS = (
     "broker_dispatch_exception",
     "okx order failed",
     "all operations failed",
-    # V253: bounded ACK reconciliation could not establish a confirmed exchange
-    # ACK/fill/reject. These are explicitly soft/unconfirmed outcomes elsewhere
-    # in the pipeline and must not be promoted into exchange-rejection samples.
     "confirmed_order_rejected:ack_timeout",
     "ack_timeout_no_confirmed_fill",
     "terminal_reject_status:unfilled",
@@ -151,47 +101,143 @@ def _is_non_exchange_rejection(reason: Any) -> bool:
     return bool(text) and any(marker in text for marker in _NON_EXCHANGE_MARKERS)
 
 
+def _context_payload() -> dict[str, str]:
+    value = getattr(_CONTEXT, "rejection", None)
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _set_context(*, symbol: str, side: str, reason: str) -> dict[str, str]:
+    previous = _context_payload()
+    _CONTEXT.rejection = {
+        "symbol": str(symbol or "")[:64],
+        "side": str(side or "")[:32],
+        "reason": str(reason or "")[:1024],
+    }
+    return previous
+
+
+def _restore_context(previous: dict[str, str]) -> None:
+    if previous:
+        _CONTEXT.rejection = previous
+    elif hasattr(_CONTEXT, "rejection"):
+        delattr(_CONTEXT, "rejection")
+
+
+def _append_provenance(protector: Any, *, order_id: str, accepted: bool, context: dict[str, str]) -> None:
+    try:
+        history = getattr(protector, "_nija_order_result_provenance_v256", None)
+        if not isinstance(history, deque):
+            maxlen = int(getattr(getattr(protector, "_cfg", None), "order_window_size", 20) or 20)
+            history = deque(maxlen=max(5, maxlen))
+            setattr(protector, "_nija_order_result_provenance_v256", history)
+        history.append({
+            "timestamp": time.time(),
+            "order_id": str(order_id or "")[:256],
+            "accepted": bool(accepted),
+            "source": "execution_pipeline" if context else "direct_or_legacy",
+            "symbol": context.get("symbol", ""),
+            "side": context.get("side", ""),
+            "reason": context.get("reason", ""),
+            "known_non_exchange": _is_non_exchange_rejection(context.get("reason", "")) if context else False,
+        })
+    except Exception:
+        LOGGER.debug("V256 rejection provenance append failed", exc_info=True)
+
+
+def _patch_exchange_recorder() -> bool:
+    module = importlib.import_module("bot.exchange_kill_switch")
+    cls = getattr(module, "ExchangeKillSwitchProtector", None)
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "record_order_result", None)
+    if not callable(current):
+        return False
+    if getattr(current, _RECORDER_PATCH_ATTR, False):
+        return True
+    original = current
+
+    @wraps(original)
+    def record_order_result_v256(self: Any, order_id: str, accepted: bool, *args: Any, **kwargs: Any) -> Any:
+        context = _context_payload()
+        reason = context.get("reason", "")
+        if not bool(accepted) and reason and _is_non_exchange_rejection(reason):
+            _append_provenance(self, order_id=order_id, accepted=False, context=context)
+            LOGGER.critical(
+                "EXCHANGE_REJECT_V256_RECORDER_NON_EXCHANGE_IGNORED marker=%s v228_marker=%s "
+                "order_id=%s symbol=%s side=%s reason=%s exchange_sample_mutated=false "
+                "exchange_order_provenance=false rejection_window_unchanged=true kill_switch_unchanged=true "
+                "execution_authority_unchanged=true execution_proof_fabricated=false safety_gates_bypassed=false",
+                V256_MARKER, MARKER, str(order_id)[:256], context.get("symbol", ""),
+                context.get("side", ""), reason[:512],
+            )
+            return None
+        result = original(self, order_id, accepted, *args, **kwargs)
+        _append_provenance(self, order_id=order_id, accepted=bool(accepted), context=context)
+        return result
+
+    setattr(record_order_result_v256, _RECORDER_PATCH_ATTR, True)
+    setattr(record_order_result_v256, "__wrapped__", original)
+    setattr(cls, "record_order_result", record_order_result_v256)
+    return True
+
+
 def _patch_execution_pipeline() -> bool:
     module = importlib.import_module("bot.execution_pipeline")
     cls = getattr(module, "ExecutionPipeline", None)
     if not isinstance(cls, type):
         return False
 
+    current_reject = getattr(cls, "_on_order_rejected", None)
+    if callable(current_reject) and not getattr(current_reject, _REJECT_HANDLER_PATCH_ATTR, False):
+        original_reject = current_reject
+
+        @wraps(original_reject)
+        def on_order_rejected_v256(self: Any, request: Any, error: str) -> Any:
+            previous = _set_context(
+                symbol=str(getattr(request, "symbol", "unknown") or "unknown"),
+                side=str(getattr(request, "side", "unknown") or "unknown"),
+                reason=str(error or "unknown exchange rejection"),
+            )
+            try:
+                return original_reject(self, request, error)
+            finally:
+                _restore_context(previous)
+
+        setattr(on_order_rejected_v256, _REJECT_HANDLER_PATCH_ATTR, True)
+        setattr(on_order_rejected_v256, "__wrapped__", original_reject)
+        cls._on_order_rejected = on_order_rejected_v256
+
     current = getattr(cls, "_emit_execution_rejection_telemetry", None)
     if not callable(current):
         return False
-    if getattr(current, _PATCH_ATTR, False):
-        return True
+    if not getattr(current, _PATCH_ATTR, False):
+        original = current
 
-    @wraps(current)
-    def _emit_execution_rejection_telemetry_v228(
-        self: Any,
-        *,
-        symbol: str,
-        side: str,
-        reason: str,
-    ) -> Any:
-        if _is_non_exchange_rejection(reason):
-            LOGGER.critical(
-                "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s v253_marker=%s "
-                "symbol=%s side=%s reason=%s exchange_sample_mutated=false "
-                "exchange_order_provenance=false route_guard_provenance_v232=true "
-                "lifecycle_provenance_v247=true soft_timeout_provenance_v253=true "
-                "kill_switch_unchanged=true execution_authority_unchanged=true "
-                "execution_proof_fabricated=false safety_gates_bypassed=false",
-                MARKER,
-                V253_MARKER,
-                str(symbol)[:64],
-                str(side)[:32],
-                str(reason)[:512],
-            )
-            return None
-        return current(self, symbol=symbol, side=side, reason=reason)
+        @wraps(original)
+        def emit_v228(self: Any, *, symbol: str, side: str, reason: str) -> Any:
+            if _is_non_exchange_rejection(reason):
+                LOGGER.critical(
+                    "EXCHANGE_REJECT_V228_NON_EXCHANGE_IGNORED marker=%s v253_marker=%s v256_marker=%s "
+                    "symbol=%s side=%s reason=%s exchange_sample_mutated=false exchange_order_provenance=false "
+                    "route_guard_provenance_v232=true lifecycle_provenance_v247=true soft_timeout_provenance_v253=true "
+                    "recorder_guard_v256=true kill_switch_unchanged=true execution_authority_unchanged=true "
+                    "execution_proof_fabricated=false safety_gates_bypassed=false",
+                    MARKER, V253_MARKER, V256_MARKER, str(symbol)[:64], str(side)[:32], str(reason)[:512],
+                )
+                return None
+            previous = _set_context(symbol=symbol, side=side, reason=reason)
+            try:
+                return original(self, symbol=symbol, side=side, reason=reason)
+            finally:
+                _restore_context(previous)
 
-    setattr(_emit_execution_rejection_telemetry_v228, _PATCH_ATTR, True)
-    setattr(_emit_execution_rejection_telemetry_v228, "__wrapped__", current)
-    setattr(cls, "_emit_execution_rejection_telemetry", _emit_execution_rejection_telemetry_v228)
-    return True
+        setattr(emit_v228, _PATCH_ATTR, True)
+        setattr(emit_v228, "__wrapped__", original)
+        cls._emit_execution_rejection_telemetry = emit_v228
+
+    return bool(getattr(getattr(cls, "_emit_execution_rejection_telemetry", None), _PATCH_ATTR, False)) and bool(
+        getattr(getattr(cls, "_on_order_rejected", None), _REJECT_HANDLER_PATCH_ATTR, False)
+    )
 
 
 def _register_manifest_if_loaded() -> bool:
@@ -212,47 +258,38 @@ def _register_manifest_if_loaded() -> bool:
 def _worker() -> None:
     while True:
         try:
+            _patch_exchange_recorder()
             _patch_execution_pipeline()
             _register_manifest_if_loaded()
         except Exception as exc:
             LOGGER.warning(
-                "EXCHANGE_REJECT_V228_REASSERT_ERROR marker=%s v253_marker=%s err=%s:%s "
-                "trading_fail_closed=true",
-                MARKER,
-                V253_MARKER,
-                type(exc).__name__,
-                exc,
+                "EXCHANGE_REJECT_V228_REASSERT_ERROR marker=%s v256_marker=%s err=%s:%s trading_fail_closed=true",
+                MARKER, V256_MARKER, type(exc).__name__, exc,
             )
-        time.sleep(5.0)
+        time.sleep(2.0)
 
 
 def install() -> bool:
     global _THREAD
-    if not _patch_execution_pipeline():
-        os.environ[_FLAG] = "0"
+    recorder_ok = _patch_exchange_recorder()
+    pipeline_ok = _patch_execution_pipeline()
+    manifest_ok = _register_manifest_if_loaded()
+    ready = recorder_ok and pipeline_ok and manifest_ok
+    os.environ[_FLAG] = "1" if ready else "0"
+    if not ready:
         return False
-    if not _register_manifest_if_loaded():
-        os.environ[_FLAG] = "0"
-        return False
-    os.environ[_FLAG] = "1"
     with _LOCK:
         if _THREAD is None or not _THREAD.is_alive():
-            _THREAD = threading.Thread(
-                target=_worker,
-                name="ExchangeRejectDispatchProvenanceV228",
-                daemon=True,
-            )
+            _THREAD = threading.Thread(target=_worker, name="ExchangeRejectDispatchProvenanceV228", daemon=True)
             _THREAD.start()
     LOGGER.critical(
-        "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s v253_marker=%s ready=true "
-        "local_predispatch_rejects_excluded=true route_guard_provenance_v232=true "
-        "lifecycle_provenance_v247=true soft_timeout_provenance_v253=true "
-        "real_exchange_path_unchanged=true rejection_thresholds_unchanged=true "
-        "rejection_window_not_cleared=true kill_switch_unchanged=true "
-        "execution_authority_unchanged=true execution_proof_fabricated=false "
-        "forced_activation=false safety_gates_bypassed=false",
-        MARKER,
-        V253_MARKER,
+        "EXCHANGE_REJECT_DISPATCH_PROVENANCE_V228_READY marker=%s v253_marker=%s v256_marker=%s ready=true "
+        "local_predispatch_rejects_excluded=true route_guard_provenance_v232=true lifecycle_provenance_v247=true "
+        "soft_timeout_provenance_v253=true rejection_reason_context_v256=true recorder_boundary_guard_v256=true "
+        "provenance_history_v256=true real_exchange_path_unchanged=true rejection_thresholds_unchanged=true "
+        "rejection_window_not_cleared=true kill_switch_unchanged=true execution_authority_unchanged=true "
+        "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+        MARKER, V253_MARKER, V256_MARKER,
     )
     return True
 
@@ -262,10 +299,7 @@ def install_import_hook() -> bool:
 
 
 __all__ = [
-    "MARKER",
-    "V253_MARKER",
-    "install",
-    "install_import_hook",
-    "_is_non_exchange_rejection",
-    "_patch_execution_pipeline",
+    "MARKER", "V253_MARKER", "V256_MARKER", "install", "install_import_hook",
+    "_is_non_exchange_rejection", "_patch_execution_pipeline", "_patch_exchange_recorder",
+    "_context_payload",
 ]

--- a/tests/test_exchange_rejection_recorder_provenance_v256.py
+++ b/tests/test_exchange_rejection_recorder_provenance_v256.py
@@ -41,7 +41,7 @@ def _fake_modules(monkeypatch):
     return exchange, pipeline
 
 
-def test_v256_recorder_excludes_known_local_rejection(monkeypatch):
+def test_v256_emitter_excludes_known_local_rejection(monkeypatch):
     from bot import exchange_reject_dispatch_provenance_v228_patch as patch
 
     exchange, pipeline = _fake_modules(monkeypatch)
@@ -53,6 +53,26 @@ def test_v256_recorder_excludes_known_local_rejection(monkeypatch):
     request = type("Request", (), {"symbol": "BTC-USD", "side": "buy"})()
 
     worker._on_order_rejected(request, "dispatch_disabled: dispatch.enabled=false")
+
+    assert protector.samples == []
+
+
+def test_v256_recorder_fallback_excludes_known_local_rejection(monkeypatch):
+    from bot import exchange_reject_dispatch_provenance_v228_patch as patch
+
+    exchange, _pipeline = _fake_modules(monkeypatch)
+    assert patch._patch_exchange_recorder() is True
+
+    protector = exchange.ExchangeKillSwitchProtector()
+    previous = patch._set_context(
+        symbol="BTC-USD",
+        side="buy",
+        reason="dispatch_disabled: dispatch.enabled=false",
+    )
+    try:
+        protector.record_order_result("exec-reject:pipeline:BTC-USD:buy", False)
+    finally:
+        patch._restore_context(previous)
 
     assert protector.samples == []
     provenance = list(protector._nija_order_result_provenance_v256)

--- a/tests/test_exchange_rejection_recorder_provenance_v256.py
+++ b/tests/test_exchange_rejection_recorder_provenance_v256.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+
+def _fake_modules(monkeypatch):
+    exchange = ModuleType("bot.exchange_kill_switch")
+
+    class ExchangeKillSwitchProtector:
+        def __init__(self):
+            self.samples = []
+
+        def record_order_result(self, order_id: str, accepted: bool):
+            self.samples.append(bool(accepted))
+
+    exchange.ExchangeKillSwitchProtector = ExchangeKillSwitchProtector
+    monkeypatch.setitem(sys.modules, "bot.exchange_kill_switch", exchange)
+
+    pipeline = ModuleType("bot.execution_pipeline")
+
+    class ExecutionPipeline:
+        def __init__(self, protector):
+            self.protector = protector
+
+        def _emit_execution_rejection_telemetry(self, *, symbol: str, side: str, reason: str):
+            self.protector.record_order_result(
+                order_id=f"exec-reject:pipeline:{symbol}:{side}",
+                accepted=False,
+            )
+
+        def _on_order_rejected(self, request, error: str):
+            self._emit_execution_rejection_telemetry(
+                symbol=request.symbol,
+                side=request.side,
+                reason=error,
+            )
+
+    pipeline.ExecutionPipeline = ExecutionPipeline
+    monkeypatch.setitem(sys.modules, "bot.execution_pipeline", pipeline)
+    return exchange, pipeline
+
+
+def test_v256_recorder_excludes_known_local_rejection(monkeypatch):
+    from bot import exchange_reject_dispatch_provenance_v228_patch as patch
+
+    exchange, pipeline = _fake_modules(monkeypatch)
+    assert patch._patch_exchange_recorder() is True
+    assert patch._patch_execution_pipeline() is True
+
+    protector = exchange.ExchangeKillSwitchProtector()
+    worker = pipeline.ExecutionPipeline(protector)
+    request = type("Request", (), {"symbol": "BTC-USD", "side": "buy"})()
+
+    worker._on_order_rejected(request, "dispatch_disabled: dispatch.enabled=false")
+
+    assert protector.samples == []
+    provenance = list(protector._nija_order_result_provenance_v256)
+    assert len(provenance) == 1
+    assert provenance[0]["known_non_exchange"] is True
+    assert "dispatch_disabled" in provenance[0]["reason"]
+
+
+def test_v256_recorder_preserves_unclassified_exchange_rejection(monkeypatch):
+    from bot import exchange_reject_dispatch_provenance_v228_patch as patch
+
+    exchange, pipeline = _fake_modules(monkeypatch)
+    assert patch._patch_exchange_recorder() is True
+    assert patch._patch_execution_pipeline() is True
+
+    protector = exchange.ExchangeKillSwitchProtector()
+    worker = pipeline.ExecutionPipeline(protector)
+    request = type("Request", (), {"symbol": "ETH-USD", "side": "buy"})()
+
+    reason = "Kraken AddOrder rejected: EOrder:Insufficient funds"
+    worker._on_order_rejected(request, reason)
+
+    assert protector.samples == [False]
+    provenance = list(protector._nija_order_result_provenance_v256)
+    assert len(provenance) == 1
+    assert provenance[0]["known_non_exchange"] is False
+    assert provenance[0]["reason"] == reason
+
+
+def test_v256_classifier_keeps_soft_ack_timeout_out_of_exchange_window():
+    from bot import exchange_reject_dispatch_provenance_v228_patch as patch
+
+    assert patch._is_non_exchange_rejection(
+        "confirmed_order_rejected:ack_timeout_no_confirmed_fill"
+    ) is True
+    assert patch._is_non_exchange_rejection(
+        "Kraken AddOrder rejected: EOrder:Insufficient funds"
+    ) is False


### PR DESCRIPTION
## Summary
- carry the real `_on_order_rejected` reason through the execution telemetry path
- guard `ExchangeKillSwitchProtector.record_order_result` against known local/pre-dispatch/soft-ACK failures
- preserve all unclassified/genuine exchange rejection behavior and thresholds
- retain a bounded provenance history for accepted/rejected samples
- never clear the existing rejection window or kill switch, and never fabricate execution/nonce/ACK/fill/readiness proof

## Production evidence
Runtime remains healthy across Kraken/Coinbase/OKX and position sync, but the global stop is still latched by `EXCHANGE_MONITOR` at 5/5 current-process rejection samples. The heartbeat's later `dispatch_disabled` failure is correctly classified as non-exchange, proving the current stop is upstream of that heartbeat attempt.

## Tests
Adds focused regression tests proving:
1. `dispatch_disabled` does not append a rejection sample,
2. an unclassified concrete Kraken AddOrder rejection still appends `False`, and
3. ACK-timeout/no-confirmed-fill remains non-exchange.