### PR TITLE
Add production Stripe web checkout and billing state

### DIFF
--- a/billing_store.py
+++ b/billing_store.py
@@ -1,0 +1,168 @@
+"""Persistent billing state for NIJA web subscriptions.
+
+This module stores Stripe identifiers and subscription state separately from
+internal NIJA trading-permission tiers and commercial offer assignments.
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class BillingRecord:
+    user_id: str
+    provider: str
+    customer_id: Optional[str]
+    subscription_id: Optional[str]
+    checkout_session_id: Optional[str]
+    status: str
+    offer_code: Optional[str]
+    current_period_end: Optional[int]
+    updated_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "user_id": self.user_id,
+            "provider": self.provider,
+            "customer_id": self.customer_id,
+            "subscription_id": self.subscription_id,
+            "checkout_session_id": self.checkout_session_id,
+            "status": self.status,
+            "offer_code": self.offer_code,
+            "current_period_end": self.current_period_end,
+            "updated_at": self.updated_at,
+        }
+
+
+class BillingStore:
+    def __init__(self, db_path: str = "users.db") -> None:
+        self.db_path = db_path
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_schema(self) -> None:
+        with closing(self._connect()) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS billing_subscriptions (
+                    user_id TEXT PRIMARY KEY,
+                    provider TEXT NOT NULL DEFAULT 'stripe',
+                    customer_id TEXT,
+                    subscription_id TEXT,
+                    checkout_session_id TEXT,
+                    status TEXT NOT NULL,
+                    offer_code TEXT,
+                    current_period_end INTEGER,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_billing_subscription_id "
+                "ON billing_subscriptions(subscription_id) "
+                "WHERE subscription_id IS NOT NULL"
+            )
+            conn.commit()
+
+    def upsert(
+        self,
+        *,
+        user_id: str,
+        status: str,
+        customer_id: Optional[str] = None,
+        subscription_id: Optional[str] = None,
+        checkout_session_id: Optional[str] = None,
+        offer_code: Optional[str] = None,
+        current_period_end: Optional[int] = None,
+    ) -> BillingRecord:
+        updated_at = datetime.now(timezone.utc).isoformat()
+        with closing(self._connect()) as conn:
+            conn.execute(
+                """
+                INSERT INTO billing_subscriptions (
+                    user_id, provider, customer_id, subscription_id,
+                    checkout_session_id, status, offer_code,
+                    current_period_end, updated_at
+                ) VALUES (?, 'stripe', ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                    customer_id = COALESCE(excluded.customer_id, billing_subscriptions.customer_id),
+                    subscription_id = COALESCE(excluded.subscription_id, billing_subscriptions.subscription_id),
+                    checkout_session_id = COALESCE(excluded.checkout_session_id, billing_subscriptions.checkout_session_id),
+                    status = excluded.status,
+                    offer_code = COALESCE(excluded.offer_code, billing_subscriptions.offer_code),
+                    current_period_end = COALESCE(excluded.current_period_end, billing_subscriptions.current_period_end),
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    user_id,
+                    customer_id,
+                    subscription_id,
+                    checkout_session_id,
+                    status,
+                    offer_code,
+                    current_period_end,
+                    updated_at,
+                ),
+            )
+            conn.commit()
+        record = self.get(user_id)
+        if record is None:
+            raise RuntimeError("Billing record was not persisted")
+        return record
+
+    def get(self, user_id: str) -> Optional[BillingRecord]:
+        with closing(self._connect()) as conn:
+            row = conn.execute(
+                """
+                SELECT user_id, provider, customer_id, subscription_id,
+                       checkout_session_id, status, offer_code,
+                       current_period_end, updated_at
+                FROM billing_subscriptions WHERE user_id = ?
+                """,
+                (user_id,),
+            ).fetchone()
+        return self._row(row) if row else None
+
+    def find_user_by_subscription(self, subscription_id: str) -> Optional[str]:
+        with closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT user_id FROM billing_subscriptions WHERE subscription_id = ?",
+                (subscription_id,),
+            ).fetchone()
+        return str(row[0]) if row else None
+
+    @staticmethod
+    def _row(row: sqlite3.Row) -> BillingRecord:
+        return BillingRecord(
+            user_id=str(row["user_id"]),
+            provider=str(row["provider"]),
+            customer_id=row["customer_id"],
+            subscription_id=row["subscription_id"],
+            checkout_session_id=row["checkout_session_id"],
+            status=str(row["status"]),
+            offer_code=row["offer_code"],
+            current_period_end=(
+                int(row["current_period_end"])
+                if row["current_period_end"] is not None
+                else None
+            ),
+            updated_at=str(row["updated_at"]),
+        )
+
+
+_store: Optional[BillingStore] = None
+
+
+def get_billing_store(db_path: str = "users.db") -> BillingStore:
+    global _store
+    if _store is None or _store.db_path != db_path:
+        _store = BillingStore(db_path=db_path)
+    return _store

