### PR TITLE
Bound pre-core symbol discovery liveness v269

### DIFF
--- a/bot/runtime_precore_strategy_lookup_v207_patch.py
+++ b/bot/runtime_precore_strategy_lookup_v207_patch.py
@@ -1,23 +1,21 @@
-"""Keep v203 install-time strategy discovery non-importing during pre-core startup.
+"""Keep pre-core strategy discovery and construction nonblocking.
 
 Production deployment 22cde3c showed an 85 second startup stall between the
 v190 pre-core publication deferral and v203's IMMEDIATE_SKIPPED result while the
-canonical runtime was still generation 0 / BOOT_INIT.  v203's fallback called
-strategy_publication_patch._existing(), whose helper may import a broad set of
-runtime modules.  That is inappropriate inside the pre-core installer path: the
-real canonical strategy belongs to bot_main Step 2.5 and v190 intentionally
-keeps that path single-owner.
+canonical runtime was still generation 0 / BOOT_INIT. v207 originally narrowed
+v203's install-time lookup so it observes only already-loaded strategy pointers.
 
-v207 narrows only v203's install-time *lookup*.  It can observe:
-* the current publication module's existing _PUBLISHED pointer;
-* strategy pointers already present in already-loaded modules/state dictionaries;
-* v127's already-loaded cached publication closure via v203's existing helper.
+Production deployment b02a2238 later exposed the next pre-core liveness edge:
+TradingStrategy construction can synchronously perform broker market discovery
+before bot_main can start and register the canonical core thread. v269 bounds
+that read-only discovery. This module chains v269 at the narrowest safe point:
+after the TradingStrategy class has already loaded and immediately before the
+canonical builder invokes its constructor. That avoids a new early import fanout
+while guaranteeing the constructor cannot enter unbounded market discovery.
 
