### PR TITLE
Add all-account connectivity truth v266

### DIFF
--- a/bot/all_account_connectivity_truth_v266_patch.py
+++ b/bot/all_account_connectivity_truth_v266_patch.py
@@ -1,23 +1,19 @@
-"""All-account connectivity truth and recovery liveness v266.
+"""All-account connectivity truth v266.
 
-The platform can remain safely LIVE_ACTIVE while an isolated user account is
-unavailable.  The remaining production gap was narrower: the canonical live
-broker reconciler reported only aggregate user counts and did not explicitly
-pulse the already-installed v86/v90 authenticated Kraken-user recovery chain.
-That made a persistent 1/2 user snapshot ambiguous even though the recovery
-machinery itself was present.
+NIJA may remain safely LIVE_ACTIVE while an isolated user account is
+unavailable. The production gap addressed here is observability: v86/v90
+already own authenticated Kraken-user rebuild/reconnect behavior, but a stable
+1/2 aggregate connectivity snapshot does not reveal whether the unavailable
+account is in backoff, missing credentials, unavailable, or reconnecting.
 
-This patch does two things without weakening any safety gate:
-
-* every live-broker reconciliation pass performs one best-effort v86/v90 user
-  reconciliation pulse before publishing the connectivity snapshot; and
-* v86 reconciliation emits a state-sensitive diagnostic including the existing
-  per-account recovery state plus canonical failed/missing-credential counts.
+This patch wraps the existing v86 reconciliation call only to emit a
+state-sensitive diagnostic containing the existing per-account recovery state
+and canonical failed/missing-credential counts. It does not add another
+reconciliation call, reconnect attempt, broker I/O path, or retry cadence.
 
 No credentials, connected flags, trading eligibility, balances, writer proof,
