### PR TITLE
Repair platform activation liveness v280

### DIFF
--- a/bot/runtime_platform_activation_liveness_v280_patch.py
+++ b/bot/runtime_platform_activation_liveness_v280_patch.py
@@ -5,18 +5,20 @@ Kraken-only while process-wide Coinbase/OKX PLATFORM objects could still exist,
 and showed position_sync_ready briefly report true before v146 correctly revoked
 it because independent authoritative fetch proof was missing.
 
-v280 repairs liveness only. It may adopt an existing, unique process-wide PLATFORM
-Coinbase/OKX broker into the canonical manager, reconnect an existing configured
+v280 repairs liveness only. It may adopt an existing process-wide PLATFORM
+Coinbase/OKX broker into the canonical manager, reconnect that exact configured
 broker through its real connect() method, synchronize the manager's normal
 connection mirrors only after real connection success, wake authoritative v108
-position sync, and request a normal canonical capital refresh. It also immediately
-wakes v108 after v182 reasserts the fetch-proof chain instead of waiting for an
-unrelated future capital refresh.
+position sync, and request a normal canonical capital refresh when topology or
+connectivity actually changed. It also immediately wakes v108 after v182
+reasserts the fetch-proof chain instead of waiting for an unrelated future
+capital refresh.
 
-The patch never creates credentials, never marks a failed connect successful,
-never lowers broker-count/capital/notional thresholds, never fabricates position,
-nonce, execution, order, acknowledgement, fill, or heartbeat proof, never clears
-a kill switch or rejection window, and never forces activation.
+The patch never creates credentials or broker objects, never marks a failed
+connect successful, never lowers broker-count/capital/notional thresholds, never
+fabricates position, nonce, execution, order, acknowledgement, fill, or heartbeat
+proof, never clears a kill switch or rejection window, and never forces
+activation. Recovery broker I/O is bounded by a per-instance retry floor.
 """
 from __future__ import annotations
 
@@ -24,6 +26,7 @@ import importlib
 import logging
 import os
 import threading
+import time
 from functools import wraps
 from typing import Any
 
@@ -33,12 +36,20 @@ RELEASE_ID = "20260829-runtime-convergence-v280"
 _READY_FLAG = "NIJA_RUNTIME_PLATFORM_ACTIVATION_LIVENESS_V280_READY"
 _PATCH_ATTR = "_nija_runtime_platform_activation_liveness_v280"
 _LOCK = threading.RLock()
-_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
 _SUPPORTED = ("coinbase", "okx")
+_LAST_CONNECT_AT: dict[tuple[str, int], float] = {}
 
 
 def _label(value: Any) -> str:
     return str(getattr(value, "value", value) or "").strip().lower()
+
+
+def _connect_retry_s() -> float:
+    try:
+        configured = float(os.environ.get("NIJA_PLATFORM_ACTIVATION_RECOVERY_RETRY_S", "30") or 30.0)
+    except (TypeError, ValueError):
+        configured = 30.0
+    return max(15.0, min(300.0, configured))
 
 
 def _is_platform_account(broker: Any) -> bool:
@@ -66,6 +77,16 @@ def _platform_key(manager: Any, venue: str) -> Any:
                 return key
     broker_type = getattr(_broker_module(), "BrokerType", None)
     return getattr(broker_type, venue.upper(), None)
+
+
+def _manager_entry(manager: Any, venue: str) -> tuple[Any, Any]:
+    mapping = getattr(manager, "_platform_brokers", None)
+    if not isinstance(mapping, dict):
+        return None, None
+    for key, broker in list(mapping.items()):
+        if _label(key) == venue:
+            return key, broker
+    return None, None
 
 
 def _global_candidate(venue: str) -> Any:
@@ -104,17 +125,10 @@ def _adopt_existing(manager: Any, venue: str, broker: Any) -> bool:
     mapping = getattr(manager, "_platform_brokers", None)
     if not isinstance(mapping, dict):
         return False
-    existing_key = None
-    existing = None
-    for key, value in list(mapping.items()):
-        if _label(key) == venue:
-            existing_key, existing = key, value
-            break
+    existing_key, existing = _manager_entry(manager, venue)
     if existing is broker:
         return True
     if existing is not None and existing is not broker:
-        # Ambiguous ownership remains fail closed. Never replace a live manager
-        # object with another process-wide object without a dedicated proof.
         LOGGER.critical(
             "PLATFORM_ACTIVATION_V280_AMBIGUOUS marker=%s venue=%s manager_id=%s global_id=%s "
             "registry_mutated=false trading_fail_closed=true",
@@ -148,6 +162,7 @@ def _connect_existing(manager: Any, venue: str, broker: Any) -> bool:
         if callable(sync) and key is not None:
             sync(key, broker)
         return True
+
     if not _credentials_configured(broker) or not _configured_by_policy(venue, broker):
         LOGGER.warning(
             "PLATFORM_ACTIVATION_V280_CONNECT_INELIGIBLE marker=%s venue=%s credentials=%s "
@@ -156,6 +171,34 @@ def _connect_existing(manager: Any, venue: str, broker: Any) -> bool:
             str(_configured_by_policy(venue, broker)).lower(),
         )
         return False
+
+    attempt_key = (venue, id(broker))
+    now = time.monotonic()
+    with _LOCK:
+        previous = float(_LAST_CONNECT_AT.get(attempt_key, 0.0) or 0.0)
+        if previous > 0.0 and (now - previous) < _connect_retry_s():
+            LOGGER.debug(
+                "PLATFORM_ACTIVATION_V280_CONNECT_DEFERRED marker=%s venue=%s retry_in_s=%.2f "
+                "duplicate_io_suppressed=true trading_fail_closed=true",
+                MARKER, venue, _connect_retry_s() - (now - previous),
+            )
+            return False
+        _LAST_CONNECT_AT[attempt_key] = now
+
+    # Prefer the manager's normal reconnect owner when available. It calls the
+    # broker's real connect() method and synchronizes readiness only on success.
+    reconnect = getattr(manager, "try_reconnect_platform_broker", None)
+    key = _platform_key(manager, venue)
+    if callable(reconnect) and key is not None:
+        try:
+            return bool(reconnect(key)) and bool(getattr(broker, "connected", False))
+        except Exception as exc:
+            LOGGER.warning(
+                "PLATFORM_ACTIVATION_V280_RECONNECT_FAILED marker=%s venue=%s error=%s:%s trading_fail_closed=true",
+                MARKER, venue, type(exc).__name__, exc,
+            )
+            return False
+
     connect = getattr(broker, "connect", None)
     if not callable(connect):
         return False
@@ -169,7 +212,6 @@ def _connect_existing(manager: Any, venue: str, broker: Any) -> bool:
         return False
     if not connected:
         return False
-    key = _platform_key(manager, venue)
     sync = getattr(manager, "_sync_reconnect_readiness", None)
     if callable(sync) and key is not None:
         sync(key, broker)
@@ -193,14 +235,16 @@ def _wake_position_sync(manager: Any, trigger: str) -> int:
         return 0
 
 
-def _request_capital_refresh(manager: Any, trigger: str) -> None:
+def _request_capital_refresh(manager: Any, trigger: str) -> bool:
     refresh = getattr(manager, "refresh_capital_authority", None)
     if not callable(refresh):
-        return
+        return False
     try:
         refresh(trigger=trigger)
+        return True
     except Exception:
         LOGGER.debug("v280 capital refresh failed", exc_info=True)
+        return False
 
 
 def reconcile_once() -> dict[str, str]:
@@ -208,25 +252,37 @@ def reconcile_once() -> dict[str, str]:
     outcomes: dict[str, str] = {}
     if manager is None:
         return {"manager": "missing"}
+
+    topology_changed = False
     for venue in _SUPPORTED:
+        _, before = _manager_entry(manager, venue)
         candidate = _global_candidate(venue)
         if candidate is None:
             outcomes[venue] = "no_existing_platform_object"
             continue
+        before_connected = bool(getattr(candidate, "connected", False))
         if not _adopt_existing(manager, venue, candidate):
             outcomes[venue] = "ownership_ambiguous"
             continue
-        if _connect_existing(manager, venue, candidate):
+        if before is None:
+            topology_changed = True
+        connected = _connect_existing(manager, venue, candidate)
+        if connected:
             outcomes[venue] = "connected"
+            if not before_connected:
+                topology_changed = True
         else:
             outcomes[venue] = "not_connected"
+
     workers = _wake_position_sync(manager, "v280_platform_reconcile")
-    _request_capital_refresh(manager, "v280_platform_reconcile")
+    refresh_requested = False
+    if topology_changed or workers > 0:
+        refresh_requested = _request_capital_refresh(manager, "v280_platform_reconcile")
     LOGGER.critical(
         "PLATFORM_ACTIVATION_V280_RECONCILE marker=%s outcomes=%s position_workers=%d "
-        "capital_refresh_requested=true thresholds_unchanged=true execution_proof_fabricated=false "
-        "forced_activation=false safety_gates_bypassed=false",
-        MARKER, outcomes, workers,
+        "topology_changed=%s capital_refresh_requested=%s duplicate_io_bounded=true "
+        "thresholds_unchanged=true execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+        MARKER, outcomes, workers, str(topology_changed).lower(), str(refresh_requested).lower(),
     )
     return outcomes
 
@@ -304,5 +360,5 @@ def install_import_hook() -> bool:
 __all__ = [
     "MARKER", "RELEASE_ID", "install", "install_import_hook", "reconcile_once",
     "_global_candidate", "_adopt_existing", "_connect_existing", "_wake_position_sync",
-    "_patch_v182_install",
+    "_patch_v182_install", "_connect_retry_s",
 ]

--- a/bot/runtime_platform_activation_liveness_v280_patch.py
+++ b/bot/runtime_platform_activation_liveness_v280_patch.py
@@ -1,0 +1,308 @@
+"""Platform activation liveness recovery v280.
+
+Production on 2026-08-29 showed the canonical MultiAccountBrokerManager shrink to
+Kraken-only while process-wide Coinbase/OKX PLATFORM objects could still exist,
+and showed position_sync_ready briefly report true before v146 correctly revoked
+it because independent authoritative fetch proof was missing.
+
+v280 repairs liveness only. It may adopt an existing, unique process-wide PLATFORM
+Coinbase/OKX broker into the canonical manager, reconnect an existing configured
+broker through its real connect() method, synchronize the manager's normal
+connection mirrors only after real connection success, wake authoritative v108
+position sync, and request a normal canonical capital refresh. It also immediately
+wakes v108 after v182 reasserts the fetch-proof chain instead of waiting for an
+unrelated future capital refresh.
+
+The patch never creates credentials, never marks a failed connect successful,
+never lowers broker-count/capital/notional thresholds, never fabricates position,
+nonce, execution, order, acknowledgement, fill, or heartbeat proof, never clears
+a kill switch or rejection window, and never forces activation.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from functools import wraps
+from typing import Any
+
+LOGGER = logging.getLogger("nija.runtime_platform_activation_liveness_v280")
+MARKER = "20260829-platform-activation-liveness-v280"
+RELEASE_ID = "20260829-runtime-convergence-v280"
+_READY_FLAG = "NIJA_RUNTIME_PLATFORM_ACTIVATION_LIVENESS_V280_READY"
+_PATCH_ATTR = "_nija_runtime_platform_activation_liveness_v280"
+_LOCK = threading.RLock()
+_TRUE = {"1", "true", "yes", "on", "enabled", "y"}
+_SUPPORTED = ("coinbase", "okx")
+
+
+def _label(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").strip().lower()
+
+
+def _is_platform_account(broker: Any) -> bool:
+    account = _label(getattr(broker, "account_type", ""))
+    # Older platform adapters may not expose account_type. They are accepted only
+    # when they are already held by the process-wide PLATFORM instance registry.
+    return not account or account == "platform" or account.endswith(".platform")
+
+
+def _canonical_manager() -> Any:
+    module = importlib.import_module("bot.multi_account_broker_manager")
+    getter = getattr(module, "get_broker_manager", None)
+    return getter() if callable(getter) else None
+
+
+def _broker_module() -> Any:
+    return importlib.import_module("bot.broker_manager")
+
+
+def _platform_key(manager: Any, venue: str) -> Any:
+    mapping = getattr(manager, "_platform_brokers", None)
+    if isinstance(mapping, dict):
+        for key in mapping:
+            if _label(key) == venue:
+                return key
+    broker_type = getattr(_broker_module(), "BrokerType", None)
+    return getattr(broker_type, venue.upper(), None)
+
+
+def _global_candidate(venue: str) -> Any:
+    module = _broker_module()
+    instances = getattr(module, "_PLATFORM_BROKER_INSTANCES", None)
+    candidate = instances.get(venue) if isinstance(instances, dict) else None
+    if candidate is None or not _is_platform_account(candidate):
+        return None
+    return candidate
+
+
+def _credentials_configured(broker: Any) -> bool:
+    value = getattr(broker, "credentials_configured", None)
+    if value is None:
+        # Do not invent credentials. If an older adapter lacks the attribute,
+        # only an already-connected object may be adopted.
+        return bool(getattr(broker, "connected", False))
+    return bool(value)
+
+
+def _configured_by_policy(venue: str, broker: Any) -> bool:
+    try:
+        cfg = importlib.import_module("bot.execution_venue_config")
+        if venue == "coinbase":
+            fn = getattr(cfg, "should_initialize_coinbase_platform", None)
+            return bool(fn(os.environ)) if callable(fn) else False
+        if venue == "okx":
+            fn = getattr(cfg, "should_initialize_okx_platform", None)
+            return bool(fn(os.environ, credentials_configured=_credentials_configured(broker))) if callable(fn) else False
+    except Exception:
+        return False
+    return False
+
+
+def _adopt_existing(manager: Any, venue: str, broker: Any) -> bool:
+    mapping = getattr(manager, "_platform_brokers", None)
+    if not isinstance(mapping, dict):
+        return False
+    existing_key = None
+    existing = None
+    for key, value in list(mapping.items()):
+        if _label(key) == venue:
+            existing_key, existing = key, value
+            break
+    if existing is broker:
+        return True
+    if existing is not None and existing is not broker:
+        # Ambiguous ownership remains fail closed. Never replace a live manager
+        # object with another process-wide object without a dedicated proof.
+        LOGGER.critical(
+            "PLATFORM_ACTIVATION_V280_AMBIGUOUS marker=%s venue=%s manager_id=%s global_id=%s "
+            "registry_mutated=false trading_fail_closed=true",
+            MARKER, venue, id(existing), id(broker),
+        )
+        return False
+    key = existing_key or _platform_key(manager, venue)
+    if key is None:
+        return False
+    lock = getattr(manager, "_registry_meta_lock", None) or _LOCK
+    with lock:
+        mapping[key] = broker
+    try:
+        refresh = getattr(manager, "refresh_registry", None)
+        if callable(refresh):
+            refresh()
+    except Exception:
+        LOGGER.debug("v280 refresh_registry failed for %s", venue, exc_info=True)
+    LOGGER.critical(
+        "PLATFORM_ACTIVATION_V280_ADOPTED marker=%s venue=%s broker_id=%s "
+        "existing_process_platform_object=true connectivity_fabricated=false credentials_fabricated=false",
+        MARKER, venue, id(broker),
+    )
+    return True
+
+
+def _connect_existing(manager: Any, venue: str, broker: Any) -> bool:
+    if bool(getattr(broker, "connected", False)):
+        sync = getattr(manager, "_sync_reconnect_readiness", None)
+        key = _platform_key(manager, venue)
+        if callable(sync) and key is not None:
+            sync(key, broker)
+        return True
+    if not _credentials_configured(broker) or not _configured_by_policy(venue, broker):
+        LOGGER.warning(
+            "PLATFORM_ACTIVATION_V280_CONNECT_INELIGIBLE marker=%s venue=%s credentials=%s "
+            "policy_allowed=%s trading_fail_closed=true",
+            MARKER, venue, str(_credentials_configured(broker)).lower(),
+            str(_configured_by_policy(venue, broker)).lower(),
+        )
+        return False
+    connect = getattr(broker, "connect", None)
+    if not callable(connect):
+        return False
+    try:
+        connected = bool(connect()) and bool(getattr(broker, "connected", False))
+    except Exception as exc:
+        LOGGER.warning(
+            "PLATFORM_ACTIVATION_V280_CONNECT_FAILED marker=%s venue=%s error=%s:%s trading_fail_closed=true",
+            MARKER, venue, type(exc).__name__, exc,
+        )
+        return False
+    if not connected:
+        return False
+    key = _platform_key(manager, venue)
+    sync = getattr(manager, "_sync_reconnect_readiness", None)
+    if callable(sync) and key is not None:
+        sync(key, broker)
+    LOGGER.critical(
+        "PLATFORM_ACTIVATION_V280_CONNECTED marker=%s venue=%s real_connect=true "
+        "broker_health_unchanged=true readiness_not_fabricated=true",
+        MARKER, venue,
+    )
+    return True
+
+
+def _wake_position_sync(manager: Any, trigger: str) -> int:
+    try:
+        v108 = importlib.import_module("bot.platform_position_sync_v108_patch")
+        dispatch = getattr(v108, "dispatch_platform_position_sync", None)
+        if not callable(dispatch):
+            return 0
+        return int(dispatch(manager, trigger=trigger) or 0)
+    except Exception:
+        LOGGER.debug("v280 position wake failed", exc_info=True)
+        return 0
+
+
+def _request_capital_refresh(manager: Any, trigger: str) -> None:
+    refresh = getattr(manager, "refresh_capital_authority", None)
+    if not callable(refresh):
+        return
+    try:
+        refresh(trigger=trigger)
+    except Exception:
+        LOGGER.debug("v280 capital refresh failed", exc_info=True)
+
+
+def reconcile_once() -> dict[str, str]:
+    manager = _canonical_manager()
+    outcomes: dict[str, str] = {}
+    if manager is None:
+        return {"manager": "missing"}
+    for venue in _SUPPORTED:
+        candidate = _global_candidate(venue)
+        if candidate is None:
+            outcomes[venue] = "no_existing_platform_object"
+            continue
+        if not _adopt_existing(manager, venue, candidate):
+            outcomes[venue] = "ownership_ambiguous"
+            continue
+        if _connect_existing(manager, venue, candidate):
+            outcomes[venue] = "connected"
+        else:
+            outcomes[venue] = "not_connected"
+    workers = _wake_position_sync(manager, "v280_platform_reconcile")
+    _request_capital_refresh(manager, "v280_platform_reconcile")
+    LOGGER.critical(
+        "PLATFORM_ACTIVATION_V280_RECONCILE marker=%s outcomes=%s position_workers=%d "
+        "capital_refresh_requested=true thresholds_unchanged=true execution_proof_fabricated=false "
+        "forced_activation=false safety_gates_bypassed=false",
+        MARKER, outcomes, workers,
+    )
+    return outcomes
+
+
+def _patch_v182_install() -> bool:
+    v182 = importlib.import_module("bot.runtime_position_fetch_proof_v182_patch")
+    current = getattr(v182, "install", None)
+    if not callable(current):
+        return False
+    if bool(getattr(current, _PATCH_ATTR, False)):
+        return True
+    original = current
+
+    @wraps(original)
+    def install_v280() -> bool:
+        ready = bool(original())
+        if not ready:
+            return False
+        manager = _canonical_manager()
+        if manager is not None:
+            workers = _wake_position_sync(manager, "v280_v182_reassert")
+            LOGGER.critical(
+                "POSITION_FETCH_V280_IMMEDIATE_WAKE marker=%s workers=%d "
+                "authoritative_v108_only=true synthetic_success=false",
+                MARKER, workers,
+            )
+        return True
+
+    setattr(install_v280, _PATCH_ATTR, True)
+    setattr(install_v280, "__wrapped__", original)
+    v182.install = install_v280
+    v182.install_import_hook = install_v280
+    return True
+
+
+def _register_manifest() -> bool:
+    manifest = importlib.import_module("bot.runtime_release_manifest_patch")
+    required = getattr(manifest, "_REQUIRED_FLAGS", None)
+    if not isinstance(required, dict):
+        return False
+    required["runtime_platform_activation_liveness_v280"] = _READY_FLAG
+    return True
+
+
+def install() -> bool:
+    with _LOCK:
+        try:
+            v182_ok = _patch_v182_install()
+            manifest_ok = _register_manifest()
+            outcomes = reconcile_once()
+            ready = bool(v182_ok and manifest_ok and "manager" not in outcomes)
+        except Exception as exc:
+            ready = False
+            outcomes = {"error": f"{type(exc).__name__}:{exc}"}
+            LOGGER.exception(
+                "PLATFORM_ACTIVATION_LIVENESS_V280_FAILED marker=%s trading_fail_closed=true",
+                MARKER,
+            )
+        os.environ[_READY_FLAG] = "1" if ready else "0"
+        if ready:
+            LOGGER.critical(
+                "PLATFORM_ACTIVATION_LIVENESS_V280_READY marker=%s ready=true outcomes=%s "
+                "existing_platform_objects_only=true real_connect_required=true authoritative_position_fetch_required=true "
+                "capital_thresholds_unchanged=true freshness_extended=false kill_switch_unchanged=true "
+                "execution_proof_fabricated=false forced_activation=false safety_gates_bypassed=false",
+                MARKER, outcomes,
+            )
+        return ready
+
+
+def install_import_hook() -> bool:
+    return install()
+
+
+__all__ = [
+    "MARKER", "RELEASE_ID", "install", "install_import_hook", "reconcile_once",
+    "_global_candidate", "_adopt_existing", "_connect_existing", "_wake_position_sync",
+    "_patch_v182_install",
+]

--- a/bot/runtime_post_import_convergence_patch.py
+++ b/bot/runtime_post_import_convergence_patch.py
@@ -10,7 +10,7 @@ from types import ModuleType
 from typing import Any
 
 logger = logging.getLogger("nija.runtime_post_import_convergence")
-_MARKER = "20260828-post-import-convergence-v263"
+_MARKER = "20260829-post-import-convergence-v280"
 _LOCK = threading.RLock()
 _STARTED = False
 _LAST_PREREQUISITES: dict[str, bool] = {}
@@ -123,6 +123,7 @@ def _install_v244_heartbeat_broker_manager_terminal(): return _install_named("bo
 def _install_v263_heartbeat_state_machine_gate(): return _install_named("bot.runtime_heartbeat_state_machine_gate_v263_patch", "v263_install_missing", "HEARTBEAT_STATE_MACHINE_GATE_V263_INSTALL_ERROR")
 def _install_v267_capital_position_liveness(): return _install_named("bot.runtime_capital_position_liveness_v267_patch", "v267_install_missing", "RUNTIME_CAPITAL_POSITION_LIVENESS_V267_INSTALL_ERROR")
 def _install_v268_platform_kraken_registry_liveness(): return _install_named("bot.runtime_platform_kraken_registry_liveness_v268_patch", "v268_install_missing", "RUNTIME_PLATFORM_KRAKEN_REGISTRY_LIVENESS_V268_INSTALL_ERROR")
+def _install_v280_platform_activation_liveness(): return _install_named("bot.runtime_platform_activation_liveness_v280_patch", "v280_install_missing", "RUNTIME_PLATFORM_ACTIVATION_LIVENESS_V280_INSTALL_ERROR")
 
 
 def _iteration() -> bool:
@@ -145,6 +146,7 @@ def _iteration() -> bool:
     v263 = _install_v263_heartbeat_state_machine_gate()
     v267 = _install_v267_capital_position_liveness()
     v268 = _install_v268_platform_kraken_registry_liveness()
+    v280 = _install_v280_platform_activation_liveness()
     prerequisites = {
         "audit_patched": patched,
         "v154_execution_recovery": _install_v154_recovery(),
@@ -175,6 +177,7 @@ def _iteration() -> bool:
         "v263_heartbeat_state_machine_gate": v263,
         "v267_capital_position_liveness": v267,
         "v268_platform_kraken_registry_liveness": v268,
+        "v280_platform_activation_liveness": v280,
     }
     global _LAST_PREREQUISITES
     _LAST_PREREQUISITES = dict(prerequisites)
@@ -218,4 +221,4 @@ def install() -> bool:
         return ready
 
 
-__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_install_v244_heartbeat_broker_manager_terminal", "_install_v263_heartbeat_state_machine_gate", "_install_v267_capital_position_liveness", "_install_v268_platform_kraken_registry_liveness", "_iteration", "_LAST_PREREQUISITES"]
+__all__ = ["install", "_policy", "_required_broker_count", "_apply_broker_threshold", "_canonicalize_alias", "_patch_quiescence_audit", "_install_v233_heartbeat_terminal_authority", "_install_v234_kraken_read_lock_recovery", "_install_v236_heartbeat_final_submit", "_install_v237_kraken_local_contention_health", "_install_v238_heartbeat_marker_convergence", "_install_v239_all_account_profit_targets", "_install_v240_heartbeat_terminal_lifecycle", "_install_v241_kraken_local_contention_alias", "_install_v242_kraken_local_contention_instance", "_install_v244_heartbeat_broker_manager_terminal", "_install_v263_heartbeat_state_machine_gate", "_install_v267_capital_position_liveness", "_install_v268_platform_kraken_registry_liveness", "_install_v280_platform_activation_liveness", "_iteration", "_LAST_PREREQUISITES"]

--- a/tests/test_runtime_platform_activation_liveness_v280.py
+++ b/tests/test_runtime_platform_activation_liveness_v280.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import bot.runtime_platform_activation_liveness_v280_patch as v280
+
+
+class _Broker:
+    def __init__(self, *, connected: bool = False, credentials: bool = True, connect_result: bool = True):
+        self.connected = connected
+        self.credentials_configured = credentials
+        self.account_type = "platform"
+        self._connect_result = connect_result
+        self.connect_calls = 0
+
+    def connect(self):
+        self.connect_calls += 1
+        if self._connect_result:
+            self.connected = True
+        return self._connect_result
+
+
+class _Manager:
+    def __init__(self):
+        self._platform_brokers = {}
+        self._registry_meta_lock = v280.threading.RLock()
+        self.sync_calls = []
+        self.refresh_registry_calls = 0
+
+    def refresh_registry(self):
+        self.refresh_registry_calls += 1
+
+    def _sync_reconnect_readiness(self, key, broker):
+        self.sync_calls.append((key, broker))
+
+
+def test_v280_adopts_only_existing_process_platform_candidate(monkeypatch):
+    broker = _Broker(connected=True)
+    manager = _Manager()
+    key = SimpleNamespace(value="coinbase")
+    monkeypatch.setattr(v280, "_platform_key", lambda manager, venue: key)
+
+    assert v280._adopt_existing(manager, "coinbase", broker) is True
+    assert manager._platform_brokers[key] is broker
+    assert manager.refresh_registry_calls == 1
+
+
+def test_v280_refuses_conflicting_manager_identity(monkeypatch):
+    existing = _Broker(connected=True)
+    candidate = _Broker(connected=True)
+    manager = _Manager()
+    key = SimpleNamespace(value="coinbase")
+    manager._platform_brokers[key] = existing
+
+    assert v280._adopt_existing(manager, "coinbase", candidate) is False
+    assert manager._platform_brokers[key] is existing
+
+
+def test_v280_never_connects_without_real_credentials(monkeypatch):
+    broker = _Broker(connected=False, credentials=False)
+    manager = _Manager()
+    key = SimpleNamespace(value="coinbase")
+    manager._platform_brokers[key] = broker
+    monkeypatch.setattr(v280, "_configured_by_policy", lambda venue, broker: True)
+
+    assert v280._connect_existing(manager, "coinbase", broker) is False
+    assert broker.connect_calls == 0
+    assert manager.sync_calls == []
+
+
+def test_v280_requires_connect_return_and_connected_state(monkeypatch):
+    broker = _Broker(connected=False, credentials=True, connect_result=False)
+    manager = _Manager()
+    key = SimpleNamespace(value="coinbase")
+    manager._platform_brokers[key] = broker
+    monkeypatch.setattr(v280, "_configured_by_policy", lambda venue, broker: True)
+
+    assert v280._connect_existing(manager, "coinbase", broker) is False
+    assert broker.connect_calls == 1
+    assert manager.sync_calls == []
+
+
+def test_v280_syncs_only_after_real_connection(monkeypatch):
+    broker = _Broker(connected=False, credentials=True, connect_result=True)
+    manager = _Manager()
+    key = SimpleNamespace(value="coinbase")
+    manager._platform_brokers[key] = broker
+    monkeypatch.setattr(v280, "_configured_by_policy", lambda venue, broker: True)
+
+    assert v280._connect_existing(manager, "coinbase", broker) is True
+    assert broker.connect_calls == 1
+    assert manager.sync_calls == [(key, broker)]
+
+
+def test_v280_v182_reassert_wakes_authoritative_position_sync(monkeypatch):
+    calls = []
+    manager = object()
+
+    def original_install():
+        calls.append("install")
+        return True
+
+    fake_v182 = SimpleNamespace(install=original_install, install_import_hook=original_install)
+    real_import = v280.importlib.import_module
+
+    def fake_import(name):
+        if name == "bot.runtime_position_fetch_proof_v182_patch":
+            return fake_v182
+        return real_import(name)
+
+    monkeypatch.setattr(v280.importlib, "import_module", fake_import)
+    monkeypatch.setattr(v280, "_canonical_manager", lambda: manager)
+    monkeypatch.setattr(v280, "_wake_position_sync", lambda mgr, trigger: calls.append((mgr, trigger)) or 1)
+
+    assert v280._patch_v182_install() is True
+    assert fake_v182.install() is True
+    assert calls == ["install", (manager, "v280_v182_reassert")]
+
+
+def test_v280_no_candidate_never_fabricates_broker(monkeypatch):
+    manager = _Manager()
+    monkeypatch.setattr(v280, "_canonical_manager", lambda: manager)
+    monkeypatch.setattr(v280, "_global_candidate", lambda venue: None)
+    monkeypatch.setattr(v280, "_wake_position_sync", lambda manager, trigger: 0)
+    monkeypatch.setattr(v280, "_request_capital_refresh", lambda manager, trigger: None)
+
+    outcomes = v280.reconcile_once()
+    assert outcomes == {
+        "coinbase": "no_existing_platform_object",
+        "okx": "no_existing_platform_object",
+    }
+    assert manager._platform_brokers == {}


### PR DESCRIPTION
Repairs the current production activation liveness blockers observed on deployment b98bdc407681724b5cef2b02a587f44a1c27af2a.

Changes:
- Recover detached existing Coinbase/OKX PLATFORM broker objects into the canonical MultiAccountBrokerManager without creating credentials or broker state.
- Require real connection success before synchronizing connectivity/readiness mirrors.
- Bound reconnect exchange I/O with a per-instance retry floor.
- Immediately dispatch authoritative v108 position reconciliation after v182 reasserts the exact v98 fetch-proof chain, closing the position_sync_ready liveness gap seen when v146 correctly revoked a marker-only success.
- Request canonical capital refresh only when topology/connectivity changes or a real position-sync worker starts.
- Chain v280 into post-import convergence so production actually executes and continuously verifies the repair.
- Add focused fail-closed tests.

Safety invariants preserved: no broker-count/capital/min-notional threshold reduction, no fabricated position/nonce/execution/heartbeat/order/ack/fill proof, no rejection-window clearing, no kill-switch bypass, no forced trade or activation.