-It never imports modules merely to discover a strategy, never constructs or
-publishes a strategy, never starts a second publisher, and never changes any
-writer/nonce/risk/kill-switch/capital/position/order/fill or activation gate.
-Future canonical Step 2.5 publication remains wrapped by v203 and therefore
-re-arms the existing heartbeat scheduler normally after real publication.
+Neither repair constructs or publishes a strategy during install, starts a
+second publisher, grants execution authority, nor changes writer/nonce/risk/
+kill-switch/capital/position/order/fill or activation gates.
 """
 from __future__ import annotations
 
@@ -25,6 +23,7 @@ import logging
 import os
 import sys
 import threading
+from functools import wraps
 from types import ModuleType
 from typing import Any
 
@@ -32,6 +31,7 @@ LOGGER = logging.getLogger("nija.runtime_precore_strategy_lookup_v207")
 MARKER = "20260824-precore-strategy-lookup-v207"
 _READY_FLAG = "NIJA_PRECORE_STRATEGY_LOOKUP_V207_READY"
 _PATCH_ATTR = "_nija_precore_strategy_lookup_v207"
+_BUILD_PATCH_ATTR = "_nija_precore_strategy_builder_v269"
 _LOCK = threading.RLock()
 
 
@@ -128,7 +128,7 @@ def _patch_v203() -> bool:
     previous = current
 
     def _already_published_strategy_nonblocking(module: Any) -> Any:
-        # Use the publication object supplied by v203 when available.  The
+        # Use the publication object supplied by v203 when available. The
         # imported canonical object above is only a safe fallback and is already
         # loaded by v196/v203's normal install chain.
         target = module if module is not None else publication
@@ -143,21 +143,76 @@ def _patch_v203() -> bool:
     return bool(callable(installed) and getattr(installed, _PATCH_ATTR, False))
 
 
+def _patch_strategy_builder() -> bool:
+    """Install v269 immediately before the canonical strategy constructor runs."""
+    try:
+        import bot.strategy_publication_patch as publication
+    except Exception as exc:
+        LOGGER.critical(
+            "PRECORE_STRATEGY_BUILDER_V269_IMPORT_FAILED marker=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+    current = getattr(publication, "_build_strategy", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _BUILD_PATCH_ATTR, False)):
+        return True
+    previous = current
+
+    @wraps(previous)
+    def _build_strategy_with_v269(cls: type, brokers: dict[Any, dict[str, Any]]) -> Any:
+        # publish_canonical_strategy resolves cls before reaching this builder,
+        # so bot.trading_strategy is already loaded. v269 therefore patches the
+        # existing class and does not create a new pre-core import fanout.
+        try:
+            from bot.runtime_precore_symbol_discovery_liveness_v269_patch import (
+                install as install_v269,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"precore_symbol_discovery_v269_import_failed:{type(exc).__name__}:{exc}"
+            ) from exc
+        if not install_v269():
+            raise RuntimeError("precore_symbol_discovery_v269_install_failed")
+        LOGGER.critical(
+            "PRECORE_STRATEGY_BUILDER_V269_ARMED marker=%s "
+            "constructor_next=true early_import_fanout=false trading_fail_closed=true",
+            MARKER,
+        )
+        return previous(cls, brokers)
+
+    setattr(_build_strategy_with_v269, _BUILD_PATCH_ATTR, True)
+    setattr(_build_strategy_with_v269, "__wrapped__", previous)
+    publication._build_strategy = _build_strategy_with_v269
+    return True
+
+
 def install() -> bool:
     with _LOCK:
-        ready = _patch_v203()
+        lookup_ready = _patch_v203()
+        builder_ready = _patch_strategy_builder()
+        ready = bool(lookup_ready and builder_ready)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
-                "PRECORE_STRATEGY_LOOKUP_V207_FAILED marker=%s trading_fail_closed=true",
+                "PRECORE_STRATEGY_LOOKUP_V207_FAILED marker=%s lookup_ready=%s "
+                "builder_v269_ready=%s trading_fail_closed=true",
                 MARKER,
+                str(lookup_ready).lower(),
+                str(builder_ready).lower(),
             )
             return False
         LOGGER.critical(
             "PRECORE_STRATEGY_LOOKUP_V207_READY marker=%s ready=true "
             "install_time_lookup_nonblocking=true broad_existing_scan=false "
             "already_loaded_pointers_only=true v127_cached_pointer_allowed=true "
-            "step2_5_single_owner_preserved=true strategy_constructed=false "
+            "step2_5_single_owner_preserved=true strategy_constructor_v269_guarded=true "
+            "early_trading_strategy_import=false strategy_constructed=false "
             "strategy_published=false execution_authority_granted=false "
             "proof_fabricated=false forced_activation=false "
             "writer_nonce_risk_killswitch_capital_position_order_fill_gates_unchanged=true "
@@ -178,4 +233,5 @@ __all__ = [
     "_valid_strategy",
     "_loaded_strategy_pointer",
     "_nonblocking_existing_strategy",
+    "_patch_strategy_builder",
 ]

--- a/bot/runtime_precore_symbol_discovery_liveness_v269_patch.py
+++ b/bot/runtime_precore_symbol_discovery_liveness_v269_patch.py
@@ -1,0 +1,238 @@
+"""Bound pre-core market-symbol discovery so startup can reach core registration.
+
+Production runtime b02a2238 reached TradingStrategy construction but an earlier
+cycle remained without a registered core until the writer's 600 second terminal
+startup deadline. TradingStrategy._populate_symbols() performs synchronous,
+read-only get_available_markets()/get_all_products() calls before bot_main can
+start and register the canonical core thread. A broker read that never returns
+can therefore pin the only pre-core startup path indefinitely.
+
+v269 bounds only those read-only discovery calls and keeps at most one in-flight
+worker for each broker/method. A timeout does not mark the broker healthy,
+does not publish strategy or execution readiness, and does not mutate capital,
+nonce, kill-switch, risk, order, fill, or trading state. TradingStrategy's
+existing broker-safe fallback symbol universe remains authoritative whenever
+live discovery is unavailable.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import queue
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_precore_symbol_discovery_liveness_v269")
+MARKER = "20260828-precore-symbol-discovery-liveness-v269"
+RELEASE_ID = "20260828-runtime-convergence-v269"
+_READY_FLAG = "NIJA_RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269_READY"
+_PATCH_ATTR = "_nija_runtime_precore_symbol_discovery_liveness_v269"
+_LOCK = threading.RLock()
+_FLIGHT_LOCK = threading.RLock()
+_FLIGHTS: dict[tuple[int, str], threading.Thread] = {}
+
+
+def _timeout_s() -> float:
+    try:
+        value = float(os.environ.get("NIJA_PRECORE_SYMBOL_DISCOVERY_TIMEOUT_S", "5") or 5.0)
+    except (TypeError, ValueError):
+        value = 5.0
+    return max(0.5, min(15.0, value))
+
+
+def _bounded_read(broker: Any, method_name: str) -> Any:
+    """Execute one read-only discovery call with a per-method single-flight."""
+    method = getattr(broker, method_name, None)
+    if not callable(method):
+        raise AttributeError(method_name)
+
+    key = (id(broker), method_name)
+    result_queue: "queue.Queue[tuple[str, Any]]" = queue.Queue(maxsize=1)
+
+    with _FLIGHT_LOCK:
+        existing = _FLIGHTS.get(key)
+        if existing is not None and existing.is_alive():
+            raise TimeoutError(f"precore_symbol_discovery_inflight:{method_name}")
+        _FLIGHTS.pop(key, None)
+        worker_ref: dict[str, threading.Thread] = {}
+
+        def _runner() -> None:
+            try:
+                result_queue.put_nowait(("result", method()))
+            except BaseException as exc:
+                try:
+                    result_queue.put_nowait(("error", exc))
+                except queue.Full:
+                    pass
+            finally:
+                worker = worker_ref.get("worker")
+                with _FLIGHT_LOCK:
+                    if worker is not None and _FLIGHTS.get(key) is worker:
+                        _FLIGHTS.pop(key, None)
+
+        worker = threading.Thread(
+            target=_runner,
+            name=f"PrecoreSymbolDiscovery-{type(broker).__name__}-{method_name}",
+            daemon=True,
+        )
+        worker_ref["worker"] = worker
+        _FLIGHTS[key] = worker
+        worker.start()
+
+    timeout = _timeout_s()
+    try:
+        kind, payload = result_queue.get(timeout=timeout)
+    except queue.Empty as exc:
+        raise TimeoutError(
+            f"precore_symbol_discovery_timeout:{method_name}:{timeout:.2f}s"
+        ) from exc
+    if kind == "error":
+        raise payload
+    return payload
+
+
+def _patch_trading_strategy() -> bool:
+    try:
+        module = importlib.import_module("bot.trading_strategy")
+        cls = getattr(module, "TradingStrategy", None)
+    except Exception as exc:
+        LOGGER.error(
+            "PRECORE_SYMBOL_DISCOVERY_V269_IMPORT_FAILED marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    if not isinstance(cls, type):
+        return False
+
+    current = getattr(cls, "_discover_broker_symbols", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+
+    original = current
+
+    @wraps(original)
+    def bounded_discovery(self: Any, broker: Any) -> list[str]:
+        broker_name = "unknown"
+        try:
+            broker_name = str(self._broker_key_from_obj(broker) or "unknown")
+        except Exception:
+            broker_name = type(broker).__name__.lower()
+
+        for method_name in ("get_available_markets", "get_all_products"):
+            if not callable(getattr(broker, method_name, None)):
+                continue
+            try:
+                products = _bounded_read(broker, method_name)
+            except TimeoutError as exc:
+                LOGGER.warning(
+                    "PRECORE_SYMBOL_DISCOVERY_V269_TIMEOUT marker=%s broker=%s method=%s "
+                    "timeout_s=%.2f detail=%s read_only=true single_flight=true "
+                    "fallback_preserved=true broker_health_unchanged=true",
+                    MARKER,
+                    broker_name,
+                    method_name,
+                    _timeout_s(),
+                    exc,
+                )
+                continue
+            except Exception as exc:
+                LOGGER.info(
+                    "PRECORE_SYMBOL_DISCOVERY_V269_READ_FAILED marker=%s broker=%s method=%s "
+                    "error=%s:%s fallback_preserved=true broker_health_unchanged=true",
+                    MARKER,
+                    broker_name,
+                    method_name,
+                    type(exc).__name__,
+                    exc,
+                )
+                continue
+
+            if isinstance(products, list):
+                dedupe = getattr(self, "_dedupe_symbols", None)
+                if callable(dedupe):
+                    discovered = list(dedupe(products) or [])
+                else:
+                    seen: set[str] = set()
+                    discovered = []
+                    for raw in products:
+                        symbol = str(raw or "").strip()
+                        if symbol and symbol not in seen:
+                            seen.add(symbol)
+                            discovered.append(symbol)
+                if discovered:
+                    return discovered
+        # Preserve the original caller contract: _populate_symbols() owns the
+        # asset-class-safe fallback when discovery yields no symbols.
+        return []
+
+    setattr(bounded_discovery, _PATCH_ATTR, True)
+    setattr(bounded_discovery, "__wrapped__", original)
+    cls._discover_broker_symbols = bounded_discovery
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        installers = getattr(manifest, "_INSTALLERS", None)
+        if not isinstance(required, dict):
+            return False
+        required["precore_symbol_discovery_liveness_v269"] = _READY_FLAG
+        own = ("bot.runtime_precore_symbol_discovery_liveness_v269_patch", "install_import_hook")
+        if isinstance(installers, tuple) and own not in installers:
+            manifest._INSTALLERS = tuple(installers) + (own,)
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        patched = _patch_trading_strategy()
+        manifest = _patch_release_manifest()
+        ready = bool(patched and manifest)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269_FAILED marker=%s "
+                "strategy_patch=%s manifest=%s trading_fail_closed=true",
+                MARKER,
+                str(patched).lower(),
+                str(manifest).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269 marker=%s ready=true "
+            "timeout_s=%.2f read_only_market_discovery=true single_flight=true "
+            "late_result_discarded=true broker_safe_fallback_preserved=true "
+            "capital_thresholds_unchanged=true freshness_extended=false "
+            "nonce_policy_unchanged=true kill_switch_unchanged=true risk_gates_unchanged=true "
+            "order_fill_gates_unchanged=true execution_proof_fabricated=false "
+            "forced_trade=false forced_activation=false safety_gates_bypassed=false",
+            MARKER,
+            _timeout_s(),
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_timeout_s",
+    "_bounded_read",
+    "_patch_trading_strategy",
+    "_patch_release_manifest",
+]

--- a/tests/test_runtime_precore_symbol_discovery_liveness_v269.py
+++ b/tests/test_runtime_precore_symbol_discovery_liveness_v269.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "bot" / "runtime_precore_symbol_discovery_liveness_v269_patch.py"
+V207 = ROOT / "bot" / "runtime_precore_strategy_lookup_v207_patch.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _strategy_module() -> ModuleType:
+    module = ModuleType("bot.trading_strategy")
+
+    class TradingStrategy:
+        @staticmethod
+        def _broker_key_from_obj(_broker):
+            return "kraken"
+
+        @staticmethod
+        def _dedupe_symbols(symbols):
+            out = []
+            seen = set()
+            for raw in symbols:
+                symbol = str(raw or "").strip()
+                if symbol and symbol not in seen:
+                    seen.add(symbol)
+                    out.append(symbol)
+            return out
+
+        def _discover_broker_symbols(self, broker):
+            return list(broker.get_available_markets())
+
+    module.TradingStrategy = TradingStrategy
+    return module
+
+
+def test_v269_bounds_hung_discovery_and_preserves_fallback_contract(monkeypatch) -> None:
+    v269 = _load("test_precore_symbol_v269_timeout", PATCH)
+    strategy_module = _strategy_module()
+    monkeypatch.setitem(sys.modules, "bot.trading_strategy", strategy_module)
+    monkeypatch.setenv("NIJA_PRECORE_SYMBOL_DISCOVERY_TIMEOUT_S", "0.05")
+    monkeypatch.setattr(v269, "_timeout_s", lambda: 0.05)
+
+    block = threading.Event()
+
+    class Broker:
+        connected = True
+
+        def get_available_markets(self):
+            block.wait(1.0)
+            return ["BTC-USD"]
+
+    assert v269._patch_trading_strategy() is True
+    strategy = strategy_module.TradingStrategy()
+    started = time.monotonic()
+    assert strategy._discover_broker_symbols(Broker()) == []
+    elapsed = time.monotonic() - started
+    block.set()
+
+    assert elapsed < 0.30
+
+
+def test_v269_successful_discovery_is_deduped(monkeypatch) -> None:
+    v269 = _load("test_precore_symbol_v269_success", PATCH)
+    strategy_module = _strategy_module()
+    monkeypatch.setitem(sys.modules, "bot.trading_strategy", strategy_module)
+
+    class Broker:
+        connected = True
+
+        def get_available_markets(self):
+            return ["BTC-USD", "BTC-USD", "ETH-USD", ""]
+
+    assert v269._patch_trading_strategy() is True
+    strategy = strategy_module.TradingStrategy()
+    assert strategy._discover_broker_symbols(Broker()) == ["BTC-USD", "ETH-USD"]
+
+
+def test_v269_single_flight_refuses_duplicate_hung_read(monkeypatch) -> None:
+    v269 = _load("test_precore_symbol_v269_singleflight", PATCH)
+    monkeypatch.setattr(v269, "_timeout_s", lambda: 0.05)
+    release = threading.Event()
+    calls = []
+
+    class Broker:
+        def get_available_markets(self):
+            calls.append(time.monotonic())
+            release.wait(1.0)
+            return ["BTC-USD"]
+
+    broker = Broker()
+    try:
+        v269._bounded_read(broker, "get_available_markets")
+        assert False, "first read should time out"
+    except TimeoutError:
+        pass
+
+    started = time.monotonic()
+    try:
+        v269._bounded_read(broker, "get_available_markets")
+        assert False, "duplicate read should be rejected while first worker is alive"
+    except TimeoutError as exc:
+        assert "inflight" in str(exc)
+    elapsed = time.monotonic() - started
+    release.set()
+
+    assert len(calls) == 1
+    assert elapsed < 0.10
+
+
+def test_v269_does_not_mutate_trading_safety_state(monkeypatch) -> None:
+    v269 = _load("test_precore_symbol_v269_invariants", PATCH)
+    strategy_module = _strategy_module()
+    manifest = ModuleType("bot.runtime_release_manifest_patch")
+    manifest._REQUIRED_FLAGS = {}
+    manifest._INSTALLERS = ()
+    monkeypatch.setitem(sys.modules, "bot.trading_strategy", strategy_module)
+    monkeypatch.setitem(sys.modules, "bot.runtime_release_manifest_patch", manifest)
+
+    names = (
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY",
+        "NIJA_RUNTIME_TRADING_STATE",
+        "NIJA_KILL_SWITCH_ACTIVE",
+        "NIJA_WRITER_FENCING_TOKEN",
+        "NIJA_WRITER_LEASE_GENERATION",
+    )
+    before = {name: os.environ.get(name) for name in names}
+
+    assert v269.install() is True
+
+    after = {name: os.environ.get(name) for name in names}
+    assert after == before
+    assert os.environ["NIJA_RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269_READY"] == "1"
+    assert manifest._REQUIRED_FLAGS["precore_symbol_discovery_liveness_v269"] == (
+        "NIJA_RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269_READY"
+    )
+
+
+def test_v207_arms_v269_at_constructor_boundary(monkeypatch) -> None:
+    v207 = _load("test_precore_strategy_v207_builder_v269", V207)
+    publication = ModuleType("bot.strategy_publication_patch")
+    calls = []
+
+    def build(cls, brokers):
+        calls.append(("build", cls, brokers))
+        return cls()
+
+    publication._build_strategy = build
+    monkeypatch.setitem(sys.modules, "bot.strategy_publication_patch", publication)
+
+    v269 = ModuleType("bot.runtime_precore_symbol_discovery_liveness_v269_patch")
+
+    def install_v269():
+        calls.append(("v269",))
+        return True
+
+    v269.install = install_v269
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.runtime_precore_symbol_discovery_liveness_v269_patch",
+        v269,
+    )
+
+    assert v207._patch_strategy_builder() is True
+
+    class Strategy:
+        pass
+
+    result = publication._build_strategy(Strategy, {"kraken": {"entry_ready": True}})
+    assert isinstance(result, Strategy)
+    assert calls[0] == ("v269",)
+    assert calls[1][0] == "build"


