### PR TITLE
Repair strategy publication writer handoff v275

### DIFF
--- a/bot/runtime_heartbeat_marker_convergence_v238_patch.py
+++ b/bot/runtime_heartbeat_marker_convergence_v238_patch.py
@@ -1,4 +1,4 @@
-"""Re-arm genuine heartbeat execution after a proven writer renewal (v238).
+"""Re-arm genuine heartbeat execution after a proven writer renewal (v238/v275).
 
 Production on 2026-08-26 showed the entrypoint writer lease renewing successfully
 while the live activation circuit breaker still reported
@@ -6,10 +6,19 @@ while the live activation circuit breaker still reported
 called ``authority_heartbeat._write_heartbeat_marker()`` from a writer renewal.
 That is AUTH_VERIFY liveness, not ORDER_VERIFY/FILL_VERIFY execution proof.
 
-This corrected v238 never writes an execution heartbeat marker from writer renewal.
+The corrected v238 never writes an execution heartbeat marker from writer renewal.
 A healthy renewal is only a liveness wake-up: locate the already-published strategy
-and idempotently ensure its genuine heartbeat scheduler is running. The normal
-heartbeat order path must obtain a real broker result and
+and idempotently ensure its genuine heartbeat scheduler is running. Production on
+2026-08-29 then exposed a second startup gap: the writer renewed while the canonical
+strategy publication monitor remained deferred, leaving v238 permanently at
+``strategy_not_published``. v275 closes only that owner handoff. After a proven
+healthy writer renewal, and only when no strategy is already published, v238 may
+idempotently arm the existing strategy publication monitor. The publication module's
+own live-capital, runtime-state, writer-token, writer-generation, and hydrated-broker
+checks remain authoritative. v238 still reports scheduler-not-ready until a real
+strategy exists and never publishes readiness itself.
+
+The normal heartbeat order path must obtain a real broker result and
 ``TradingStrategy._persist_heartbeat_marker`` remains the owner of execution proof.
 Activation convergence is woken only after the canonical trading-state-machine
 verifier confirms that genuine marker is present, stage-sufficient, and fresh.
@@ -27,7 +36,29 @@ from typing import Any
 
 LOGGER = logging.getLogger("nija.runtime_heartbeat_marker_convergence_v238")
 MARKER = "20260826-heartbeat-marker-convergence-v238"
+V275_MARKER = "20260829-strategy-publication-writer-handoff-v275"
 _PATCH_ATTR = "_nija_heartbeat_marker_convergence_v238"
+
+
+def _arm_strategy_publication_monitor(publication: Any) -> tuple[bool, str]:
+    """Arm the existing publisher after writer proof; never publish readiness here."""
+    starter = getattr(publication, "start_monitor", None)
+    if not callable(starter):
+        return False, "publication_start_unavailable"
+    try:
+        armed = bool(starter())
+    except Exception as exc:
+        return False, f"publication_start_error:{type(exc).__name__}:{exc}"
+    if armed:
+        LOGGER.warning(
+            "STRATEGY_PUBLICATION_WRITER_HANDOFF_V275_ARMED marker=%s "
+            "writer_renewal_required=true publication_monitor_only=true "
+            "strategy_published=false readiness_fabricated=false execution_authority_granted=false "
+            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            V275_MARKER,
+        )
+        return True, "publication_monitor_armed"
+    return False, "publication_monitor_not_armed"
 
 
 def _rearm_genuine_heartbeat() -> tuple[bool, str]:
@@ -40,7 +71,10 @@ def _rearm_genuine_heartbeat() -> tuple[bool, str]:
             return False, "v203_helpers_unavailable"
         strategy = finder(publication)
         if strategy is None:
-            return False, "strategy_not_published"
+            armed, detail = _arm_strategy_publication_monitor(publication)
+            if armed:
+                return False, f"strategy_not_published:{detail}"
+            return False, f"strategy_not_published:{detail}"
         ready = bool(ensure(strategy))
         return ready, "scheduler_alive" if ready else "scheduler_not_alive"
     except Exception as exc:
@@ -162,7 +196,8 @@ def install() -> bool:
             "HEARTBEAT_MARKER_CONVERGENCE_V238_READY marker=%s ready=true genuine_writer_renewal_wakeup_only=true "
             "real_heartbeat_scheduler_rearmed=true execution_marker_owner=TradingStrategy._persist_heartbeat_marker "
             "canonical_execution_marker_verifier=true activation_reconcile_after_genuine_marker_only=true "
