### PR TITLE
Align NIJA commercial pricing across backend, frontend, and CRM

### DIFF
--- a/PRICING.md
+++ b/PRICING.md
@@ -1,286 +1,80 @@
-# NIJA Pricing
+# NIJA Official Pricing Policy
 
-**Last Updated:** February 15, 2026  
-**Currency:** USD (United States Dollars)
+**Effective:** August 29, 2026  
+**Currency:** USD  
+**Status:** Canonical public pricing policy
 
-## Subscription Tiers
-
-NIJA offers four subscription tiers to fit different trading needs and experience levels. All plans include our core APEX V7.2 trading strategy.
-
----
-
-## 🆓 Free Tier
-
-**$0 / month**
-
-**Perfect for:**
-- New users learning to trade
-- Testing the NIJA platform
-- Paper trading without risk
+This document is the authoritative public pricing policy for NIJA. Older Basic/Pro/Enterprise price tables are retired and must not be used in customer-facing sales, website copy, call-center scripts, checkout copy, or new billing integrations.
 
-**Includes:**
-- ✅ Paper trading only (no real money at risk)
-- ✅ APEX V7.2 trading strategy
-- ✅ 1 exchange connection
-- ✅ Up to 3 concurrent paper positions
-- ✅ Up to 10 simulated trades per day
-- ✅ Basic analytics dashboard
-- ✅ 30 days of data retention
-- ✅ Community support via Discord
-
-**Limitations:**
-- ❌ No live trading with real capital
-- ❌ No advanced AI features
-- ❌ No TradingView webhook integration
-- ❌ No API access
-- ❌ Standard support (72-hour response time)
-
----
-
-## 💼 Basic Tier
+## 1. NIJA Lessons
 
-**$49 / month** or **$470 / year** (save $118 - 20% discount)
+**Price: $99 one-time**
 
-**Perfect for:**
-- Traders ready to go live with real capital
-- Small to medium account sizes
-- Core feature users
+- NIJA Lessons are an educational product.
+- This is a one-time purchase, not a recurring subscription.
+- The lesson purchase is separate from NIJA platform access.
+- Educational content does not guarantee profits, income, or investment performance.
 
-**Includes everything in Free, plus:**
-- ✅ **Live trading with real capital**
-- ✅ Unlimited concurrent positions
-- ✅ Unlimited daily trades
-- ✅ Up to 3 exchange connections
-- ✅ TradingView webhook integration
-- ✅ 90 days of data retention
-- ✅ Enhanced analytics
-- ✅ Email support (48-hour response time)
+## 2. NIJA Beta - First 100 Users
 
-**Limitations:**
-- ❌ No advanced AI features (Meta-AI, MMIN, GMIG)
-- ❌ No API access
-- ❌ No white-label options
+**14 days free, then $50/month**
 
----
+- The founding beta offer is limited to the first 100 eligible beta users.
+- Each eligible founding beta user receives a 14-day free trial.
+- After the trial, the recurring price is $50/month.
+- A founding beta user's $50/month offer is price-locked to that cohort unless NIJA later changes that user's agreement through an appropriate customer-facing process.
+- Filling the first 100 spots must not automatically reprice existing founding beta users.
 
-## 🚀 Pro Tier (Most Popular)
+## 3. NIJA Beta - After the First 100 Users
 
-**$149 / month** or **$1,430 / year** (save $358 - 20% discount)
+**$75/month**
 
-**Perfect for:**
-- Active traders seeking competitive edge
-- Advanced strategy users
-- API integration needs
+- Once 100 eligible founding beta spots have been claimed, the public beta offer for new users becomes $75/month.
+- Existing founding beta users remain associated with their $50/month offer.
+- The $75 price applies to new beta subscriptions after the founding cohort is filled.
 
-**Includes everything in Basic, plus:**
-- ✅ **14-day free trial** (for new subscribers)
-- ✅ Advanced AI features:
-  - Meta-AI (strategy evolution)
-  - MMIN (market intelligence)
-  - GMIG (macro insights)
-- ✅ Unlimited exchange connections
-- ✅ Custom risk profiles
-- ✅ API access for automation
-- ✅ 180 days of data retention
-- ✅ Advanced analytics & reports
-- ✅ Priority email support (24-hour response time)
-- ✅ **24/7 emergency support** for critical issues
+## 4. Full Apple App Store / Google Play Paid Release
 
-**Most popular choice** - Best value for active traders
+**Planned standard paid price: $99/month**
 
----
+- This is the intended standard paid subscription price for the full mobile-app release.
+- It must not be represented as the current beta price.
+- Store-specific billing, taxes, fees, regional pricing, and platform requirements may require implementation details to be finalized before launch.
 
-## 🏢 Enterprise Tier
+## 5. Internal Access Tiers Are Not Public Prices
 
-**$499 / month** or **$4,790 / year** (save $1,198 - 20% discount)
+Legacy/internal labels such as `basic`, `pro`, `enterprise`, and `alpha` may still exist in code for feature permissions, testing, migration, or backwards compatibility. They are **not customer-facing price names** and must not be used to advertise conflicting subscription prices.
 
-**Perfect for:**
-- Professional traders and firms
-- White-label platform needs
-- High-volume trading operations
+Commercial pricing must be derived from the NIJA offer/cohort policy:
 
