### PR TITLE
Fix hardening enforcement rejection provenance

### DIFF
--- a/bot/exchange_kill_switch_alias_provenance_v258_patch.py
+++ b/bot/exchange_kill_switch_alias_provenance_v258_patch.py
@@ -29,6 +29,7 @@ from typing import Any, Callable
 
 LOGGER = logging.getLogger("nija.exchange_kill_switch_alias_provenance_v258")
 MARKER = "20260828-exchange-killswitch-alias-provenance-v258"
+V269_MARKER = "20260828-hardening-enforcement-provenance-v269"
 _FLAG = "NIJA_EXCHANGE_KILLSWITCH_ALIAS_PROVENANCE_V258_READY"
 _RECORDER_ATTR = "_nija_exchange_killswitch_alias_recorder_v258"
 _REJECT_ATTR = "_nija_exchange_killswitch_alias_reject_context_v258"
@@ -95,10 +96,20 @@ _NON_EXCHANGE_MARKERS = (
     "terminal_reject_status:unfilled",
 )
 
+# ``HARDENING_ENFORCEMENT`` is the documented execution-layer return code for a
+# position-cap/minimum-size/average-position/dust block.  That control returns
+# before broker API dispatch.  Keep it exact-match only so an arbitrary exchange
+# message that merely contains the token cannot be reclassified as local.
+_EXACT_NON_EXCHANGE_CODES = frozenset({"hardening_enforcement"})
+
 
 def _is_non_exchange(reason: Any) -> bool:
     text = str(reason or "").strip().lower()
-    return bool(text) and any(marker in text for marker in _NON_EXCHANGE_MARKERS)
+    if not text:
+        return False
+    if text in _EXACT_NON_EXCHANGE_CODES:
+        return True
+    return any(marker in text for marker in _NON_EXCHANGE_MARKERS)
 
 
 def _context_payload() -> dict[str, str]:
