### PR TITLE
Fix heartbeat terminal lifecycle authority v276

### DIFF
--- a/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
+++ b/bot/runtime_heartbeat_broker_manager_terminal_v244_patch.py
@@ -18,7 +18,9 @@ bounded failover for proven process-local read contention and preserves authorit
 position/capital ownership. v273 adds heartbeat-only venue failover after an unchanged
 ECEL POSITION_CAP_EXCEEDED result. v274 repairs the heartbeat selection race when the
 canonical ready-venue string is temporarily empty but broker-local live venues remain
-published; it is selection-only and grants no readiness or execution authority.
+published; it is selection-only and grants no readiness or execution authority. v276
+bridges only the already-verified startup probe through the terminal lifecycle assertion
+that otherwise calls the ordinary LIVE-only can_execute() path.
 
 Ordinary orders, lifecycle state, nonce, risk, capital, broker health, kill switch,
 minimum notional, exchange acknowledgement, fill proof, and readiness remain unchanged.
@@ -197,6 +199,23 @@ def _install_v274_heartbeat_live_venue_selection() -> bool:
         return False
 
 
+def _install_v276_heartbeat_terminal_authority() -> bool:
+    """Install the terminal lifecycle exception for verified startup probes only."""
+    try:
+        module = importlib.import_module("bot.runtime_heartbeat_terminal_authority_v276_patch")
+        installer = getattr(module, "install", None) or getattr(module, "install_import_hook", None)
+        ready = bool(callable(installer) and installer())
+        if not ready:
+            LOGGER.error("HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V276_INSTALL_FAILED marker=%s trading_fail_closed=true", MARKER)
+        return ready
+    except Exception as exc:
+        LOGGER.error(
+            "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_V276_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+            MARKER, type(exc).__name__, exc,
+        )
+        return False
+
+
 def install() -> bool:
     try:
         v240 = importlib.import_module("bot.runtime_heartbeat_terminal_lifecycle_v240_patch")
@@ -207,20 +226,21 @@ def install() -> bool:
         v255_ready = _install_v255_terminal_activation_liveness()
         v273_ready = _install_v273_heartbeat_position_cap_failover()
         v274_ready = _install_v274_heartbeat_live_venue_selection()
-        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready and v273_ready and v274_ready)
+        v276_ready = _install_v276_heartbeat_terminal_authority()
+        ready = bool(upstream and methods_ready and context_handoff_ready and v255_ready and v273_ready and v274_ready and v276_ready)
     except Exception as exc:
         LOGGER.error(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
             MARKER, type(exc).__name__, exc,
         )