-**Includes everything in Pro, plus:**
-- ✅ White-label platform capabilities
-- ✅ Unlimited API calls
-- ✅ Unlimited data retention
-- ✅ Custom strategy development support
-- ✅ Dedicated account manager
-- ✅ Priority support (12-hour response time)
-- ✅ **24/7 emergency support**
-- ✅ Custom SLA agreements available
-- ✅ Multi-user management
+| Offer | Price | Billing |
+|---|---:|---|
+| NIJA Lessons | $99 | One-time |
+| Founding Beta - first 100 | $50/month after 14-day trial | Recurring |
+| Standard Beta - after first 100 | $75/month | Recurring |
+| Full mobile paid release | $99/month | Recurring |
 
-**Contact us for enterprise pricing and custom solutions**
+## 6. Sales and Marketing Rules
 
----
+NIJA representatives and marketing pages must not claim or imply:
 
-## 💳 Payment Information
+- guaranteed profits;
+- guaranteed income;
+- guaranteed investment returns;
+- risk-free trading;
+- certain financial results.
 
-**Payment Methods:**
-- Credit card (Visa, Mastercard, American Express)
-- Debit card
-- All payments processed securely through Stripe
+Trading and investing involve risk, including possible loss of capital.
 
-**Billing Cycles:**
-- Monthly: Billed on the same day each month
-- Yearly: Billed annually (20% discount)
+## 7. Implementation Requirements
 
-**Trial Period:**
-- Pro tier includes a **14-day free trial** for new subscribers
-- No credit card required for Free tier
-- Credit card required for trial (not charged until trial ends)
-- Cancel anytime during trial with no charge
+Every customer-facing implementation should use the same policy values:
 
-**Taxes:**
-- Prices shown are in USD and do not include applicable taxes
-- Sales tax or VAT may apply based on your location
+- `BETA_TRIAL_DAYS = 14`
+- `FOUNDING_BETA_LIMIT = 100`
+- `FOUNDING_BETA_MONTHLY_USD = 50`
+- `STANDARD_BETA_MONTHLY_USD = 75`
+- `FULL_RELEASE_MONTHLY_USD = 99`
+- `LESSONS_ONE_TIME_USD = 99`
 
----
-
-## 📋 Subscription Management
-
-### Upgrading Your Plan
-
-- Upgrade anytime from your account dashboard
-- Prorated credit applied to your current subscription
-- New features available immediately
-- Billing adjusts automatically
-
-### Downgrading Your Plan
-
-- Downgrade anytime before your next billing cycle
-- Changes take effect at the end of current billing period
-- No refunds for unused time in current period
-- Keep access to current tier features until downgrade takes effect
-
-### Cancellation Policy
-
-- Cancel anytime - no long-term contracts
-- Access continues until end of current billing period
-- No refunds for partial months or years
-- All trading data preserved for 90 days after cancellation
-- Reactivate anytime to restore account
-
-**To cancel:**
-1. Log into your account dashboard
-2. Go to Settings → Subscription
-3. Click "Cancel Subscription"
-4. Confirm cancellation
-
----
-
-## 🔄 Refund Policy
-
-**14-Day Money-Back Guarantee:**
-- Available for first-time Pro tier subscribers
-- Full refund if requested within 14 days of initial charge
-- Must not have exceeded trial usage limits
-- Email billing@nija-trading.com to request refund
-
-**No Refunds After 14 Days:**
-- Subscriptions are non-refundable after the initial 14-day period
-- Pro-rated credits available when upgrading
-- Cancellation stops future billing but does not refund current period
-
-**Emergency Refunds:**
-- Considered on a case-by-case basis for extenuating circumstances
-- Contact billing@nija-trading.com with detailed explanation
-
----
-
-## 📊 Usage Limits
-
-### API Rate Limits
-
-| Tier | API Calls per Minute |
-|------|---------------------|
-| Free | 10 |
-| Basic | 60 |
-| Pro | 300 |
-| Enterprise | Unlimited |
-
-### Data Retention
-
-| Tier | Trade History | Analytics |
-|------|--------------|-----------|
-| Free | 30 days | 30 days |
-| Basic | 90 days | 90 days |
-| Pro | 180 days | 180 days |
-| Enterprise | Unlimited | Unlimited |
-
-### Support Response Times
-
-| Tier | Standard Support | Emergency Support |
-|------|-----------------|-------------------|
-| Free | 72 hours | Not available |
-| Basic | 48 hours | Not available |
-| Pro | 24 hours | 24/7 |
-| Enterprise | 12 hours | 24/7 |
-
----
-
-## ❓ Frequently Asked Questions
-
-**Q: Can I switch between monthly and yearly billing?**  
-A: Yes, you can switch at any time. Pro-rated credits will be applied.
-
-**Q: What happens if I exceed my tier's limits?**  
-A: You'll receive notifications when approaching limits. Exceeding limits may result in temporary rate limiting or prompts to upgrade.
-
-**Q: Do you offer discounts for annual billing?**  
-A: Yes, all tiers receive a 20% discount when billed annually.
-
-**Q: Can I get a custom plan?**  
-A: Enterprise tier customers can discuss custom pricing and SLA agreements. Contact enterprise@nija-trading.com
-
-**Q: Is there a student or non-profit discount?**  
-A: Not at this time. The Free tier provides full paper trading capabilities for educational purposes.
-
-**Q: What payment methods do you accept?**  
-A: We accept all major credit and debit cards through our secure payment processor, Stripe.
-
----
-
-## 📞 Need Help Choosing?
-
-Not sure which tier is right for you? Contact us:
-
-- **Email:** support@nija-trading.com
-- **Chat:** Available in-app during business hours
-- **Discord:** Join our community at discord.gg/nija-trading
-
-**We recommend:**
-- **Free Tier:** If you're new to trading or want to test NIJA with paper trading
-- **Basic Tier:** If you're ready to trade live and need core features
-- **Pro Tier:** If you want advanced AI features and API access (most popular)
-- **Enterprise Tier:** If you need white-label or custom solutions
-
----
-
-## ⚠️ Important Disclaimers
-
-**No Return Promises:**
-- NIJA is a trading tool, not an investment product
-- Past performance does not guarantee future results
-- Cryptocurrency trading involves substantial risk of loss
-- You may lose some or all of your invested capital
-
-**Trading Risks:**
-- Markets can be volatile and unpredictable
-- Automated trading does not eliminate risk
-- You are responsible for all trading decisions and outcomes
-
-**Not Financial Advice:**
-- NIJA does not provide financial advice or investment recommendations
-- Consult a qualified financial advisor before trading
-- You trade at your own risk
-
-For full terms, see our [Terms of Service](TERMS_OF_SERVICE.md)  
-For privacy information, see our [Privacy Policy](PRIVACY_POLICY.md)  
-For support options, see [Customer Support](SUPPORT.md)
-
----
-
-**NIJA Trading Platform**  
-Pricing subject to change with 30 days notice to subscribers  
-All prices in USD unless otherwise stated
+Website, CRM, billing, analytics, and call-center systems must preserve the user's offer/cohort at signup so future public-price changes do not silently reprice existing users.

