### PR TITLE
Guard direct TradingStrategy alias before pre-core construction

### DIFF
--- a/bot/runtime_precore_strategy_lookup_v207_patch.py
+++ b/bot/runtime_precore_strategy_lookup_v207_patch.py
@@ -13,12 +13,22 @@ after the TradingStrategy class has already loaded and immediately before the
 canonical builder invokes its constructor. That avoids a new early import fanout
 while guaranteeing the constructor cannot enter unbounded market discovery.
 
+The production bot.py path also imports the same source as top-level
+``trading_strategy`` and constructs that class directly.  v271 closes that alias
+race with a narrow import loader: after the top-level module executes, but before
+``from trading_strategy import TradingStrategy`` returns to bot.py, v269 is
+applied to every loaded strategy alias.  The loader performs no strategy
+construction and grants no runtime authority.
+
 Neither repair constructs or publishes a strategy during install, starts a
 second publisher, grants execution authority, nor changes writer/nonce/risk/
 kill-switch/capital/position/order/fill or activation gates.
 """
 from __future__ import annotations
 
+import importlib
+import importlib.abc
+import importlib.machinery
 import logging
 import os
 import sys
@@ -32,7 +42,9 @@ MARKER = "20260824-precore-strategy-lookup-v207"
 _READY_FLAG = "NIJA_PRECORE_STRATEGY_LOOKUP_V207_READY"
 _PATCH_ATTR = "_nija_precore_strategy_lookup_v207"
 _BUILD_PATCH_ATTR = "_nija_precore_strategy_builder_v269"
+_ALIAS_LOADER_ATTR = "_nija_precore_strategy_alias_loader_v271"
 _LOCK = threading.RLock()
+_ALIAS_FINDER: Any = None
 
 
 def _valid_strategy(candidate: Any) -> bool:
@@ -143,6 +155,105 @@ def _patch_v203() -> bool:
     return bool(callable(installed) and getattr(installed, _PATCH_ATTR, False))
 
 
+def _patch_loaded_strategy_aliases() -> bool:
+    """Apply v269 to any TradingStrategy modules already resident in memory."""
+    try:
+        from bot.runtime_precore_symbol_discovery_liveness_v269_patch import (
+            _patch_trading_strategy as patch_v269,
+        )
+    except Exception as exc:
+        LOGGER.warning(
+            "PRECORE_STRATEGY_ALIAS_V271_V269_IMPORT_FAILED marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    try:
+        return bool(patch_v269())
+    except Exception as exc:
+        LOGGER.warning(
+            "PRECORE_STRATEGY_ALIAS_V271_PATCH_FAILED marker=%s error=%s:%s",
+            MARKER,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+class _TradingStrategyAliasLoader(importlib.abc.Loader):
+    """Delegate module execution, then patch the loaded top-level strategy alias."""
+
+    def __init__(self, wrapped: Any) -> None:
+        self._wrapped = wrapped
+        setattr(self, _ALIAS_LOADER_ATTR, True)
+
+    def create_module(self, spec: Any) -> Any:
+        creator = getattr(self._wrapped, "create_module", None)
+        if callable(creator):
+            return creator(spec)
+        return None
+
+    def exec_module(self, module: Any) -> None:
+        executor = getattr(self._wrapped, "exec_module", None)
+        if not callable(executor):
+            raise ImportError("trading_strategy loader has no exec_module")
+        executor(module)
+        if not _patch_loaded_strategy_aliases():
+            raise ImportError("precore_strategy_alias_v271_patch_failed")
+        LOGGER.critical(
+            "PRECORE_STRATEGY_ALIAS_V271_PATCHED marker=%s module=%s "
+            "constructor_not_started=true market_discovery_bounded=true "
+            "execution_authority_unchanged=true safety_gates_bypassed=false",
+            MARKER,
+            getattr(module, "__name__", "trading_strategy"),
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+class _TradingStrategyAliasFinder(importlib.abc.MetaPathFinder):
+    """Wrap only the top-level trading_strategy loader without broad imports."""
+
+    def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+        if fullname != "trading_strategy":
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or spec.loader is None:
+            return spec
+        if bool(getattr(spec.loader, _ALIAS_LOADER_ATTR, False)):
+            return spec
+        spec.loader = _TradingStrategyAliasLoader(spec.loader)
+        return spec
+
+
+def _install_strategy_alias_guard() -> bool:
+    """Guarantee v269 is applied before bot.py receives top-level TradingStrategy."""
+    global _ALIAS_FINDER
+
+    # If the direct-entry alias is already loaded, patch synchronously now.
+    if isinstance(sys.modules.get("trading_strategy"), ModuleType):
+        return _patch_loaded_strategy_aliases()
+
+    # Reuse an existing finder across re-installs/import aliases.
+    for finder in list(sys.meta_path):
+        if isinstance(finder, _TradingStrategyAliasFinder):
+            _ALIAS_FINDER = finder
+            return True
+
+    finder = _TradingStrategyAliasFinder()
+    sys.meta_path.insert(0, finder)
+    _ALIAS_FINDER = finder
+    LOGGER.critical(
+        "PRECORE_STRATEGY_ALIAS_V271_ARMED marker=%s target=trading_strategy "
+        "post_exec_pre_constructor=true early_strategy_import=false "
+        "execution_authority_unchanged=true safety_gates_bypassed=false",
+        MARKER,
+    )
+    return True
+
+
 def _patch_strategy_builder() -> bool:
     """Install v269 immediately before the canonical strategy constructor runs."""
     try:
@@ -167,8 +278,8 @@ def _patch_strategy_builder() -> bool:
     @wraps(previous)
     def _build_strategy_with_v269(cls: type, brokers: dict[Any, dict[str, Any]]) -> Any:
         # publish_canonical_strategy resolves cls before reaching this builder,
-        # so bot.trading_strategy is already loaded. v269 therefore patches the
-        # existing class and does not create a new pre-core import fanout.
+        # so a strategy module is already loaded. v269 patches every resident
+        # alias and does not create a second production strategy class.
         try:
             from bot.runtime_precore_symbol_discovery_liveness_v269_patch import (
                 install as install_v269,
@@ -196,15 +307,17 @@ def install() -> bool:
     with _LOCK:
         lookup_ready = _patch_v203()
         builder_ready = _patch_strategy_builder()
-        ready = bool(lookup_ready and builder_ready)
+        alias_guard_ready = _install_strategy_alias_guard()
+        ready = bool(lookup_ready and builder_ready and alias_guard_ready)
         os.environ[_READY_FLAG] = "1" if ready else "0"
         if not ready:
             LOGGER.critical(
                 "PRECORE_STRATEGY_LOOKUP_V207_FAILED marker=%s lookup_ready=%s "
-                "builder_v269_ready=%s trading_fail_closed=true",
+                "builder_v269_ready=%s alias_guard_v271_ready=%s trading_fail_closed=true",
                 MARKER,
                 str(lookup_ready).lower(),
                 str(builder_ready).lower(),
+                str(alias_guard_ready).lower(),
             )
             return False
         LOGGER.critical(
@@ -212,6 +325,7 @@ def install() -> bool:
             "install_time_lookup_nonblocking=true broad_existing_scan=false "
             "already_loaded_pointers_only=true v127_cached_pointer_allowed=true "
             "step2_5_single_owner_preserved=true strategy_constructor_v269_guarded=true "
+            "top_level_strategy_alias_v271_guarded=true post_exec_pre_constructor_patch=true "
             "early_trading_strategy_import=false strategy_constructed=false "
             "strategy_published=false execution_authority_granted=false "
             "proof_fabricated=false forced_activation=false "
@@ -234,4 +348,6 @@ __all__ = [
     "_loaded_strategy_pointer",
     "_nonblocking_existing_strategy",
     "_patch_strategy_builder",
+    "_patch_loaded_strategy_aliases",
+    "_install_strategy_alias_guard",
 ]

--- a/bot/runtime_precore_symbol_discovery_liveness_v269_patch.py
+++ b/bot/runtime_precore_symbol_discovery_liveness_v269_patch.py
@@ -13,6 +13,12 @@ does not publish strategy or execution readiness, and does not mutate capital,
 nonce, kill-switch, risk, order, fill, or trading state. TradingStrategy's
 existing broker-safe fallback symbol universe remains authoritative whenever
 live discovery is unavailable.
+
+The production entrypoint imports the same source file through both
+``bot.trading_strategy`` and top-level ``trading_strategy`` module names.  The
+liveness guard therefore patches every already-loaded TradingStrategy alias,
+not only the package-qualified class.  This prevents the direct bot.py
+constructor path from escaping the bounded discovery contract.
 """
 from __future__ import annotations
 