-            "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+            "strategy_publication_writer_handoff_v275=true execution_proof_fabricated=false forced_activation=false "
+            "safety_gates_bypassed=false",
             MARKER,
         )
     return ready
@@ -174,8 +209,10 @@ def install_import_hook() -> bool:
 
 __all__ = [
     "MARKER",
+    "V275_MARKER",
     "install",
     "install_import_hook",
+    "_arm_strategy_publication_monitor",
     "_rearm_genuine_heartbeat",
     "_genuine_execution_marker_ready",
 ]

--- a/bot/runtime_heartbeat_marker_convergence_v238_patch.py
+++ b/bot/runtime_heartbeat_marker_convergence_v238_patch.py
@@ -15,8 +15,9 @@ strategy publication monitor remained deferred, leaving v238 permanently at
 healthy writer renewal, and only when no strategy is already published, v238 may
 idempotently arm the existing strategy publication monitor. The publication module's
 own live-capital, runtime-state, writer-token, writer-generation, and hydrated-broker
-checks remain authoritative. v238 still reports scheduler-not-ready until a real
-strategy exists and never publishes readiness itself.
+checks remain authoritative. Install-time rearm never arms publication; only the
+healthy writer-renewal path may do so. v238 still reports scheduler-not-ready until a
+real strategy exists and never publishes readiness itself.
 
 The normal heartbeat order path must obtain a real broker result and
 ``TradingStrategy._persist_heartbeat_marker`` remains the owner of execution proof.
@@ -61,7 +62,7 @@ def _arm_strategy_publication_monitor(publication: Any) -> tuple[bool, str]:
     return False, "publication_monitor_not_armed"
 
 
-def _rearm_genuine_heartbeat() -> tuple[bool, str]:
+def _rearm_genuine_heartbeat(*, allow_publication_arm: bool = False) -> tuple[bool, str]:
     try:
         v203 = importlib.import_module("bot.runtime_existing_strategy_heartbeat_rearm_v203_patch")
         publication = importlib.import_module("bot.strategy_publication_patch")
@@ -71,9 +72,9 @@ def _rearm_genuine_heartbeat() -> tuple[bool, str]:
             return False, "v203_helpers_unavailable"
         strategy = finder(publication)
         if strategy is None:
-            armed, detail = _arm_strategy_publication_monitor(publication)
-            if armed:
-                return False, f"strategy_not_published:{detail}"
+            if not allow_publication_arm:
+                return False, "strategy_not_published"
+            _armed, detail = _arm_strategy_publication_monitor(publication)
             return False, f"strategy_not_published:{detail}"
         ready = bool(ensure(strategy))
         return ready, "scheduler_alive" if ready else "scheduler_not_alive"
@@ -147,7 +148,7 @@ def _patch_entrypoint_writer() -> bool:
                 healthy = bool(proof and proof[0])
                 reason = str(proof[1] if len(proof) > 1 else "unknown")
             if acquired and not lost and healthy:
