### PR TITLE
Separate nonce readiness from execution proof v272

### DIFF
--- a/bot/runtime_authority_nonce_truth_convergence_v231_patch.py
+++ b/bot/runtime_authority_nonce_truth_convergence_v231_patch.py
@@ -12,9 +12,21 @@ Production on 2026-08-25 exposed two coupled readiness defects:
 
 v231 keeps those facts independent. Writer authority is reconstructed only from
 current distributed-writer authority, a fresh writer heartbeat, and a clear kill
-switch. Nonce readiness remains the existing v16/current runtime nonce proof; if
-Kraken is connected, no Coinbase-only shortcut is permitted. Execution readiness
-requires both independent proofs.
+switch. Nonce readiness is reconstructed from the canonical raw nonce sync/lease
+gates; if Kraken is connected, no Coinbase-only shortcut is permitted.
+
+Production on 2026-08-29 then exposed a second coupling: v16's
+``_runtime_writer_nonce_ready`` checks the genuine heartbeat execution marker
+*before* its raw nonce gates. A missing ORDER/FILL marker therefore made both
+``execution_ready`` and ``nonce_ready`` false even when raw nonce authority was
+healthy. v272 separates those proofs at the v231 convergence boundary:
+
+* ``nonce_ready`` requires the canonical raw nonce sync/lease proof only;
+* ``execution_ready`` additionally requires a fresh, stage-sufficient heartbeat
+  execution marker. v169 provenance validation remains authoritative, so only
+  ``source=heartbeat_trade`` / ``proof_kind=execution_probe`` can satisfy
+  ORDER_VERIFY/FILL_VERIFY policy;
+* writer authority remains an independent current distributed-writer proof.
 
 When position synchronization is still false after a healthy authority heartbeat,
 v231 wakes the existing v161 authoritative position-sync monitor immediately.
@@ -36,8 +48,10 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.runtime_authority_nonce_truth_convergence_v231")
 MARKER = "20260825-runtime-authority-nonce-truth-convergence-v231"
+V272_MARKER = "20260829-nonce-execution-proof-separation-v272"
 RELEASE_ID = "20260825-runtime-convergence-v231"
 _READY_FLAG = "NIJA_RUNTIME_AUTHORITY_NONCE_TRUTH_V231_READY"
+_V272_READY_FLAG = "NIJA_NONCE_EXECUTION_PROOF_SEPARATION_V272_READY"
 _PATCH_ATTR = "_nija_runtime_authority_nonce_truth_v231"
 _LOCK = threading.RLock()
 _INSTALLED = False
@@ -89,6 +103,49 @@ def _current_writer_authority_proof() -> tuple[bool, str]:
     return True, f"writer_authority_current;{heartbeat_detail or 'heartbeat_fresh'}"
 
 
+def _raw_nonce_authority_proof() -> tuple[bool, str]:
+    """Return raw nonce sync/lease truth without consulting execution proof."""
+    try:
+        authority = importlib.import_module("bot.execution_authority_context")
+        probe = getattr(authority, "_runtime_nonce_authority_status", None)
+        if not callable(probe):
+            return False, "runtime_nonce_authority_probe_missing"
+        ready, detail = probe()
+        if not bool(ready):
+            return False, str(detail or "runtime_nonce_authority_not_ready")
+        return True, str(detail or "raw_nonce_authority_current")
+    except Exception as exc:
+        return False, f"runtime_nonce_authority_probe_failed:{type(exc).__name__}:{exc}"
+
+
+def _execution_marker_proof() -> tuple[bool, str]:
+    """Return genuine execution-marker truth with v169 provenance enforcement."""
+    try:
+        status = getattr(_tsm(), "_heartbeat_verification_status", None)
+        if not callable(status):
+            return False, "heartbeat_verification_probe_missing"
+        ready, detail, meta = status()
+        meta = dict(meta or {})
+        if not bool(ready):
+            return False, str(detail or "heartbeat_execution_marker_not_ready")
+        source = str(meta.get("source", "") or "").strip().lower()
+        proof_kind = str(meta.get("proof_kind", "") or "").strip().lower()
+        # v169 normally enforces these fields in the wrapped status function.
+        # Re-check them here so v272 remains fail closed if wrapper ordering ever
+        # changes during a late import/reassertion.
+        required = str(meta.get("required_stage", "ORDER_VERIFY") or "ORDER_VERIFY").strip().upper()
+        if required in {"ORDER_VERIFY", "FILL_VERIFY"}:
+            if source != "heartbeat_trade" or proof_kind != "execution_probe":
+                return False, (
+                    "execution_provenance_invalid:"
+                    f"source={source or 'missing'}:kind={proof_kind or 'missing'}"
+                )
+        stage = str(meta.get("stage", "") or "").strip().upper()
+        return True, f"execution_marker_current:stage={stage or 'verified'}"
+    except Exception as exc:
+        return False, f"heartbeat_verification_probe_failed:{type(exc).__name__}:{exc}"
+
+
 def _kraken_nonce_required() -> bool:
     """Use canonical runtime broker topology, never legacy env absence."""
     tsm = _tsm()