-        ready, surfaces, context_handoff_ready, v255_ready, v273_ready, v274_ready = False, (), False, False, False, False
+        ready, surfaces, context_handoff_ready, v255_ready, v273_ready, v274_ready, v276_ready = False, (), False, False, False, False, False
     os.environ[_FLAG] = "1" if ready else "0"
     if ready:
         LOGGER.critical(
             "HEARTBEAT_BROKER_MANAGER_TERMINAL_V244_READY marker=%s ready=true surfaces=%s "
             "coinbase_live_terminal_required=true kraken_live_terminal_required=true verified_v233_grant_fallback=true "
             "canonical_context_preferred=true pipeline_context_handoff_v246=true terminal_activation_liveness_v255=true "
-            "heartbeat_position_cap_failover_v273=true heartbeat_live_venue_selection_v274=true "
+            "heartbeat_position_cap_failover_v273=true heartbeat_live_venue_selection_v274=true heartbeat_terminal_authority_v276=true "
             "startup_writer_reverification_required=true grant_ttl_not_extended=true ordinary_orders_unchanged=true "
             "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
             MARKER, ",".join(surfaces),
@@ -242,6 +262,7 @@ __all__ = [
     "_install_v255_terminal_activation_liveness",
     "_install_v273_heartbeat_position_cap_failover",
     "_install_v274_heartbeat_live_venue_selection",
+    "_install_v276_heartbeat_terminal_authority",
     "_verified_reason",
     "_writer_ready",
 ]

--- a/bot/runtime_heartbeat_terminal_authority_v276_patch.py
+++ b/bot/runtime_heartbeat_terminal_authority_v276_patch.py
@@ -1,0 +1,213 @@
+"""Bridge the verified startup heartbeat through terminal execution authority (v276).
+
+Production on 2026-08-29 proved the canonical heartbeat reached the final execution
+authority assertion with a healthy writer/core, connected brokers/users, canonical
+position sync, a clear kill switch, and an upstream ECEL-accepted order, but
+``assert_execution_dispatch_permitted()`` still called the ordinary ``can_execute()``
+path and failed at ``lifecycle_phase:BOOT``.  The authority module itself documents
+startup probes as the explicit pre-LIVE exception and already provides
+``can_execute_startup_probe()`` plus ``assert_startup_write_authority()`` for that
+purpose.
+
+v276 closes only that terminal integration gap.  The ordinary assertion always runs
+first.  Only an ``ExecutionBlocked`` result whose reason is exactly a pre-LIVE
+lifecycle denial may be reconsidered, and only when v263 independently re-verifies
+HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE, LIVE_PENDING_CONFIRMATION, live runtime mode,
+distributed writer authority, a clear kill switch, and raw nonce authority.  The
+canonical startup-probe checker is then re-run before returning.
+
+No lifecycle state, readiness, capital, broker health, risk, ECEL, minimum-notional,
+order acknowledgement, fill proof, heartbeat marker, or activation state is mutated.
+Ordinary orders and every non-lifecycle denial remain fail closed.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import os
+import sys
+import threading
+from functools import wraps
+from types import ModuleType
+from typing import Any, Callable
+
+LOGGER = logging.getLogger("nija.runtime_heartbeat_terminal_authority_v276")
+MARKER = "20260829-heartbeat-terminal-authority-v276"
+_READY_FLAG = "NIJA_HEARTBEAT_TERMINAL_AUTHORITY_V276_READY"
+_PATCH_ATTR = "_nija_heartbeat_terminal_authority_v276"
+_IMPORT_HOOK_ATTR = "_NIJA_HEARTBEAT_TERMINAL_AUTHORITY_V276_IMPORT_HOOK"
+_ALLOWED_LIFECYCLE_REASONS = {"lifecycle_phase:BOOT", "lifecycle_phase:WARM"}
+_LOCK = threading.RLock()
+
+
+def _authority_module() -> ModuleType:
+    module = sys.modules.get("bot.execution_authority_context")
+    if not isinstance(module, ModuleType):
+        module = importlib.import_module("bot.execution_authority_context")
+    if not isinstance(module, ModuleType):
+        raise RuntimeError("canonical_execution_authority_unavailable")
+    return module
+
+
+def _verified_startup_probe() -> tuple[bool, str]:
+    try:
+        v263 = importlib.import_module("bot.runtime_heartbeat_state_machine_gate_v263_patch")
+        verifier = getattr(v263, "_verified_startup_probe", None)
+        if not callable(verifier):
+            return False, "v263_verifier_unavailable"
+        verified, detail = verifier()
+        if not bool(verified):
+            return False, str(detail or "v263_verification_failed")
+
+        authority = _authority_module()
+        checker = getattr(authority, "can_execute_startup_probe", None)
+        if not callable(checker):
+            return False, "startup_probe_checker_unavailable"
+        allowed, reason = checker()
+        if not bool(allowed):
+            return False, f"startup_probe_denied:{reason or 'unknown'}"
+        return True, str(reason or detail or "HEARTBEAT_TRADE")
+    except Exception as exc:
+        return False, f"verification_error:{type(exc).__name__}:{exc}"
+
+
+def _is_lifecycle_execution_block(authority: ModuleType, exc: BaseException) -> bool:
+    blocked_cls = getattr(authority, "ExecutionBlocked", None)
+    if not isinstance(blocked_cls, type) or not isinstance(exc, blocked_cls):
+        return False
+    return str(exc).strip() in _ALLOWED_LIFECYCLE_REASONS
+
+
+def _wrap_assertion(current: Callable[[], None], authority: ModuleType) -> Callable[[], None]:
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return current
+
+    @wraps(current)
+    def assert_execution_dispatch_permitted_v276() -> None:
+        try:
+            return current()
+        except Exception as exc:
+            if not _is_lifecycle_execution_block(authority, exc):
+                raise
+
+            verified, detail = _verified_startup_probe()
+            if not verified:
+                LOGGER.info(
+                    "HEARTBEAT_TERMINAL_AUTHORITY_V276_DEFERRED marker=%s original_reason=%s detail=%s "
+                    "ordinary_orders_unchanged=true trading_fail_closed=true",
+                    MARKER,
+                    str(exc),
+                    detail,
+                )
+                raise
+
+            LOGGER.critical(
+                "HEARTBEAT_TERMINAL_AUTHORITY_V276_ALLOWED marker=%s probe_reason=%s original_reason=%s "
+                "ordinary_can_execute_ran_first=true lifecycle_state_unchanged=true startup_probe_reverified=true "
+                "distributed_writer_reverified=true raw_nonce_authority=true kill_switch_clear=true "
+                "readiness_mutated=false capital_mutated=false heartbeat_marker_written=false "
+                "ordinary_orders_unchanged=true risk_broker_health_ecel_min_notional_order_ack_fill_gates_unchanged=true "
+                "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+                MARKER,
+                detail,
+                str(exc),
+            )
+            return None
+
+    setattr(assert_execution_dispatch_permitted_v276, _PATCH_ATTR, True)
+    setattr(assert_execution_dispatch_permitted_v276, "__wrapped__", current)
+    return assert_execution_dispatch_permitted_v276
+
+
+def _patch_loaded_authority() -> bool:
+    authority = _authority_module()
+    current = getattr(authority, "assert_execution_dispatch_permitted", None)
+    if not callable(current):
+        return False
+    wrapped = _wrap_assertion(current, authority)
+    setattr(authority, "assert_execution_dispatch_permitted", wrapped)
+    installed = getattr(authority, "assert_execution_dispatch_permitted", None)
+    return bool(callable(installed) and getattr(installed, _PATCH_ATTR, False))
+
+
+def _install_import_reassertion_hook() -> bool:
+    if bool(getattr(builtins, _IMPORT_HOOK_ATTR, False)):
+        return True
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+        module = original_import(name, globals, locals, fromlist, level)
+        if str(name or "").endswith("execution_authority_context"):
+            try:
+                _patch_loaded_authority()
+            except Exception as exc:
+                LOGGER.error(
+                    "HEARTBEAT_TERMINAL_AUTHORITY_V276_REASSERT_FAILED marker=%s imported=%s error=%s:%s "
+                    "trading_fail_closed=true",
+                    MARKER,
+                    name,
+                    type(exc).__name__,
+                    exc,
+                )
+        return module
+
+    builtins.__import__ = guarded_import
+    setattr(builtins, _IMPORT_HOOK_ATTR, True)
+    return True
+
+
+def _patch_release_manifest() -> bool:
+    try:
+        manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+        required = getattr(manifest, "_REQUIRED_FLAGS", None)
+        if not isinstance(required, dict):
+            return False
+        required["heartbeat_terminal_authority_v276"] = _READY_FLAG
+        return True
+    except Exception:
+        return False
+
+
+def install() -> bool:
+    with _LOCK:
+        try:
+            patched = _patch_loaded_authority()
+            hook_ok = _install_import_reassertion_hook()
+            manifest_ok = _patch_release_manifest()
+            ready = bool(patched and hook_ok and manifest_ok)
+        except Exception as exc:
+            LOGGER.error(
+                "HEARTBEAT_TERMINAL_AUTHORITY_V276_INSTALL_ERROR marker=%s error=%s:%s trading_fail_closed=true",
+                MARKER,
+                type(exc).__name__,
+                exc,
+            )
+            ready = False
+
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if ready:
+            LOGGER.critical(
+                "HEARTBEAT_TERMINAL_AUTHORITY_V276_READY marker=%s ready=true ordinary_assertion_first=true "
+                "lifecycle_denial_only=true trusted_startup_probe_only=true live_pending_only=true "
+                "distributed_writer_reverification_required=true raw_nonce_authority_required=true kill_switch_clear_required=true "
+                "lifecycle_state_unchanged=true readiness_mutated=false ordinary_orders_unchanged=true "
+                "risk_capital_broker_health_ecel_min_notional_order_ack_fill_gates_unchanged=true "
+                "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+                MARKER,
+            )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER",
+    "install",
+    "install_import_hook",
+    "_verified_startup_probe",
+    "_is_lifecycle_execution_block",
+    "_wrap_assertion",
+]

--- a/bot/tests/test_runtime_heartbeat_terminal_authority_v276.py
+++ b/bot/tests/test_runtime_heartbeat_terminal_authority_v276.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from bot import runtime_heartbeat_terminal_authority_v276_patch as v276
+
+
+class FakeExecutionBlocked(RuntimeError):
+    pass
+
+
+def _authority() -> ModuleType:
+    module = ModuleType("bot.execution_authority_context")
+    module.ExecutionBlocked = FakeExecutionBlocked
+    return module
+
+
+def test_trusted_startup_probe_crosses_only_lifecycle_denial(monkeypatch):
+    authority = _authority()
+    calls = {"ordinary": 0, "verify": 0}
+
+    def current():
+        calls["ordinary"] += 1
+        raise FakeExecutionBlocked("lifecycle_phase:BOOT")
+
+    def verified():
+        calls["verify"] += 1
+        return True, "HEARTBEAT_TRADE"
+
+    monkeypatch.setattr(v276, "_verified_startup_probe", verified)
+    wrapped = v276._wrap_assertion(current, authority)
+
+    assert wrapped() is None
+    assert calls == {"ordinary": 1, "verify": 1}
+
+
+def test_ordinary_lifecycle_denial_remains_fail_closed(monkeypatch):
+    authority = _authority()
+
+    def current():
+        raise FakeExecutionBlocked("lifecycle_phase:BOOT")
+
+    monkeypatch.setattr(
+        v276,
+        "_verified_startup_probe",
+        lambda: (False, "startup_probe_denied:probe_reason_not_whitelisted"),
+    )
+    wrapped = v276._wrap_assertion(current, authority)
+
+    with pytest.raises(FakeExecutionBlocked, match="lifecycle_phase:BOOT"):
+        wrapped()
+
+
+def test_non_lifecycle_execution_denial_is_never_reconsidered(monkeypatch):
+    authority = _authority()
+    verification_called = {"value": False}
+
+    def current():
+        raise FakeExecutionBlocked("nonce.authority")
+
+    def verified():
+        verification_called["value"] = True
+        return True, "HEARTBEAT_TRADE"
+
+    monkeypatch.setattr(v276, "_verified_startup_probe", verified)
+    wrapped = v276._wrap_assertion(current, authority)
+
+    with pytest.raises(FakeExecutionBlocked, match="nonce.authority"):
+        wrapped()
+    assert verification_called["value"] is False
+
+
+def test_unrelated_exception_is_never_swallowed(monkeypatch):
+    authority = _authority()
+
+    def current():
+        raise RuntimeError("unexpected-terminal-error")
+
+    monkeypatch.setattr(v276, "_verified_startup_probe", lambda: (True, "HEARTBEAT_TRADE"))
+    wrapped = v276._wrap_assertion(current, authority)
+
+    with pytest.raises(RuntimeError, match="unexpected-terminal-error"):
+        wrapped()
+
+
+def test_lifecycle_reason_match_is_exact():
+    authority = _authority()
+    assert v276._is_lifecycle_execution_block(authority, FakeExecutionBlocked("lifecycle_phase:BOOT"))
+    assert v276._is_lifecycle_execution_block(authority, FakeExecutionBlocked("lifecycle_phase:WARM"))
+    assert not v276._is_lifecycle_execution_block(authority, FakeExecutionBlocked("lifecycle_phase:LIVE"))
+    assert not v276._is_lifecycle_execution_block(authority, FakeExecutionBlocked("state.live_active"))


### PR DESCRIPTION
Closes the startup heartbeat proof deadlock observed in production on 2026-08-29. The ordinary terminal execution assertion still runs first. Only an exact BOOT/WARM lifecycle ExecutionBlocked result may be crossed, and only for the already-whitelisted HEARTBEAT_TRADE/HEARTBEAT_TRADE_CLOSE context after v263 re-verifies LIVE_PENDING_CONFIRMATION, live runtime mode, distributed writer authority, raw nonce authority, and a clear kill switch. Ordinary orders and all non-lifecycle denials remain fail-closed. No lifecycle/readiness/capital/risk/ECEL/order/fill state is fabricated or mutated.

Adds five focused regression tests and makes v244 readiness depend on v276 installation.