### PR TITLE
Fix heartbeat position-cap venue failover v273

### DIFF
--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -2,27 +2,21 @@
 
 Production proved the heartbeat passed the pipeline authority gate and router, then
 failed a second authority validation inside bot.broker_manager after the bounded v233
-grant expired.  The canonical startup-probe ContextVar is the preferred authority
+grant expired. The canonical startup-probe ContextVar is the preferred authority
 carrier, but the same-thread v233 grant is the bounded fallback when the ContextVar
 scope has already unwound before the broker-manager terminal.
 
-v244 wraps the actual live broker-manager submit methods.  It enters only when v236
+v244 wraps the actual live broker-manager submit methods. It enters only when v236
 can resolve an already-verified HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE from either the
 canonical ContextVar or the still-live same-thread v233 grant, and current startup
-writer authority is reverified immediately at the terminal method.  The canonical
+writer authority is reverified immediately at the terminal method. The canonical
 authority bindings are anchored for that method call so its inner
 _reject_if_unauthorized_order_submit check observes the verified probe.
 
-v246 is installed from this already-authoritative heartbeat convergence slot.  It
-copies existing ContextVars into ExecutionPipeline's timeout worker so the verified
-startup probe is not lost merely because routing crosses a ThreadPoolExecutor
-boundary.  v246 creates no authority and does not patch the stdlib executor globally.
-
-v255 is installed from this terminal convergence owner after v244/v246 are ready. It
-adds bounded failover between already-ready heartbeat venues for proven process-local
-read contention, reasserts real position-fetch proof propagation, and prevents a
-non-owner capital refresh thread from mutating BootstrapFSM. It never creates proof or
-weakens any execution gate.
+v246 copies existing ContextVars into ExecutionPipeline's timeout worker. v255 adds
+bounded failover for proven process-local read contention and preserves authoritative
+position/capital ownership. v273 adds heartbeat-only venue failover after an unchanged
+ECEL POSITION_CAP_EXCEEDED result, without bypassing the account position cap.
 
 Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
 minimum notional, exchange acknowledgement, fill proof, and readiness remain unchanged.
@@ -58,8 +52,7 @@ def _verified_reason() -> str | None:
             resolved = resolver()
         except Exception as exc:
             LOGGER.warning(
-                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_RESOLVE_ERROR marker=%s "
-                "error=%s:%s trading_fail_closed=true",
+                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_RESOLVE_ERROR marker=%s error=%s:%s trading_fail_closed=true",
                 MARKER, type(exc).__name__, exc,
             )
             resolved = None