--- a/mobile_backend_server.py
+++ b/mobile_backend_server.py
@@ -23,6 +23,7 @@ from education_system import register_education_api
 from mobile_api import mobile_api, MOBILE_API_BASE
 from account_deletion_api import account_deletion_api
 from pricing_api import pricing_api
+from stripe_billing_api import stripe_billing_api
 from commercial_pricing_runtime_patch import install_commercial_pricing_runtime_patch
 
 logging.basicConfig(
@@ -56,7 +57,7 @@ CORS(
         r"/api/*": {
             "origins": _allowed_origins,
             "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-            "allow_headers": ["Content-Type", "Authorization"],
+            "allow_headers": ["Content-Type", "Authorization", "Stripe-Signature"],
             "expose_headers": ["Content-Type", "Authorization"],
             "supports_credentials": True,
             "max_age": 3600,
@@ -70,12 +71,14 @@ _PUBLIC_MOBILE_PATHS = {
     "/api/mobile/config",
     "/api/v1/subscription/tiers",
     "/api/commercial/pricing",
+    "/api/billing/webhook",
 }
 _PROTECTED_PREFIXES = (
     "/api/mobile/",
     "/api/v1/",
     "/api/account/",
     "/api/commercial/offer/",
+    "/api/billing/",
 )
 
 
@@ -122,6 +125,9 @@ logger.info("Registered account_deletion_api blueprint")
 app.register_blueprint(pricing_api)
 logger.info("Registered canonical pricing_api blueprint")
 
+app.register_blueprint(stripe_billing_api)
+logger.info("Registered Stripe web billing blueprint")
+
 register_unified_mobile_api(app, socketio)
 register_iap_api(app)
 register_education_api(app)
@@ -137,7 +143,7 @@ logger.info("Installed canonical commercial pricing integration")
 def index():
     return jsonify({
         "name": "NIJA Mobile API",
-        "version": "1.1.0",
+        "version": "1.2.0",
         "description": "Mobile-ready REST and WebSocket API for NIJA trading platform",
         "documentation": "/api/docs",
         "health": "/health",
@@ -148,12 +154,14 @@ def index():
             "iap": "/api/iap",
             "education": "/api/education",
             "commercial_pricing": "/api/commercial/pricing",
+            "web_billing": "/api/billing",
         },
         "features": [
             "Authenticated trading control and monitoring",
             "Real-time position updates via WebSocket",
             "Subscription management",
             "Canonical commercial pricing policy",
+            "Signed Stripe web checkout and webhook processing",
             "In-app purchase validation (iOS/Android)",
             "Education content delivery",
             "Performance analytics",
@@ -172,7 +180,7 @@ def index():
 def api_documentation():
     return jsonify({
         "title": "NIJA Mobile API Documentation",
-        "version": "1.1.0",
+        "version": "1.2.0",
         "base_url": request.host_url,
         "authentication": {
             "type": "Bearer JWT",
@@ -186,6 +194,11 @@ def api_documentation():
             "Commercial Pricing": {
                 "get_public_pricing": "GET /api/commercial/pricing",
                 "get_locked_user_offer": "GET /api/commercial/offer/<user_id>",
+            },
+            "Web Billing": {
+                "create_checkout": "POST /api/billing/checkout",
+                "get_status": "GET /api/billing/status",
+                "stripe_webhook": "POST /api/billing/webhook",
             },
             "Trading Control": {
                 "start_trading": "POST /api/v1/trading/start",

--- a/stripe_billing_api.py
+++ b/stripe_billing_api.py
@@ -1,0 +1,220 @@
+"""Production Stripe Checkout integration for NIJA web subscriptions.
+
+Secrets and Stripe Price IDs are read only from environment variables. The API
+uses the user's already-locked NIJA commercial offer so Stripe cannot become a
+second source of pricing truth.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from flask import Blueprint, jsonify, request
+
+from auth.user_database import get_user_database
+from billing_store import get_billing_store
+from commercial_offer_store import get_commercial_offer_store
+from pricing_policy import FOUNDING_BETA_OFFER, STANDARD_BETA_OFFER
+
+logger = logging.getLogger("nija.billing.stripe")
+
+stripe_billing_api = Blueprint("stripe_billing_api", __name__)
+
+_PRICE_ENV = {
+    FOUNDING_BETA_OFFER: "STRIPE_PRICE_FOUNDING_BETA",
+    STANDARD_BETA_OFFER: "STRIPE_PRICE_STANDARD_BETA",
+}
+
+
+def _stripe_module():
+    import stripe
+
+    secret = os.getenv("STRIPE_SECRET_KEY", "").strip()
+    if not secret:
+        raise RuntimeError("Stripe is not configured")
+    stripe.api_key = secret
+    return stripe
+
+
+def _site_url() -> str:
+    return os.getenv("NIJA_PUBLIC_SITE_URL", "https://nijaaitrading.com").rstrip("/")
+
+
+def _price_id_for_offer(offer_code: str) -> str:
+    env_name = _PRICE_ENV.get(offer_code)
+    if not env_name:
+        raise RuntimeError("This NIJA offer is not available for web subscription checkout")
+    value = os.getenv(env_name, "").strip()
+    if not value:
+        raise RuntimeError(f"Stripe Price ID is not configured for {offer_code}")
+    return value
+
+
+def _obj_value(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@stripe_billing_api.post("/api/billing/checkout")
+def create_checkout_session():
+    """Create Stripe Checkout for the authenticated user's locked beta offer."""
+    user_id = getattr(request, "user_id", None)
+    if not isinstance(user_id, str) or not user_id:
+        return jsonify({"error": "Authentication required"}), 401
+
+    assignment = get_commercial_offer_store().get_assignment(user_id)
+    if assignment is None:
+        return jsonify({"error": "Commercial offer not assigned"}), 409
+
+    try:
+        price_id = _price_id_for_offer(assignment.offer_code)
+        stripe = _stripe_module()
+    except RuntimeError as exc:
+        logger.error("Stripe checkout configuration error: %s", exc)
+        return jsonify({"error": "Checkout is temporarily unavailable"}), 503
+
+    user = get_user_database().get_user(user_id)
+    if not user or not user.get("email"):
+        return jsonify({"error": "User account email is unavailable"}), 409
+
+    success_url = os.getenv(
+        "STRIPE_CHECKOUT_SUCCESS_URL",
+        f"{_site_url()}/checkout/success?session_id={{CHECKOUT_SESSION_ID}}",
+    )
+    cancel_url = os.getenv(
+        "STRIPE_CHECKOUT_CANCEL_URL",
+        f"{_site_url()}/checkout/cancelled",
+    )
+
+    metadata = {
+        "nija_user_id": user_id,
+        "nija_offer_code": assignment.offer_code,
+        "nija_price_locked": "true",
+    }
+    subscription_data: dict[str, Any] = {"metadata": metadata}
+    if assignment.trial_days > 0:
+        subscription_data["trial_period_days"] = assignment.trial_days
+
+    try:
+        session = stripe.checkout.Session.create(
+            mode="subscription",
+            customer_email=user["email"],
+            line_items=[{"price": price_id, "quantity": 1}],
+            success_url=success_url,
+            cancel_url=cancel_url,
+            allow_promotion_codes=False,
+            client_reference_id=user_id,
+            metadata=metadata,
+            subscription_data=subscription_data,
+        )
+    except Exception as exc:
+        logger.exception("Stripe Checkout Session creation failed for user %s", user_id)
+        return jsonify({"error": "Checkout could not be created"}), 502
+
+    session_id = str(_obj_value(session, "id", ""))
+    checkout_url = _obj_value(session, "url")
+    if not session_id or not checkout_url:
+        logger.error("Stripe returned an incomplete checkout session for user %s", user_id)
+        return jsonify({"error": "Checkout could not be created"}), 502
+
+    get_billing_store().upsert(
+        user_id=user_id,
+        checkout_session_id=session_id,
+        status="checkout_created",
+        offer_code=assignment.offer_code,
+    )
+
+    return jsonify(
+        {
+            "checkout_url": checkout_url,
+            "checkout_session_id": session_id,
+            "commercial_offer": assignment.to_dict(),
+        }
+    )
+
+
+@stripe_billing_api.get("/api/billing/status")
+def billing_status():
+    user_id = getattr(request, "user_id", None)
+    if not isinstance(user_id, str) or not user_id:
+        return jsonify({"error": "Authentication required"}), 401
+    record = get_billing_store().get(user_id)
+    if record is None:
+        return jsonify({"status": "not_started"})
+    return jsonify(record.to_dict())
+
+
+@stripe_billing_api.post("/api/billing/webhook")
+def stripe_webhook():
+    """Verify Stripe signature and persist authoritative subscription status."""
+    secret = os.getenv("STRIPE_WEBHOOK_SECRET", "").strip()
+    if not secret:
+        logger.error("Stripe webhook received before webhook secret was configured")
+        return jsonify({"error": "Webhook is not configured"}), 503
+
+    try:
+        stripe = _stripe_module()
+    except RuntimeError:
+        return jsonify({"error": "Webhook is not configured"}), 503
+
+    signature = request.headers.get("Stripe-Signature", "")
+    try:
+        event = stripe.Webhook.construct_event(request.get_data(), signature, secret)
+    except Exception:
+        logger.warning("Rejected Stripe webhook with invalid payload or signature")
+        return jsonify({"error": "Invalid webhook"}), 400
+
+    event_type = _obj_value(event, "type", "")
+    data = _obj_value(event, "data", {})
+    obj = _obj_value(data, "object", {})
+
+    if event_type == "checkout.session.completed":
+        metadata = _obj_value(obj, "metadata", {}) or {}
+        user_id = _obj_value(metadata, "nija_user_id")
+        offer_code = _obj_value(metadata, "nija_offer_code")
+        if user_id:
+            get_billing_store().upsert(
+                user_id=str(user_id),
+                customer_id=_string_or_none(_obj_value(obj, "customer")),
+                subscription_id=_string_or_none(_obj_value(obj, "subscription")),
+                checkout_session_id=_string_or_none(_obj_value(obj, "id")),
+                status="checkout_completed",
+                offer_code=_string_or_none(offer_code),
+            )
+
+    elif event_type in {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }:
+        subscription_id = _string_or_none(_obj_value(obj, "id"))
+        metadata = _obj_value(obj, "metadata", {}) or {}
+        user_id = _obj_value(metadata, "nija_user_id")
+        if not user_id and subscription_id:
+            user_id = get_billing_store().find_user_by_subscription(subscription_id)
+        if user_id:
+            get_billing_store().upsert(
+                user_id=str(user_id),
+                customer_id=_string_or_none(_obj_value(obj, "customer")),
+                subscription_id=subscription_id,
+                status=str(_obj_value(obj, "status", "unknown")),
+                offer_code=_string_or_none(_obj_value(metadata, "nija_offer_code")),
+                current_period_end=_int_or_none(_obj_value(obj, "current_period_end")),
+            )
+
+    return jsonify({"received": True})
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    return str(value) if value not in (None, "") else None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_billing_store.py
+++ b/tests/test_billing_store.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from billing_store import BillingStore
+
+
+def test_billing_store_persists_and_updates_subscription(tmp_path: Path):
+    store = BillingStore(str(tmp_path / "billing.db"))
+
+    created = store.upsert(
+        user_id="user_1",
+        status="checkout_created",
+        checkout_session_id="cs_test_1",
+        offer_code="founding_beta",
+    )
+    assert created.user_id == "user_1"
+    assert created.status == "checkout_created"
+    assert created.offer_code == "founding_beta"
+
+    updated = store.upsert(
+        user_id="user_1",
+        status="trialing",
+        customer_id="cus_test_1",
+        subscription_id="sub_test_1",
+        current_period_end=2000000000,
+    )
+    assert updated.customer_id == "cus_test_1"
+    assert updated.subscription_id == "sub_test_1"
+    assert updated.checkout_session_id == "cs_test_1"
+    assert updated.offer_code == "founding_beta"
+    assert updated.status == "trialing"
+    assert updated.current_period_end == 2000000000
+    assert store.find_user_by_subscription("sub_test_1") == "user_1"
+
+
+def test_billing_store_keeps_users_separate(tmp_path: Path):
+    store = BillingStore(str(tmp_path / "billing.db"))
+    store.upsert(user_id="user_a", status="active", subscription_id="sub_a")
+    store.upsert(user_id="user_b", status="canceled", subscription_id="sub_b")
+
+    assert store.get("user_a").status == "active"
+    assert store.get("user_b").status == "canceled"
+    assert store.find_user_by_subscription("sub_a") == "user_a"
+    assert store.find_user_by_subscription("sub_b") == "user_b"


### PR DESCRIPTION
## Purpose
Complete NIJA's code-side production web billing integration while preserving the canonical commercial pricing policy and first-100 cohort lock.

## Changes
- Adds authenticated `POST /api/billing/checkout` using the user's locked NIJA commercial offer.
- Adds `GET /api/billing/status` for persisted billing state.
- Adds public `POST /api/billing/webhook` with Stripe signature verification.
- Persists Stripe customer, subscription, checkout-session, status, offer code, and current-period-end separately from trading permission tiers.
- Applies the 14-day trial only to users already assigned the founding-beta offer.
- Uses environment variables for Stripe secret, webhook secret, Price IDs, and success/cancel URLs. No secrets or live Price IDs are committed.
- Adds billing-store regression tests.
- Protects all `/api/billing/*` endpoints with JWT except the signed Stripe webhook.

## Required production configuration
- `STRIPE_SECRET_KEY`
- `STRIPE_WEBHOOK_SECRET`
- `STRIPE_PRICE_FOUNDING_BETA` ($50/month recurring Price)
- `STRIPE_PRICE_STANDARD_BETA` ($75/month recurring Price)
- `NIJA_PUBLIC_SITE_URL=https://nijaaitrading.com`
- optional `STRIPE_CHECKOUT_SUCCESS_URL`
- optional `STRIPE_CHECKOUT_CANCEL_URL`

## Scope
This does not change trading strategy, broker execution, risk, nonce, capital, or kill-switch behavior. Mobile App Store / Google Play IAP remains separate from web Stripe billing.