@@ -116,22 +173,27 @@ def _patch_v16_proof_collection() -> bool:
         proofs = dict(proofs or {})
         details = dict(details or {})
 
-        # Preserve the existing v16 nonce proof. It already flows through the
-        # canonical runtime writer/nonce gate and must remain false while a
-        # connected Kraken lease is pending. Only authority is decoupled from it.
-        nonce_ready = bool(proofs.get("nonce_ready", False))
         authority_ready, authority_detail = _current_writer_authority_proof()
+        nonce_ready, nonce_detail = _raw_nonce_authority_proof()
+        execution_marker_ready, execution_marker_detail = _execution_marker_proof()
         execution_pipeline = bool(details.get("execution_pipeline_wired", False))
         risk_ready = bool(proofs.get("risk_ready", False))
 
         proofs["authority_ready"] = bool(authority_ready)
         proofs["nonce_ready"] = bool(nonce_ready)
         proofs["execution_ready"] = bool(
-            execution_pipeline and risk_ready and authority_ready and nonce_ready
+            execution_pipeline
+            and risk_ready
+            and authority_ready
+            and nonce_ready
+            and execution_marker_ready
         )
         details["v231_writer_authority"] = authority_detail
         details["v231_kraken_nonce_required"] = _kraken_nonce_required()
-        details["v231_nonce_ready"] = nonce_ready
+        details["v231_nonce_ready"] = bool(nonce_ready)
+        details["v272_raw_nonce_detail"] = nonce_detail
+        details["v272_execution_marker_ready"] = bool(execution_marker_ready)
+        details["v272_execution_marker_detail"] = execution_marker_detail
         return proofs, details
 
     setattr(collect_v231, _PATCH_ATTR, True)
@@ -141,38 +203,27 @@ def _patch_v16_proof_collection() -> bool:
 
 
 def _correct_heartbeat_nonce_truth() -> tuple[bool, str]:
-    """Undo only the legacy Coinbase-only nonce shortcut when Kraken is active."""
-    if not _kraken_nonce_required():
-        return True, "kraken_nonce_not_applicable"
-
-    # Re-use the canonical v16 nonce proof after v231 collection patching.
-    try:
-        proofs, _details = _v16()._collect_proofs()
-        nonce_ready = bool(dict(proofs or {}).get("nonce_ready", False))
-    except Exception as exc:
-        nonce_ready = False
-        LOGGER.warning(
-            "AUTHORITY_NONCE_V231_NONCE_PROBE_ERROR marker=%s error=%s:%s trading_fail_closed=true",
-            MARKER,
-            type(exc).__name__,
-            exc,
-        )
-
+    """Correct nonce readiness from raw nonce authority, never execution proof."""
+    nonce_ready, nonce_detail = _raw_nonce_authority_proof()
     readiness = _readiness()
     table = dict(readiness.snapshot())
+
     if nonce_ready:
         if not bool(table.get("nonce_ready", False)):
             readiness.mark_ready("nonce_ready")
-        return True, "kraken_nonce_current_proof_true"
+        return True, nonce_detail or "raw_nonce_current_proof_true"
 
     if bool(table.get("nonce_ready", False)):
-        readiness.revoke_ready("nonce_ready", reason="v231_active_kraken_nonce_proof_false")
+        readiness.revoke_ready("nonce_ready", reason="v272_raw_nonce_authority_false")
         LOGGER.warning(
-            "AUTHORITY_NONCE_V231_FALSE_COINBASE_SHORTCUT_REVOKED marker=%s "
-            "kraken_active=true nonce_ready=false proof_fabricated=false trading_fail_closed=true",
-            MARKER,
+            "AUTHORITY_NONCE_V272_RAW_NONCE_REVOKED marker=%s kraken_nonce_required=%s "
+            "detail=%s nonce_ready=false execution_marker_ignored_for_nonce=true "
+            "proof_fabricated=false trading_fail_closed=true",
+            V272_MARKER,
+            str(_kraken_nonce_required()).lower(),
+            nonce_detail or "raw_nonce_authority_false",
         )