-                rearmed, rearm_detail = _rearm_genuine_heartbeat()
+                rearmed, rearm_detail = _rearm_genuine_heartbeat(allow_publication_arm=True)
                 LOGGER.critical(
                     "HEARTBEAT_MARKER_V238_LIVENESS_WAKE marker=%s source=entrypoint_writer_renewal "
                     "lease_acquired=true writer_lost=false renewal_health=true scheduler_ready=%s "

--- a/bot/tests/test_strategy_publication_writer_handoff_v275.py
+++ b/bot/tests/test_strategy_publication_writer_handoff_v275.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+import bot.runtime_heartbeat_marker_convergence_v238_patch as v238
+
+
+def test_install_time_rearm_does_not_arm_publication(monkeypatch):
+    calls = {"start": 0}
+
+    publication = SimpleNamespace(
+        start_monitor=lambda: calls.__setitem__("start", calls["start"] + 1) or True
+    )
+    v203 = SimpleNamespace(
+        _already_published_strategy=lambda _publication: None,
+        _ensure_heartbeat_scheduler=lambda _strategy: True,
+    )
+
+    def fake_import(name):
+        if name == "bot.runtime_existing_strategy_heartbeat_rearm_v203_patch":
+            return v203
+        if name == "bot.strategy_publication_patch":
+            return publication
+        raise AssertionError(name)
+
+    monkeypatch.setattr(v238.importlib, "import_module", fake_import)
+
+    ready, detail = v238._rearm_genuine_heartbeat()
+
+    assert ready is False
+    assert detail == "strategy_not_published"
+    assert calls["start"] == 0
+
+
+def test_writer_rearm_arms_existing_publication_monitor(monkeypatch):
+    calls = {"start": 0}
+
+    def start_monitor():
+        calls["start"] += 1
+        return True
+
+    publication = SimpleNamespace(start_monitor=start_monitor)
+    v203 = SimpleNamespace(
+        _already_published_strategy=lambda _publication: None,
+        _ensure_heartbeat_scheduler=lambda _strategy: True,
+    )
+
+    def fake_import(name):
+        if name == "bot.runtime_existing_strategy_heartbeat_rearm_v203_patch":
+            return v203
+        if name == "bot.strategy_publication_patch":
+            return publication
+        raise AssertionError(name)
+
+    monkeypatch.setattr(v238.importlib, "import_module", fake_import)
+
+    ready, detail = v238._rearm_genuine_heartbeat(allow_publication_arm=True)
+
+    assert ready is False
+    assert detail == "strategy_not_published:publication_monitor_armed"
+    assert calls["start"] == 1
+
+
+def test_existing_strategy_rearms_scheduler_without_starting_publication(monkeypatch):
+    strategy = object()
+    calls = {"ensure": 0, "start": 0}
+
+    publication = SimpleNamespace(
+        start_monitor=lambda: calls.__setitem__("start", calls["start"] + 1) or True
+    )
+
+    def ensure(candidate):
+        assert candidate is strategy
+        calls["ensure"] += 1
+        return True
+
+    v203 = SimpleNamespace(
+        _already_published_strategy=lambda _publication: strategy,
+        _ensure_heartbeat_scheduler=ensure,
+    )
+
+    def fake_import(name):
+        if name == "bot.runtime_existing_strategy_heartbeat_rearm_v203_patch":
+            return v203
+        if name == "bot.strategy_publication_patch":
+            return publication
+        raise AssertionError(name)
+
+    monkeypatch.setattr(v238.importlib, "import_module", fake_import)
+
+    ready, detail = v238._rearm_genuine_heartbeat(allow_publication_arm=True)
+
+    assert ready is True
+    assert detail == "scheduler_alive"
+    assert calls["ensure"] == 1
+    assert calls["start"] == 0
+
+
+def test_publication_start_failure_stays_fail_closed(monkeypatch):
+    publication = SimpleNamespace(start_monitor=lambda: False)
+    v203 = SimpleNamespace(
+        _already_published_strategy=lambda _publication: None,
+        _ensure_heartbeat_scheduler=lambda _strategy: True,
+    )
+
+    def fake_import(name):
+        if name == "bot.runtime_existing_strategy_heartbeat_rearm_v203_patch":
+            return v203
+        if name == "bot.strategy_publication_patch":
+            return publication
+        raise AssertionError(name)
+
+    monkeypatch.setattr(v238.importlib, "import_module", fake_import)
+
+    ready, detail = v238._rearm_genuine_heartbeat(allow_publication_arm=True)
+
+    assert ready is False
+    assert detail == "strategy_not_published:publication_monitor_not_armed"


### PR DESCRIPTION
Production runtime at deployment 258cf134f988bd45fae3386cb9e7b20c8d70fa8e repeatedly renewed the active writer while v238 reported `scheduler_detail=strategy_not_published` and the v190 owner path remained `background_monitor_started=false`. This left genuine heartbeat execution proof permanently unavailable even though platform position sync and platform broker connectivity were healthy.

This change keeps startup fail-closed and only closes the missing owner handoff:

- install-time v238 behavior remains unchanged and does not arm publication;
- only a proven healthy entrypoint writer renewal may idempotently call the existing `strategy_publication_patch.start_monitor()`;
- the publication module still enforces live-capital, runtime-state, writer-token, writer-generation, hydrated-broker and entry-ready broker checks;
- v238 continues to report scheduler-not-ready until a real TradingStrategy is published;
- no execution proof, readiness, capital, nonce, risk, kill-switch, broker-health, ECEL, minimum-notional, order or fill gate is fabricated or bypassed.

Adds focused regression tests for install-time fencing, healthy-writer handoff, existing-strategy idempotence and failed-start fail-closed behavior.