### PR TITLE
Preserve optional auto-exit monitor interface

### DIFF
--- a/bot/kraken_all_account_exit_runtime_patch.py
+++ b/bot/kraken_all_account_exit_runtime_patch.py
@@ -667,7 +667,7 @@ def _patch_auto_exit_module(module: ModuleType) -> bool:
     if not callable(starter) or getattr(starter, "_nija_account_local_disabled_v1", False):
         return False
 
-    def start_monitor(engine: Any) -> None:
+    def start_monitor(engine: Any | None = None) -> None:
         logger.warning(
             "GLOBAL_SINGLETON_AUTO_EXIT_DISABLED marker=%s reason=account_local_kraken_supervisor_active",
             _MARKER,

--- a/bot/tests/test_protective_exit_authority_v265.py
+++ b/bot/tests/test_protective_exit_authority_v265.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from bot.pipeline_request_contract import PipelineRequest, validate_pipeline_request
 from bot import runtime_protective_exit_authority_v265_patch as v265
+from bot import kraken_all_account_exit_runtime_patch as kraken_exit
 
 
 def test_pipeline_request_accepts_explicit_close_effect():
@@ -103,3 +104,20 @@ def test_kraken_ack_without_fill_remains_open():
     assert result["pending_order_id"] == "pending-123"
     assert v265._filled_result({"status": "accepted", "order_id": "pending-123"}) is False
     assert v265._filled_result({"status": "filled", "order_id": "filled-123"}) is True
+
+
+def test_kraken_auto_exit_patch_preserves_optional_noarg_monitor_interface():
+    module = ModuleType("bot.auto_exit_sl_tp_runtime_patch_test")
+    calls = []
+
+    def original_start_monitor(engine=None):
+        calls.append(engine)
+        return None
+
+    module._start_monitor = original_start_monitor
+
+    assert kraken_exit._patch_auto_exit_module(module) is True
+    assert module._start_monitor() is None
+    assert module._start_monitor(SimpleNamespace()) is None
+    assert getattr(module._start_monitor, "_nija_account_local_disabled_v1", False) is True
+    assert calls == []


### PR DESCRIPTION
Fixes a latent runtime compatibility defect in `bot.kraken_all_account_exit_runtime_patch` where monkey-patching `_start_monitor` changed its interface from optional/no-arg to a required `engine` argument. That could make protective-exit reassertion fail after import/restart ordering changes.

Changes:
- preserve `_start_monitor(engine: Any | None = None)` compatibility while keeping the global singleton disabled under the account-local Kraken supervisor
- add regression coverage proving both no-arg and engine-arg calls remain safe

Safety invariants unchanged: no forced trade/activation, no fabricated execution proof, and no changes to writer/nonce/risk/capital/kill-switch/min-notional/fill gates.