@@ -20,6 +26,7 @@ import importlib
 import logging
 import os
 import queue
+import sys
 import threading
 from functools import wraps
 from typing import Any
@@ -93,21 +100,7 @@ def _bounded_read(broker: Any, method_name: str) -> Any:
     return payload
 
 
-def _patch_trading_strategy() -> bool:
-    try:
-        module = importlib.import_module("bot.trading_strategy")
-        cls = getattr(module, "TradingStrategy", None)
-    except Exception as exc:
-        LOGGER.error(
-            "PRECORE_SYMBOL_DISCOVERY_V269_IMPORT_FAILED marker=%s error=%s:%s",
-            MARKER,
-            type(exc).__name__,
-            exc,
-        )
-        return False
-    if not isinstance(cls, type):
-        return False
-
+def _patch_strategy_class(cls: type) -> bool:
     current = getattr(cls, "_discover_broker_symbols", None)
     if not callable(current):
         return False
@@ -177,6 +170,61 @@ def _patch_trading_strategy() -> bool:
     return True
 
 
+def _patch_trading_strategy() -> bool:
+    """Patch every loaded TradingStrategy alias used by production startup."""
+    modules: list[Any] = []
+    seen_modules: set[int] = set()
+
+    # Prefer already-loaded modules so the patch never creates a second strategy
+    # module merely to prove readiness.  Import the package-qualified module only
+    # when neither alias is resident; this preserves the original v269 install
+    # contract used by unit tests and the canonical publication builder.
+    for module_name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(module_name)
+        if module is not None and id(module) not in seen_modules:
+            seen_modules.add(id(module))
+            modules.append(module)
+
+    if not modules:
+        try:
+            module = importlib.import_module("bot.trading_strategy")
+            modules.append(module)
+        except Exception as exc:
+            LOGGER.error(
+                "PRECORE_SYMBOL_DISCOVERY_V269_IMPORT_FAILED marker=%s error=%s:%s",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+    patched_classes = 0
+    seen_classes: set[int] = set()
+    patched_aliases: list[str] = []
+    for module in modules:
+        cls = getattr(module, "TradingStrategy", None)
+        if not isinstance(cls, type) or id(cls) in seen_classes:
+            continue
+        seen_classes.add(id(cls))
+        if _patch_strategy_class(cls):
+            patched_classes += 1
+            patched_aliases.append(str(getattr(module, "__name__", "unknown")))
+
+    if patched_classes == 0:
+        return False
+
+    LOGGER.critical(
+        "PRECORE_SYMBOL_DISCOVERY_V269_ALIASES_PATCHED marker=%s patched_classes=%d aliases=%s "
+        "top_level_alias_guarded=%s package_alias_guarded=%s safety_gates_bypassed=false",
+        MARKER,
+        patched_classes,
+        ",".join(sorted(patched_aliases)),
+        str("trading_strategy" in patched_aliases).lower(),
+        str("bot.trading_strategy" in patched_aliases).lower(),
+    )
+    return True
+
+
 def _patch_release_manifest() -> bool:
     try:
         manifest = importlib.import_module("bot.runtime_release_manifest_patch")
@@ -212,7 +260,7 @@ def install() -> bool:
             "RUNTIME_PRECORE_SYMBOL_DISCOVERY_LIVENESS_V269 marker=%s ready=true "
             "timeout_s=%.2f read_only_market_discovery=true single_flight=true "
             "late_result_discarded=true broker_safe_fallback_preserved=true "
-            "capital_thresholds_unchanged=true freshness_extended=false "
+            "module_aliases_guarded=true capital_thresholds_unchanged=true freshness_extended=false "
             "nonce_policy_unchanged=true kill_switch_unchanged=true risk_gates_unchanged=true "
             "order_fill_gates_unchanged=true execution_proof_fabricated=false "
             "forced_trade=false forced_activation=false safety_gates_bypassed=false",
@@ -233,6 +281,7 @@ __all__ = [
     "install_import_hook",
     "_timeout_s",
     "_bounded_read",
+    "_patch_strategy_class",
     "_patch_trading_strategy",
     "_patch_release_manifest",
 ]

--- a/tests/test_runtime_precore_strategy_alias_v271.py
+++ b/tests/test_runtime_precore_strategy_alias_v271.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V207 = ROOT / "bot" / "runtime_precore_strategy_lookup_v207_patch.py"
+V269 = ROOT / "bot" / "runtime_precore_symbol_discovery_liveness_v269_patch.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _strategy_module(name: str) -> ModuleType:
+    module = ModuleType(name)
+
+    class TradingStrategy:
+        @staticmethod
+        def _broker_key_from_obj(_broker):
+            return "kraken"
+
+        @staticmethod
+        def _dedupe_symbols(symbols):
+            return list(dict.fromkeys(str(item) for item in symbols if item))
+
+        def _discover_broker_symbols(self, broker):
+            return list(broker.get_available_markets())
+
+    module.TradingStrategy = TradingStrategy
+    return module
+
+
+def test_v269_patches_top_level_strategy_alias_without_package_alias(monkeypatch) -> None:
+    v269 = _load("test_precore_alias_v269", V269)
+    top_level = _strategy_module("trading_strategy")
+    monkeypatch.setitem(sys.modules, "trading_strategy", top_level)
+    monkeypatch.delitem(sys.modules, "bot.trading_strategy", raising=False)
+
+    original = top_level.TradingStrategy._discover_broker_symbols
+    assert v269._patch_trading_strategy() is True
+    patched = top_level.TradingStrategy._discover_broker_symbols
+
+    assert patched is not original
+    assert getattr(patched, v269._PATCH_ATTR, False) is True
+
+
+def test_v269_patches_distinct_package_and_top_level_classes(monkeypatch) -> None:
+    v269 = _load("test_precore_alias_v269_dual", V269)
+    package_module = _strategy_module("bot.trading_strategy")
+    top_level = _strategy_module("trading_strategy")
+    monkeypatch.setitem(sys.modules, "bot.trading_strategy", package_module)
+    monkeypatch.setitem(sys.modules, "trading_strategy", top_level)
+
+    assert package_module.TradingStrategy is not top_level.TradingStrategy
+    assert v269._patch_trading_strategy() is True
+    assert getattr(
+        package_module.TradingStrategy._discover_broker_symbols,
+        v269._PATCH_ATTR,
+        False,
+    ) is True
+    assert getattr(
+        top_level.TradingStrategy._discover_broker_symbols,
+        v269._PATCH_ATTR,
+        False,
+    ) is True
+
+
+def test_v207_alias_guard_patches_already_loaded_top_level_alias(monkeypatch) -> None:
+    v207 = _load("test_precore_alias_v207_loaded", V207)
+    top_level = _strategy_module("trading_strategy")
+    monkeypatch.setitem(sys.modules, "trading_strategy", top_level)
+
+    v269 = ModuleType("bot.runtime_precore_symbol_discovery_liveness_v269_patch")
+    calls = []
+
+    def patch():
+        calls.append("patched")
+        return True
+
+    v269._patch_trading_strategy = patch
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.runtime_precore_symbol_discovery_liveness_v269_patch",
+        v269,
+    )
+
+    assert v207._install_strategy_alias_guard() is True
+    assert calls == ["patched"]
+
+
+def test_v207_alias_guard_arms_without_importing_strategy(monkeypatch) -> None:
+    v207 = _load("test_precore_alias_v207_arm", V207)
+    monkeypatch.delitem(sys.modules, "trading_strategy", raising=False)
+    original_meta_path = list(sys.meta_path)
+    monkeypatch.setattr(sys, "meta_path", list(original_meta_path))
+
+    assert v207._install_strategy_alias_guard() is True
+    assert "trading_strategy" not in sys.modules
+    assert any(
+        isinstance(finder, v207._TradingStrategyAliasFinder)
+        for finder in sys.meta_path
+    )


### PR DESCRIPTION
Fixes the production startup stall proven by the 2026-08-29 runtime: capital and broker connectivity recovered, but the core thread never registered and the process hit the 600s terminal restart deadline.

Root cause: bot.py imports TradingStrategy through the top-level `trading_strategy` module, while v269 previously patched only `bot.trading_strategy.TradingStrategy`. The direct constructor could therefore escape bounded pre-core market discovery.

Changes:
- patch every loaded TradingStrategy alias in v269;
- add a narrow top-level `trading_strategy` import loader in v207 so v269 is applied after module execution but before bot.py receives the class;
- preserve all writer, nonce, capital, kill-switch, risk, position, order/fill, and activation gates;
- add regression coverage for top-level-only, dual-alias, already-loaded, and pre-import paths.