@@ -379,19 +390,21 @@ def install() -> bool:
             _THREAD.start()
     os.environ[_FLAG] = "1"
     LOGGER.critical(
-        "EXCHANGE_REJECT_V258_READY marker=%s ready=true dual_kill_switch_identity_guard=true "
+        "EXCHANGE_REJECT_V258_READY marker=%s v269_marker=%s ready=true dual_kill_switch_identity_guard=true "
         "dual_pipeline_context_guard=true counted_sample_diagnostics=true provenance_history=true "
-        "legacy_alias_import_forced=false rejection_window_cleared=false kill_switch_mutated=false "
-        "rejection_thresholds_unchanged=true minimum_sample_unchanged=true genuine_exchange_rejects_unchanged=true "
-        "execution_authority_unchanged=true execution_proof_fabricated=false forced_activation=false "
-        "safety_gates_bypassed=false",
+        "hardening_enforcement_exact_non_exchange=true legacy_alias_import_forced=false "
+        "rejection_window_cleared=false kill_switch_mutated=false rejection_thresholds_unchanged=true "
+        "minimum_sample_unchanged=true genuine_exchange_rejects_unchanged=true execution_authority_unchanged=true "
+        "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
         MARKER,
+        V269_MARKER,
     )
     return True
 
 
 __all__ = [
     "MARKER",
+    "V269_MARKER",
     "install",
     "reassert_loaded",
     "_is_non_exchange",

--- a/bot/tests/test_exchange_rejection_stale_latch_v226.py
+++ b/bot/tests/test_exchange_rejection_stale_latch_v226.py
@@ -104,6 +104,37 @@ def test_v267_proves_five_reclassified_local_samples(monkeypatch):
     assert detail == "verified_non_exchange_current_window:5"
 
 
+def test_v269_v267_proves_five_exact_hardening_enforcement_samples(monkeypatch):
+    records = [_local_record(i, reason="HARDENING_ENFORCEMENT") for i in range(5)]
+    protector = _Protector(results=(False,) * 5, provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    from bot import exchange_kill_switch_alias_provenance_v258_patch as v258
+    assert v258._is_non_exchange("HARDENING_ENFORCEMENT") is True
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is True
+    assert count == 5
+    assert detail == "verified_non_exchange_current_window:5"
+
+
+def test_v269_v267_refuses_hardening_token_embedded_in_exchange_message(monkeypatch):
+    records = [_local_record(i, reason="HARDENING_ENFORCEMENT") for i in range(4)]
+    records.append(
+        _local_record(
+            4,
+            reason="Coinbase rejected order: HARDENING_ENFORCEMENT upstream policy",
+        )
+    )
+    protector = _Protector(results=(False,) * 5, provenance=records)
+    monkeypatch.setattr(v226, "_minimum_samples", lambda _protector: 5)
+
+    ok, detail, count = v226._current_window_false_positive_proof(protector)
+    assert ok is False
+    assert count == 0
+    assert detail.startswith("provenance_not_non_exchange:4:")
+
+
 def test_v267_refuses_one_genuine_exchange_rejection(monkeypatch):
     records = [_local_record(i) for i in range(4)]
     records.append(_local_record(4, reason="Kraken AddOrder rejected: EOrder:Insufficient funds"))

--- a/tests/test_exchange_killswitch_alias_provenance_v258.py
+++ b/tests/test_exchange_killswitch_alias_provenance_v258.py
@@ -84,6 +84,55 @@ def test_v258_local_predispatch_reason_is_not_counted(monkeypatch):
     assert history[-1]["reason"] == "dispatch_disabled: dispatch.enabled=false"
 
 
+def test_v269_exact_hardening_enforcement_is_local_predispatch(monkeypatch):
+    canonical = _kill_module("bot.exchange_kill_switch")
+    monkeypatch.setitem(sys.modules, "bot.exchange_kill_switch", canonical)
+    assert v258._patch_kill_switch_module(canonical) is True
+
+    pipeline_module = _pipeline_module(
+        "bot.execution_pipeline",
+        canonical._protector.record_order_result,
+    )
+    monkeypatch.setitem(sys.modules, "bot.execution_pipeline", pipeline_module)
+    assert v258._patch_pipeline_module(pipeline_module) is True
+
+    request = SimpleNamespace(symbol="BTC-USD", side="buy")
+    result = pipeline_module.ExecutionPipeline()._on_order_rejected(
+        request,
+        "HARDENING_ENFORCEMENT",
+    )
+
+    assert result is None
+    assert canonical._protector._order_results == []
+    history = list(canonical._protector._nija_order_result_provenance_v258)
+    assert history[-1]["known_non_exchange"] is True
+    assert history[-1]["source"] == "execution_pipeline"
+    assert history[-1]["reason"] == "HARDENING_ENFORCEMENT"
+
+
+def test_v269_hardening_token_inside_exchange_message_still_counts(monkeypatch):
+    canonical = _kill_module("bot.exchange_kill_switch")
+    monkeypatch.setitem(sys.modules, "bot.exchange_kill_switch", canonical)
+    assert v258._patch_kill_switch_module(canonical) is True
+
+    pipeline_module = _pipeline_module(
+        "bot.execution_pipeline",
+        canonical._protector.record_order_result,
+    )
+    monkeypatch.setitem(sys.modules, "bot.execution_pipeline", pipeline_module)
+    assert v258._patch_pipeline_module(pipeline_module) is True
+
+    request = SimpleNamespace(symbol="BTC-USD", side="buy")
+    reason = "Coinbase rejected order: HARDENING_ENFORCEMENT upstream policy"
+    result = pipeline_module.ExecutionPipeline()._on_order_rejected(request, reason)
+
+    assert result == "recorded"
+    assert canonical._protector._order_results == [False]
+    history = list(canonical._protector._nija_order_result_provenance_v258)
+    assert history[-1]["known_non_exchange"] is False
+    assert history[-1]["reason"] == reason
+
+
 def test_v258_genuine_exchange_reject_still_counts(monkeypatch):
     canonical = _kill_module("bot.exchange_kill_switch")
     monkeypatch.setitem(sys.modules, "bot.exchange_kill_switch", canonical)


### PR DESCRIPTION
Classify the exact local pre-dispatch `HARDENING_ENFORCEMENT` return code as non-exchange provenance so verified stale rejection windows can recover through v267. The classification is exact-match only; embedded/look-alike exchange messages continue to count. Adds v258 and v267 regression coverage. Rejection thresholds, minimum samples, kill-switch semantics, writer/nonce/risk/capital/order/fill gates, and genuine exchange rejection handling remain unchanged.