### PR TITLE
Fix heartbeat live-venue selection race v274

### DIFF
--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -16,7 +16,9 @@ _reject_if_unauthorized_order_submit check observes the verified probe.
 v246 copies existing ContextVars into ExecutionPipeline's timeout worker. v255 adds
 bounded failover for proven process-local read contention and preserves authoritative
 position/capital ownership. v273 adds heartbeat-only venue failover after an unchanged
-ECEL POSITION_CAP_EXCEEDED result, without bypassing the account position cap.
+ECEL POSITION_CAP_EXCEEDED result. v274 repairs the heartbeat selection race when the
+canonical ready-venue string is temporarily empty but broker-local live venues remain
+published; it is selection-only and grants no readiness or execution authority.
 
 Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
 minimum notional, exchange acknowledgement, fill proof, and readiness remain unchanged.
@@ -178,6 +180,23 @@ def _install_v273_heartbeat_position_cap_failover() -> bool:
         return False
 
 
+def _install_v274_heartbeat_live_venue_selection() -> bool:
+    """Install heartbeat-only live-venue selector fallback; no readiness is granted."""
+    try:
+        module = importlib.import_module("bot.runtime_heartbeat_live_venue_selection_v274_patch")
+        installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
+        ready = bool(callable(installer) and installer())
+        if not ready:
+            LOGGER.error("HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V274_INSTALL_FAILED marker=%s trading_fail_closed=true", MARKER)
+        return ready
+    except Exception as exc:
+        LOGGER.error(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V274_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        return False
+
+
 def install() -> bool:
     try:
         v240 = importlib.import_module("bot.runtime_heartbeat_terminal_lifecycle_v240_patch")
@@ -187,21 +206,23 @@ def install() -> bool:
         context_handoff_ready = _install_v246_context_handoff()
         v255_ready = _install_v255_terminal_activation_liveness()
         v273_ready = _install_v273_heartbeat_position_cap_failover()
-        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready and v273_ready)
+        v274_ready = _install_v274_heartbeat_live_venue_selection()
+        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready and v273_ready and v274_ready)
     except Exception as exc:
         LOGGER.error(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
-        ready, surfaces, context_handoff_ready, v255_ready, v273_ready = False, (), False, False, False
+        ready, surfaces, context_handoff_ready, v255_ready, v273_ready, v274_ready = False, (), False, False, False, False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
             "coinbase_live_terminal_required=true kraken_live_terminal_required=true verified_v233_grant_fallback=true "
             "canonical_context_preferred=true pipeline_context_handoff_v246=true terminal_activation_liveness_v255=true "
-            "heartbeat_position_cap_failover_v273=true startup_writer_reverification_required=true grant_ttl_not_extended=true "
-            "ordinary_orders_unchanged=true execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            "heartbeat_position_cap_failover_v273=true heartbeat_live_venue_selection_v274=true "
+            "startup_writer_reverification_required=true grant_ttl_not_extended=true ordinary_orders_unchanged=true "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
             MARKER, ",".join(surfaces),
         )
     return ready
@@ -220,6 +241,7 @@ __all__ = [
     "_install_v246_context_handoff",
     "_install_v255_terminal_activation_liveness",
     "_install_v273_heartbeat_position_cap_failover",
+    "_install_v274_heartbeat_live_venue_selection",
     "_verified_reason",
     "_writer_ready",
 ]