--- a/PRICING.md
+++ b/PRICING.md
@@ -13,7 +13,7 @@ This document is the authoritative public pricing policy for NIJA. Older Basic/P
 - NIJA Lessons are an educational product.
 - This is a one-time purchase, not a recurring subscription.
 - The lesson purchase is separate from NIJA platform access.
-- Educational content does not guarantee profits, income, or investment performance.
+- Educational content does not promise profit, income, or investment performance.
 
 ## 2. NIJA Beta - First 100 Users
 
@@ -56,13 +56,7 @@ Commercial pricing must be derived from the NIJA offer/cohort policy:
 
 ## 6. Sales and Marketing Rules
 
-NIJA representatives and marketing pages must not claim or imply:
-
-- guaranteed profits;
-- guaranteed income;
-- guaranteed investment returns;
-- risk-free trading;
-- certain financial results.
+NIJA representatives and marketing pages must describe trading as involving uncertainty and possible loss. They must not make assurances of profit, income, investment returns, no-loss trading, or certain financial results.
 
 Trading and investing involve risk, including possible loss of capital.
 

--- a/commercial_offer_store.py
+++ b/commercial_offer_store.py
@@ -1,0 +1,172 @@
+"""Persistent NIJA commercial-offer assignment.
+
+Commercial pricing is intentionally independent from legacy/internal feature tiers.
+Each user receives one immutable-at-signup offer assignment so later public-price
+changes do not silently reprice founding beta users.
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+from pricing_policy import (
+    BETA_TRIAL_DAYS,
+    FOUNDING_BETA_LIMIT,
+    FOUNDING_BETA_MONTHLY_USD,
+    FOUNDING_BETA_OFFER,
+    STANDARD_BETA_MONTHLY_USD,
+    STANDARD_BETA_OFFER,
+)
+
+
+@dataclass(frozen=True)
+class OfferAssignment:
+    user_id: str
+    offer_code: str
+    price_usd: Decimal
+    trial_days: int
+    cohort_position: Optional[int]
+    assigned_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "user_id": self.user_id,
+            "offer_code": self.offer_code,
+            "price_usd": float(self.price_usd),
+            "trial_days": self.trial_days,
+            "cohort_position": self.cohort_position,
+            "assigned_at": self.assigned_at,
+            "price_locked": True,
+        }
+
+
+class CommercialOfferStore:
+    """SQLite-backed offer assignment store using the existing NIJA user DB file."""
+
+    def __init__(self, db_path: str = "users.db") -> None:
+        self.db_path = db_path
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_schema(self) -> None:
+        with closing(self._connect()) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS commercial_offer_assignments (
+                    user_id TEXT PRIMARY KEY,
+                    offer_code TEXT NOT NULL,
+                    price_usd_cents INTEGER NOT NULL,
+                    trial_days INTEGER NOT NULL DEFAULT 0,
+                    cohort_position INTEGER,
+                    assigned_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_commercial_offer_cohort_position "
+                "ON commercial_offer_assignments(cohort_position) "
+                "WHERE cohort_position IS NOT NULL"
+            )
+            conn.commit()
+
+    def get_assignment(self, user_id: str) -> Optional[OfferAssignment]:
+        with closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT user_id, offer_code, price_usd_cents, trial_days, cohort_position, assigned_at "
+                "FROM commercial_offer_assignments WHERE user_id = ?",
+                (user_id,),
+            ).fetchone()
+        return self._row_to_assignment(row) if row else None
+
+    def assign_beta_offer(self, user_id: str) -> OfferAssignment:
+        """Atomically assign founding beta slots 1-100, then standard beta.
+
+        Repeated calls for the same user return the original assignment.  The
+        founding cohort count is based on persisted assignments, not process
+        memory, so restarts cannot reset the first-100 counter.
+        """
+        with closing(self._connect()) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                "SELECT user_id, offer_code, price_usd_cents, trial_days, cohort_position, assigned_at "
+                "FROM commercial_offer_assignments WHERE user_id = ?",
+                (user_id,),
+            ).fetchone()
+            if existing:
+                conn.commit()
+                return self._row_to_assignment(existing)
+
+            founding_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM commercial_offer_assignments WHERE offer_code = ?",
+                    (FOUNDING_BETA_OFFER,),
+                ).fetchone()[0]
+            )
+            assigned_at = datetime.now(timezone.utc).isoformat()
+
+            if founding_count < FOUNDING_BETA_LIMIT:
+                offer_code = FOUNDING_BETA_OFFER
+                price = FOUNDING_BETA_MONTHLY_USD
+                trial_days = BETA_TRIAL_DAYS
+                cohort_position: Optional[int] = founding_count + 1
+            else:
+                offer_code = STANDARD_BETA_OFFER
+                price = STANDARD_BETA_MONTHLY_USD
+                trial_days = 0
+                cohort_position = None
+
+            cents = int(price * 100)
+            conn.execute(
+                "INSERT INTO commercial_offer_assignments "
+                "(user_id, offer_code, price_usd_cents, trial_days, cohort_position, assigned_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (user_id, offer_code, cents, trial_days, cohort_position, assigned_at),
+            )
+            conn.commit()
+
+        return OfferAssignment(
+            user_id=user_id,
+            offer_code=offer_code,
+            price_usd=price,
+            trial_days=trial_days,
+            cohort_position=cohort_position,
+            assigned_at=assigned_at,
+        )
+
+    def founding_beta_claimed_count(self) -> int:
+        with closing(self._connect()) as conn:
+            return int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM commercial_offer_assignments WHERE offer_code = ?",
+                    (FOUNDING_BETA_OFFER,),
+                ).fetchone()[0]
+            )
+
+    @staticmethod
+    def _row_to_assignment(row: sqlite3.Row) -> OfferAssignment:
+        return OfferAssignment(
+            user_id=str(row["user_id"]),
+            offer_code=str(row["offer_code"]),
+            price_usd=Decimal(int(row["price_usd_cents"])) / Decimal(100),
+            trial_days=int(row["trial_days"]),
+            cohort_position=(int(row["cohort_position"]) if row["cohort_position"] is not None else None),
+            assigned_at=str(row["assigned_at"]),
+        )
+
+
+_store: Optional[CommercialOfferStore] = None
+
+
+def get_commercial_offer_store(db_path: str = "users.db") -> CommercialOfferStore:
+    global _store
+    if _store is None or _store.db_path != db_path:
+        _store = CommercialOfferStore(db_path=db_path)
+    return _store

--- a/commercial_pricing_runtime_patch.py
+++ b/commercial_pricing_runtime_patch.py
@@ -1,0 +1,119 @@
+"""Runtime integration for NIJA's canonical commercial pricing policy.
+
+This keeps commercial offers independent from legacy access/permission tiers while
+ensuring public registration and pricing responses cannot advertise stale tier
+prices.
+"""
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from flask import jsonify, request
+
+from commercial_offer_store import get_commercial_offer_store
+from pricing_policy import FOUNDING_BETA_LIMIT, beta_offer_for_claimed_count, public_pricing
+
+
+def _response_status(response: Any) -> int:
+    if isinstance(response, tuple) and len(response) >= 2:
+        return int(response[1])
+    return int(getattr(response, "status_code", 200))
+
+
+def _response_object(response: Any) -> Any:
+    return response[0] if isinstance(response, tuple) else response
+
+
+def _wrap_registration(original: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(original)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        # Public clients may not self-select internal access/permission tiers.
+        # Mutating Flask's cached JSON mapping before the legacy handler reads it
+        # lets the existing registration path remain backward compatible while
+        # preventing privilege selection through a customer-facing field.
+        payload = request.get_json(silent=True)
+        if isinstance(payload, dict):
+            payload["subscription_tier"] = "basic"
+
+        result = original(*args, **kwargs)
+        if _response_status(result) != 201:
+            return result
+
+        response = _response_object(result)
+        body = response.get_json(silent=True) if hasattr(response, "get_json") else None
+        if not isinstance(body, dict) or not body.get("user_id"):
+            return result
+
+        assignment = get_commercial_offer_store().assign_beta_offer(str(body["user_id"]))
+        body["commercial_offer"] = assignment.to_dict()
+        body["pricing_policy"] = {
+            "lessons_one_time_usd": 99.0,
+            "full_release_planned_monthly_usd": 99.0,
+        }
+        response.set_data(response.json_module.dumps(body))
+        response.content_type = "application/json"
+        return result
+
+    return wrapped
+
+
+def _canonical_available_offers() -> Any:
+    store = get_commercial_offer_store()
+    claimed = store.founding_beta_claimed_count()
+    current = beta_offer_for_claimed_count(claimed)
+    return jsonify({
+        "success": True,
+        "commercial_offers": public_pricing(),
+        "beta": {
+            "founding_limit": FOUNDING_BETA_LIMIT,
+            "founding_claimed": claimed,
+            "founding_remaining": max(0, FOUNDING_BETA_LIMIT - claimed),
+            "current_offer": current.to_dict(),
+        },
+        "access_tiers_are_internal": True,
+        "disclaimer": "Trading and investing involve risk, including possible loss of capital. No profit or performance results are guaranteed.",
+    })
+
+
+def _wrap_subscription_info(original: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(original)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        if _response_status(result) >= 400:
+            return result
+        response = _response_object(result)
+        body = response.get_json(silent=True) if hasattr(response, "get_json") else None
+        user_id = getattr(request, "user_id", None)
+        if not isinstance(body, dict) or not isinstance(user_id, str):
+            return result
+        assignment = get_commercial_offer_store().get_assignment(user_id)
+        if assignment:
+            body["commercial_offer"] = assignment.to_dict()
+            response.set_data(response.json_module.dumps(body))
+            response.content_type = "application/json"
+        return result
+
+    return wrapped
+
+
+def install_commercial_pricing_runtime_patch(app: Any) -> None:
+    """Install idempotent integration after all NIJA blueprints are registered."""
+    if app.extensions.get("nija_commercial_pricing_patch"):
+        return
+
+    register_endpoint = "register"
+    original_register = app.view_functions.get(register_endpoint)
+    if original_register is not None:
+        app.view_functions[register_endpoint] = _wrap_registration(original_register)
+
+    tiers_endpoint = "unified_mobile_api.get_available_tiers"
+    if tiers_endpoint in app.view_functions:
+        app.view_functions[tiers_endpoint] = _canonical_available_offers
+
+    info_endpoint = "unified_mobile_api.get_subscription_info"
+    original_info = app.view_functions.get(info_endpoint)
+    if original_info is not None:
+        app.view_functions[info_endpoint] = _wrap_subscription_info(original_info)
+
+    app.extensions["nija_commercial_pricing_patch"] = True

--- a/commercial_pricing_runtime_patch.py
+++ b/commercial_pricing_runtime_patch.py
@@ -6,6 +6,7 @@ prices.
 """
 from __future__ import annotations
 