@@ -98,15 +91,14 @@ def _wrap_method(current: Callable[..., Any], module: ModuleType, surface: str) 
         bindings = getattr(v236, "_canonical_terminal_bindings", None)
         if not callable(scope) or not callable(bindings) or not _writer_ready():
             LOGGER.warning(
-                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_DEFERRED marker=%s surface=%s "
-                "probe_reason=%s startup_writer_reverified=false trading_fail_closed=true",
+                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_DEFERRED marker=%s surface=%s probe_reason=%s startup_writer_reverified=false trading_fail_closed=true",
                 MARKER, surface, reason,
             )
             return current(self, *args, **kwargs)
         LOGGER.critical(
-            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED marker=%s surface=%s "
-            "probe_reason=%s verified_upstream_authority=true startup_writer_reverified=true "
-            "canonical_terminal_bindings=true grant_ttl_not_extended=true ordinary_orders_unchanged=true "
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_REANCHORED marker=%s surface=%s probe_reason=%s "
+            "verified_upstream_authority=true startup_writer_reverified=true canonical_terminal_bindings=true "
+            "grant_ttl_not_extended=true ordinary_orders_unchanged=true "
             "lifecycle_nonce_risk_capital_broker_health_killswitch_min_notional_fill_gates_unchanged=true "
             "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
             MARKER, surface, reason,
@@ -135,10 +127,7 @@ def _patch_broker_manager_methods() -> tuple[bool, tuple[str, ...]]:
             setattr(cls, method_name, wrapped)
             if bool(getattr(getattr(cls, method_name, None), _PATCH_ATTR, False)):
                 patched.append(surface)
-    required = all(
-        surface in patched
-        for surface in ("CoinbaseBroker.place_market_order", "KrakenBroker.place_market_order")
-    )
+    required = all(surface in patched for surface in ("CoinbaseBroker.place_market_order", "KrakenBroker.place_market_order"))
     return required, tuple(sorted(set(patched)))
 
 
@@ -149,30 +138,41 @@ def _install_v246_context_handoff() -> bool:
         return bool(callable(installer) and installer())
     except Exception as exc:
         LOGGER.error(
-            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V246_INSTALL_ERROR marker=%s "
-            "error=%s:%s trading_fail_closed=true",
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V246_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
         return False
 
 
 def _install_v255_terminal_activation_liveness() -> bool:
-    """Install the terminal liveness repair after the verified submit chain is ready."""
+    """Install v255 after the verified submit chain is ready."""
     try:
         module = importlib.import_module("bot.runtime_terminal_activation_liveness_v255_patch")
         installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
         ready = bool(callable(installer) and installer())
         if not ready:
-            LOGGER.error(
-                "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V255_INSTALL_FAILED marker=%s "
-                "trading_fail_closed=true",
-                MARKER,
-            )
+            LOGGER.error("HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V255_INSTALL_FAILED marker=%s trading_fail_closed=true", MARKER)
         return ready
     except Exception as exc:
         LOGGER.error(
-            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V255_INSTALL_ERROR marker=%s "
-            "error=%s:%s trading_fail_closed=true",
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V255_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        return False
+
+
+def _install_v273_heartbeat_position_cap_failover() -> bool:
+    """Install heartbeat-only venue failover without bypassing ECEL position caps."""
+    try:
+        module = importlib.import_module("bot.runtime_heartbeat_position_cap_failover_v273_patch")
+        installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
+        ready = bool(callable(installer) and installer())
+        if not ready:
+            LOGGER.error("HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V273_INSTALL_FAILED marker=%s trading_fail_closed=true", MARKER)
+        return ready
+    except Exception as exc:
+        LOGGER.error(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V273_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
         return False
@@ -186,23 +186,22 @@ def install() -> bool:
         methods_ready, surfaces = _patch_broker_manager_methods()
         context_handoff_ready = _install_v246_context_handoff()
         v255_ready = _install_v255_terminal_activation_liveness()
-        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready)
+        v273_ready = _install_v273_heartbeat_position_cap_failover()
+        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready and v273_ready)
     except Exception as exc:
         LOGGER.error(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
-        ready, surfaces, context_handoff_ready, v255_ready = False, (), False, False
+        ready, surfaces, context_handoff_ready, v255_ready, v273_ready = False, (), False, False, False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
-            "coinbase_live_terminal_required=true kraken_live_terminal_required=true "
-            "verified_v233_grant_fallback=true canonical_context_preferred=true "
-            "pipeline_context_handoff_v246=true terminal_activation_liveness_v255=true "
-            "startup_writer_reverification_required=true grant_ttl_not_extended=true "
-            "ordinary_orders_unchanged=true execution_proof_fabricated=false "
-            "forced_activation=false safety_gates_bypassed=false",
+            "coinbase_live_terminal_required=true kraken_live_terminal_required=true verified_v233_grant_fallback=true "
+            "canonical_context_preferred=true pipeline_context_handoff_v246=true terminal_activation_liveness_v255=true "
+            "heartbeat_position_cap_failover_v273=true startup_writer_reverification_required=true grant_ttl_not_extended=true "
+            "ordinary_orders_unchanged=true execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
             MARKER, ",".join(surfaces),
         )
     return ready
@@ -220,6 +219,7 @@ __all__ = [
     "_patch_broker_manager_methods",
     "_install_v246_context_handoff",
     "_install_v255_terminal_activation_liveness",
+    "_install_v273_heartbeat_position_cap_failover",
     "_verified_reason",
     "_writer_ready",
 ]

--- a/bot/runtime_heartbeat_position_cap_failover_v273_patch.py
+++ b/bot/runtime_heartbeat_position_cap_failover_v273_patch.py
@@ -1,0 +1,387 @@
+"""Heartbeat position-cap venue failover for genuine startup proof (v273).
+
+Production on 2026-08-29 proved the startup heartbeat reached Coinbase through
+all canonical writer/nonce/lifecycle gates but the local execution hardening
+layer rejected the verification BUY because that account was already above its
+tier position-count cap. That local pre-dispatch denial is valid for Coinbase,
+but it must not permanently deadlock execution proof when another venue already
+published by NIJA's canonical execution-readiness set can run the same probe.
+
+v273 does not bypass the position cap. It observes the unchanged ECEL result
+only inside the already-authorized HEARTBEAT_TRADE ContextVar, temporarily
+quarantines the position-cap-blocked venue for heartbeat selection, and retries
+on another already-ready venue. Ordinary orders, account tier limits, ECEL,
+risk, capital, writer/nonce authority, kill switch, broker health, minimum
+notional, exchange acknowledgement, fill confirmation, and activation remain
+unchanged. No failed/local validation is treated as execution proof.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_heartbeat_position_cap_failover_v273")
+MARKER = "20260829-heartbeat-position-cap-failover-v273"
+RELEASE_ID = "20260829-runtime-convergence-v273"
+_READY_FLAG = "NIJA_HEARTBEAT_POSITION_CAP_FAILOVER_V273_READY"
+_HARDENING_PATCH_ATTR = "_nija_heartbeat_position_cap_failover_v273_hardening"
+_STRATEGY_PATCH_ATTR = "_nija_heartbeat_position_cap_failover_v273_strategy"
+_LOCK = threading.RLock()
+_TLS = threading.local()
+_ALLOWED_REASON = "HEARTBEAT_TRADE"
+
+
+def _quarantine_s() -> float:
+    try:
+        configured = float(os.environ.get("NIJA_HEARTBEAT_POSITION_CAP_QUARANTINE_S", "60") or 60.0)
+    except (TypeError, ValueError):
+        configured = 60.0
+    return max(15.0, min(300.0, configured))
+
+
+def _max_fallbacks() -> int:
+    try:
+        configured = int(float(os.environ.get("NIJA_HEARTBEAT_POSITION_CAP_MAX_FALLBACKS", "2") or 2))
+    except (TypeError, ValueError):
+        configured = 2
+    return max(1, min(3, configured))
+
+
+def _clear_cap_block() -> None:
+    _TLS.cap_block = None
+
+
+def _set_cap_block(reason: str, *, symbol: str = "", side: str = "") -> None:
+    _TLS.cap_block = {
+        "reason": str(reason or ""),
+        "symbol": str(symbol or ""),
+        "side": str(side or ""),
+        "at": time.monotonic(),
+    }
+
+
+def _recent_cap_block(max_age_s: float = 3.0) -> dict[str, Any] | None:
+    value = getattr(_TLS, "cap_block", None)
+    if not isinstance(value, dict):
+        return None
+    try:
+        age = time.monotonic() - float(value.get("at", 0.0) or 0.0)
+    except Exception:
+        return None
+    if age < 0.0 or age > max_age_s:
+        return None
+    reason = str(value.get("reason", "") or "")
+    upper = reason.upper()
+    if "POSITION_CAP_EXCEEDED" not in upper and "POSITION CAP REACHED" not in upper:
+        return None
+    return dict(value)
+
+
+def _trusted_heartbeat_probe() -> tuple[bool, str]:
+    if threading.current_thread().name != "HeartbeatTrade":
+        return False, "not_heartbeat_thread"
+    try:
+        v263 = importlib.import_module("bot.runtime_heartbeat_state_machine_gate_v263_patch")
+        verifier = getattr(v263, "_verified_startup_probe", None)
+        if not callable(verifier):
+            return False, "v263_verifier_unavailable"
+        ok, detail = verifier()
+        reason = str(detail or "").strip().upper()
+        if not bool(ok) or reason != _ALLOWED_REASON:
+            return False, reason or "startup_probe_not_verified"
+        return True, reason
+    except Exception as exc:
+        return False, f"startup_probe_verification_error:{type(exc).__name__}:{exc}"
+
+
+def _broker_key(strategy: Any, broker: Any) -> str:
+    try:
+        v255 = importlib.import_module("bot.runtime_terminal_activation_liveness_v255_patch")
+        resolver = getattr(v255, "_broker_key", None)
+        if callable(resolver):
+            value = str(resolver(strategy, broker) or "").strip().lower()
+            if value:
+                return value
+    except Exception:
+        pass
+    resolver = getattr(strategy, "_broker_key_from_obj", None)
+    if callable(resolver):
+        try:
+            value = str(resolver(broker) or "").strip().lower()
+            if value:
+                return value
+        except Exception:
+            pass
+    broker_type = str(getattr(broker, "broker_type", "") or "").strip().lower()
+    if broker_type:
+        return broker_type
+    name = type(broker).__name__.replace("Broker", "").strip().lower()
+    return name or "unknown"
+
+
+def _active_quarantine(strategy: Any, attr: str) -> dict[str, float]:
+    now = time.monotonic()
+    current = getattr(strategy, attr, None)
+    raw = dict(current) if isinstance(current, dict) else {}
+    active: dict[str, float] = {}
+    for name, expiry in raw.items():
+        try:
+            expiry_value = float(expiry or 0.0)
+        except Exception:
+            continue
+        if expiry_value > now:
+            active[str(name).strip().lower()] = expiry_value
+    setattr(strategy, attr, active)
+    return active
+
+
+def _quarantine_cap_venue(strategy: Any, broker: Any, detail: str) -> str:
+    venue = _broker_key(strategy, broker)
+    active = _active_quarantine(strategy, "_nija_heartbeat_position_cap_until")
+    active[venue] = time.monotonic() + _quarantine_s()
+    setattr(strategy, "_nija_heartbeat_position_cap_until", active)
+    LOGGER.warning(
+        "HEARTBEAT_POSITION_CAP_V273_QUARANTINED marker=%s venue=%s ttl_s=%.1f detail=%s "
+        "position_cap_unchanged=true broker_health_unchanged=true rejection_window_unchanged=true "
+        "execution_proof_fabricated=false trading_fail_closed=true",
+        MARKER, venue, _quarantine_s(), detail,
+    )
+    return venue
+
+
+def _ready_venue_filter(strategy: Any) -> tuple[str | None, tuple[str, ...], tuple[str, ...]]:
+    if "NIJA_EXECUTION_READY_VENUES" not in os.environ:
+        return None, (), ()
+    raw = str(os.environ.get("NIJA_EXECUTION_READY_VENUES", "") or "")
+    ready = tuple(dict.fromkeys(part.strip().lower() for part in raw.split(",") if part.strip()))
+    cap = _active_quarantine(strategy, "_nija_heartbeat_position_cap_until")
+    local = _active_quarantine(strategy, "_nija_heartbeat_local_busy_until")
+    blocked_set = set(cap) | set(local)
+    blocked = tuple(sorted(name for name in ready if name in blocked_set))
+    allowed = tuple(name for name in ready if name not in blocked_set)
+    return raw, allowed, blocked
+
+
+def _candidate_brokers(strategy: Any) -> dict[Any, Any]:
+    candidates: dict[Any, Any] = {}
+    manager = getattr(strategy, "multi_account_manager", None)
+    if manager is not None:
+        try:
+            candidates.update(getattr(manager, "platform_brokers", {}) or {})
+        except Exception as exc:
+            LOGGER.debug("Heartbeat v273 MABM lookup failed: %s", exc)
+    broker_manager = getattr(strategy, "broker_manager", None)
+    if broker_manager is not None:
+        try:
+            candidates.update(getattr(broker_manager, "brokers", {}) or {})
+            primary = broker_manager.get_primary_broker()
+            if primary is not None:
+                candidates.setdefault(getattr(primary, "broker_type", "primary"), primary)
+        except Exception as exc:
+            LOGGER.debug("Heartbeat v273 BrokerManager lookup failed: %s", exc)
+    broker = getattr(strategy, "broker", None)
+    if broker is not None:
+        candidates.setdefault(getattr(broker, "broker_type", "cached"), broker)
+    return candidates
+
+
+def _wrap_hardening(current: Callable[..., Any]) -> Callable[..., Any]:
+    if bool(getattr(current, _HARDENING_PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def validate_v273(self: Any, *args: Any, **kwargs: Any):
+        result = current(self, *args, **kwargs)
+        try:
+            is_valid = bool(result[0]) if isinstance(result, tuple) and result else bool(result)
+            detail = str(result[1] or "") if isinstance(result, tuple) and len(result) > 1 else ""
+            if is_valid:
+                return result
+            upper = detail.upper()
+            if "POSITION_CAP_EXCEEDED" not in upper and "POSITION CAP REACHED" not in upper:
+                return result
+            trusted, probe_reason = _trusted_heartbeat_probe()
+            if not trusted or probe_reason != _ALLOWED_REASON:
+                return result
+            symbol = str(kwargs.get("symbol", args[0] if len(args) > 0 else "") or "")
+            side = str(kwargs.get("side", args[1] if len(args) > 1 else "") or "")
+            if side.strip().upper() not in {"BUY", "ENTER", "OPEN"}:
+                return result
+            _set_cap_block(detail, symbol=symbol, side=side)
+            LOGGER.info(
+                "HEARTBEAT_POSITION_CAP_V273_OBSERVED marker=%s symbol=%s side=%s probe_reason=%s "
+                "ecel_result_unchanged=true order_not_submitted=true position_cap_unchanged=true",
+                MARKER, symbol, side, probe_reason,
+            )
+        except Exception as exc:
+            LOGGER.debug("Heartbeat v273 hardening observation failed: %s", exc)
+        return result
+
+    setattr(validate_v273, _HARDENING_PATCH_ATTR, True)
+    setattr(validate_v273, "__wrapped__", current)
+    return validate_v273
+
+
+def _patch_hardening() -> tuple[bool, tuple[str, ...]]:
+    try:
+        importlib.import_module("bot.execution_layer_hardening")
+    except Exception as exc:
+        LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_HARDENING_IMPORT_DEFERRED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
+    patched: list[str] = []
+    seen: set[int] = set()
+    for name in ("bot.execution_layer_hardening", "execution_layer_hardening"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        cls = getattr(module, "ExecutionLayerHardening", None)
+        if not isinstance(cls, type) or id(cls) in seen:
+            continue
+        seen.add(id(cls))
+        current = getattr(cls, "validate_order_hardening", None)
+        if not callable(current):
+            continue
+        wrapped = _wrap_hardening(current)
+        setattr(cls, "validate_order_hardening", wrapped)
+        if bool(getattr(getattr(cls, "validate_order_hardening", None), _HARDENING_PATCH_ATTR, False)):
+            patched.append(str(getattr(module, "__name__", name)))
+    return bool(patched), tuple(sorted(set(patched)))
+
+
+def _wrap_selector(current: Callable[..., Any]) -> Callable[..., Any]:
+    if bool(getattr(current, _STRATEGY_PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def select_v273(self: Any):
+        raw, allowed, blocked = _ready_venue_filter(self)
+        cap_blocked = set(_active_quarantine(self, "_nija_heartbeat_position_cap_until"))
+        if raw is None or not cap_blocked:
+            return current(self)
+        if not allowed:
+            LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_NO_READY_FALLBACK marker=%s blocked=%s canonical_ready_set_only=true retry_later=true trading_fail_closed=true", MARKER, ",".join(blocked))
+            return None
+        allowed_set = set(allowed)
+        candidates = {raw_key: broker for raw_key, broker in _candidate_brokers(self).items() if broker is not None and _broker_key(self, broker) in allowed_set}
+        selector = getattr(self, "_select_entry_broker", None)
+        if not callable(selector):
+            LOGGER.error("HEARTBEAT_POSITION_CAP_V273_SELECTOR_MISSING marker=%s trading_fail_closed=true", MARKER)
+            return None
+        selected, _name, status = selector(candidates)
+        if selected is None or _broker_key(self, selected) not in allowed_set:
+            LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_FAILOVER_UNAVAILABLE marker=%s allowed=%s blocked=%s status=%s trading_fail_closed=true", MARKER, ",".join(allowed), ",".join(blocked), status or "no_matching_broker_objects")
+            return None
+        self.broker = selected
+        broker_manager = getattr(self, "broker_manager", None)
+        if broker_manager is not None:
+            try:
+                broker_manager.active_broker = selected
+            except Exception:
+                pass
+        LOGGER.critical("HEARTBEAT_POSITION_CAP_V273_FAILOVER marker=%s blocked=%s selected=%s canonical_ready_set_only=true position_cap_unchanged=true ordinary_routing_unchanged=true broker_health_unchanged=true execution_proof_fabricated=false", MARKER, ",".join(blocked), _broker_key(self, selected))
+        return selected
+
+    setattr(select_v273, _STRATEGY_PATCH_ATTR, True)
+    setattr(select_v273, "__wrapped__", current)
+    return select_v273
+
+
+def _wrap_execute(current: Callable[..., Any]) -> Callable[..., Any]:
+    if bool(getattr(current, _STRATEGY_PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def execute_v273(self: Any) -> bool:
+        fallbacks = 0
+        while True:
+            _clear_cap_block()
+            if bool(current(self)):
+                return True
+            block = _recent_cap_block()
+            if block is None:
+                return False
+            broker = getattr(self, "broker", None)
+            if broker is None:
+                LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_BROKER_UNKNOWN marker=%s trading_fail_closed=true", MARKER)
+                return False
+            failed_venue = _quarantine_cap_venue(self, broker, str(block.get("reason", "")))
+            fallbacks += 1
+            if fallbacks > _max_fallbacks():
+                LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_FALLBACK_LIMIT marker=%s failed_venue=%s fallbacks=%d max_fallbacks=%d retry_later=true trading_fail_closed=true", MARKER, failed_venue, fallbacks - 1, _max_fallbacks())
+                return False
+            _raw, allowed, blocked = _ready_venue_filter(self)
+            if not allowed:
+                LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_ALL_READY_VENUES_BLOCKED marker=%s failed_venue=%s blocked=%s retry_later=true trading_fail_closed=true", MARKER, failed_venue, ",".join(blocked))
+                return False
+            LOGGER.critical("HEARTBEAT_POSITION_CAP_V273_IMMEDIATE_RETRY marker=%s failed_venue=%s fallback=%d max_fallbacks=%d allowed=%s position_cap_unchanged=true ordinary_orders_unchanged=true safety_gates_unchanged=true", MARKER, failed_venue, fallbacks, _max_fallbacks(), ",".join(allowed))
+
+    setattr(execute_v273, _STRATEGY_PATCH_ATTR, True)
+    setattr(execute_v273, "__wrapped__", current)
+    return execute_v273
+
+
+def _patch_trading_strategy() -> tuple[bool, tuple[str, ...]]:
+    try:
+        importlib.import_module("bot.trading_strategy")
+    except Exception as exc:
+        LOGGER.warning("HEARTBEAT_POSITION_CAP_V273_STRATEGY_IMPORT_DEFERRED marker=%s error=%s:%s", MARKER, type(exc).__name__, exc)
+    patched: list[str] = []
+    seen: set[int] = set()
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        cls = getattr(module, "TradingStrategy", None)
+        if not isinstance(cls, type) or id(cls) in seen:
+            continue
+        seen.add(id(cls))
+        selector = getattr(cls, "_get_heartbeat_broker", None)
+        execute = getattr(cls, "_execute_heartbeat_trade", None)
+        if not callable(selector) or not callable(execute):
+            continue
+        cls._get_heartbeat_broker = _wrap_selector(selector)
+        cls._execute_heartbeat_trade = _wrap_execute(execute)
+        if all(bool(getattr(getattr(cls, method, None), _STRATEGY_PATCH_ATTR, False)) for method in ("_get_heartbeat_broker", "_execute_heartbeat_trade")):
+            patched.append(str(getattr(module, "__name__", name)))
+    return bool(patched), tuple(sorted(set(patched)))
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["heartbeat_position_cap_failover_v273"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        try:
+            hardening_ready, hardening_surfaces = _patch_hardening()
+            strategy_ready, strategy_surfaces = _patch_trading_strategy()
+            manifest_ready = _register_manifest()
+            ready = bool(hardening_ready and strategy_ready and manifest_ready)
+        except Exception as exc:
+            LOGGER.error("HEARTBEAT_POSITION_CAP_V273_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true", MARKER, type(exc).__name__, exc, exc_info=True)
+            ready, hardening_surfaces, strategy_surfaces, manifest_ready = False, (), (), False
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if ready:
+            LOGGER.critical("HEARTBEAT_POSITION_CAP_FAILOVER_V273_READY marker=%s ready=true hardening_surfaces=%s strategy_surfaces=%s canonical_ready_set_only=true trusted_heartbeat_context_only=true position_cap_unchanged=true ecel_result_unchanged=true ordinary_orders_unchanged=true writer_nonce_risk_capital_killswitch_broker_health_min_notional_order_fill_gates_unchanged=true execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false", MARKER, ",".join(hardening_surfaces), ",".join(strategy_surfaces))
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = ["MARKER", "RELEASE_ID", "install", "install_import_hook", "_trusted_heartbeat_probe", "_recent_cap_block", "_quarantine_cap_venue", "_ready_venue_filter", "_wrap_hardening", "_wrap_selector", "_wrap_execute", "_patch_hardening", "_patch_trading_strategy"]

--- a/tests/test_runtime_heartbeat_position_cap_failover_v273.py
+++ b/tests/test_runtime_heartbeat_position_cap_failover_v273.py
@@ -1,0 +1,117 @@
+import time
+
+from bot import runtime_heartbeat_position_cap_failover_v273_patch as v273
+
+
+class Broker:
+    def __init__(self, broker_type):
+        self.broker_type = broker_type
+
+
+class BrokerManager:
+    def __init__(self, brokers):
+        self.brokers = brokers
+        self.active_broker = None
+
+    def get_primary_broker(self):
+        return self.brokers.get("coinbase")
+
+
+class Strategy:
+    def __init__(self):
+        self.broker_manager = BrokerManager({
+            "coinbase": Broker("coinbase"),
+            "kraken": Broker("kraken"),
+            "okx": Broker("okx"),
+        })
+        self.multi_account_manager = None
+        self.broker = self.broker_manager.brokers["coinbase"]
+
+    def _broker_key_from_obj(self, broker):
+        return broker.broker_type
+
+    def _select_entry_broker(self, candidates):
+        for name in ("coinbase", "kraken", "okx"):
+            if name in candidates:
+                return candidates[name], name, "ready"
+        return None, None, "none"
+
+
+def test_hardening_observes_trusted_heartbeat_cap_without_changing_result(monkeypatch):
+    v273._clear_cap_block()
+    monkeypatch.setattr(v273, "_trusted_heartbeat_probe", lambda: (True, "HEARTBEAT_TRADE"))
+    expected = (False, "POSITION_CAP_EXCEEDED: Position cap reached: 2/1 positions", {"x": 1})
+
+    def original(_self, *args, **kwargs):
+        return expected
+
+    wrapped = v273._wrap_hardening(original)
+    result = wrapped(object(), symbol="BTC-USD", side="BUY")
+    assert result is expected
+    block = v273._recent_cap_block()
+    assert block is not None
+    assert block["symbol"] == "BTC-USD"
+    assert block["side"] == "BUY"
+
+
+def test_hardening_does_not_mark_ordinary_order(monkeypatch):
+    v273._clear_cap_block()
+    monkeypatch.setattr(v273, "_trusted_heartbeat_probe", lambda: (False, "not_heartbeat_thread"))
+
+    def original(_self, *args, **kwargs):
+        return (False, "POSITION_CAP_EXCEEDED: Position cap reached", {})
+
+    wrapped = v273._wrap_hardening(original)
+    result = wrapped(object(), symbol="BTC-USD", side="BUY")
+    assert result[0] is False
+    assert v273._recent_cap_block() is None
+
+
+def test_selector_excludes_cap_and_local_contention_venues(monkeypatch):
+    strategy = Strategy()
+    monkeypatch.setenv("NIJA_EXECUTION_READY_VENUES", "coinbase,kraken,okx")
+    now = time.monotonic()
+    strategy._nija_heartbeat_position_cap_until = {"coinbase": now + 60.0}
+    strategy._nija_heartbeat_local_busy_until = {"kraken": now + 60.0}
+
+    def original(_self):
+        return _self.broker_manager.brokers["coinbase"]
+
+    selected = v273._wrap_selector(original)(strategy)
+    assert selected is strategy.broker_manager.brokers["okx"]
+    assert strategy.broker is selected
+    assert strategy.broker_manager.active_broker is selected
+
+
+def test_execute_retries_after_cap_block_then_succeeds(monkeypatch):
+    strategy = Strategy()
+    monkeypatch.setenv("NIJA_EXECUTION_READY_VENUES", "coinbase,kraken,okx")
+    monkeypatch.setattr(v273, "_max_fallbacks", lambda: 2)
+    calls = {"count": 0}
+
+    def original(_self):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            v273._set_cap_block("POSITION_CAP_EXCEEDED: Position cap reached", symbol="BTC-USD", side="BUY")
+            return False
+        return True
+
+    wrapped = v273._wrap_execute(original)
+    assert wrapped(strategy) is True
+    assert calls["count"] == 2
+    assert "coinbase" in strategy._nija_heartbeat_position_cap_until
+
+
+def test_execute_does_not_retry_unrelated_failure(monkeypatch):
+    strategy = Strategy()
+    monkeypatch.setenv("NIJA_EXECUTION_READY_VENUES", "coinbase,kraken,okx")
+    calls = {"count": 0}
+
+    def original(_self):
+        calls["count"] += 1
+        return False
+
+    wrapped = v273._wrap_execute(original)
+    assert wrapped(strategy) is False
+    assert calls["count"] == 1
+    assert not hasattr(strategy, "_nija_heartbeat_position_cap_until")


### PR DESCRIPTION
Production v272 correctly separated raw nonce readiness from genuine execution proof, exposing the remaining terminal blocker: the startup heartbeat reaches Coinbase but ECEL rejects the verification BUY with POSITION_CAP_EXCEEDED because the account already has 2/1 STARTER positions.

This change does not bypass or relax the position cap. It:
- observes the unchanged ECEL position-cap denial only inside the already-verified HEARTBEAT_TRADE startup-probe context;
- temporarily quarantines that venue for heartbeat selection only;
- retries on another venue already present in NIJA_EXECUTION_READY_VENUES;
- preserves ordinary order routing, tier limits, ECEL, writer/nonce authority, risk, capital, kill switch, broker health, minimum notional, acknowledgement and fill gates;
- never converts a local validation failure into execution proof.

Validation: 5 focused v273 regression tests pass locally. No GitHub Actions/status check surfaced for the branch head, so CI is not claimed as passed.