--- a/bot/runtime_heartbeat_live_venue_selection_v274_patch.py
+++ b/bot/runtime_heartbeat_live_venue_selection_v274_patch.py
@@ -1,0 +1,269 @@
+"""Heartbeat live-venue selection fallback for startup execution proof (v274).
+
+Production on 2026-08-29 exposed a readiness-source race: the broker-local contract
+reported active=coinbase,kraken,okx while the three-venue execution reconciler had
+published NIJA_EXECUTION_READY_VENUES as an empty string because canonical capital
+was temporarily stale. TradingStrategy._get_heartbeat_broker therefore failed before
+an otherwise eligible startup heartbeat could reach the existing writer/nonce/risk/
+capital/kill-switch/ECEL/order/fill gates.
+
+v274 repairs selection only. When the canonical execution-ready variable is present
+but temporarily empty, and only on the HeartbeatTrade thread, it may resolve a broker
+from NIJA_ACTIVE_LIVE_VENUES. That broker receives no readiness, authority, capital,
+or execution proof from this patch; the unchanged execution pipeline must still pass
+all canonical safety gates. If no matching live broker object exists, selection stays
+fail-closed. Ordinary order routing is untouched.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_heartbeat_live_venue_selection_v274")
+MARKER = "20260829-heartbeat-live-venue-selection-v274"
+RELEASE_ID = "20260829-runtime-convergence-v274"
+_READY_FLAG = "NIJA_HEARTBEAT_LIVE_VENUE_SELECTION_V274_READY"
+_PATCH_ATTR = "_nija_heartbeat_live_venue_selection_v274"
+_LOCK = threading.RLock()
+
+
+def _truthy(name: str) -> bool:
+    return str(os.environ.get(name, "") or "").strip().lower() in {
+        "1", "true", "yes", "on", "enabled", "y"
+    }
+
+
+def _live_venue_fallback_set() -> tuple[bool, tuple[str, ...], str]:
+    """Return a selection-only fallback set; never infer execution readiness."""
+    if threading.current_thread().name != "HeartbeatTrade":
+        return False, (), "not_heartbeat_thread"
+    if "NIJA_EXECUTION_READY_VENUES" not in os.environ:
+        return False, (), "canonical_readiness_not_published"
+    canonical_raw = str(os.environ.get("NIJA_EXECUTION_READY_VENUES", "") or "").strip()
+    if canonical_raw:
+        return False, (), "canonical_ready_set_nonempty"
+    if not _truthy("NIJA_GLOBAL_TRADING_READY"):
+        return False, (), "broker_local_global_ready_false"
+    active_raw = str(os.environ.get("NIJA_ACTIVE_LIVE_VENUES", "") or "")
+    active = tuple(
+        dict.fromkeys(
+            part.strip().lower()
+            for part in active_raw.split(",")
+            if part.strip()
+        )
+    )
+    if not active:
+        return False, (), "broker_local_active_set_empty"
+    return True, active, "broker_local_selection_only"
+
+
+def _candidate_brokers(strategy: Any) -> dict[Any, Any]:
+    try:
+        v273 = importlib.import_module("bot.runtime_heartbeat_position_cap_failover_v273_patch")
+        resolver = getattr(v273, "_candidate_brokers", None)
+        if callable(resolver):
+            return dict(resolver(strategy) or {})
+    except Exception:
+        pass
+    candidates: dict[Any, Any] = {}
+    manager = getattr(strategy, "multi_account_manager", None)
+    if manager is not None:
+        for attr in ("platform_brokers", "_platform_brokers"):
+            mapping = getattr(manager, attr, None)
+            if isinstance(mapping, dict):
+                candidates.update(mapping)
+    broker_manager = getattr(strategy, "broker_manager", None)
+    if broker_manager is not None:
+        mapping = getattr(broker_manager, "brokers", None)
+        if isinstance(mapping, dict):
+            candidates.update(mapping)
+        try:
+            primary = broker_manager.get_primary_broker()
+        except Exception:
+            primary = None
+        if primary is not None:
+            candidates.setdefault(getattr(primary, "broker_type", "primary"), primary)
+    broker = getattr(strategy, "broker", None)
+    if broker is not None:
+        candidates.setdefault(getattr(broker, "broker_type", "cached"), broker)
+    return candidates
+
+
+def _broker_key(strategy: Any, broker: Any) -> str:
+    try:
+        v273 = importlib.import_module("bot.runtime_heartbeat_position_cap_failover_v273_patch")
+        resolver = getattr(v273, "_broker_key", None)
+        if callable(resolver):
+            value = str(resolver(strategy, broker) or "").strip().lower()
+            if value:
+                return value
+    except Exception:
+        pass
+    resolver = getattr(strategy, "_broker_key_from_obj", None)
+    if callable(resolver):
+        try:
+            value = str(resolver(broker) or "").strip().lower()
+            if value:
+                return value
+        except Exception:
+            pass
+    value = str(getattr(broker, "broker_type", "") or "").strip().lower()
+    if value:
+        return value
+    return type(broker).__name__.replace("Broker", "").strip().lower() or "unknown"
+
+
+def _wrap_selector(current: Callable[..., Any]) -> Callable[..., Any]:
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def select_v274(self: Any):
+        selected = current(self)
+        if selected is not None:
+            return selected
+
+        allowed_fallback, live_venues, reason = _live_venue_fallback_set()
+        if not allowed_fallback:
+            return None
+
+        live_set = set(live_venues)
+        candidates = {
+            raw_key: broker
+            for raw_key, broker in _candidate_brokers(self).items()
+            if broker is not None and _broker_key(self, broker) in live_set
+        }
+        if not candidates:
+            LOGGER.warning(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_NO_MATCH marker=%s active=%s "
+                "selection_only=true trading_fail_closed=true",
+                MARKER, ",".join(live_venues),
+            )
+            return None
+
+        selector = getattr(self, "_select_entry_broker", None)
+        if not callable(selector):
+            LOGGER.error(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_SELECTOR_MISSING marker=%s "
+                "selection_only=true trading_fail_closed=true",
+                MARKER,
+            )
+            return None
+        try:
+            fallback, _name, status = selector(candidates)
+        except Exception as exc:
+            LOGGER.warning(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_SELECTOR_ERROR marker=%s error=%s:%s "
+                "selection_only=true trading_fail_closed=true",
+                MARKER, type(exc).__name__, exc,
+            )
+            return None
+        if fallback is None or _broker_key(self, fallback) not in live_set:
+            LOGGER.warning(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_UNAVAILABLE marker=%s active=%s status=%s "
+                "selection_only=true trading_fail_closed=true",
+                MARKER, ",".join(live_venues), status or "no_matching_broker",
+            )
+            return None
+
+        self.broker = fallback
+        broker_manager = getattr(self, "broker_manager", None)
+        if broker_manager is not None:
+            try:
+                broker_manager.active_broker = fallback
+            except Exception:
+                pass
+        LOGGER.critical(
+            "HEARTBEAT_LIVE_VENUE_SELECTION_V274_FALLBACK marker=%s selected=%s active=%s reason=%s "
+            "selection_only=true execution_readiness_not_granted=true capital_ready_not_granted=true "
+            "writer_nonce_risk_killswitch_ecel_min_notional_order_fill_gates_unchanged=true "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            MARKER, _broker_key(self, fallback), ",".join(live_venues), reason,
+        )
+        return fallback
+
+    setattr(select_v274, _PATCH_ATTR, True)
+    setattr(select_v274, "__wrapped__", current)
+    return select_v274
+
+
+def _patch_trading_strategy() -> tuple[bool, tuple[str, ...]]:
+    try:
+        importlib.import_module("bot.trading_strategy")
+    except Exception as exc:
+        LOGGER.warning(
+            "HEARTBEAT_LIVE_VENUE_SELECTION_V274_IMPORT_DEFERRED marker=%s error=%s:%s",
+            MARKER, type(exc).__name__, exc,
+        )
+    patched: list[str] = []
+    seen: set[int] = set()
+    for name in ("bot.trading_strategy", "trading_strategy"):
+        module = sys.modules.get(name)
+        if not isinstance(module, ModuleType):
+            continue
+        cls = getattr(module, "TradingStrategy", None)
+        if not isinstance(cls, type) or id(cls) in seen:
+            continue
+        seen.add(id(cls))
+        current = getattr(cls, "_get_heartbeat_broker", None)
+        if not callable(current):
+            continue
+        cls._get_heartbeat_broker = _wrap_selector(current)
+        if bool(getattr(getattr(cls, "_get_heartbeat_broker", None), _PATCH_ATTR, False)):
+            patched.append(str(getattr(module, "__name__", name)))
+    return bool(patched), tuple(sorted(set(patched)))
+
+
+def _register_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["heartbeat_live_venue_selection_v274"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        try:
+            strategy_ready, strategy_surfaces = _patch_trading_strategy()
+            manifest_ready = _register_manifest()
+            ready = bool(strategy_ready and manifest_ready)
+        except Exception as exc:
+            LOGGER.error(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_INSTALL_ERROR marker=%s error=%s:%s "
+                "trading_fail_closed=true",
+                MARKER, type(exc).__name__, exc, exc_info=True,
+            )
+            ready, strategy_surfaces, manifest_ready = False, (), False
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if ready:
+            LOGGER.critical(
+                "HEARTBEAT_LIVE_VENUE_SELECTION_V274_READY marker=%s ready=true strategy_surfaces=%s "
+                "heartbeat_thread_only=true canonical_empty_only=true broker_local_active_set_only=true "
+                "selection_only=true execution_readiness_not_granted=true capital_ready_not_granted=true "
+                "ordinary_orders_unchanged=true writer_nonce_risk_capital_killswitch_ecel_min_notional_order_fill_gates_unchanged=true "
+                "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+                MARKER, ",".join(strategy_surfaces),
+            )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER", "RELEASE_ID", "install", "install_import_hook",
+    "_live_venue_fallback_set", "_candidate_brokers", "_broker_key",
+    "_wrap_selector", "_patch_trading_strategy",
+]

--- a/tests/test_runtime_heartbeat_live_venue_selection_v274.py
+++ b/tests/test_runtime_heartbeat_live_venue_selection_v274.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import threading
+
+import bot.runtime_heartbeat_live_venue_selection_v274_patch as v274
+
+
+class _Broker:
+    def __init__(self, name: str) -> None:
+        self.broker_type = name
+
+
+class _Strategy:
+    def __init__(self) -> None:
+        self.broker = None
+        self.multi_account_manager = type(
+            "M", (), {"platform_brokers": {"c": _Broker("coinbase"), "k": _Broker("kraken")}}
+        )()
+        self.broker_manager = None
+
+    def _select_entry_broker(self, candidates):
+        broker = next(iter(candidates.values()), None)
+        return broker, getattr(broker, "broker_type", None), "ok" if broker else "none"
+
+
+def _on_heartbeat(fn):
+    out = []
+    thread = threading.Thread(target=lambda: out.append(fn()), name="HeartbeatTrade")
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    return out[0]
+
+
+def _reset_env() -> None:
+    for key in (
+        "NIJA_EXECUTION_READY_VENUES",
+        "NIJA_GLOBAL_TRADING_READY",
+        "NIJA_ACTIVE_LIVE_VENUES",
+    ):
+        os.environ.pop(key, None)
+
+
+def test_v274_requires_canonical_readiness_publication():
+    _reset_env()
+    assert _on_heartbeat(lambda: v274._live_venue_fallback_set()[0]) is False
+
+
+def test_v274_never_overrides_nonempty_canonical_ready_set():
+    _reset_env()
+    os.environ["NIJA_EXECUTION_READY_VENUES"] = "coinbase"
+    os.environ["NIJA_GLOBAL_TRADING_READY"] = "1"
+    os.environ["NIJA_ACTIVE_LIVE_VENUES"] = "coinbase,kraken"
+    assert _on_heartbeat(lambda: v274._live_venue_fallback_set()[0]) is False
+
+
+def test_v274_empty_canonical_set_is_heartbeat_thread_only():
+    _reset_env()
+    os.environ["NIJA_EXECUTION_READY_VENUES"] = ""
+    os.environ["NIJA_GLOBAL_TRADING_READY"] = "1"
+    os.environ["NIJA_ACTIVE_LIVE_VENUES"] = "coinbase,kraken"
+    assert v274._live_venue_fallback_set()[0] is False
+    assert _on_heartbeat(v274._live_venue_fallback_set) == (
+        True,
+        ("coinbase", "kraken"),
+        "broker_local_selection_only",
+    )
+
+
+def test_v274_wrapper_preserves_original_selection_success():
+    _reset_env()
+    strategy = _Strategy()
+    expected = _Broker("okx")
+    wrapped = v274._wrap_selector(lambda self: expected)
+    assert wrapped(strategy) is expected
+
+
+def test_v274_wrapper_uses_only_broker_local_active_venue():
+    _reset_env()
+    os.environ["NIJA_EXECUTION_READY_VENUES"] = ""
+    os.environ["NIJA_GLOBAL_TRADING_READY"] = "1"
+    os.environ["NIJA_ACTIVE_LIVE_VENUES"] = "kraken"
+    strategy = _Strategy()
+    wrapped = v274._wrap_selector(lambda self: None)
+    selected = _on_heartbeat(lambda: wrapped(strategy))
+    assert selected is not None
+    assert selected.broker_type == "kraken"


### PR DESCRIPTION
Production v273 is deployed and healthy, but the startup heartbeat still failed before reaching venue-specific failover because TradingStrategy._get_heartbeat_broker saw NIJA_EXECUTION_READY_VENUES as an empty published set while the broker-local readiness contract simultaneously reported active=coinbase,kraken,okx. Capital was temporarily stale, so the canonical readiness reconciler correctly withheld execution-ready status; however, that also prevented the heartbeat from selecting any broker to reach the unchanged downstream safety gates.

v274 repairs selection only:
- activates only on the HeartbeatTrade thread;
- activates only when NIJA_EXECUTION_READY_VENUES is present but empty;
- requires NIJA_GLOBAL_TRADING_READY=1 and uses only NIJA_ACTIVE_LIVE_VENUES;
- does not set or mutate NIJA_EXECUTION_READY_VENUES, capital readiness, execution authority, nonce, writer, kill switch, broker health, ECEL, minimum notional, order or fill proof;
- preserves ordinary order routing;
- remains fail-closed if no matching live broker object can be resolved.

Validation: syntax check passed and 5 focused v274 regression tests passed locally. No GitHub Actions/status check surfaced for the branch head, so CI is not claimed as passed.