-    return False, "kraken_nonce_current_proof_false"
+    return False, nonce_detail or "raw_nonce_current_proof_false"
 
 
 def _wake_position_sync_if_needed() -> bool:
@@ -239,6 +290,7 @@ def _register_manifest() -> bool:
         if not isinstance(required, dict):
             return False
         required["runtime_authority_nonce_truth_v231"] = _READY_FLAG
+        required["nonce_execution_proof_separation_v272"] = _V272_READY_FLAG
         return True
     except Exception:
         return False
@@ -252,6 +304,7 @@ def install() -> bool:
         manifest_ok = _register_manifest()
         ready = bool(v16_ok and heartbeat_ok and manifest_ok)
         os.environ[_READY_FLAG] = "1" if ready else "0"
+        os.environ[_V272_READY_FLAG] = "1" if ready else "0"
         _INSTALLED = ready
         LOGGER.critical(
             "RUNTIME_AUTHORITY_NONCE_TRUTH_V231 marker=%s ready=%s "
@@ -263,6 +316,16 @@ def install() -> bool:
             MARKER,
             str(ready).lower(),
         )
+        LOGGER.critical(
+            "NONCE_EXECUTION_PROOF_SEPARATION_V272 marker=%s ready=%s "
+            "raw_nonce_independent=true execution_marker_independent=true "
+            "v169_execution_provenance_required=true nonce_from_execution_marker=false "
+            "execution_requires_raw_nonce=true execution_requires_genuine_marker=true "
+            "writer_authority_independent=true readiness_fabricated=false "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            V272_MARKER,
+            str(ready).lower(),
+        )
         return ready
 
 