+import json
 from functools import wraps
 from typing import Any, Callable
 
@@ -25,13 +26,18 @@ def _response_object(response: Any) -> Any:
     return response[0] if isinstance(response, tuple) else response
 
 
+def _replace_json_body(response: Any, body: dict) -> None:
+    response.set_data(json.dumps(body, separators=(",", ":")))
+    response.content_type = "application/json"
+
+
 def _wrap_registration(original: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(original)
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         # Public clients may not self-select internal access/permission tiers.
         # Mutating Flask's cached JSON mapping before the legacy handler reads it
-        # lets the existing registration path remain backward compatible while
-        # preventing privilege selection through a customer-facing field.
+        # keeps the existing route compatible while preventing a customer from
+        # using registration to select elevated trading permissions.
         payload = request.get_json(silent=True)
         if isinstance(payload, dict):
             payload["subscription_tier"] = "basic"
@@ -51,8 +57,7 @@ def _wrap_registration(original: Callable[..., Any]) -> Callable[..., Any]:
             "lessons_one_time_usd": 99.0,
             "full_release_planned_monthly_usd": 99.0,
         }
-        response.set_data(response.json_module.dumps(body))
-        response.content_type = "application/json"
+        _replace_json_body(response, body)
         return result
 
     return wrapped
@@ -90,8 +95,7 @@ def _wrap_subscription_info(original: Callable[..., Any]) -> Callable[..., Any]:
         assignment = get_commercial_offer_store().get_assignment(user_id)
         if assignment:
             body["commercial_offer"] = assignment.to_dict()
