### PR TITLE
Preserve registered platform capital completeness v270

### DIFF
--- a/bot/runtime_capital_platform_source_graph_v189_patch.py
+++ b/bot/runtime_capital_platform_source_graph_v189_patch.py
@@ -14,7 +14,12 @@ adapter does not expose a connected attribute).  It never supplies a balance,
 never reuses a stale balance, never changes expected-broker thresholds, never
 extends freshness/publication expiry, and never promotes a partial snapshot.
 The original CapitalAuthority refresh path still performs the authenticated
-balance read and all existing 3/3 completeness/freshness gates remain intact.
+balance read and all existing completeness/freshness gates remain intact.
+
+Production on 2026-08-29 then proved a separate denominator problem when three
+platform brokers were registered but Kraken was disconnected.  v189 therefore
+chains the v270 registered-platform completeness guard so connected-source
+selection can never redefine the registered platform denominator.
 """
 from __future__ import annotations
 
@@ -165,6 +170,27 @@ def _patch_capital_authority_refresh() -> bool:
     return True
 
 
+def _install_registered_platform_completeness_v270() -> bool:
+    try:
+        companion = importlib.import_module(
+            "bot.runtime_registered_platform_capital_completeness_v270_patch"
+        )
+        installer = getattr(companion, "install_import_hook", None) or getattr(
+            companion, "install", None
+        )
+        return bool(callable(installer) and installer())
+    except Exception as exc:
+        LOGGER.critical(
+            "REGISTERED_PLATFORM_CAPITAL_V270_CHAIN_FAILED marker=%s error=%s:%s "
+            "trading_fail_closed=true",
+            MARKER,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
 def _patch_release_manifest() -> bool:
     try:
         manifest = importlib.import_module("bot.runtime_release_manifest_patch")
@@ -184,23 +210,25 @@ def _patch_release_manifest() -> bool:
 def install() -> bool:
     with _LOCK:
         authority_ok = _patch_capital_authority_refresh()
+        v270_ok = _install_registered_platform_completeness_v270()
         manifest_ok = _patch_release_manifest()
-        ready = bool(authority_ok and manifest_ok)
+        ready = bool(authority_ok and v270_ok and manifest_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "RUNTIME_CAPITAL_PLATFORM_SOURCE_GRAPH_V189_FAILED marker=%s authority=%s "
-                "manifest=%s trading_fail_closed=true",
+                "registered_platform_v270=%s manifest=%s trading_fail_closed=true",
                 MARKER,
                 str(authority_ok).lower(),
+                str(v270_ok).lower(),
                 str(manifest_ok).lower(),
             )
             return False
         LOGGER.critical(
             "RUNTIME_CAPITAL_PLATFORM_SOURCE_GRAPH_V189 marker=%s ready=true "
             "canonical_registry_only=true connected_platform_sources_only=true "
-            "balances_fabricated=false stale_balance_reused=false "
-            "completeness_threshold_unchanged=true freshness_ttl_unchanged=true "
+            "registered_platform_v270=true balances_fabricated=false stale_balance_reused=false "
+            "completeness_threshold_not_lowered=true freshness_ttl_unchanged=true "
             "publication_expiry_extended=false forced_activation=false safety_gates_bypassed=false",
             MARKER,
         )
@@ -221,5 +249,6 @@ __all__ = [
     "_broker_is_connected",
     "_supplement_platform_sources",
     "_patch_capital_authority_refresh",
+    "_install_registered_platform_completeness_v270",
     "_patch_release_manifest",
 ]

--- a/bot/runtime_registered_platform_capital_completeness_v270_patch.py
+++ b/bot/runtime_registered_platform_capital_completeness_v270_patch.py
@@ -1,0 +1,342 @@
+"""Registered-platform capital completeness guard v270.
+
+Production on 2026-08-29 showed three platform brokers registered while Kraken
+was disconnected, but the capital stack could still report the most recent
+publication as accepted and MultiAccountBrokerManager.refresh_capital_authority()
+contains a fallback that treats positive non-Kraken capital as ready when Kraken
+is disconnected.  That can let current connectivity shrink the effective
+completeness denominator below the registered platform topology.
+
+v270 preserves the configured platform topology as the capital denominator.  It
+never fabricates connectivity, balances, freshness, publication status, nonce,
+execution authority, order/fill proof, or activation.  It only raises the
+CapitalAuthority expected-broker floor to the registered platform count, refuses
+a READY refresh result while any registered platform broker is disconnected or
+while the current result has fewer contributing brokers, and prevents startup
+lock release under the same incomplete condition.  Protective exits are not
+changed.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any, Mapping
+
+LOGGER = logging.getLogger("nija.runtime_registered_platform_capital_completeness_v270")
+MARKER = "20260828-registered-platform-capital-completeness-v270"
+RELEASE_ID = "20260828-runtime-convergence-v270"
+_READY_FLAG = "NIJA_RUNTIME_REGISTERED_PLATFORM_CAPITAL_COMPLETENESS_V270_READY"
+_REFRESH_PATCH_ATTR = "_nija_registered_platform_capital_completeness_v270_refresh"
+_FINALIZE_PATCH_ATTR = "_nija_registered_platform_capital_completeness_v270_finalize"
+_LOCK = threading.RLock()
+
+
+def _platform_mapping(manager: Any) -> dict[Any, Any]:
+    raw = getattr(manager, "platform_brokers", None)
+    if callable(raw):
+        try:
+            raw = raw()
+        except Exception:
+            raw = None
+    if not isinstance(raw, Mapping):
+        raw = getattr(manager, "_platform_brokers", None)
+    if not isinstance(raw, Mapping):
+        return {}
+    return {key: broker for key, broker in raw.items() if broker is not None}
+
+
+def _platform_counts(manager: Any) -> tuple[int, int]:
+    mapping = _platform_mapping(manager)
+    registered = len(mapping)
+    connected = 0
+    for broker in mapping.values():
+        try:
+            if bool(getattr(broker, "connected", False)):
+                connected += 1
+        except Exception:
+            pass
+    return registered, connected
+
+
+def _authority() -> Any:
+    try:
+        module = importlib.import_module("bot.capital_authority")
+        getter = getattr(module, "get_capital_authority", None)
+        return getter() if callable(getter) else None
+    except Exception:
+        return None
+
+
+def _raise_expected_floor(manager: Any) -> tuple[int, int, int]:
+    registered, connected = _platform_counts(manager)
+    authority = _authority()
+    expected_before = 0
+    if authority is not None:
+        try:
+            expected_before = int(getattr(authority, "expected_brokers", 0) or 0)
+        except Exception:
+            expected_before = 0
+        if registered > expected_before:
+            setter = getattr(authority, "set_expected_brokers", None)
+            if callable(setter):
+                setter(registered)
+    return registered, connected, max(expected_before, registered)
+
+
+def _result_valid_brokers(result: Any) -> int:
+    if not isinstance(result, Mapping):
+        return 0
+    try:
+        return max(0, int(float(result.get("valid_brokers", 0) or 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _current_publication_accepted_and_fresh(authority: Any) -> bool:
+    if authority is None:
+        return False
+    status_getter = getattr(authority, "get_snapshot_publication_status", None)
+    if callable(status_getter):
+        try:
+            status = status_getter()
+            if not bool(getattr(status, "accepted", False)):
+                return False
+            if bool(getattr(status, "stale", False)):
+                return False
+        except Exception:
+            return False
+    stale = getattr(authority, "is_stale", None)
+    if callable(stale):
+        try:
+            if bool(stale()):
+                return False
+        except Exception:
+            return False
+    complete = getattr(authority, "is_brokers_complete", None)
+    if callable(complete):
+        try:
+            if not bool(complete()):
+                return False
+        except Exception:
+            return False
+    return True
+
+
+def _fail_closed_result(manager: Any, result: Any, *, registered: int, connected: int) -> Any:
+    valid = _result_valid_brokers(result)
+    if not isinstance(result, Mapping):
+        return result
+    if registered <= 0:
+        return result
+    if connected >= registered and valid >= registered:
+        return result
+
+    state_lock = getattr(manager, "_capital_state_lock", None) or _LOCK
+    try:
+        with state_lock:
+            setattr(manager, "_capital_ready", False)
+            setattr(manager, "_trading_halted_due_to_capital", True)
+    except Exception:
+        setattr(manager, "_capital_ready", False)
+        setattr(manager, "_trading_halted_due_to_capital", True)
+
+    corrected = dict(result)
+    corrected["ready"] = 0.0
+    corrected["pending"] = 1.0
+    corrected["registered_platform_brokers"] = float(registered)
+    corrected["connected_platform_brokers"] = float(connected)
+    corrected["registered_platform_complete"] = 0.0
+    LOGGER.critical(
+        "REGISTERED_PLATFORM_CAPITAL_V270_FAIL_CLOSED marker=%s "
+        "registered=%d connected=%d valid_brokers=%d original_ready=%s "
+        "capital_mutated=false freshness_extended=false publication_expiry_extended=false "
+        "execution_authority_unchanged=true forced_trade=false forced_activation=false "
+        "safety_gates_bypassed=false",
+        MARKER,
+        registered,
+        connected,
+        valid,
+        result.get("ready"),
+    )
+    return corrected
+
+
+def _patch_refresh() -> bool:
+    try:
+        module = importlib.import_module("bot.multi_account_broker_manager")
+        cls = getattr(module, "MultiAccountBrokerManager", None)
+    except Exception:
+        return False
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "refresh_capital_authority", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _REFRESH_PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def refresh_v270(self: Any, *args: Any, **kwargs: Any) -> Any:
+        registered, connected, expected = _raise_expected_floor(self)
+        result = original(self, *args, **kwargs)
+        corrected = _fail_closed_result(
+            self,
+            result,
+            registered=registered,
+            connected=connected,
+        )
+        if isinstance(corrected, Mapping) and float(corrected.get("ready", 0.0) or 0.0) > 0.0:
+            LOGGER.info(
+                "REGISTERED_PLATFORM_CAPITAL_V270_COMPLETE marker=%s registered=%d "
+                "connected=%d valid_brokers=%d expected_floor=%d",
+                MARKER,
+                registered,
+                connected,
+                _result_valid_brokers(corrected),
+                expected,
+            )
+        return corrected
+
+    setattr(refresh_v270, _REFRESH_PATCH_ATTR, True)
+    setattr(refresh_v270, "__wrapped__", original)
+    cls.refresh_capital_authority = refresh_v270
+    return True
+
+
+def _patch_finalize() -> bool:
+    try:
+        module = importlib.import_module("bot.multi_account_broker_manager")
+        cls = getattr(module, "MultiAccountBrokerManager", None)
+    except Exception:
+        return False
+    if not isinstance(cls, type):
+        return False
+    current = getattr(cls, "finalize_bootstrap_ready", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _FINALIZE_PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def finalize_v270(self: Any, *args: Any, **kwargs: Any) -> Any:
+        registered, connected, expected = _raise_expected_floor(self)
+        authority = _authority()
+        complete = bool(
+            registered > 0
+            and connected >= registered
+            and _current_publication_accepted_and_fresh(authority)
+        )
+        if not complete:
+            LOGGER.critical(
+                "REGISTERED_PLATFORM_CAPITAL_V270_STARTUP_LOCK_HELD marker=%s "
+                "registered=%d connected=%d expected_floor=%d publication_current=false "
+                "startup_lock_released=false trading_fail_closed=true "
+                "execution_authority_unchanged=true forced_activation=false "
+                "safety_gates_bypassed=false",
+                MARKER,
+                registered,
+                connected,
+                expected,
+            )
+            return False
+        return original(self, *args, **kwargs)
+
+    setattr(finalize_v270, _FINALIZE_PATCH_ATTR, True)
+    setattr(finalize_v270, "__wrapped__", original)
+    cls.finalize_bootstrap_ready = finalize_v270
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        installers = getattr(manifest, "_INSTALLERS", None)
+        if not isinstance(required, dict):
+            return False
+        required["runtime_registered_platform_capital_completeness_v270"] = _READY_FLAG
+        own = (
+            "bot.runtime_registered_platform_capital_completeness_v270_patch",
+            "install_import_hook",
+        )
+        if isinstance(installers, tuple) and own not in installers:
+            manifest._INSTALLERS = tuple(installers) + (own,)
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        refresh_ok = _patch_refresh()
+        finalize_ok = _patch_finalize()
+        manifest_ok = _patch_release_manifest()
+        try:
+            module = importlib.import_module("bot.multi_account_broker_manager")
+            getter = getattr(module, "get_broker_manager", None)
+            manager = getter() if callable(getter) else None
+        except Exception:
+            manager = None
+        registered = connected = expected = 0
+        if manager is not None:
+            registered, connected, expected = _raise_expected_floor(manager)
+            if registered > 0 and connected < registered:
+                try:
+                    lock = getattr(manager, "_capital_state_lock", None) or _LOCK
+                    with lock:
+                        setattr(manager, "_capital_ready", False)
+                        setattr(manager, "_trading_halted_due_to_capital", True)
+                except Exception:
+                    pass
+        ready = bool(refresh_ok and finalize_ok and manifest_ok)
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if not ready:
+            LOGGER.critical(
+                "RUNTIME_REGISTERED_PLATFORM_CAPITAL_COMPLETENESS_V270_FAILED marker=%s "
+                "refresh_patch=%s finalize_patch=%s manifest=%s trading_fail_closed=true",
+                MARKER,
+                str(refresh_ok).lower(),
+                str(finalize_ok).lower(),
+                str(manifest_ok).lower(),
+            )
+            return False
+        LOGGER.critical(
+            "RUNTIME_REGISTERED_PLATFORM_CAPITAL_COMPLETENESS_V270 marker=%s ready=true "
+            "registered=%d connected=%d expected_floor=%d registered_denominator_preserved=true "
+            "startup_lock_incomplete_blocked=true stale_snapshot_not_promoted=true "
+            "user_brokers_excluded=true capital_thresholds_not_lowered=true "
+            "freshness_extended=false publication_expiry_extended=false "
+            "execution_authority_unchanged=true forced_trade=false forced_activation=false "
+            "safety_gates_bypassed=false",
+            MARKER,
+            registered,
+            connected,
+            expected,
+        )
+        return True
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "RELEASE_ID",
+    "install",
+    "install_import_hook",
+    "_platform_mapping",
+    "_platform_counts",
+    "_raise_expected_floor",
+    "_result_valid_brokers",
+    "_current_publication_accepted_and_fresh",
+    "_fail_closed_result",
+    "_patch_refresh",
+    "_patch_finalize",
+    "_patch_release_manifest",
+]

--- a/tests/test_runtime_registered_platform_capital_completeness_v270.py
+++ b/tests/test_runtime_registered_platform_capital_completeness_v270.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import threading
+from types import SimpleNamespace
+
+from bot import runtime_registered_platform_capital_completeness_v270_patch as v270
+
+
+class _Broker:
+    def __init__(self, connected: bool) -> None:
+        self.connected = connected
+
+
+class _Authority:
+    def __init__(self, *, expected: int = 2, accepted: bool = True, stale: bool = False, complete: bool = True) -> None:
+        self.expected_brokers = expected
+        self._accepted = accepted
+        self._stale = stale
+        self._complete = complete
+        self.set_calls = []
+
+    def set_expected_brokers(self, count: int) -> None:
+        self.expected_brokers = max(self.expected_brokers, int(count))
+        self.set_calls.append(int(count))
+
+    def get_snapshot_publication_status(self):
+        return SimpleNamespace(accepted=self._accepted, stale=self._stale)
+
+    def is_stale(self) -> bool:
+        return self._stale
+
+    def is_brokers_complete(self) -> bool:
+        return self._complete
+
+
+class _Manager:
+    def __init__(self, connected=(True, True, False)) -> None:
+        self._platform_brokers = {
+            "coinbase": _Broker(connected[0]),
+            "okx": _Broker(connected[1]),
+            "kraken": _Broker(connected[2]),
+        }
+        self._capital_state_lock = threading.RLock()
+        self._capital_ready = True
+        self._trading_halted_due_to_capital = False
+
+
+def test_platform_counts_preserve_registered_denominator() -> None:
+    manager = _Manager((True, True, False))
+    assert v270._platform_counts(manager) == (3, 2)
+
+
+def test_three_registered_two_connected_forces_ready_false() -> None:
+    manager = _Manager((True, True, False))
+    result = {
+        "ready": 1.0,
+        "total_capital": 103.35,
+        # Simulate a previously accepted/stale 3-broker snapshot being read back.
+        "valid_brokers": 3.0,
+    }
+
+    corrected = v270._fail_closed_result(
+        manager,
+        result,
+        registered=3,
+        connected=2,
+    )
+
+    assert corrected["ready"] == 0.0
+    assert corrected["pending"] == 1.0
+    assert corrected["registered_platform_brokers"] == 3.0
+    assert corrected["connected_platform_brokers"] == 2.0
+    assert manager._capital_ready is False
+    assert manager._trading_halted_due_to_capital is True
+
+
+def test_three_registered_three_connected_three_valid_remains_ready() -> None:
+    manager = _Manager((True, True, True))
+    result = {"ready": 1.0, "total_capital": 103.35, "valid_brokers": 3.0}
+
+    corrected = v270._fail_closed_result(
+        manager,
+        result,
+        registered=3,
+        connected=3,
+    )
+
+    assert corrected is result
+    assert manager._capital_ready is True
+
+
+def test_current_publication_rejects_stale_or_incomplete() -> None:
+    assert v270._current_publication_accepted_and_fresh(
+        _Authority(accepted=True, stale=False, complete=True)
+    ) is True
+    assert v270._current_publication_accepted_and_fresh(
+        _Authority(accepted=True, stale=True, complete=True)
+    ) is False
+    assert v270._current_publication_accepted_and_fresh(
+        _Authority(accepted=False, stale=False, complete=True)
+    ) is False
+    assert v270._current_publication_accepted_and_fresh(
+        _Authority(accepted=True, stale=False, complete=False)
+    ) is False
+
+
+def test_expected_floor_only_raises_to_registered_count(monkeypatch) -> None:
+    manager = _Manager((True, True, False))
+    authority = _Authority(expected=2)
+    monkeypatch.setattr(v270, "_authority", lambda: authority)
+
+    registered, connected, expected = v270._raise_expected_floor(manager)
+
+    assert (registered, connected, expected) == (3, 2, 3)
+    assert authority.expected_brokers == 3
+    assert authority.set_calls == [3]
+
+
+def test_expected_floor_never_lowers_existing_stricter_threshold(monkeypatch) -> None:
+    manager = _Manager((True, True, True))
+    authority = _Authority(expected=4)
+    monkeypatch.setattr(v270, "_authority", lambda: authority)
+
+    registered, connected, expected = v270._raise_expected_floor(manager)
+
+    assert (registered, connected, expected) == (3, 3, 4)
+    assert authority.expected_brokers == 4
+    assert authority.set_calls == []
+
+
+def test_install_helper_does_not_mutate_execution_safety_environment(monkeypatch) -> None:
+    names = (
+        "NIJA_RUNTIME_EXECUTION_AUTHORITY",
+        "NIJA_NONCE_READY",
+        "NIJA_KILL_SWITCH_ACTIVE",
+        "NIJA_CAPITAL_FRESHNESS_TTL_S",
+    )
+    values = ("0", "0", "1", "90")
+    for name, value in zip(names, values):
+        monkeypatch.setenv(name, value)
+    before = {name: os.environ[name] for name in names}
+
+    manager = _Manager((True, True, False))
+    authority = _Authority(expected=2)
+    monkeypatch.setattr(v270, "_authority", lambda: authority)
+    v270._raise_expected_floor(manager)
+    v270._fail_closed_result(
+        manager,
+        {"ready": 1.0, "total_capital": 100.0, "valid_brokers": 3.0},
+        registered=3,
+        connected=2,
+    )
+
+    assert {name: os.environ[name] for name in names} == before


### PR DESCRIPTION
## Production evidence
Runtime on 2026-08-29 showed `platform_accounts_registered=3` while only Coinbase and OKX were connected (`platform_accounts_connected=2`, Kraken disconnected). The capital path could still expose an accepted prior publication and `refresh_capital_authority()` contains a non-Kraken fallback that can treat positive partial capital as ready.

## Change
- Add v270 registered-platform capital completeness guard.
- Raise CapitalAuthority expected-broker floor to the registered platform count; never lower it.
- Force refresh result back to fail-closed when connected or current contributing brokers are below the registered platform topology.
- Hold startup-lock finalization unless all registered platform brokers are connected and the current publication is accepted, non-stale, and broker-complete.
- Chain v270 through the existing v189 capital source-graph installer.
- Add regression tests for the exact 3-registered/2-connected case, stale/incomplete publication, stricter threshold preservation, and safety-environment invariants.

## Safety invariants
No fabricated connectivity/balance/capital/proof. No freshness or publication-expiry extension. No nonce, kill-switch, risk, min-notional, order/fill, strategy threshold, or execution-authority relaxation. Protective exits unchanged.