### PR TITLE
Install rejection provenance before runtime startup

### DIFF
--- a/bot/tests/test_canonical_fast_entrypoint_v28.py
+++ b/bot/tests/test_canonical_fast_entrypoint_v28.py
@@ -44,6 +44,11 @@ def test_launcher_preserves_defer_flag_through_main_handoff(monkeypatch, tmp_pat
         "_bootstrap_writer_first",
         lambda: (bot_entry, bot_main),
     )
+    monkeypatch.setattr(
+        launcher,
+        "_install_exchange_rejection_provenance_before_runtime",
+        lambda: None,
+    )
 
     def _run_path(path: str, *, run_name: str) -> None:
         observed["path"] = path

--- a/bot/tests/test_canonical_writer_first_v59.py
+++ b/bot/tests/test_canonical_writer_first_v59.py
@@ -40,6 +40,12 @@ def test_launcher_orders_writer_before_main_runtime_fanout(monkeypatch, tmp_path
         events.append("writer")
         return bot_entry, bot_main
 
+    monkeypatch.setattr(
+        launcher,
+        "_install_exchange_rejection_provenance_before_runtime",
+        lambda: events.append("provenance"),
+    )
+
     def _single_identity(entry, main):
         assert entry is bot_entry
         assert main is bot_main
@@ -49,7 +55,90 @@ def test_launcher_orders_writer_before_main_runtime_fanout(monkeypatch, tmp_path
     monkeypatch.setattr(launcher, "_run_main_single_identity", _single_identity)
 
     assert launcher.main() == 0
-    assert events == ["guards", "writer", "main"]
+    assert events == ["guards", "writer", "provenance", "main"]
+
+
+def test_launcher_installs_rejection_provenance_before_runtime(monkeypatch) -> None:
+    launcher = _load("test_canonical_writer_first_v59_provenance")
+    events: list[str] = []
+
+    provenance = ModuleType("bot.exchange_kill_switch_alias_provenance_v258_patch")
+
+    def _install_provenance() -> bool:
+        events.append("v258_install")
+        monkeypatch.setenv(
+            "NIJA_EXCHANGE_KILLSWITCH_ALIAS_PROVENANCE_V258_READY",
+            "1",
+        )
+        return True
+
+    provenance.install = _install_provenance
+    provenance.reassert_loaded = lambda: events.append("v258_reassert") or True
+
+    internal = ModuleType("bot.exchange_kill_switch_internal_reject_guard_patch")
+
+    def _install_internal() -> None:
+        events.append("internal_install")
+        monkeypatch.setenv(
+            "NIJA_EXCHANGE_KILL_SWITCH_IGNORE_INTERNAL_ROUTING_REJECTS",
+            "true",
+        )
+
+    internal.install_import_hook = _install_internal
+
+    modules = {
+        provenance.__name__: provenance,
+        internal.__name__: internal,
+    }
+    monkeypatch.setattr(launcher, "_canonical_import", modules.__getitem__)
+
+    launcher._install_exchange_rejection_provenance_before_runtime()
+
+    assert events == [
+        "v258_install",
+        "v258_reassert",
+        "internal_install",
+        "v258_reassert",
+    ]
+
+
+def test_launcher_releases_writer_when_rejection_provenance_fails(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    launcher = _load("test_canonical_writer_first_v59_provenance_failure")
+    fake_main = tmp_path / "main.py"
+    fake_main.write_text("pass\n", encoding="utf-8")
+    monkeypatch.setattr(launcher, "MAIN_PATH", fake_main)
+    monkeypatch.setattr(launcher, "install_canonical_startup_guard", lambda: object())
+
+    bot_entry = ModuleType("bot.bot")
+    bot_main = ModuleType("bot.bot_main")
+    monkeypatch.setattr(
+        launcher,
+        "_bootstrap_writer_first",
+        lambda: (bot_entry, bot_main),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_install_exchange_rejection_provenance_before_runtime",
+        lambda: (_ for _ in ()).throw(RuntimeError("provenance failed")),
+    )
+    released: list[str] = []
+    monkeypatch.setattr(
+        launcher,
+        "_release_early_writer",
+        lambda _main, *, reason: released.append(reason),
+    )
+
+    try:
+        launcher.main()
+    except RuntimeError as exc:
+        assert str(exc) == "provenance failed"
+    else:
+        raise AssertionError("provenance failure must stop canonical startup")
+
+    assert released == ["exchange_rejection_provenance_pre_runtime_failed"]
 
 
 def test_writer_first_requires_exact_distributed_runtime(monkeypatch) -> None:

--- a/scripts/canonical_runtime_launcher_v26.py
+++ b/scripts/canonical_runtime_launcher_v26.py
@@ -354,6 +354,59 @@ def _bootstrap_writer_first() -> tuple[ModuleType, ModuleType]:
     return bot_entry, bot_main
 
 
+def _install_exchange_rejection_provenance_before_runtime() -> None:
+    """Install rejection provenance before any runtime order can be recorded.
+
+    The canonical launcher deliberately defers ``sitecustomize``'s broad patch
+    fanout.  The exchange rejection recorder is different: if it is installed
+    after the heartbeat scheduler starts, the boolean rejection window can
+    contain samples with no corresponding provenance.  Such a window is
+    intentionally unrecoverable because NIJA cannot distinguish a local
+    pre-dispatch denial from a genuine exchange rejection.
+
+    At this point the exact writer is already established and the canonical
+    bot modules are loaded, but ``bot.bot.main`` has not started any runtime
+    work.  Installing and reasserting both guards here therefore closes the
+    provenance race without granting execution authority or changing any
+    kill-switch, risk, nonce, capital, order, ACK, or fill gate.
+    """
+    provenance = _canonical_import(
+        "bot.exchange_kill_switch_alias_provenance_v258_patch"
+    )
+    install_provenance = getattr(provenance, "install", None)
+    reassert_provenance = getattr(provenance, "reassert_loaded", None)
+    if not callable(install_provenance) or not bool(install_provenance()):
+        raise RuntimeError("exchange rejection provenance v258 installer failed")
+    if not callable(reassert_provenance) or not bool(reassert_provenance()):
+        raise RuntimeError("exchange rejection provenance v258 reassertion failed")
+    if os.environ.get("NIJA_EXCHANGE_KILLSWITCH_ALIAS_PROVENANCE_V258_READY") != "1":
+        raise RuntimeError("exchange rejection provenance v258 did not attest ready")
+
+    internal_guard = _canonical_import(
+        "bot.exchange_kill_switch_internal_reject_guard_patch"
+    )
+    install_internal_guard = getattr(internal_guard, "install_import_hook", None)
+    if not callable(install_internal_guard):
+        raise RuntimeError("exchange internal-reject guard installer unavailable")
+    install_internal_guard()
+    if os.environ.get("NIJA_EXCHANGE_KILL_SWITCH_IGNORE_INTERNAL_ROUTING_REJECTS") != "true":
+        raise RuntimeError("exchange internal-reject guard did not attest ready")
+
+    # The internal guard adds another wrapper and import hook.  Reassert v258
+    # once more so the final loaded method chain is instrumented before runtime.
+    if not bool(reassert_provenance()):
+        raise RuntimeError("exchange rejection provenance final reassertion failed")
+    LOGGER.critical(
+        "CANONICAL_REJECTION_PROVENANCE_PRE_RUNTIME_READY "
+        "marker=20260828-canonical-rejection-provenance-v268 "
+        "writer_first=true runtime_not_started=true v258_ready=true "
+        "internal_reject_guard=true rejection_window_unchanged=true "
+        "kill_switch_unchanged=true rejection_thresholds_unchanged=true "
+        "execution_authority_unchanged=true execution_proof_fabricated=false "
+        "forced_activation=false safety_gates_bypassed=false"
+    )
+
+
 def _run_main_single_identity(bot_entry: ModuleType, bot_main: ModuleType) -> None:
     """Run ``main.py`` while reusing the canonical ``bot.bot`` module once."""
     original_run_module = runpy.run_module
@@ -405,6 +458,14 @@ def main() -> int:
     _start_render_memory_pressure_guard()
     install_canonical_startup_guard()
     bot_entry, bot_main = _bootstrap_writer_first()
+    try:
+        _install_exchange_rejection_provenance_before_runtime()
+    except Exception:
+        _release_early_writer(
+            bot_main,
+            reason="exchange_rejection_provenance_pre_runtime_failed",
+        )
+        raise
     print(
         "CANONICAL_ENTRYPOINT_FAST_PATH_ARMED marker=20260816-canonical-runtime-launcher-v111 "
         "package_hook_fanout=deferred bootstrap_import_loader=frozen_bootstrap",


### PR DESCRIPTION
## Problem

Production is fail-closed with an active EXCHANGE_MONITOR kill switch after a 5/5 rejection window. Runtime evidence shows the provenance history is empty (`provenance_history_short:0<5`) even though the later provenance patches report ready. The canonical launcher defers site hooks, so the v258 alias provenance and internal-routing reject guard can install after early order results are already recorded.

That race prevents the conservative v267 recovery path from distinguishing historical local pre-dispatch failures from genuine exchange rejections. Authority, execution, and nonce readiness consequently remain blocked.

## Change

- Install and attest v258 rejection provenance after exact distributed writer acquisition and before runtime handoff.
- Install the internal-routing rejection guard at the same boundary.
- Reassert v258 after the guard wrapper is installed.
- Fail closed and release early writer authority if this setup cannot be proven.
- Add regression coverage for ordering and failure cleanup.

## Safety invariants

- Does not clear the rejection window directly.
- Does not deactivate the kill switch.
- Does not weaken writer, nonce, risk, capital, ECEL, minimum-notional, order, or fill gates.
- Genuine exchange rejections and manual/risk stops remain authoritative.
- Runtime recovery still requires the existing exact v267 provenance and health checks.

## Validation

- `python3 -m py_compile` passed for changed and involved modules.
- `git diff --check` passed.
- Focused startup-order and v267 invariant checks passed.
- Confirmed five local dispatch-disabled samples are recoverable only with exact provenance.
- Confirmed a genuine insufficient-funds exchange refusal remains preserved.
- Full pytest was not run locally because pytest is unavailable in the execution image.

Deployment and live execution proof must wait for CI plus human review.