### PR TITLE
Recover verified false exchange rejection window

### DIFF
--- a/bot/exchange_rejection_stale_latch_v226_patch.py
+++ b/bot/exchange_rejection_stale_latch_v226_patch.py
@@ -1,31 +1,23 @@
-"""Recover a persisted historical multi-sample EXCHANGE_MONITOR rejection latch v226.
+"""Recover verified stale EXCHANGE_MONITOR rejection latches (v226/v267).
 
-Production on 2026-08-24 proved a global stop with causal reason ``5/5 orders
-rejected`` surviving into a new healthy runtime.  ExchangeKillSwitchProtector
-persists its triggered flag/reason/history but does not persist the rolling
-``_order_results`` deque.  Therefore a restarted process can inherit the old
-trigger while having no current rejection samples with which to prove the storm
-is still occurring.  The global hard stop then prevents the heartbeat order that
-would otherwise establish fresh execution health.
+v226 recovers a persisted full-rejection latch only when the current process has
+no rejection samples. v267 adds a second, deliberately narrow path for the
+production deadlock where the current process contains rejection samples that
+can all be proven, from recorder provenance, to be local/pre-dispatch outcomes
+that are now classified as non-exchange failures.
 
-v226 closes only that persisted-latch deadlock.  It may clear an EXCHANGE_MONITOR
-multi-sample rejection stop once per process, and only when all of these are true:
-* the causal source is exactly EXCHANGE_MONITOR;
-* the reason is exactly an order-rejection-rate stop with rejected==total and
-  total >= the configured minimum sample count;
-* the ExchangeKillSwitchProtector is itself persisted-triggered with the same
-  order-rejection reason;
-* its current in-memory ``_order_results`` window is empty, proving the samples
-  belong to a prior process rather than the current runtime;
-* every non-order exchange-health gate is currently non-RED;
-* the exact distributed writer/core is healthy;
-* all non-stop structural readiness proofs are current.
-
-Manual/UI/CLI, risk/drawdown, auth, balance, API-instability, unknown, mixed-rate,
-and same-process rejection stops are preserved.  After deactivation the normal
-heartbeat, nonce, authority, order and fill proofs must be re-earned.  A new real
-5/5 storm in the same process cannot be auto-cleared because the current rolling
-window is non-empty and the recovery is one-shot.
+Safety invariants:
+* only an exact EXCHANGE_MONITOR 100% multi-sample rejection stop is eligible;
+* manual/UI/CLI, risk/drawdown, auth, balance, API-instability and unknown stops
+  are preserved;
+* the current rejection deque is never cleared unless every sample is rejected
+  and every corresponding provenance record is positively classified as
+  non-exchange by the live v258 classifier;
+* unknown or genuine exchange rejections preserve the stop;
+* all non-order exchange gates must be non-RED;
+* exact writer/core and structural readiness proofs must be current;
+* recovery is one-shot and normal heartbeat/nonce/authority/order/fill proofs
+  must be re-earned afterwards.
 """
 from __future__ import annotations
 
@@ -39,6 +31,7 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.exchange_rejection_stale_latch_v226")
 MARKER = "20260824-exchange-rejection-stale-latch-v226"
+V267_MARKER = "20260828-current-rejection-provenance-recovery-v267"
 _FLAG = "NIJA_EXCHANGE_REJECTION_STALE_LATCH_V226_READY"
 _LOCK = threading.RLock()
 _THREAD: threading.Thread | None = None
@@ -104,6 +97,30 @@ def _exact_persisted_rejection_signature(record: dict[str, Any], protector: Any)
     return True, reason[:512]
 
 
+def _nonorder_gates_nonred(status: dict[str, Any]) -> tuple[bool, str]:
+    for gate in list(status.get("gates") or []):
+        if not isinstance(gate, dict):
+            continue
+        if str(gate.get("gate") or "").strip().lower() == "order_rejection":
+            continue
+        if str(gate.get("status") or "").strip().lower() == "red":
+            return False, f"current_exchange_gate_red:{gate.get('gate') or 'unknown'}"
+    return True, "current_exchange_nonorder_gates_nonred"
+
+
+def _read_current_results(protector: Any) -> tuple[bool, list[bool] | str]:
+    lock = getattr(protector, "_lock", None)
+    try:
+        if lock is None:
+            results = list(getattr(protector, "_order_results", ()) or ())
+        else:
+            with lock:
+                results = list(getattr(protector, "_order_results", ()) or ())
+        return True, [bool(value) for value in results]
+    except Exception:
+        return False, "current_order_window_unreadable"
+
+
 def _protector_persisted_latch(protector: Any, causal_reason: str) -> tuple[bool, str]:
     try:
         status = dict(protector.get_status() or {})
@@ -114,29 +131,101 @@ def _protector_persisted_latch(protector: Any, causal_reason: str) -> tuple[bool
     trigger_reason = str(status.get("trigger_reason") or "").strip()
     if "order rejection" not in trigger_reason.lower():
         return False, "protector_trigger_not_order_rejection"
-    # The protector's rolling order window is intentionally not persisted.  An
-    # empty window while its persisted trigger is active is the key replay proof.
+    readable, payload = _read_current_results(protector)
+    if not readable:
+        return False, str(payload)
+    current_results = payload if isinstance(payload, list) else []
+    if current_results:
+        return False, f"current_process_rejection_samples_present:{len(current_results)}"
+    return _nonorder_gates_nonred(status)
+
+
+def _current_window_false_positive_proof(protector: Any) -> tuple[bool, str, int]:
+    """Prove that every current rejection sample is local/non-exchange.
+
+    The core protector stores only booleans. v258 separately stores bounded
+    per-result provenance. We require an exact tail alignment: the last N
+    provenance records must have accepted values matching the N current window
+    booleans, all N booleans must be False, and every matched reason must be
+    positively classified by the *current* v258 classifier. This deliberately
+    rejects ambiguous histories rather than guessing.
+    """
+    try:
+        status = dict(protector.get_status() or {})
+    except Exception as exc:
+        return False, f"protector_status_error:{type(exc).__name__}:{exc}", 0
+    if not bool(status.get("triggered")):
+        return False, "protector_not_triggered", 0
+    trigger_reason = str(status.get("trigger_reason") or "").strip().lower()
+    if "order rejection" not in trigger_reason:
+        return False, "protector_trigger_not_order_rejection", 0
+    gates_ok, gates_detail = _nonorder_gates_nonred(status)
+    if not gates_ok:
+        return False, gates_detail, 0
+
+    readable, payload = _read_current_results(protector)
+    if not readable:
+        return False, str(payload), 0
+    results = payload if isinstance(payload, list) else []
+    minimum = _minimum_samples(protector)
+    if len(results) < minimum:
+        return False, f"current_window_below_minimum:{len(results)}<{minimum}", 0
+    if any(results):
+        return False, "current_window_contains_accepted_samples", 0
+
+    history = getattr(protector, "_nija_order_result_provenance_v258", None)
+    try:
+        records = list(history or ())
+    except Exception:
+        return False, "provenance_history_unreadable", 0
+    if len(records) < len(results):
+        return False, f"provenance_history_short:{len(records)}<{len(results)}", 0
+
+    tail = records[-len(results):]
+    accepted_tail = [bool(item.get("accepted")) if isinstance(item, dict) else True for item in tail]
+    if accepted_tail != results:
+        return False, "provenance_tail_not_aligned_with_current_window", 0
+
+    try:
+        v258 = importlib.import_module("bot.exchange_kill_switch_alias_provenance_v258_patch")
+        classifier = getattr(v258, "_is_non_exchange", None)
+    except Exception:
+        classifier = None
+    if not callable(classifier):
+        return False, "v258_classifier_missing", 0
+
+    for index, item in enumerate(tail):
+        if not isinstance(item, dict):
+            return False, f"provenance_record_invalid:{index}", 0
+        reason = str(item.get("reason") or "").strip()
+        source = str(item.get("source") or "").strip()
+        if source != "execution_pipeline":
+            return False, f"provenance_source_not_execution_pipeline:{index}:{source or 'missing'}", 0
+        if not reason:
+            return False, f"provenance_reason_missing:{index}", 0
+        if not bool(classifier(reason)):
+            return False, f"provenance_not_non_exchange:{index}:{reason[:160]}", 0
+
+    return True, f"verified_non_exchange_current_window:{len(results)}", len(results)
+
+
+def _clear_verified_current_window(protector: Any, expected_count: int) -> tuple[bool, str]:
     lock = getattr(protector, "_lock", None)
     try:
         if lock is None:
-            current_results = list(getattr(protector, "_order_results", ()) or ())
+            results = getattr(protector, "_order_results", None)
+            if results is None or len(results) != expected_count or any(bool(v) for v in results):
+                return False, "current_window_changed_before_clear"
+            results.clear()
         else:
             with lock:
-                current_results = list(getattr(protector, "_order_results", ()) or ())
-    except Exception:
-        return False, "current_order_window_unreadable"
-    if current_results:
-        return False, f"current_process_rejection_samples_present:{len(current_results)}"
-
-    gates = list(status.get("gates") or [])
-    for gate in gates:
-        if not isinstance(gate, dict):
-            continue
-        if str(gate.get("gate") or "").strip().lower() == "order_rejection":
-            continue
-        if str(gate.get("status") or "").strip().lower() == "red":
-            return False, f"current_exchange_gate_red:{gate.get('gate') or 'unknown'}"
-    return True, "persisted_trigger_empty_current_window_nonorder_gates_nonred"
+                results = getattr(protector, "_order_results", None)
+                if results is None or len(results) != expected_count or any(bool(v) for v in results):
+                    return False, "current_window_changed_before_clear"
+                results.clear()
+        return True, f"verified_current_window_cleared:{expected_count}"
+    except Exception as exc:
+        return False, f"verified_current_window_clear_error:{type(exc).__name__}:{exc}"
 
 
 def _writer_and_structural_ready() -> tuple[bool, str]:
@@ -180,42 +269,56 @@ def attempt_recovery_once() -> bool:
         record = _causal_record(kill_status)
         signature_ok, signature_detail = _exact_persisted_rejection_signature(record, protector)
         if not signature_ok:
-            LOGGER.info(
-                "EXCHANGE_REJECTION_STALE_LATCH_V226_INELIGIBLE marker=%s detail=%s active_preserved=true",
-                MARKER,
-                signature_detail,
-            )
+            LOGGER.info("EXCHANGE_REJECTION_STALE_LATCH_V226_INELIGIBLE marker=%s detail=%s active_preserved=true", MARKER, signature_detail)
             return False
 
         persisted_ok, persisted_detail = _protector_persisted_latch(protector, signature_detail)
+        recovery_mode = "persisted_empty_window"
+        verified_count = 0
         if not persisted_ok:
-            LOGGER.info(
-                "EXCHANGE_REJECTION_STALE_LATCH_V226_INELIGIBLE marker=%s detail=%s active_preserved=true",
-                MARKER,
-                persisted_detail,
-            )
-            return False
+            if not str(persisted_detail).startswith("current_process_rejection_samples_present:"):
+                LOGGER.info("EXCHANGE_REJECTION_STALE_LATCH_V226_INELIGIBLE marker=%s detail=%s active_preserved=true", MARKER, persisted_detail)
+                return False
+            proven, proof_detail, verified_count = _current_window_false_positive_proof(protector)
+            if not proven:
+                LOGGER.warning(
+                    "CURRENT_REJECTION_PROVENANCE_V267_PRESERVED marker=%s detail=%s active_preserved=true trading_fail_closed=true",
+                    V267_MARKER,
+                    proof_detail,
+                )
+                return False
+            recovery_mode = "verified_current_non_exchange_window"
 
         ready, ready_detail = _writer_and_structural_ready()
         if not ready:
-            LOGGER.warning(
-                "EXCHANGE_REJECTION_STALE_LATCH_V226_WAIT marker=%s blocker=%s active_preserved=true trading_fail_closed=true",
-                MARKER,
-                ready_detail,
-            )
+            LOGGER.warning("EXCHANGE_REJECTION_STALE_LATCH_V226_WAIT marker=%s blocker=%s active_preserved=true trading_fail_closed=true", MARKER, ready_detail)
             return False
+
+        if recovery_mode == "verified_current_non_exchange_window":
+            cleared, clear_detail = _clear_verified_current_window(protector, verified_count)
+            if not cleared:
+                LOGGER.warning(
+                    "CURRENT_REJECTION_PROVENANCE_V267_CLEAR_REFUSED marker=%s detail=%s active_preserved=true trading_fail_closed=true",
+                    V267_MARKER,
+                    clear_detail,
+                )
+                return False
+            LOGGER.critical(
+                "CURRENT_REJECTION_PROVENANCE_V267_RECLASSIFIED marker=%s samples=%d exact_tail_alignment=true "
+                "all_samples_non_exchange=true rejection_thresholds_unchanged=true genuine_exchange_rejects_preserved=true "
+                "manual_risk_auth_unknown_preserved=true safety_gates_bypassed=false",
+                V267_MARKER,
+                verified_count,
+            )
 
         deactivate = getattr(ks, "deactivate", None)
         if not callable(deactivate):
             return False
         result = deactivate(
-            "v226 verified recovery from persisted EXCHANGE_MONITOR full-rejection latch after current health proof"
+            "v226/v267 verified recovery from EXCHANGE_MONITOR full-rejection latch after current health and provenance proof"
         )
         if result is False:
-            LOGGER.critical(
-                "EXCHANGE_REJECTION_STALE_LATCH_V226_DEACTIVATE_REFUSED marker=%s trading_fail_closed=true",
-                MARKER,
-            )
+            LOGGER.critical("EXCHANGE_REJECTION_STALE_LATCH_V226_DEACTIVATE_REFUSED marker=%s trading_fail_closed=true", MARKER)
             return False
         after = dict(ks.get_status() or {})
         if bool(after.get("is_active")) or bool(after.get("kill_file_exists")):
@@ -229,16 +332,17 @@ def attempt_recovery_once() -> bool:
 
         reset = getattr(protector, "reset", None)
         if callable(reset):
-            reset("v226 cleared persisted rejection latch after canonical stop deactivation")
+            reset("v226/v267 cleared verified rejection latch after canonical stop deactivation")
 
         _RECOVERED = True
         LOGGER.critical(
-            "EXCHANGE_REJECTION_STALE_LATCH_V226_RECOVERED marker=%s causal_source=EXCHANGE_MONITOR "
-            "persisted_replay_only=true current_order_window_empty=true one_shot=true "
-            "causal_reason=%s current_exchange_nonorder_gates_nonred=true writer_proof=exact "
-            "structural_proofs=current authority_nonce_execution_not_fabricated=true "
+            "EXCHANGE_REJECTION_STALE_LATCH_V226_RECOVERED marker=%s v267_marker=%s causal_source=EXCHANGE_MONITOR "
+            "recovery_mode=%s one_shot=true causal_reason=%s current_exchange_nonorder_gates_nonred=true "
+            "writer_proof=exact structural_proofs=current authority_nonce_execution_not_fabricated=true "
             "activation_must_reprove=true forced_activation=false safety_gates_bypassed=false",
             MARKER,
+            V267_MARKER,
+            recovery_mode,
             signature_detail,
         )
         return True
@@ -293,19 +397,16 @@ def install() -> bool:
     os.environ[_FLAG] = "1"
     with _LOCK:
         if _THREAD is None or not _THREAD.is_alive():
-            _THREAD = threading.Thread(
-                target=_worker,
-                name="ExchangeRejectionStaleLatchV226",
-                daemon=True,
-            )
+            _THREAD = threading.Thread(target=_worker, name="ExchangeRejectionStaleLatchV226", daemon=True)
             _THREAD.start()
     LOGGER.critical(
-        "EXCHANGE_REJECTION_STALE_LATCH_V226_READY marker=%s ready=true "
-        "exchange_monitor_only=true full_rejection_multi_sample_only=true persisted_replay_only=true "
-        "current_order_window_must_be_empty=true nonorder_exchange_gates_must_be_nonred=true "
+        "EXCHANGE_REJECTION_STALE_LATCH_V226_READY marker=%s v267_marker=%s ready=true "
+        "exchange_monitor_only=true full_rejection_multi_sample_only=true persisted_replay_only=false "
+        "current_window_requires_exact_provenance=true nonorder_exchange_gates_must_be_nonred=true "
         "writer_structural_proofs_required=true one_shot=true manual_risk_auth_unknown_preserved=true "
         "authority_nonce_execution_unchanged=true forced_activation=false safety_gates_bypassed=false",
         MARKER,
+        V267_MARKER,
     )
     return True
 
@@ -315,7 +416,8 @@ def install_import_hook() -> bool:
 
 
 __all__ = [
-    "MARKER", "install", "install_import_hook", "attempt_recovery_once",
+    "MARKER", "V267_MARKER", "install", "install_import_hook", "attempt_recovery_once",
     "_exact_persisted_rejection_signature", "_protector_persisted_latch",
+    "_current_window_false_positive_proof", "_clear_verified_current_window",
     "_writer_and_structural_ready",
 ]

--- a/bot/tests/test_exchange_rejection_stale_latch_v226.py
+++ b/bot/tests/test_exchange_rejection_stale_latch_v226.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import threading
+from collections import deque
 from types import SimpleNamespace
 
 from bot import exchange_rejection_stale_latch_v226_patch as v226
 
 
 class _Protector:
-    def __init__(self, *, results=(), gates=None, triggered=True):
+    def __init__(self, *, results=(), gates=None, triggered=True, provenance=()):
         self._cfg = SimpleNamespace(order_window_size=20)
         self._lock = threading.Lock()
-        self._order_results = list(results)
+        self._order_results = deque(results, maxlen=20)
+        self._nija_order_result_provenance_v258 = deque(provenance, maxlen=20)
         self._status = {
             "triggered": triggered,
             "trigger_reason": "Order rejection rate 100.0% >= 50% (5/5 orders rejected)",
@@ -25,6 +27,20 @@ class _Protector:
         return dict(self._status)
 
 
+def _local_record(index: int, reason: str = "ETH-USD not available on Kraken"):
+    return {
+        "timestamp": float(index),
+        "order_id": f"local-{index}",
+        "accepted": False,
+        "kill_switch_module": "bot.exchange_kill_switch",
+        "source": "execution_pipeline",
+        "symbol": "ETH-USD",
+        "side": "buy",
+        "reason": reason,
+        "known_non_exchange": False,
+    }
+
+
 def test_exact_persisted_5_of_5_signature_is_eligible(monkeypatch):
     protector = _Protector()
     monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
@@ -37,7 +53,7 @@ def test_exact_persisted_5_of_5_signature_is_eligible(monkeypatch):
     assert "5/5 orders rejected" in detail
 
 
-def test_current_process_samples_block_recovery():
+def test_current_process_samples_block_legacy_recovery():
     protector = _Protector(results=(False, False, False, False, False))
     ok, detail = v226._protector_persisted_latch(protector, "unused")
     assert ok is False
@@ -70,3 +86,88 @@ def test_manual_or_partial_rejection_signatures_are_preserved(monkeypatch):
         "reason": "Exchange kill-switch: Order rejection rate 60.0% >= 50% (3/5 orders rejected)",
     }
     assert v226._exact_persisted_rejection_signature(partial, protector)[0] is False
+
+
+def test_v267_proves_five_reclassified_local_samples(monkeypatch):
+    protector = _Protector(
+        results=(False, False, False, False, False),
+        provenance=tuple(_local_record(i) for i in range(5)),
+    )
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    from bot import exchange_kill_switch_alias_provenance_v258_patch as v258
+    monkeypatch.setattr(v258, "_is_non_exchange", lambda reason: "not available on kraken" in reason.lower())
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is True
+    assert count == 5
+    assert detail == "verified_non_exchange_current_window:5"
+
+
+def test_v267_refuses_one_genuine_exchange_rejection(monkeypatch):
+    records = [_local_record(i) for i in range(4)]
+    records.append(_local_record(4, reason="Kraken AddOrder rejected: EOrder:Insufficient funds"))
+    protector = _Protector(results=(False,) * 5, provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    from bot import exchange_kill_switch_alias_provenance_v258_patch as v258
+    monkeypatch.setattr(v258, "_is_non_exchange", lambda reason: "not available on kraken" in reason.lower())
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is False
+    assert count == 0
+    assert detail.startswith("provenance_not_non_exchange:4:")
+
+
+def test_v267_refuses_unknown_or_direct_legacy_source(monkeypatch):
+    records = [_local_record(i) for i in range(5)]
+    records[-1]["source"] = "direct_or_legacy"
+    protector = _Protector(results=(False,) * 5, provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    from bot import exchange_kill_switch_alias_provenance_v258_patch as v258
+    monkeypatch.setattr(v258, "_is_non_exchange", lambda _reason: True)
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is False
+    assert count == 0
+    assert detail == "provenance_source_not_execution_pipeline:4:direct_or_legacy"
+
+
+def test_v267_refuses_provenance_tail_mismatch(monkeypatch):
+    records = [_local_record(i) for i in range(5)]
+    records[-1]["accepted"] = True
+    protector = _Protector(results=(False,) * 5, provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is False
+    assert count == 0
+    assert detail == "provenance_tail_not_aligned_with_current_window"
+
+
+def test_v267_refuses_window_with_accepted_sample(monkeypatch):
+    records = [_local_record(i) for i in range(5)]
+    records[-1]["accepted"] = True
+    protector = _Protector(results=(False, False, False, False, True), provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is False
+    assert count == 0
+    assert detail == "current_window_contains_accepted_samples"
+
+
+def test_v267_clears_only_unchanged_verified_window():
+    protector = _Protector(results=(False,) * 5)
+    ok, detail = v226._clear_verified_current_window(protector, 5)
+    assert ok is True
+    assert detail == "verified_current_window_cleared:5"
+    assert list(protector._order_results) == []
+
+
+def test_v267_clear_refuses_changed_window():
+    protector = _Protector(results=(False, False, False, False, True))
+    ok, detail = v226._clear_verified_current_window(protector, 5)
+    assert ok is False
+    assert detail == "current_window_changed_before_clear"


### PR DESCRIPTION
## Summary

Fix the current production deadlock where NIJA has a healthy 3/3 platform capital/position state but remains fail-closed behind an EXCHANGE_MONITOR 5/5 rejection latch.

### Change
- Extend the existing v226 recovery worker with a v267 provenance-safe current-window recovery path.
- Require exact tail alignment between the core rejection deque and v258 per-order provenance.
- Require every current sample to be rejected, sourced through `execution_pipeline`, and positively classified by the *current* v258 non-exchange classifier.
- Preserve the stop for genuine exchange rejects, unknown/direct legacy samples, accepted samples, provenance mismatches, non-order RED gates, or missing writer/structural proof.
- Clear only the verified false-positive rejection deque, then use the existing canonical kill-switch deactivation path.
- Require heartbeat, authority, nonce, execution, ACK/fill proofs to be earned normally after recovery.

### Safety
- No threshold changes.
- No kill-switch bypass.
- No fabricated readiness, execution, nonce, ACK, fill, or authority proof.
- Manual/UI/CLI/risk/auth/unknown stops remain fail-closed.
- Genuine exchange rejection behavior is unchanged.
- Protective exit behavior is unchanged and remains governed by v265.

### Tests
Adds regression coverage for:
- five reclassified local Kraken pre-submit rejects -> eligible;
- one genuine exchange rejection -> preserved;
- unknown/direct legacy source -> preserved;
- provenance tail mismatch -> preserved;
- accepted sample in window -> preserved;
- atomic clear only for an unchanged verified rejection window.