-nonce state, execution authority, kill-switch state, or platform readiness are
-fabricated.  User failures remain isolated and never become a reason to force
-or revoke global LIVE_ACTIVE by this patch.
+nonce state, execution authority, kill-switch state, platform readiness, order,
+or fill state are fabricated or changed.
 """
 from __future__ import annotations
 
@@ -25,8 +21,6 @@ import logging
 import os
 import sys
 import threading
-import time
-from types import ModuleType
 from typing import Any
 
 from bot import kraken_all_account_supervision_v86 as v86
@@ -36,9 +30,7 @@ LOGGER = logging.getLogger("nija.all_account_connectivity_truth_v266")
 MARKER = "20260828-all-account-connectivity-truth-v266"
 _LOCK = threading.RLock()
 _INSTALLED = False
-_MONITOR_STARTED = False
 _ORIGINAL_V86_RECONCILE = None
-_PATCHED_V25_IDS: set[int] = set()
 _LAST_STATE_SIGNATURE = ""
 
 
@@ -99,8 +91,9 @@ def _emit_state(manager: Any, state: dict[str, Any], *, source: str) -> None:
     log(
         "ALL_ACCOUNT_CONNECTIVITY_V266_STATE marker=%s source=%s registered=%s "
         "connected=%s disconnected=%s recovery_reason=%s states=%s "
-        "user_failures=%s user_without_credentials=%s authenticated_only=true "
-        "fabricated_connected=false fabricated_credentials=false "
+        "user_failures=%s user_without_credentials=%s authenticated_recovery_owner=v86_v90 "
+        "extra_broker_io=false retry_cadence_unchanged=true fabricated_connected=false "
+        "fabricated_credentials=false trading_eligibility_unchanged=true "
         "platform_live_state_unchanged=true user_failure_isolated=true",
         MARKER,
         source,
@@ -126,6 +119,8 @@ def _patch_v86_reconcile() -> bool:
     _ORIGINAL_V86_RECONCILE = original
 
     def _reconcile_once(manager: Any = None) -> dict[str, Any]:
+        # Exactly one call to the pre-existing v86/v90 path. v266 observes its
+        # result only; it does not add broker I/O or change recovery policy.
         state = original(manager)
         observed_manager = manager if manager is not None else _canonical_manager()
         if isinstance(state, dict):
@@ -138,107 +133,25 @@ def _patch_v86_reconcile() -> bool:
     return True
 
 
-def _pulse_user_recovery(manager: Any) -> dict[str, Any]:
-    """Run one existing v86/v90 recovery pass; never synthesize readiness."""
-    try:
-        state = v86.reconcile_once(manager)
-    except Exception as exc:
-        LOGGER.warning(
-            "ALL_ACCOUNT_CONNECTIVITY_V266_PULSE_FAILED marker=%s error=%s:%s "
-            "isolated=true platform_live_state_unchanged=true",
-            MARKER,
-            type(exc).__name__,
-            exc,
-        )
-        return {"ok": False, "reason": f"reconcile_error:{type(exc).__name__}", "states": {}}
-    return state if isinstance(state, dict) else {"ok": False, "reason": "invalid_reconcile_state", "states": {}}
-
-
-def _patch_live_broker_reconciler(module: ModuleType) -> bool:
-    module_id = id(module)
-    with _LOCK:
-        if module_id in _PATCHED_V25_IDS:
-            return True
-    original = getattr(module, "_reconcile_brokers_once", None)
-    if not callable(original):
-        return False
-    if getattr(original, "_nija_v266_user_recovery_pulse", False):
-        with _LOCK:
-            _PATCHED_V25_IDS.add(module_id)
-        return True
-
-    def _reconcile_brokers_once() -> dict[str, bool]:
-        manager_getter = getattr(module, "_manager", None)
-        manager = manager_getter() if callable(manager_getter) else _canonical_manager()
-        state = _pulse_user_recovery(manager)
-        _emit_state(manager, state, source="live_broker_reconcile")
-        # Preserve v25 as the sole owner of platform connectivity publication,
-        # broker registration, and exit-supervisor reconciliation.
-        return original()
-
-    setattr(_reconcile_brokers_once, "_nija_v266_user_recovery_pulse", True)
-    setattr(_reconcile_brokers_once, "_nija_v266_original", original)
-    module._reconcile_brokers_once = _reconcile_brokers_once
-    with _LOCK:
-        _PATCHED_V25_IDS.add(module_id)
-    LOGGER.critical(
-        "ALL_ACCOUNT_CONNECTIVITY_V266_V25_PATCHED marker=%s module=%s "
-        "authenticated_recovery_pulse=true platform_connectivity_return_unchanged=true "
-        "user_failure_isolated=true safety_gates_bypassed=false",
-        MARKER,
-        getattr(module, "__name__", "unknown"),
-    )
-    return True
-
-
-def _try_patch_v25_loaded() -> bool:
-    patched = False
-    for name in ("bot.live_broker_profit_exit_convergence_v25", "live_broker_profit_exit_convergence_v25"):
-        module = sys.modules.get(name)
-        if isinstance(module, ModuleType):
-            patched = _patch_live_broker_reconciler(module) or patched
-    return patched
-
-
-def _monitor() -> None:
-    deadline = time.monotonic() + 600.0
-    while time.monotonic() < deadline:
-        _patch_v86_reconcile()
-        if _try_patch_v25_loaded():
-            return
-        time.sleep(0.25)
-    LOGGER.warning(
-        "ALL_ACCOUNT_CONNECTIVITY_V266_MONITOR_EXPIRED marker=%s v86_patched=%s "
-        "platform_live_state_unchanged=true",
-        MARKER,
-        bool(getattr(getattr(v86, "reconcile_once", None), "_nija_v266_connectivity_truth", False)),
-    )
-
-
 def install_import_hook() -> bool:
-    global _INSTALLED, _MONITOR_STARTED
-    _patch_v86_reconcile()
-    _try_patch_v25_loaded()
+    global _INSTALLED
+    patched = _patch_v86_reconcile()
     with _LOCK:
-        if not _MONITOR_STARTED:
-            _MONITOR_STARTED = True
-            threading.Thread(
-                target=_monitor,
-                name="AllAccountConnectivityTruthV266",
-                daemon=True,
-            ).start()
-        _INSTALLED = True
-    os.environ["NIJA_ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_INSTALLED"] = "1"
+        _INSTALLED = bool(patched)
+    if patched:
+        os.environ["NIJA_ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_INSTALLED"] = "1"
     LOGGER.critical(
-        "ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_READY marker=%s ready=true "
+        "ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_READY marker=%s ready=%s "
         "v86_state_sensitive_diagnostics=true v90_recovery_path_preserved=true "
-        "live_broker_recovery_pulse=true credentials_fabricated=false "
-        "connected_fabricated=false trading_eligibility_fabricated=false "
-        "platform_live_state_unchanged=true kill_switch_unchanged=true "
-        "writer_nonce_risk_capital_order_fill_gates_unchanged=true safety_gates_bypassed=false",
+        "extra_reconcile_calls=false extra_broker_io=false retry_cadence_unchanged=true "
+        "credentials_fabricated=false connected_fabricated=false "
+        "trading_eligibility_unchanged=true platform_live_state_unchanged=true "
+        "kill_switch_unchanged=true writer_nonce_risk_capital_order_fill_gates_unchanged=true "
+        "safety_gates_bypassed=false",
         MARKER,
+        str(bool(patched)).lower(),
     )
-    return True
+    return bool(patched)
 
 
 def install() -> bool:
@@ -249,7 +162,7 @@ __all__ = [
     "MARKER",
     "install",
     "install_import_hook",
-    "_pulse_user_recovery",
-    "_patch_live_broker_reconciler",
     "_patch_v86_reconcile",
+    "_registry_counts",
+    "_state_signature",
 ]

--- a/bot/all_account_connectivity_truth_v266_patch.py
+++ b/bot/all_account_connectivity_truth_v266_patch.py
@@ -1,0 +1,255 @@
+"""All-account connectivity truth and recovery liveness v266.
+
+The platform can remain safely LIVE_ACTIVE while an isolated user account is
+unavailable.  The remaining production gap was narrower: the canonical live
+broker reconciler reported only aggregate user counts and did not explicitly
+pulse the already-installed v86/v90 authenticated Kraken-user recovery chain.
+That made a persistent 1/2 user snapshot ambiguous even though the recovery
+machinery itself was present.
+
+This patch does two things without weakening any safety gate:
+
+* every live-broker reconciliation pass performs one best-effort v86/v90 user
+  reconciliation pulse before publishing the connectivity snapshot; and
+* v86 reconciliation emits a state-sensitive diagnostic including the existing
+  per-account recovery state plus canonical failed/missing-credential counts.
+
+No credentials, connected flags, trading eligibility, balances, writer proof,
+nonce state, execution authority, kill-switch state, or platform readiness are
+fabricated.  User failures remain isolated and never become a reason to force
+or revoke global LIVE_ACTIVE by this patch.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from types import ModuleType
+from typing import Any
+
+from bot import kraken_all_account_supervision_v86 as v86
+
+
+LOGGER = logging.getLogger("nija.all_account_connectivity_truth_v266")
+MARKER = "20260828-all-account-connectivity-truth-v266"
+_LOCK = threading.RLock()
+_INSTALLED = False
+_MONITOR_STARTED = False
+_ORIGINAL_V86_RECONCILE = None
+_PATCHED_V25_IDS: set[int] = set()
+_LAST_STATE_SIGNATURE = ""
+
+
+def _canonical_manager() -> Any:
+    module = sys.modules.get("bot.multi_account_broker_manager")
+    getter = getattr(module, "get_broker_manager", None) if module is not None else None
+    if callable(getter):
+        try:
+            return getter()
+        except Exception:
+            return None
+    return getattr(module, "multi_account_broker_manager", None) if module is not None else None
+
+
+def _registry_counts(manager: Any) -> tuple[int, int]:
+    if manager is None:
+        return 0, 0
+    try:
+        from bot.account_registry_snapshot import build_account_registry_snapshot
+
+        snapshot = build_account_registry_snapshot(manager)
+        return int(snapshot.user_failures), int(snapshot.user_without_credentials)
+    except Exception:
+        return (
+            len(getattr(manager, "_failed_user_connections", {}) or {}),
+            len(getattr(manager, "_users_without_credentials", {}) or {}),
+        )
+
+
+def _state_signature(state: dict[str, Any], failed: int, missing: int) -> str:
+    states = state.get("states", {}) if isinstance(state, dict) else {}
+    try:
+        ordered = tuple(sorted((str(k), str(v)) for k, v in states.items()))
+    except Exception:
+        ordered = ()
+    return repr((
+        state.get("registered", 0) if isinstance(state, dict) else 0,
+        state.get("connected", 0) if isinstance(state, dict) else 0,
+        state.get("disconnected", 0) if isinstance(state, dict) else 0,
+        state.get("reason", "unknown") if isinstance(state, dict) else "invalid_state",
+        failed,
+        missing,
+        ordered,
+    ))
+
+
+def _emit_state(manager: Any, state: dict[str, Any], *, source: str) -> None:
+    global _LAST_STATE_SIGNATURE
+    failed, missing = _registry_counts(manager)
+    signature = _state_signature(state, failed, missing)
+    with _LOCK:
+        if signature == _LAST_STATE_SIGNATURE:
+            return
+        _LAST_STATE_SIGNATURE = signature
+    states = state.get("states", {}) if isinstance(state, dict) else {}
+    ready = bool(state.get("ok")) if isinstance(state, dict) else False
+    log = LOGGER.critical if ready else LOGGER.warning
+    log(
+        "ALL_ACCOUNT_CONNECTIVITY_V266_STATE marker=%s source=%s registered=%s "
+        "connected=%s disconnected=%s recovery_reason=%s states=%s "
+        "user_failures=%s user_without_credentials=%s authenticated_only=true "
+        "fabricated_connected=false fabricated_credentials=false "
+        "platform_live_state_unchanged=true user_failure_isolated=true",
+        MARKER,
+        source,
+        state.get("registered", 0) if isinstance(state, dict) else 0,
+        state.get("connected", 0) if isinstance(state, dict) else 0,
+        state.get("disconnected", 0) if isinstance(state, dict) else 0,
+        state.get("reason", "unknown") if isinstance(state, dict) else "invalid_state",
+        states,
+        failed,
+        missing,
+    )
+
+
+def _patch_v86_reconcile() -> bool:
+    global _ORIGINAL_V86_RECONCILE
+    current = getattr(v86, "reconcile_once", None)
+    if not callable(current):
+        return False
+    if getattr(current, "_nija_v266_connectivity_truth", False):
+        return True
+
+    original = current
+    _ORIGINAL_V86_RECONCILE = original
+
+    def _reconcile_once(manager: Any = None) -> dict[str, Any]:
+        state = original(manager)
+        observed_manager = manager if manager is not None else _canonical_manager()
+        if isinstance(state, dict):
+            _emit_state(observed_manager, state, source="v86_reconcile")
+        return state
+
+    setattr(_reconcile_once, "_nija_v266_connectivity_truth", True)
+    setattr(_reconcile_once, "_nija_v266_original", original)
+    v86.reconcile_once = _reconcile_once
+    return True
+
+
+def _pulse_user_recovery(manager: Any) -> dict[str, Any]:
+    """Run one existing v86/v90 recovery pass; never synthesize readiness."""
+    try:
+        state = v86.reconcile_once(manager)
+    except Exception as exc:
+        LOGGER.warning(
+            "ALL_ACCOUNT_CONNECTIVITY_V266_PULSE_FAILED marker=%s error=%s:%s "
+            "isolated=true platform_live_state_unchanged=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return {"ok": False, "reason": f"reconcile_error:{type(exc).__name__}", "states": {}}
+    return state if isinstance(state, dict) else {"ok": False, "reason": "invalid_reconcile_state", "states": {}}
+
+
+def _patch_live_broker_reconciler(module: ModuleType) -> bool:
+    module_id = id(module)
+    with _LOCK:
+        if module_id in _PATCHED_V25_IDS:
+            return True
+    original = getattr(module, "_reconcile_brokers_once", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_nija_v266_user_recovery_pulse", False):
+        with _LOCK:
+            _PATCHED_V25_IDS.add(module_id)
+        return True
+
+    def _reconcile_brokers_once() -> dict[str, bool]:
+        manager_getter = getattr(module, "_manager", None)
+        manager = manager_getter() if callable(manager_getter) else _canonical_manager()
+        state = _pulse_user_recovery(manager)
+        _emit_state(manager, state, source="live_broker_reconcile")
+        # Preserve v25 as the sole owner of platform connectivity publication,
+        # broker registration, and exit-supervisor reconciliation.
+        return original()
+
+    setattr(_reconcile_brokers_once, "_nija_v266_user_recovery_pulse", True)
+    setattr(_reconcile_brokers_once, "_nija_v266_original", original)
+    module._reconcile_brokers_once = _reconcile_brokers_once
+    with _LOCK:
+        _PATCHED_V25_IDS.add(module_id)
+    LOGGER.critical(
+        "ALL_ACCOUNT_CONNECTIVITY_V266_V25_PATCHED marker=%s module=%s "
+        "authenticated_recovery_pulse=true platform_connectivity_return_unchanged=true "
+        "user_failure_isolated=true safety_gates_bypassed=false",
+        MARKER,
+        getattr(module, "__name__", "unknown"),
+    )
+    return True
+
+
+def _try_patch_v25_loaded() -> bool:
+    patched = False
+    for name in ("bot.live_broker_profit_exit_convergence_v25", "live_broker_profit_exit_convergence_v25"):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            patched = _patch_live_broker_reconciler(module) or patched
+    return patched
+
+
+def _monitor() -> None:
+    deadline = time.monotonic() + 600.0
+    while time.monotonic() < deadline:
+        _patch_v86_reconcile()
+        if _try_patch_v25_loaded():
+            return
+        time.sleep(0.25)
+    LOGGER.warning(
+        "ALL_ACCOUNT_CONNECTIVITY_V266_MONITOR_EXPIRED marker=%s v86_patched=%s "
+        "platform_live_state_unchanged=true",
+        MARKER,
+        bool(getattr(getattr(v86, "reconcile_once", None), "_nija_v266_connectivity_truth", False)),
+    )
+
+
+def install_import_hook() -> bool:
+    global _INSTALLED, _MONITOR_STARTED
+    _patch_v86_reconcile()
+    _try_patch_v25_loaded()
+    with _LOCK:
+        if not _MONITOR_STARTED:
+            _MONITOR_STARTED = True
+            threading.Thread(
+                target=_monitor,
+                name="AllAccountConnectivityTruthV266",
+                daemon=True,
+            ).start()
+        _INSTALLED = True
+    os.environ["NIJA_ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_INSTALLED"] = "1"
+    LOGGER.critical(
+        "ALL_ACCOUNT_CONNECTIVITY_TRUTH_V266_READY marker=%s ready=true "
+        "v86_state_sensitive_diagnostics=true v90_recovery_path_preserved=true "
+        "live_broker_recovery_pulse=true credentials_fabricated=false "
+        "connected_fabricated=false trading_eligibility_fabricated=false "
+        "platform_live_state_unchanged=true kill_switch_unchanged=true "
+        "writer_nonce_risk_capital_order_fill_gates_unchanged=true safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
+def install() -> bool:
+    return install_import_hook()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_pulse_user_recovery",
+    "_patch_live_broker_reconciler",
+    "_patch_v86_reconcile",
+]

--- a/bot/production_runtime_convergence_v88_patch.py
+++ b/bot/production_runtime_convergence_v88_patch.py
@@ -166,7 +166,7 @@ def _install_kraken_user_supervision() -> bool:
         LOGGER.critical(
             "KRAKEN_USER_SUPERVISION_V88_CHAINED marker=%s source=v86+v90+v266 "
             "authenticated_reconnect_only=true canonical_rebuild=true writer_scoped=true "
-            "state_sensitive_diagnostics=true live_broker_recovery_pulse=true",
+            "state_sensitive_diagnostics=true extra_reconcile_calls=false retry_cadence_unchanged=true",
             MARKER,
         )
     return installed

--- a/bot/production_runtime_convergence_v88_patch.py
+++ b/bot/production_runtime_convergence_v88_patch.py
@@ -154,6 +154,9 @@ def _install_kraken_user_supervision() -> bool:
         if installed:
             from bot import kraken_user_connection_convergence_v90_patch as v90
             installed = bool(v90.install_import_hook())
+        if installed:
+            from bot import all_account_connectivity_truth_v266_patch as v266
+            installed = bool(v266.install_import_hook())
     except Exception as exc:
         LOGGER.warning("KRAKEN_USER_SUPERVISION_V88_INSTALL_FAILED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
         return False
@@ -161,8 +164,9 @@ def _install_kraken_user_supervision() -> bool:
         with _LOCK:
             _KRAKEN_SUPERVISION_INSTALLED = True
         LOGGER.critical(
-            "KRAKEN_USER_SUPERVISION_V88_CHAINED marker=%s source=v86+v90 "
-            "authenticated_reconnect_only=true canonical_rebuild=true writer_scoped=true",
+            "KRAKEN_USER_SUPERVISION_V88_CHAINED marker=%s source=v86+v90+v266 "
+            "authenticated_reconnect_only=true canonical_rebuild=true writer_scoped=true "
+            "state_sensitive_diagnostics=true live_broker_recovery_pulse=true",
             MARKER,
         )
     return installed
@@ -227,8 +231,8 @@ def install_import_hook() -> bool:
     os.environ["NIJA_PRODUCTION_RUNTIME_CONVERGENCE_V88_INSTALLED"] = "1"
     LOGGER.critical(
         "PRODUCTION_RUNTIME_CONVERGENCE_V88_INSTALLED marker=%s circuit_classification=true "
-        "kraken_user_supervision=true kraken_user_rebuild_v90=true stale_log_filter=true "
-        "risk_gates_unchanged=true nonce_gates_unchanged=true",
+        "kraken_user_supervision=true kraken_user_rebuild_v90=true all_account_connectivity_v266=true "
+        "stale_log_filter=true risk_gates_unchanged=true nonce_gates_unchanged=true",
         MARKER,
     )
     return True

--- a/bot/tests/test_all_account_connectivity_truth_v266.py
+++ b/bot/tests/test_all_account_connectivity_truth_v266.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from bot import all_account_connectivity_truth_v266_patch as v266
+
+
+class _BrokerType:
+    value = "kraken"
+
+
+class _Broker:
+    def __init__(self, connected: bool) -> None:
+        self.connected = connected
+
+
+class AllAccountConnectivityTruthV266Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        with v266._LOCK:
+            v266._PATCHED_V25_IDS.clear()
+            v266._LAST_STATE_SIGNATURE = ""
+
+    def tearDown(self) -> None:
+        with v266._LOCK:
+            v266._PATCHED_V25_IDS.clear()
+            v266._LAST_STATE_SIGNATURE = ""
+
+    def test_state_signature_changes_when_per_account_recovery_state_changes(self) -> None:
+        first = {
+            "ok": False,
+            "reason": "recovery_active",
+            "registered": 2,
+            "connected": 1,
+            "disconnected": 1,
+            "states": {
+                "user:alice:kraken": "connected",
+                "user:bob:kraken": "backoff",
+            },
+        }
+        second = dict(first)
+        second["states"] = {
+            "user:alice:kraken": "connected",
+            "user:bob:kraken": "credentials_not_configured",
+        }
+
+        self.assertNotEqual(
+            v266._state_signature(first, 1, 0),
+            v266._state_signature(second, 1, 1),
+        )
+
+    def test_registry_counts_preserve_failed_and_missing_user_truth(self) -> None:
+        manager = SimpleNamespace(
+            _platform_brokers={},
+            _platform_failed_types=set(),
+            _all_user_brokers={
+                ("alice", _BrokerType): _Broker(True),
+                ("bob", _BrokerType): _Broker(False),
+            },
+            user_brokers={"alice": {_BrokerType: _Broker(True)}},
+            _user_metadata={
+                "alice": {"brokers": {_BrokerType: True}},
+                "bob": {"brokers": {_BrokerType: False}},
+            },
+            _failed_user_connections={("bob", _BrokerType): "auth_failed"},
+            _users_without_credentials={("bob", _BrokerType): True},
+            _capital_blocked_users={},
+        )
+
+        self.assertEqual(v266._registry_counts(manager), (1, 1))
+
+    def test_pulse_delegates_to_existing_authenticated_v86_v90_path(self) -> None:
+        manager = object()
+        expected = {
+            "ok": False,
+            "reason": "recovery_active",
+            "registered": 2,
+            "connected": 1,
+            "disconnected": 1,
+            "states": {"user:bob:kraken": "reconnect_scheduled"},
+        }
+        with patch.object(v266.v86, "reconcile_once", return_value=expected) as reconcile:
+            actual = v266._pulse_user_recovery(manager)
+
+        self.assertEqual(actual, expected)
+        reconcile.assert_called_once_with(manager)
+
+    def test_live_broker_wrapper_pulses_user_recovery_and_preserves_platform_result(self) -> None:
+        module = ModuleType("bot.live_broker_profit_exit_convergence_v25_test")
+        manager = object()
+        platform_result = {"kraken": True, "coinbase": True, "okx": True}
+        calls = []
+
+        module._manager = lambda: manager
+
+        def original():
+            calls.append("original")
+            return platform_result
+
+        module._reconcile_brokers_once = original
+        recovery_state = {
+            "ok": False,
+            "reason": "recovery_active",
+            "registered": 2,
+            "connected": 1,
+            "disconnected": 1,
+            "states": {"user:bob:kraken": "backoff"},
+        }
+
+        with patch.object(v266, "_pulse_user_recovery", return_value=recovery_state) as pulse, patch.object(
+            v266, "_emit_state"
+        ) as emit:
+            self.assertTrue(v266._patch_live_broker_reconciler(module))
+            result = module._reconcile_brokers_once()
+
+        self.assertIs(result, platform_result)
+        self.assertEqual(calls, ["original"])
+        pulse.assert_called_once_with(manager)
+        emit.assert_called_once_with(manager, recovery_state, source="live_broker_reconcile")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bot/tests/test_all_account_connectivity_truth_v266.py
+++ b/bot/tests/test_all_account_connectivity_truth_v266.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from bot import all_account_connectivity_truth_v266_patch as v266
 
@@ -19,12 +19,10 @@ class _Broker:
 class AllAccountConnectivityTruthV266Tests(unittest.TestCase):
     def setUp(self) -> None:
         with v266._LOCK:
-            v266._PATCHED_V25_IDS.clear()
             v266._LAST_STATE_SIGNATURE = ""
 
     def tearDown(self) -> None:
         with v266._LOCK:
-            v266._PATCHED_V25_IDS.clear()
             v266._LAST_STATE_SIGNATURE = ""
 
     def test_state_signature_changes_when_per_account_recovery_state_changes(self) -> None:
@@ -51,14 +49,16 @@ class AllAccountConnectivityTruthV266Tests(unittest.TestCase):
         )
 
     def test_registry_counts_preserve_failed_and_missing_user_truth(self) -> None:
+        connected = _Broker(True)
+        disconnected = _Broker(False)
         manager = SimpleNamespace(
             _platform_brokers={},
             _platform_failed_types=set(),
             _all_user_brokers={
-                ("alice", _BrokerType): _Broker(True),
-                ("bob", _BrokerType): _Broker(False),
+                ("alice", _BrokerType): connected,
+                ("bob", _BrokerType): disconnected,
             },
-            user_brokers={"alice": {_BrokerType: _Broker(True)}},
+            user_brokers={"alice": {_BrokerType: connected}},
             _user_metadata={
                 "alice": {"brokers": {_BrokerType: True}},
                 "bob": {"brokers": {_BrokerType: False}},
@@ -70,7 +70,7 @@ class AllAccountConnectivityTruthV266Tests(unittest.TestCase):
 
         self.assertEqual(v266._registry_counts(manager), (1, 1))
 
-    def test_pulse_delegates_to_existing_authenticated_v86_v90_path(self) -> None:
+    def test_wrapper_observes_existing_reconcile_without_extra_call_or_state_mutation(self) -> None:
         manager = object()
         expected = {
             "ok": False,
@@ -78,46 +78,22 @@ class AllAccountConnectivityTruthV266Tests(unittest.TestCase):
             "registered": 2,
             "connected": 1,
             "disconnected": 1,
-            "states": {"user:bob:kraken": "reconnect_scheduled"},
+            "states": {
+                "user:alice:kraken": "connected",
+                "user:bob:kraken": "backoff",
+            },
         }
-        with patch.object(v266.v86, "reconcile_once", return_value=expected) as reconcile:
-            actual = v266._pulse_user_recovery(manager)
+        original = Mock(return_value=expected)
 
-        self.assertEqual(actual, expected)
-        reconcile.assert_called_once_with(manager)
+        with patch.object(v266.v86, "reconcile_once", original), patch.object(v266, "_emit_state") as emit:
+            self.assertTrue(v266._patch_v86_reconcile())
+            wrapped = v266.v86.reconcile_once
+            actual = wrapped(manager)
 
-    def test_live_broker_wrapper_pulses_user_recovery_and_preserves_platform_result(self) -> None:
-        module = ModuleType("bot.live_broker_profit_exit_convergence_v25_test")
-        manager = object()
-        platform_result = {"kraken": True, "coinbase": True, "okx": True}
-        calls = []
-
-        module._manager = lambda: manager
-
-        def original():
-            calls.append("original")
-            return platform_result
-
-        module._reconcile_brokers_once = original
-        recovery_state = {
-            "ok": False,
-            "reason": "recovery_active",
-            "registered": 2,
-            "connected": 1,
-            "disconnected": 1,
-            "states": {"user:bob:kraken": "backoff"},
-        }
-
-        with patch.object(v266, "_pulse_user_recovery", return_value=recovery_state) as pulse, patch.object(
-            v266, "_emit_state"
-        ) as emit:
-            self.assertTrue(v266._patch_live_broker_reconciler(module))
-            result = module._reconcile_brokers_once()
-
-        self.assertIs(result, platform_result)
-        self.assertEqual(calls, ["original"])
-        pulse.assert_called_once_with(manager)
-        emit.assert_called_once_with(manager, recovery_state, source="live_broker_reconcile")
+        self.assertIs(actual, expected)
+        original.assert_called_once_with(manager)
+        emit.assert_called_once_with(manager, expected, source="v86_reconcile")
+        self.assertTrue(getattr(wrapped, "_nija_v266_connectivity_truth", False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
Make the persistent 2-registered / 1-connected Kraken-user state diagnosable without altering live execution behavior.

## Changes
- Add v266 state-sensitive diagnostics around the existing v86/v90 user-supervision reconciliation result.
- Report per-account recovery states plus canonical failed-user and missing-credential counts.
- Chain v266 through production runtime convergence v88.
- Add regression tests proving the wrapper observes exactly one existing reconciliation call and preserves failed/missing-account truth.

## Risk
Low. Diagnostic-only. No additional reconciliation call or broker I/O is introduced; retry cadence and platform readiness are unchanged.

## Safety invariants
No credentials, connectivity, balances, trading eligibility, execution authority, order/fill state, kill-switch state, writer/nonce readiness, risk, or capital state are synthesized or changed. User failures remain isolated from the platform LIVE_ACTIVE state.

## Rollback
Revert this PR. No migrations or persisted-state changes.

## Validation
- Branch policy: passed
- Preflight/lint: passed
- Import smoke test: passed
- Remaining CI/security/image workflows: pending at time of update