### PR DESCRIPTION
## Production failure addressed
The deployed b02a2238 runtime previously reached the writer authority's terminal core-registration deadline after 603.3s with no canonical core registered. The newest capture shows platform connectivity and capital recovery are healthy and strategy construction reaches `NijaCoreLoop initialized`, narrowing the remaining pre-core liveness risk to synchronous strategy construction.

`TradingStrategy._populate_symbols()` performs read-only broker market discovery before `bot_main` can call `start_trading_engine()` and `register_core_thread()`. A stalled `get_available_markets()` / `get_all_products()` can therefore pin startup until writer-authority recovery restarts the process.

## Changes
- Add v269 bounded, daemonized, single-flight read-only symbol discovery.
- Default timeout 5s per broker discovery method; configurable with `NIJA_PRECORE_SYMBOL_DISCOVERY_TIMEOUT_S` and clamped to 0.5–15s.
- Discard late results and refuse duplicate in-flight reads for the same broker/method.
- Preserve existing broker-safe fallback symbol universes when discovery times out or fails.
- Chain v269 at the canonical v207 strategy-builder boundary: after `TradingStrategy` is loaded, immediately before constructor execution. This avoids new early import fanout.
- Add regression tests for timeout bounds, successful dedupe, single-flight behavior, safety-state invariants, and v207→v269 ordering.

## Safety invariants
No change to capital completeness/freshness, writer or nonce authority, kill-switch behavior, risk sizing, minimum notional, order/fill confirmation, execution proof, broker connection truth, strategy thresholds, or protective exits. No execution authority or readiness is fabricated; no forced activation/trade is introduced.