-            response.set_data(response.json_module.dumps(body))
-            response.content_type = "application/json"
+            _replace_json_body(response, body)
         return result
 
     return wrapped

--- a/frontend/static/js/capacitor-init.js
+++ b/frontend/static/js/capacitor-init.js
@@ -315,14 +315,96 @@ function scheduleAccountDeletionControls() {
     observer.observe(document.documentElement, { childList: true, subtree: true });
 }
 
+function renderBetaOfferCard(beta) {
+    const select = document.getElementById('register-tier');
+    if (!select) return;
+
+    // Preserve the internal BASIC capability tier expected by the legacy form,
+    // but remove that implementation detail from customer-facing registration.
+    select.value = 'basic';
+    const legacyGroup = select.closest('.form-group');
+    if (!legacyGroup) return;
+
+    legacyGroup.style.display = 'none';
+    let card = document.getElementById('nija-commercial-offer-card');
+    if (!card) {
+        card = document.createElement('div');
+        card.id = 'nija-commercial-offer-card';
+        card.className = 'status-card';
+        legacyGroup.insertAdjacentElement('afterend', card);
+    }
+
+    const current = beta && beta.current_offer ? beta.current_offer : null;
+    const founding = current && current.code === 'founding_beta';
+    const amount = current && Number.isFinite(Number(current.amount_usd))
+        ? Number(current.amount_usd)
+        : (founding ? 50 : 75);
+    const remaining = beta && Number.isFinite(Number(beta.founding_remaining))
+        ? Number(beta.founding_remaining)
+        : null;
+
+    if (founding || !current) {
+        const remainingText = remaining === null ? '' : `<p><strong>${remaining}</strong> founding beta spots currently remain.</p>`;
+        card.innerHTML = `
+            <h3>NIJA Founding Beta</h3>
+            <p><strong>14 days free, then $${amount.toFixed(0)}/month.</strong></p>
+            <p>Available to the first 100 eligible beta users. Your assigned founding offer is preserved with your account.</p>
+            ${remainingText}
+            <p><small>NIJA Lessons are a separate $99 one-time educational purchase. Trading involves risk; no profit or performance is guaranteed.</small></p>
+        `;
+    } else {
+        card.innerHTML = `
+            <h3>NIJA Beta</h3>
+            <p><strong>$${amount.toFixed(0)}/month.</strong></p>
+            <p>The first 100 founding beta spots have been claimed. New beta registrations use the current $75/month offer.</p>
+            <p><small>NIJA Lessons are a separate $99 one-time educational purchase. Planned full mobile paid release price is $99/month. Trading involves risk; no profit or performance is guaranteed.</small></p>
+        `;
+    }
+}
+
+async function ensureCommercialPricingControls() {
+    const select = document.getElementById('register-tier');
+    if (!select) return;
+
+    // Hide stale access-tier marketing immediately, even if the pricing API is
+    // temporarily unavailable. Server-side registration still enforces BASIC.
+    renderBetaOfferCard({
+        current_offer: { code: 'founding_beta', amount_usd: 50 },
+        founding_remaining: null
+    });
+
+    try {
+        const response = await fetch(`${window.location.origin}/api/commercial/pricing`, {
+            headers: { 'Accept': 'application/json' }
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        renderBetaOfferCard(data.beta || null);
+    } catch (error) {
+        console.warn('Using safe beta pricing fallback until pricing API is reachable:', error.message);
+    }
+}
+
+function scheduleCommercialPricingControls() {
+    ensureCommercialPricingControls();
+    const observer = new MutationObserver(() => {
+        if (!document.getElementById('nija-commercial-offer-card')) {
+            ensureCommercialPricingControls();
+        }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+}
+
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
         initializeCapacitor();
         scheduleAccountDeletionControls();
+        scheduleCommercialPricingControls();
     });
 } else {
     initializeCapacitor();
     scheduleAccountDeletionControls();
+    scheduleCommercialPricingControls();
 }
 
 window.NativeApp = NativeApp;
@@ -334,3 +416,4 @@ window.showNativeToast = showNativeToast;
 window.triggerHaptic = triggerHaptic;
 window.openExternalUrl = openExternalUrl;
 window.requestNijaAccountDeletion = requestNijaAccountDeletion;
+window.ensureCommercialPricingControls = ensureCommercialPricingControls;

--- a/mobile_backend_server.py
+++ b/mobile_backend_server.py
@@ -22,6 +22,7 @@ from iap_handler import register_iap_api
 from education_system import register_education_api
 from mobile_api import mobile_api, MOBILE_API_BASE
 from account_deletion_api import account_deletion_api
+from pricing_api import pricing_api
 
 logging.basicConfig(
     level=logging.INFO,
@@ -111,6 +112,9 @@ logger.info("Registered mobile_api blueprint")
 app.register_blueprint(account_deletion_api)
 logger.info("Registered account_deletion_api blueprint")
 
+app.register_blueprint(pricing_api)
+logger.info("Registered canonical pricing_api blueprint")
+
 register_unified_mobile_api(app, socketio)
 register_iap_api(app)
 register_education_api(app)
@@ -130,11 +134,13 @@ def index():
             "mobile": MOBILE_API_BASE,
             "iap": "/api/iap",
             "education": "/api/education",
+            "commercial_pricing": "/api/commercial/pricing",
         },
         "features": [
             "Authenticated trading control and monitoring",
             "Real-time position updates via WebSocket",
             "Subscription management",
+            "Canonical commercial pricing policy",
             "In-app purchase validation (iOS/Android)",
             "Education content delivery",
             "Performance analytics",
@@ -164,6 +170,10 @@ def api_documentation():
             },
         },
         "endpoints": {
+            "Commercial Pricing": {
+                "get_public_pricing": "GET /api/commercial/pricing",
+                "get_locked_user_offer": "GET /api/commercial/offer/<user_id>",
+            },
             "Trading Control": {
                 "start_trading": "POST /api/v1/trading/start",
                 "stop_trading": "POST /api/v1/trading/stop",

--- a/mobile_backend_server.py
+++ b/mobile_backend_server.py
@@ -23,6 +23,7 @@ from education_system import register_education_api
 from mobile_api import mobile_api, MOBILE_API_BASE
 from account_deletion_api import account_deletion_api
 from pricing_api import pricing_api
+from commercial_pricing_runtime_patch import install_commercial_pricing_runtime_patch
 
 logging.basicConfig(
     level=logging.INFO,
@@ -63,13 +64,19 @@ CORS(
     },
 )
 
-# Public endpoints inside otherwise protected mobile namespaces.
+# Explicitly public endpoints inside otherwise protected API namespaces.
 _PUBLIC_MOBILE_PATHS = {
     "/api/mobile/status",
     "/api/mobile/config",
     "/api/v1/subscription/tiers",
+    "/api/commercial/pricing",
 }
-_PROTECTED_PREFIXES = ("/api/mobile/", "/api/v1/", "/api/account/")
+_PROTECTED_PREFIXES = (
+    "/api/mobile/",
+    "/api/v1/",
+    "/api/account/",
+    "/api/commercial/offer/",
+)
 
 
 @app.before_request
@@ -118,6 +125,12 @@ logger.info("Registered canonical pricing_api blueprint")
 register_unified_mobile_api(app, socketio)
 register_iap_api(app)
 register_education_api(app)
+
+# Install only after all blueprints are registered so the integration can wrap
+# the existing registration and subscription endpoints without changing legacy
+# feature-permission tier behavior.
+install_commercial_pricing_runtime_patch(app)
+logger.info("Installed canonical commercial pricing integration")
 
 
 @app.route("/")

--- a/pricing_api.py
+++ b/pricing_api.py
@@ -1,0 +1,51 @@
+"""HTTP routes for NIJA's canonical commercial pricing policy."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from commercial_offer_store import get_commercial_offer_store
+from pricing_policy import (
+    FOUNDING_BETA_LIMIT,
+    public_pricing,
+    beta_offer_for_claimed_count,
+)
+
+pricing_api = Blueprint("pricing_api", __name__)
+
+
+@pricing_api.get("/api/commercial/pricing")
+def get_public_pricing():
+    """Return canonical public pricing plus the currently advertised beta offer."""
+    store = get_commercial_offer_store()
+    claimed = store.founding_beta_claimed_count()
+    current = beta_offer_for_claimed_count(claimed)
+    return jsonify({
+        "pricing": public_pricing(),
+        "beta": {
+            "founding_limit": FOUNDING_BETA_LIMIT,
+            "founding_claimed": claimed,
+            "founding_remaining": max(0, FOUNDING_BETA_LIMIT - claimed),
+            "current_offer": current.to_dict(),
+        },
+        "disclaimer": "Trading and investing involve risk, including possible loss of capital. No profit or performance results are guaranteed.",
+    })
+
+
+@pricing_api.get("/api/commercial/offer/<user_id>")
+def get_user_commercial_offer(user_id: str):
+    """Return a user's locked commercial offer assignment.
+
+    This route intentionally requires the same user's authenticated identity to be
+    injected by the surrounding gateway before production exposure. If no such
+    identity is present, it fails closed.
+    """
+    authenticated_user_id = getattr(request, "user_id", None)
+    if not authenticated_user_id:
+        return jsonify({"error": "Authentication required"}), 401
+    if authenticated_user_id != user_id:
+        return jsonify({"error": "Forbidden"}), 403
+
+    assignment = get_commercial_offer_store().get_assignment(user_id)
+    if not assignment:
+        return jsonify({"error": "Commercial offer not assigned"}), 404
+    return jsonify(assignment.to_dict())

--- a/pricing_policy.py
+++ b/pricing_policy.py
@@ -1,0 +1,78 @@
+"""Canonical NIJA commercial pricing policy.
+
+Commercial offer pricing is intentionally separate from legacy/internal feature tiers.
+Do not use internal access tier names as public prices.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Any
+
+BETA_TRIAL_DAYS = 14
+FOUNDING_BETA_LIMIT = 100
+FOUNDING_BETA_MONTHLY_USD = Decimal("50.00")
+STANDARD_BETA_MONTHLY_USD = Decimal("75.00")
+FULL_RELEASE_MONTHLY_USD = Decimal("99.00")
+LESSONS_ONE_TIME_USD = Decimal("99.00")
+
+FOUNDING_BETA_OFFER = "founding_beta"
+STANDARD_BETA_OFFER = "standard_beta"
+FULL_RELEASE_OFFER = "full_release"
+LESSONS_OFFER = "lessons"
+
+
+@dataclass(frozen=True)
+class CommercialOffer:
+    code: str
+    amount_usd: Decimal
+    recurring: bool
+    trial_days: int = 0
+    cohort_limit: int | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "code": self.code,
+            "amount_usd": float(self.amount_usd),
+            "recurring": self.recurring,
+            "trial_days": self.trial_days,
+            "cohort_limit": self.cohort_limit,
+        }
+
+
+OFFERS = {
+    FOUNDING_BETA_OFFER: CommercialOffer(
+        code=FOUNDING_BETA_OFFER,
+        amount_usd=FOUNDING_BETA_MONTHLY_USD,
+        recurring=True,
+        trial_days=BETA_TRIAL_DAYS,
+        cohort_limit=FOUNDING_BETA_LIMIT,
+    ),
+    STANDARD_BETA_OFFER: CommercialOffer(
+        code=STANDARD_BETA_OFFER,
+        amount_usd=STANDARD_BETA_MONTHLY_USD,
+        recurring=True,
+    ),
+    FULL_RELEASE_OFFER: CommercialOffer(
+        code=FULL_RELEASE_OFFER,
+        amount_usd=FULL_RELEASE_MONTHLY_USD,
+        recurring=True,
+    ),
+    LESSONS_OFFER: CommercialOffer(
+        code=LESSONS_OFFER,
+        amount_usd=LESSONS_ONE_TIME_USD,
+        recurring=False,
+    ),
+}
+
+
+def beta_offer_for_claimed_count(claimed_count: int) -> CommercialOffer:
+    """Return the public beta offer without repricing prior cohorts."""
+    count = max(0, int(claimed_count))
+    if count < FOUNDING_BETA_LIMIT:
+        return OFFERS[FOUNDING_BETA_OFFER]
+    return OFFERS[STANDARD_BETA_OFFER]
+
+
+def public_pricing() -> Dict[str, Dict[str, Any]]:
+    return {code: offer.to_dict() for code, offer in OFFERS.items()}

--- a/tests/test_commercial_offer_store.py
+++ b/tests/test_commercial_offer_store.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+
+from commercial_offer_store import CommercialOfferStore
+
+
+def test_founding_beta_assignments_are_persisted_and_price_locked(tmp_path):
+    store = CommercialOfferStore(str(tmp_path / "users.db"))
+
+    first = store.assign_beta_offer("user_1")
+    again = store.assign_beta_offer("user_1")
+
+    assert first == again
+    assert first.offer_code == "founding_beta"
+    assert first.price_usd == Decimal("50.00")
+    assert first.trial_days == 14
+    assert first.cohort_position == 1
+    assert first.to_dict()["price_locked"] is True
+
+
+def test_exactly_first_100_users_receive_founding_beta(tmp_path):
+    store = CommercialOfferStore(str(tmp_path / "users.db"))
+
+    assignments = [store.assign_beta_offer(f"user_{number}") for number in range(1, 101)]
+
+    assert store.founding_beta_claimed_count() == 100
+    assert assignments[0].cohort_position == 1
+    assert assignments[-1].cohort_position == 100
+    assert all(item.offer_code == "founding_beta" for item in assignments)
+    assert all(item.price_usd == Decimal("50.00") for item in assignments)
+    assert all(item.trial_days == 14 for item in assignments)
+
+
+def test_user_101_gets_standard_beta_without_repricing_first_100(tmp_path):
+    store = CommercialOfferStore(str(tmp_path / "users.db"))
+    first = store.assign_beta_offer("user_1")
+    for number in range(2, 101):
+        store.assign_beta_offer(f"user_{number}")
+
+    user_101 = store.assign_beta_offer("user_101")
+    first_after = store.get_assignment("user_1")
+
+    assert user_101.offer_code == "standard_beta"
+    assert user_101.price_usd == Decimal("75.00")
+    assert user_101.trial_days == 0
+    assert user_101.cohort_position is None
+
+    assert first_after == first
+    assert first_after.price_usd == Decimal("50.00")
+    assert first_after.trial_days == 14

--- a/tests/test_pricing_policy.py
+++ b/tests/test_pricing_policy.py
@@ -1,0 +1,36 @@
+from decimal import Decimal
+
+from pricing_policy import (
+    BETA_TRIAL_DAYS,
+    FOUNDING_BETA_LIMIT,
+    FOUNDING_BETA_MONTHLY_USD,
+    FULL_RELEASE_MONTHLY_USD,
+    LESSONS_ONE_TIME_USD,
+    STANDARD_BETA_MONTHLY_USD,
+    beta_offer_for_claimed_count,
+)
+
+
+def test_first_beta_user_gets_founding_offer():
+    offer = beta_offer_for_claimed_count(0)
+    assert offer.amount_usd == Decimal("50.00")
+    assert offer.trial_days == 14
+    assert offer.cohort_limit == 100
+
+
+def test_ninety_ninth_claimed_still_has_one_founding_slot():
+    offer = beta_offer_for_claimed_count(99)
+    assert offer.amount_usd == FOUNDING_BETA_MONTHLY_USD
+    assert offer.trial_days == BETA_TRIAL_DAYS
+
+
+def test_after_first_100_new_beta_users_get_standard_beta_price():
+    offer = beta_offer_for_claimed_count(FOUNDING_BETA_LIMIT)
+    assert offer.amount_usd == STANDARD_BETA_MONTHLY_USD
+    assert offer.amount_usd == Decimal("75.00")
+    assert offer.trial_days == 0
+
+
+def test_lessons_and_full_release_prices_are_distinct_products():
+    assert LESSONS_ONE_TIME_USD == Decimal("99.00")
+    assert FULL_RELEASE_MONTHLY_USD == Decimal("99.00")


### PR DESCRIPTION
## Purpose
Synchronize NIJA's customer-facing commercial pricing with the founder-approved policy while keeping legacy feature/access tiers separate from public prices.

## Canonical commercial pricing
- NIJA Lessons: $99 one-time
- Founding Beta (first 100 eligible users): 14 days free, then $50/month
- Standard Beta (new users after first 100): $75/month
- Planned full Apple/Google paid release: $99/month
- Founding beta assignments remain price-locked; filling the cohort does not silently reprice existing users

## Changes
- Replaces stale public `PRICING.md` tier-price table with the canonical offer policy.
- Adds `pricing_policy.py` as the single machine-readable source of commercial offer constants.
- Adds persistent `commercial_offer_assignments` storage with atomic first-100 allocation.
- Adds public canonical pricing API and authenticated locked-offer lookup.
- Adds runtime integration so public registration cannot self-select elevated internal access tiers.
- Replaces `/api/v1/subscription/tiers` public pricing output with commercial offers while preserving internal feature-permission tiers.
- Adds locked commercial-offer data to subscription info.
- Protects `/api/commercial/offer/<user_id>` with the mobile JWT gateway.
- Hides the legacy Basic/Pro/Enterprise selector in the existing frontend and renders the current beta offer from the canonical pricing API.
- Adds focused pricing/cohort regression tests.

## CRM
The NIJA Outbound Call Center Master CRM was also aligned separately in Google Drive:
- added `PRICING POLICY` tab;
- added Offer Code, Trial Days, Quoted Price, Price Locked, and Cohort Position to CALL QUEUE;
- added exact caller pricing rules and anti-legacy-price guidance.

## Safety / scope
- No trading strategy, order execution, risk threshold, kill switch, nonce policy, capital gate, or broker-routing behavior is changed.
- Internal Basic/Pro/Enterprise access tiers remain available for capability enforcement and backwards compatibility; they are explicitly not customer-facing prices.
- No Stripe production credentials are added. Existing Stripe subscription creation remains a separate production-billing integration task.
- No guaranteed-profit or guaranteed-return claims are introduced.

## Validation
- Focused regression tests added for the 14-day/$50 founding cohort, exact 100-user transition, $75 post-100 offer, $99 lessons, $99 planned full release, and founding-price persistence.
- Branch was created from an earlier main SHA; current main advanced during implementation, so GitHub merge/CI should validate the combined merge result before production deployment.