@@ -272,10 +335,13 @@ def install_import_hook() -> bool:
 
 __all__ = [
     "MARKER",
+    "V272_MARKER",
     "RELEASE_ID",
     "install",
     "install_import_hook",
     "_current_writer_authority_proof",
+    "_raw_nonce_authority_proof",
+    "_execution_marker_proof",
     "_kraken_nonce_required",
     "_correct_heartbeat_nonce_truth",
     "_wake_position_sync_if_needed",

--- a/tests/test_runtime_nonce_execution_proof_separation_v272.py
+++ b/tests/test_runtime_nonce_execution_proof_separation_v272.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V231 = ROOT / "bot" / "runtime_authority_nonce_truth_convergence_v231_patch.py"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, V231)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_v16() -> ModuleType:
+    module = ModuleType("preactivation_readiness_convergence_v16_patch")
+
+    def collect():
+        return (
+            {
+                "broker_connected": True,
+                "balance_hydrated": True,
+                "authority_ready": False,
+                "capital_ready": True,
+                "risk_ready": True,
+                "strategy_ready": True,
+                "execution_ready": False,
+                "nonce_ready": False,
+                "bootstrap_ready": True,
+            },
+            {"execution_pipeline_wired": True},
+        )
+
+    module._collect_proofs = collect
+    return module
+
+
+def _install_collection(monkeypatch, module, *, nonce_ready: bool, marker_ready: bool):
+    v16 = _fake_v16()
+    monkeypatch.setattr(module, "_v16", lambda: v16)
+    monkeypatch.setattr(
+        module,
+        "_current_writer_authority_proof",
+        lambda: (True, "writer_authority_current"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_raw_nonce_authority_proof",
+        lambda: (nonce_ready, "raw_nonce_current" if nonce_ready else "raw_nonce_blocked"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_execution_marker_proof",
+        lambda: (
+            marker_ready,
+            "execution_marker_current" if marker_ready else "marker_missing",
+        ),
+    )
+    monkeypatch.setattr(module, "_kraken_nonce_required", lambda: True)
+    assert module._patch_v16_proof_collection() is True
+    return v16
+
+
+def test_marker_missing_does_not_erase_raw_nonce_readiness(monkeypatch) -> None:
+    module = _load("test_nonce_execution_v272_marker_missing")
+    v16 = _install_collection(
+        monkeypatch,
+        module,
+        nonce_ready=True,
+        marker_ready=False,
+    )
+
+    proofs, details = v16._collect_proofs()
+
+    assert proofs["authority_ready"] is True
+    assert proofs["nonce_ready"] is True
+    assert proofs["execution_ready"] is False
+    assert details["v272_raw_nonce_detail"] == "raw_nonce_current"
+    assert details["v272_execution_marker_ready"] is False
+    assert details["v272_execution_marker_detail"] == "marker_missing"
+
+
+def test_execution_ready_requires_raw_nonce_and_genuine_marker(monkeypatch) -> None:
+    module = _load("test_nonce_execution_v272_both_ready")
+    v16 = _install_collection(
+        monkeypatch,
+        module,
+        nonce_ready=True,
+        marker_ready=True,
+    )
+
+    proofs, details = v16._collect_proofs()
+
+    assert proofs["nonce_ready"] is True
+    assert proofs["execution_ready"] is True
+    assert details["v272_execution_marker_ready"] is True
+
+
+def test_valid_execution_marker_cannot_substitute_for_failed_raw_nonce(monkeypatch) -> None:
+    module = _load("test_nonce_execution_v272_nonce_failed")
+    v16 = _install_collection(
+        monkeypatch,
+        module,
+        nonce_ready=False,
+        marker_ready=True,
+    )
+
+    proofs, details = v16._collect_proofs()
+
+    assert proofs["nonce_ready"] is False
+    assert proofs["execution_ready"] is False
+    assert details["v272_raw_nonce_detail"] == "raw_nonce_blocked"
+    assert details["v272_execution_marker_ready"] is True
+
+
+def test_execution_marker_helper_rejects_wrong_provenance(monkeypatch) -> None:
+    module = _load("test_nonce_execution_v272_bad_provenance")
+    tsm = ModuleType("bot.trading_state_machine")
+    tsm._heartbeat_verification_status = lambda: (
+        True,
+        "",
+        {
+            "required_stage": "ORDER_VERIFY",
+            "stage": "FILL_VERIFY",
+            "source": "authority_heartbeat",
+            "proof_kind": "authority_liveness",
+        },
+    )
+    monkeypatch.setattr(module, "_tsm", lambda: tsm)
+
+    ready, detail = module._execution_marker_proof()
+
+    assert ready is False
+    assert detail.startswith("execution_provenance_invalid:")
+
+
+def test_nonce_reconciliation_revokes_only_from_raw_nonce_failure(monkeypatch) -> None:
+    module = _load("test_nonce_execution_v272_revoke")
+
+    class Readiness:
+        def __init__(self):
+            self.state = {"nonce_ready": True}
+            self.revocations = []
+
+        def snapshot(self):
+            return dict(self.state)
+
+        def mark_ready(self, key):
+            self.state[key] = True
+
+        def revoke_ready(self, key, reason=""):
+            self.state[key] = False
+            self.revocations.append((key, reason))
+
+    readiness = Readiness()
+    monkeypatch.setattr(module, "_readiness", lambda: readiness)
+    monkeypatch.setattr(
+        module,
+        "_raw_nonce_authority_proof",
+        lambda: (False, "nonce_lease_not_ready"),
+    )
+    monkeypatch.setattr(module, "_kraken_nonce_required", lambda: True)
+
+    ready, detail = module._correct_heartbeat_nonce_truth()
+
+    assert ready is False
+    assert detail == "nonce_lease_not_ready"
+    assert readiness.state["nonce_ready"] is False
+    assert readiness.revocations == [
+        ("nonce_ready", "v272_raw_nonce_authority_false")
+    ]


### PR DESCRIPTION
## Runtime defect
Production on deployment `a5305b3c1cdf78ed7855cdba64aa5224d819867d` now reaches `core_registered=true`, `core_alive=true`, `RUNNING_SUPERVISED`, 3/3 platform connectivity, and complete position sync, but remains fail-closed on `proof.execution_ready` and `proof.nonce_ready` while the genuine heartbeat execution marker is `marker_missing`.

The existing v16 combined writer+nonce helper checks heartbeat execution verification before raw nonce gates, so one missing execution marker incorrectly presents as two readiness blockers.

## v272 correction
- Derive `nonce_ready` only from canonical raw nonce sync/lease authority.
- Keep current writer authority independent.
- Require the genuine, stage-sufficient v169-provenance heartbeat marker independently for `execution_ready`.
- Re-check `source=heartbeat_trade` and `proof_kind=execution_probe` for ORDER/FILL policy.
- Register manifest-visible `nonce_execution_proof_separation_v272` readiness.
- Preserve all writer, nonce, kill-switch, risk, capital, position, min-notional, order/fill and LIVE activation gates.

## Regression coverage
Adds five tests covering marker-missing/raw-nonce-ready separation, both-proofs-ready, raw-nonce-failed fail-closed behavior, wrong execution provenance rejection, and nonce-readiness revocation from raw nonce failure only.

No execution proof, nonce proof, readiness, order/fill, or activation state is fabricated. GitHub Actions did not surface a branch workflow run in this environment, so the committed tests are not represented as executed CI results.